### PR TITLE
Enable TCP keep-alive on backend connections

### DIFF
--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -33,7 +33,9 @@ function defaultOptions () {
       maxConnectionsPerHost: {}
     },
     socketOptions: {
-      connectTimeout: 5000
+      connectTimeout: 5000,
+      keepAlive: true,
+      keepAliveDelay: 10000
     },
     authProvider: null,
     maxPrepared: 500

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -35,7 +35,7 @@ function defaultOptions () {
     socketOptions: {
       connectTimeout: 5000,
       keepAlive: true,
-      keepAliveDelay: 10000
+      keepAliveDelay: 0
     },
     authProvider: null,
     maxPrepared: 500

--- a/lib/client.js
+++ b/lib/client.js
@@ -25,6 +25,8 @@ var encoder = require('./encoder.js');
  * @property {Number} protocolOptions.port The port to use to connect to the Cassandra host. If not set through this method, the default port (9042) will be used instead.
  * @property {Object} socketOptions
  * @property {Number} socketOptions.connectTimeout Connection timeout in milliseconds.
+ * @property {Boolean} socketOptions.keepAlive Whether to enable TCP keepalive on the socket. Default: true.
+ * @property {Number} socketOptions.keepAliveDelay TCP keepalive delay in milliseconds. Default: 10000.
  * @property {AuthProvider} authProvider Provider to be used to authenticate to an auth-enabled host.
  * @property {Object} sslOptions Client-to-node ssl options, when set the driver will use the secure layer. You can specify cert, ca, ... options named after the Node.js tls.connect options.
  */
@@ -59,9 +61,9 @@ function Client(options) {
 
 util.inherits(Client, events.EventEmitter);
 
-/** 
+/**
  * Connects to all hosts, in case the pool is disconnected.
- * @param {function} callback is called when the pool is connected (or at least 1 connected and the rest failed to connect) or it is not possible to connect 
+ * @param {function} callback is called when the pool is connected (or at least 1 connected and the rest failed to connect) or it is not possible to connect
  */
 Client.prototype.connect = function (callback) {
   if (this.connected) return callback();

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -78,7 +78,7 @@ Connection.prototype.chainEvents = function() {
     .pipe(resultEmitter);
 };
 
-/** 
+/**
  * Connects a socket and sends the startup protocol messages.
  */
 Connection.prototype.open = function (callback) {
@@ -110,6 +110,10 @@ Connection.prototype.open = function (callback) {
     self.errorConnecting(err, true, callback);
   });
   this.netClient.setTimeout(this.options.socketOptions.connectTimeout);
+  // Improve failure detection with TCP keep-alives
+  if (this.options.socketOptions.keepAlive) {
+    this.netClient.setKeepAlive(true, this.options.socketOptions.keepAliveDelay);
+  }
 };
 
 /**


### PR DESCRIPTION
As discussed in https://datastax-oss.atlassian.net/browse/NODEJS-58, we
currently see hanging backend connections to Cassandra whenever a Cassandra
node is not cleanly shutting down (OOM or kill -9).

Enabling TCP keep-alive should speed up the detection of such hanging
connections somewhat, although with the default linux settings it should still
take 10s delay (default in this patch) plus 9x 75s keepalive interval (Linux
default settings, see
http://tldp.org/HOWTO/TCP-Keepalive-HOWTO/usingkeepalive.html).

Took the excellent work done by @gwicke and just put it into a PR. @jorgebay let me know if you'd like to add anything to this, I'd just like to make sure this setting is tweakable in the next release :). In terms of defaults to extend discussion from [jira](https://datastax-oss.atlassian.net/browse/NODEJS-58), I have set it back to node's default as that has worked the best for all our use in [`http-proxy`](https://github.com/nodejitsu/node-http-proxy/blob/master/lib/http-proxy/common.js#L110-L117) which we use heavily at nodejitsu