### PR TITLE
Accounts for the lazy initalization of availableStreamId array and fixes...

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -417,7 +417,7 @@ Connection.prototype.writeNext = function () {
  * @returns {Number}
  */
 Connection.prototype.getInFlight = function () {
-  return this.maxRequests - this.availableStreamIds.length;
+  return this.maxRequests - ( this.availableStreamIds || [] ).length;
 };
 
 /**


### PR DESCRIPTION
... the following exception

TypeError: Cannot read property 'length' of undefined
    at Connection.getInFlight (/Users/kfotev/Work/PierBelt/Wordpress/crawler-lite/node_modules/cassandra-driver/lib/connection.js:366:66)
    at /Users/kfotev/Work/PierBelt/Wordpress/crawler-lite/node_modules/cassandra-driver/lib/utils.js:178:24
    at Array.sort (native)
    at getLeastBusy (/Users/kfotev/Work/PierBelt/Wordpress/crawler-lite/node_modules/cassandra-driver/lib/host.js:116:24)
    at fn (/Users/kfotev/Work/PierBelt/Wordpress/crawler-lite/node_modules/cassandra-driver/node_modules/async/lib/async.js:641:34)
    at Object._onImmediate (/Users/kfotev/Work/PierBelt/Wordpress/crawler-lite/node_modules/cassandra-driver/node_modules/async/lib/async.js:557:34)
    at processImmediate [as _immediateCallback](timers.js:345:15)
