### PR TITLE
handleResult being called multiple times - defensive check

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -487,7 +487,12 @@ Connection.prototype.handleResult = function (header, err, result) {
   var callback = handler.callback;
   //set the callback to null to avoid it being called when freed
   handler.callback = null;
-  callback(err, result);
+
+    // null check b/c the result event is sometimes called more than once.  Clearing the callback makes the driver crash an entire app
+  // NOTE: this fix will keep things from crashing, but the message frame here will be discarded which is better than
+  // * Having the entire process crash
+  // * exexuting a callback more than once.
+  typeof(callback) === 'function' ? callback(err, result): null;
 };
 
 Connection.prototype.handleNodeEvent = function (header, event) {


### PR DESCRIPTION
This bug is really serious for me.  It makes the entire process that is running the driver crash and explode!  I am not equipped to trace this super deep at this time, but here is what I think I know.  

This patch will keep the callback process explosion from happening. That is all.  

Hopefully, some investigation from others that have been deep in the stream interface of this library can resolve more quickly than I would be able to.

* The query is sent and an instance of ResultEmitter starts listening to 'result' event using ```on()``` instead of ```once()```
https://github.com/datastax/nodejs-driver/blob/master/lib/connection.js#L76

* Inside of handleResult, the callback is cleared from the handler state object (likely b/c it only expects to be called one time)  
https://github.com/datastax/nodejs-driver/blob/master/lib/connection.js#L489

**Summary**
The read streams are sending more than a single result.  When that happens, then the driver explodes b/c of above callback error.

Here is where the results return from the parser and there are more than one ```item.result```
https://github.com/datastax/nodejs-driver/blob/master/lib/streams.js#L480

**Supporting tickets**
This seems related to reports of race conditions in the past that were not addressed.  The tracing that I did does not hint of race condition as much as stream flow logic issue, but IDK at this time.

https://datastax-oss.atlassian.net/browse/NODEJS-33
https://datastax-oss.atlassian.net/browse/NODEJS-32

**Verbose Logging of the Issue**
Here is the supporting logs where a query has more than a single result which is causing the handleResult function to be called more than 1 time before the **Done receiving frame #10** message was emitted.

**2015-03-24T21:36:28.109Z Connection Sending stream #10**
**2015-03-24T21:36:28.109Z Connection Sent stream #10**
2015-03-24T21:36:28.109Z Connection Sending stream #8
2015-03-24T21:36:28.109Z Connection Sent stream #8
2015-03-24T21:36:28.110Z Connection Received frame #2
2015-03-24T21:36:28.110Z Connection Done receiving frame #2
2015-03-24T21:36:28.116Z Connection Received frame #5
2015-03-24T21:36:28.116Z Connection Sending stream #6
2015-03-24T21:36:28.116Z Connection Sending stream #7
2015-03-24T21:36:28.116Z Connection Sending stream #8
2015-03-24T21:36:28.116Z Connection Sending stream #9
**2015-03-24T21:36:28.116Z Connection Sending stream #10**
2015-03-24T21:36:28.116Z Connection Sending stream #11
2015-03-24T21:36:28.116Z Connection Sending stream #12
2015-03-24T21:36:28.116Z Connection Done receiving frame #5
2015-03-24T21:36:28.116Z Connection Sent stream #6
2015-03-24T21:36:28.116Z Connection Sent stream #7
2015-03-24T21:36:28.117Z Connection Sent stream #8
2015-03-24T21:36:28.117Z Connection Received frame #7
2015-03-24T21:36:28.117Z Connection Done receiving frame #7
2015-03-24T21:36:28.117Z Connection Sent stream #9
**2015-03-24T21:36:28.117Z Connection Sent stream #10**
2015-03-24T21:36:28.117Z Connection Sent stream #11
2015-03-24T21:36:28.117Z Connection Sent stream #12
2015-03-24T21:36:28.117Z Connection Sending stream #7
2015-03-24T21:36:28.117Z Connection Sent stream #7
**2015-03-24T21:36:28.119Z Connection Received frame #10**
2015-03-24T21:36:28.119Z Connection Received frame #9
2015-03-24T21:36:28.119Z Connection Done receiving frame #9
2015-03-24T21:36:28.119Z Connection Received frame #8
2015-03-24T21:36:28.119Z Connection Done receiving frame #8
2015-03-24T21:36:28.119Z Connection Received frame #7
2015-03-24T21:36:28.119Z Connection Done receiving frame #7
2015-03-24T21:36:28.119Z Connection Received frame #6
2015-03-24T21:36:28.119Z Connection Done receiving frame #6
2015-03-24T21:36:28.119Z Connection Received frame #5
2015-03-24T21:36:28.120Z Connection Done receiving frame #5
2015-03-24T21:36:28.120Z Connection Received frame #3
2015-03-24T21:36:28.120Z Connection Done receiving frame #3
**2015-03-24T21:36:28.120Z Connection Received frame #10**
```