### PR TITLE
Ensure connection exists before executing batch queries

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -192,13 +192,20 @@ Client.prototype.stream = function () {
  * @param {resultCallback} callback Executes callback(err, result) when the batch was executed
  */
 Client.prototype.batch = function () {
+  var self = this;
   var args = this._parseBatchArgs.apply(null, arguments);
   //logged batch by default
   args.options = utils.extend({logged: true}, this.options.queryOptions, args.options);
-  var request = new requests.BatchRequest(args.queries, args.options.consistency, args.options);
-  var handler = new RequestHandler(this, this.options);
-  args.callback = utils.bindDomain(args.callback);
-  handler.send(request, null, args.callback);
+
+  this.connect(function afterConnect(err) {
+    if (err) {
+      return args.callback(err);
+    }
+    var request = new requests.BatchRequest(args.queries, args.options.consistency, args.options);
+    var handler = new RequestHandler(self, self.options);
+    args.callback = utils.bindDomain(args.callback);
+    handler.send(request, null, args.callback);
+  });
 };
 
 /**


### PR DESCRIPTION
Like  `client.execute`, ensure connection exists for `client.batch`.
