### PR TITLE
Manual paging

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -143,32 +143,37 @@ Client.prototype.eachRow = function () {
   args.callback = utils.bindDomain(args.callback);
   var self = this;
   function nextPage() {
-    self._innerExecute(args.query, args.params, args.options, pageCallback); }
+    self._innerExecute(args.query, args.params, args.options, pageCallback); 
+  }
   function pageCallback (err, result) {
     if (err) {
       return args.callback(err);
     }
-    if (args.options.autoPage||args.options.manualPage) {
-      //Next requests for autopaging
-      args.options.rowLength = args.options.rowLength || 0;
-      args.options.rowLength += result.rowLength;
-      args.options.rowLengthArray = args.options.rowLengthArray || [];
-      args.options.rowLengthArray.push(result.rowLength);
+      
+    //Next requests in case paging (auto or explicit) is used
+    args.options.rowLength = args.options.rowLength || 0;
+    args.options.rowLength += result.rowLength;
+    args.options.rowLengthArray = args.options.rowLengthArray || [];
+    args.options.rowLengthArray.push(result.rowLength);
 
-      if (result.meta && result.meta.pageState) {
-        //Use new page state as next request page state
-        args.options.pageState = result.meta.pageState;
-        //Issue next request for the next page
-        if (args.options.manualPage) {
-          result.nextPage = nextPage; }
-        else {
-          nextPage(); 
-          return; }
+    if (result.meta && result.meta.pageState) {
+      //Use new page state as next request page state
+      args.options.pageState = result.meta.pageState;
+      //Issue next request for the next page
+      if (args.options.autoPage) {
+        //Next request for autopaging
+        nextPage(); 
+        return; 
       }
-      //finished auto-paging
-      result.rowLength = args.options.rowLength;
-      result.rowLengthArray = args.options.rowLengthArray;
+      else {
+        //Allows for explicit (manual) paging, in case the caller needs it 
+        result.nextPage = nextPage;
+      }
     }
+    //finished auto-paging
+    result.rowLength = args.options.rowLength;
+    result.rowLengthArray = args.options.rowLengthArray;
+
     args.callback(null, result);
   }
   this._innerExecute(args.query, args.params, args.options, pageCallback);


### PR DESCRIPTION
Jorge, this small change allows for manual paging and throttling.

A new query option manualPage: true enables the paging behavior. In contrast to autoPage, manualPage does not automatically invoke self._innerExecute. Instead, the self._innerExecute is wrapped in nextPage method exposed via the result param in the second, operation status callback.

This means the status callback is invoked at end of each and every page instead of just once after everything has been read. Despite, the caller does know when there's no data left - the nextPage method is absent on the last invoke.

Please merge, or let's get this back to the drawing board and discuss a better manual paging/throttling interface.

Thanks,
-Krassimir  
