### PR TITLE
Prevent race condition where availableStreamIds isn't set

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -417,7 +417,8 @@ Connection.prototype.writeNext = function () {
  * @returns {Number}
  */
 Connection.prototype.getInFlight = function () {
-  return this.maxRequests - this.availableStreamIds.length;
+  return (this.availableStreamIds) ?
+    this.maxRequests - this.availableStreamIds.length : 0;
 };
 
 /**


### PR DESCRIPTION
Ran into a race condition where `getInFlight()` was being called before `this.availableStreamIds` was set to an array, resulting in a JS error being thrown because `this.availabileStreamIds.length` wasn't set.

This was occurring in v1.0.0-beta1, but I based this fix branch off HEAD. Let me know if it'd be easier to base off the v1.0.0-beta1 tag.

Fuller stack:

``` javascript
Uncaught TypeError: Cannot read property 'length' of undefined
      at Connection.getInFlight (XXXXX/node_modules/cassandra-driver/lib/connection.js:366:52)
      at XXXXXXXX/node_modules/cassandra-driver/lib/utils.js:178:24
      at Array.sort (native)
      at getLeastBusy (XXXXXXXXX/node_modules/cassandra-driver/lib/host.js:116:24)
      at fn (XXXXXXXXX/node_modules/async/lib/async.js:641:34)
      at Object._onImmediate (XXXXXXXXX/node_modules/async/lib/async.js:557:34)
      at processImmediate [as _immediateCallback] (timers.js:336:15)
```

Cheers.
