### PR TITLE
Manual paging support via nextPage method

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -142,28 +142,38 @@ Client.prototype.eachRow = function () {
   });
   args.callback = utils.bindDomain(args.callback);
   var self = this;
+  function nextPage() {
+    self._innerExecute(args.query, args.params, args.options, pageCallback); 
+  }
   function pageCallback (err, result) {
     if (err) {
       return args.callback(err);
     }
-    if (args.options.autoPage) {
-      //Next requests for autopaging
-      args.options.rowLength = args.options.rowLength || 0;
-      args.options.rowLength += result.rowLength;
-      args.options.rowLengthArray = args.options.rowLengthArray || [];
-      args.options.rowLengthArray.push(result.rowLength);
+      
+    //Next requests in case paging (auto or explicit) is used
+    args.options.rowLength = args.options.rowLength || 0;
+    args.options.rowLength += result.rowLength;
+    args.options.rowLengthArray = args.options.rowLengthArray || [];
+    args.options.rowLengthArray.push(result.rowLength);
 
-      if (result.meta && result.meta.pageState) {
-        //Use new page state as next request page state
-        args.options.pageState = result.meta.pageState;
-        //Issue next request for the next page
-        self._innerExecute(args.query, args.params, args.options, pageCallback);
-        return;
+    if (result.meta && result.meta.pageState) {
+      //Use new page state as next request page state
+      args.options.pageState = result.meta.pageState;
+      //Issue next request for the next page
+      if (args.options.autoPage) {
+        //Next request for autopaging
+        nextPage(); 
+        return; 
       }
-      //finished auto-paging
-      result.rowLength = args.options.rowLength;
-      result.rowLengthArray = args.options.rowLengthArray;
+      else {
+        //Allows for explicit (manual) paging, in case the caller needs it 
+        result.nextPage = nextPage;
+      }
     }
+    //finished auto-paging
+    result.rowLength = args.options.rowLength;
+    result.rowLengthArray = args.options.rowLengthArray;
+
     args.callback(null, result);
   }
   this._innerExecute(args.query, args.params, args.options, pageCallback);


### PR DESCRIPTION
Removed the manualPage option. Now nextPage is always available, except on the last page. I've been the adjusted code for about a day now. No problems so far.

Have not done any testing whether paging does in fact work via args.options.pageState in a later eachRow call...
