### PR TITLE
Update integration tests to account for host address containing port.

### DIFF
--- a/test/integration/long/client-metadata-tests.js
+++ b/test/integration/long/client-metadata-tests.js
@@ -38,11 +38,13 @@ describe('Client', function () {
         //2 replicas per each dc
         assert.strictEqual(replicas.length, 4);
         assert.strictEqual(replicas.reduce(function (val, h) { return val + (h.datacenter === 'dc1' ? 1 : 0)}, 0), 2);
+
         //pre-calculated based on murmur3
-        assert.strictEqual(replicas[0].address.charAt(replicas[0].address.length-1), '3');
-        assert.strictEqual(replicas[1].address.charAt(replicas[1].address.length-1), '7');
-        assert.strictEqual(replicas[2].address.charAt(replicas[2].address.length-1), '4');
-        assert.strictEqual(replicas[3].address.charAt(replicas[3].address.length-1), '8');
+        var lastOctets = replicas.map(helper.lastOctetOf);
+        assert.strictEqual(lastOctets[0], '3');
+        assert.strictEqual(lastOctets[1], '7');
+        assert.strictEqual(lastOctets[2], '4');
+        assert.strictEqual(lastOctets[3], '8');
 
         replicas = client.getReplicas('sampleks1', new Buffer([0, 0, 0, 3]));
         assert.ok(replicas);
@@ -50,10 +52,11 @@ describe('Client', function () {
         assert.strictEqual(replicas.length, 4);
         assert.strictEqual(replicas.reduce(function (val, h) { return val + (h.datacenter === 'dc1' ? 1 : 0)}, 0), 2);
         //pre-calculated based on murmur3
-        assert.strictEqual(replicas[0].address.charAt(replicas[0].address.length-1), '1');
-        assert.strictEqual(replicas[1].address.charAt(replicas[1].address.length-1), '5');
-        assert.strictEqual(replicas[2].address.charAt(replicas[2].address.length-1), '2');
-        assert.strictEqual(replicas[3].address.charAt(replicas[3].address.length-1), '6');
+        lastOctets = replicas.map(helper.lastOctetOf);
+        assert.strictEqual(lastOctets[0], '1');
+        assert.strictEqual(lastOctets[1], '5');
+        assert.strictEqual(lastOctets[2], '2');
+        assert.strictEqual(lastOctets[3], '6');
         done();
       });
     });
@@ -65,7 +68,8 @@ describe('Client', function () {
         assert.ok(replicas);
         assert.strictEqual(replicas.length, 1);
         //pre-calculated based on murmur3
-        assert.strictEqual(replicas[0].address.charAt(replicas[0].address.length-1), '3');
+        var lastOctets = replicas.map(helper.lastOctetOf);
+        assert.strictEqual(lastOctets[0], '3');
         done();
       });
     });

--- a/test/integration/long/load-balancing-tests.js
+++ b/test/integration/long/load-balancing-tests.js
@@ -27,7 +27,7 @@ describe('DCAwareRoundRobinPolicy', function () {
           client.execute('SELECT * FROM system.schema_columnfamilies', function (err, result) {
             assert.ifError(err);
             assert.ok(result && result.rows);
-            var hostId = result.info.queriedHost + ':9042';
+            var hostId = result.info.queriedHost;
             assert.ok(hostId);
             var h = client.hosts.get(hostId);
             assert.ok(h);
@@ -91,7 +91,7 @@ describe('TokenAwarePolicy', function () {
             assert.ifError(err);
             //for murmur id = 1, it go to replica 2
             var address = result.info.queriedHost;
-            assert.strictEqual(address.charAt(address.length-1), expectedPartition[id.toString()]);
+            assert.strictEqual(helper.lastOctetOf(address), expectedPartition[id.toString()]);
             timesNext();
           });
         }, next);
@@ -141,7 +141,7 @@ describe('TokenAwarePolicy', function () {
             assert.ifError(err);
             //for murmur id = 1, it go to replica 2
             var address = result.info.queriedHost;
-            assert.strictEqual(address.charAt(address.length-1), expectedPartition[id.toString()]);
+            assert.strictEqual(helper.lastOctetOf(address), expectedPartition[id.toString()]);
             timesNext();
           });
         }, next);

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -353,6 +353,19 @@ var helper = {
       //noinspection JSUnresolvedFunction
       it(testCase, func);
     }
+  },
+
+  /**
+   * Given a {Host} returns the last octet of its ip address.
+   * i.e. (127.0.0.247:9042) -> 247.
+   *
+   * @param {Host|string} host or host address to get ip address of.
+   * @returns {string} Last octet of the host address.
+   */
+  lastOctetOf: function(host) {
+    var address = typeof host == "string" ? host : host.address;
+    var ipAddress = address.split(':')[0].split('.');
+    return ipAddress[ipAddress.length-1];
   }
 };
 


### PR DESCRIPTION
Since host.address now includes the port number (is this intentional?) some of the 'long' integration tests needed to be updated to account for this as they used the last character of the host address to validate expected hosts.

Introduced helper.lastOctetOf for retrieving the last octet of an address or host.address.