### PR TITLE
Add support for disabling the legacy Row.get() interface

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -329,12 +329,18 @@ ResultStream.prototype.add = function (chunk) {
   this.read(0);
 };
 
+
+// Support the legacy .get accessor on rows
+var supportLegacyRowInterface = true;
+
 /**
  * Represents a result row
  * @constructor
  */
 function Row(columns) {
-  this.__columns = columns;
+  if (supportLegacyRowInterface) {
+    this.__columns = columns;
+  }
 }
 
 /**
@@ -343,6 +349,9 @@ function Row(columns) {
  * @param {String|Number} columnName Name or index of the column
  */
 Row.prototype.get = function (columnName) {
+  if (!supportLegacyRowInterface) {
+    throw new Error("Row.get called, but legacy row interface disabled with types.supportLegacyRowInterface = false!");
+  }
   if (typeof columnName === 'number') {
     if (this.__columns && this.__columns[columnName]) {
       columnName = this.__columns[columnName].name;
@@ -434,6 +443,7 @@ exports.Long = Long;
 exports.QueryLiteral = QueryLiteral;
 exports.QueueWhile = QueueWhile;
 exports.ResultStream = ResultStream;
+exports.supportLegacyRowInterface = supportLegacyRowInterface;
 exports.Row = Row;
 exports.DriverError = DriverError;
 exports.TimeoutError = TimeoutError;


### PR DESCRIPTION
This is desirable to avoid adding the .__columns member on the Row object.
This implementation uses a simple module-level boolean in the type module. We
could instead use an accessor if desired.
