### PR TITLE
Minor fix in Connection.prepareOnce name

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -309,7 +309,7 @@ Connection.prototype.changeKeyspace = function (keyspace, callback) {
  * @param {function} callback
  */
 Connection.prototype.prepareOnce = function (query, callback) {
-  var name = this.keyspace || '' + query;
+  var name = ( this.keyspace || '' ) + query;
   var info = this.preparing[name];
   if (this.preparing[name]) {
     //Its being already prepared


### PR DESCRIPTION
Fix name variable, so each keyspace+query gets it's own EventEmitter instance.
