### PR TITLE
Use prepare in trace id test for cassandra 1.2 support.

### DIFF
--- a/test/integration/short/client-each-row-tests.js
+++ b/test/integration/short/client-each-row-tests.js
@@ -353,7 +353,7 @@ describe('Client', function () {
         function selectNotExistent(next) {
           var query = util.format('SELECT * FROM %s WHERE id = ?', table);
           var called = 0;
-          client.eachRow(query, [types.Uuid.random()], { traceQuery: true}, function () {
+          client.eachRow(query, [types.Uuid.random()], {prepare: true, traceQuery: true}, function () {
             called++;
           }, function (err, result) {
             assert.ifError(err);


### PR DESCRIPTION
Trivial change to enable prepared statements on selectNotExistent in 'should retrieve the trace id when queryTrace flag is set' (was using named parameters which is not supported in 1.2).