### PR TITLE
Reset shuttingDown state after pool closes

### DIFF
--- a/lib/host.js
+++ b/lib/host.js
@@ -204,6 +204,7 @@ HostConnectionPool.prototype.shutdown = function (callback) {
     c.close(next);
   }, function (err) {
     self.connections = null;
+    self.shuttingDown = false;
     callback(err);
   });
 };

--- a/test/integration/short/client-pool-tests.js
+++ b/test/integration/short/client-pool-tests.js
@@ -470,6 +470,8 @@ describe('Client', function () {
           assert.strictEqual(hosts.length, 2);
           assert.ok(hosts[0].pool.connections.length > 0);
           assert.ok(hosts[1].pool.connections.length > 0);
+          assert.ok(hosts[0].pool.shuttingDown === false);
+          assert.ok(hosts[1].pool.shuttingDown === false);
           client.shutdown(next);
         },
         function checkPool(next) {


### PR DESCRIPTION
Previously, after `.shutdown(callback)` was called on a client, subsequent calls to shutdown did nothing, and callbacks were never fired because we return in line 197 (it doesn't appear a shutdown event is ever actually emitted, either).

I encountered this issue (and solved it with this fix) when unit testing where connections were torn down and reestablished several times throughout the test suites. Tests which waited for the pool to shut down before continuing were timing out.
