### PR TITLE
Connection handleResult - check if callback exists before invoking.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -436,7 +436,11 @@ Connection.prototype.handleResult = function (header, err, result) {
   var callback = handler.callback;
   //set the callback to null to avoid it being called when freed
   handler.callback = null;
-  callback(err, result);
+
+  //if callback null, skip
+  if (callback) {
+    callback(err, result);
+  }
 };
 
 Connection.prototype.handleNodeEvent = function (header, event) {


### PR DESCRIPTION
This line was causing Unhandled 'error' event for some queries.
Throwing: `TypeError: object is not a function`

Doing some investigation I found out that callback was null in some cases.
