### PR TITLE
Added "object" type to guessDataType in encoder

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -216,6 +216,9 @@ var encoder = (function(){
     else if (value === true || value === false) {
       type = dataTypes.boolean;
     }
+    else if (typeof value === 'object') {
+      type = dataTypes.map;
+    }
 
     if (type === null) {
       return null;


### PR DESCRIPTION
Noted when doing a batch insert that there appears to be no way for an object->map to be detected, (i.e. it required you to provide a hint). There appears to be a clause missing to guess the object type. 

(probably needs more inspection to show it conforms to a map but this seems better than nothing).