### PR TITLE
update version to match latest tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cassandra-driver",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "DataStax Node.js Driver for Apache Cassandra",
   "author": "DataStax",
   "keywords": [


### PR DESCRIPTION
package.json@1.0.3 contains correct version, this one doesn't