### PR TITLE
Integration Test Resiliency

### DIFF
--- a/test/integration/short/client-batch-tests.js
+++ b/test/integration/short/client-batch-tests.js
@@ -7,10 +7,11 @@ var Client = require('../../../lib/client.js');
 var types = require('../../../lib/types');
 var utils = require('../../../lib/utils.js');
 var errors = require('../../../lib/errors.js');
+var vit = helper.vit;
 
 describe('Client', function () {
   this.timeout(120000);
-  describe('#batch(queries, {prepare: 0}, callback) @c2_0', function () {
+  describe('#batch(queries, {prepare: 0}, callback)', function () {
     var keyspace = helper.getRandomName('ks');
     var table1 = keyspace + '.' + helper.getRandomName('tblA');
     var table2 = keyspace + '.' + helper.getRandomName('tblB');
@@ -24,7 +25,7 @@ describe('Client', function () {
       ], done);
     });
     after(helper.ccmHelper.remove);
-    it('should execute a batch of queries with no params', function (done) {
+    vit('2.0', 'should execute a batch of queries with no params', function (done) {
       var insertQuery = 'INSERT INTO %s (id, text_sample) VALUES (%s, \'%s\')';
       var selectQuery = 'SELECT * FROM %s WHERE id = %s';
       var id1 = types.Uuid.random();
@@ -58,7 +59,7 @@ describe('Client', function () {
         }
       ], done);
     });
-    it('should execute a batch of queries with params', function (done) {
+    vit('2.0', 'should execute a batch of queries with params', function (done) {
       var insertQuery = 'INSERT INTO %s (id, double_sample) VALUES (?, ?)';
       var selectQuery = 'SELECT * FROM %s WHERE id = %s';
       var id1 = types.Uuid.random();
@@ -93,7 +94,7 @@ describe('Client', function () {
         }
       ], done);
     });
-    it('should callback with error when there is a ResponseError', function (done) {
+    vit('2.0', 'should callback with error when there is a ResponseError', function (done) {
       var client = newInstance();
       client.batch(['INSERT WILL FAIL'], function (err) {
         assert.ok(err);
@@ -102,7 +103,7 @@ describe('Client', function () {
         done();
       });
     });
-    it('should validate the arguments are valid', function (done) {
+    vit('2.0', 'should validate the arguments are valid', function (done) {
       var client = newInstance();
       assert.throws(function () {
           client.batch();
@@ -137,7 +138,7 @@ describe('Client', function () {
         }
       ], done);
     });
-    it('should use hints when provided', function (done) {
+    vit('2.0', 'should use hints when provided', function (done) {
       var client = newInstance();
       var id1 = types.Uuid.random();
       var id2 = types.Uuid.random();
@@ -165,7 +166,7 @@ describe('Client', function () {
         });
       });
     });
-    it('should callback in err when wrong hints are provided', function (done) {
+    vit('2.0', 'should callback in err when wrong hints are provided', function (done) {
       var client = newInstance();
       var queries = [{
         query: util.format('INSERT INTO %s (id, text_sample, double_sample) VALUES (?, ?, ?)', table1),
@@ -204,7 +205,7 @@ describe('Client', function () {
         }
       ], done);
     });
-    it('should support protocol level timestamp @c2_1', function (done) {
+    vit('2.1', 'should support protocol level timestamp', function (done) {
       var insertQuery = 'INSERT INTO %s (id, text_sample) VALUES (?, ?)';
       var selectQuery = 'SELECT id, text_sample, writetime(text_sample) FROM %s WHERE id = %s';
       var id1 = types.Uuid.random();
@@ -242,7 +243,7 @@ describe('Client', function () {
         }
       ], done);
     });
-    it('should support serial consistency @c2_1', function (done) {
+    vit('2.1', 'should support serial consistency', function (done) {
       var insertQuery = 'INSERT INTO %s (id, text_sample) VALUES (?, ?)';
       var selectQuery = 'SELECT id, text_sample, writetime(text_sample) FROM %s WHERE id = %s';
       var id1 = types.Uuid.random();
@@ -265,7 +266,7 @@ describe('Client', function () {
         }], done);
     });
   });
-  describe('#batch(queries, {prepare: 1}, callback) @c2_0', function () {
+  describe('#batch(queries, {prepare: 1}, callback)', function () {
     var keyspace = helper.getRandomName('ks');
     var table1 = keyspace + '.' + helper.getRandomName('tblA');
     var table2 = keyspace + '.' + helper.getRandomName('tblB');
@@ -291,7 +292,7 @@ describe('Client', function () {
       ], done);
     });
     after(helper.ccmHelper.remove);
-    it('should prepare and send the request', function (done) {
+    vit('2.0', 'should prepare and send the request', function (done) {
       var client = newInstance();
       var id1 = types.Uuid.random();
       var id2 = types.Uuid.random();
@@ -321,7 +322,7 @@ describe('Client', function () {
         });
       });
     });
-    it('should callback in error when the one of the queries contains syntax error', function (done) {
+    vit('2.0', 'should callback in error when the one of the queries contains syntax error', function (done) {
       var client = newInstance();
       var queries1 = [{
         query: util.format('INSERT INTO %s (id, time, text_sample) VALUES (?, ?, ?)', table2),
@@ -340,7 +341,7 @@ describe('Client', function () {
         });
       }, done);
     });
-    it('should callback in error when the type does not match', function (done) {
+    vit('2.0', 'should callback in error when the type does not match', function (done) {
       var client = newInstance();
       var queries = [{
         query: util.format('INSERT INTO %s (id, time, int_sample) VALUES (?, ?, ?)', table1),
@@ -353,7 +354,7 @@ describe('Client', function () {
         });
       }, done);
     });
-    it('should handle multiple prepares in parallel', function (done) {
+    vit('2.0', 'should handle multiple prepares in parallel', function (done) {
       var consistency = types.consistencies.quorum;
       var id1Tbl1 = types.Uuid.random();
       var id1Tbl2 = types.Uuid.random();
@@ -408,7 +409,7 @@ describe('Client', function () {
         });
       });
     });
-    it('should allow named parameters', function (done) {
+    vit('2.0', 'should allow named parameters', function (done) {
       var client = newInstance();
       var id1 = types.Uuid.random();
       var id2 = types.Uuid.random();
@@ -438,7 +439,7 @@ describe('Client', function () {
         });
       });
     });
-    it('should execute batch containing the same query multiple times', function (done) {
+    vit('2.0', 'should execute batch containing the same query multiple times', function (done) {
       var client = newInstance();
       var id = types.Uuid.random();
       var query = util.format('INSERT INTO %s (id, time, int_sample) VALUES (?, ?, ?)', table1);

--- a/test/integration/short/client-batch-tests.js
+++ b/test/integration/short/client-batch-tests.js
@@ -368,7 +368,7 @@ describe('Client', function () {
       var client = newInstance();
       async.parallel([
         function (next) {
-          async.eachLimit(new Array(1000), 250, function (n, eachNext) {
+          async.eachLimit(new Array(1000), 100, function (n, eachNext) {
             var queries = [{
               query: query1Table1,
               params: [id1Tbl1, types.timeuuid(), types.BigDecimal.fromNumber(new Date().getTime())]
@@ -380,7 +380,7 @@ describe('Client', function () {
           }, next);
         },
         function (next) {
-          async.eachLimit(new Array(1000), 250, function (n, eachNext) {
+          async.eachLimit(new Array(1000), 100, function (n, eachNext) {
             var queries = [{
               query: query2Table1,
               params: [id2Tbl1, types.timeuuid(), types.BigDecimal.fromNumber(new Date().getTime())]

--- a/test/integration/short/client-each-row-tests.js
+++ b/test/integration/short/client-each-row-tests.js
@@ -244,13 +244,13 @@ describe('Client', function () {
         },
         function insertData(seriesNext) {
           var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table1);
-          async.times(200, function (n, next) {
+          helper.timesLimit(200, 100, function (n, next) {
             client.eachRow(query, [types.Uuid.random(), n.toString()], {prepare: 1}, noop, next);
           }, seriesNext);
         },
         function insertData(seriesNext) {
           var query = util.format('INSERT INTO %s (id, int_sample) VALUES (?, ?)', table2);
-          async.times(135, function (n, next) {
+          helper.timesLimit(135, 100, function (n, next) {
             client.eachRow(query, [types.Uuid.random(), n+1], {prepare: 1}, noop, next);
           }, seriesNext);
         },
@@ -291,7 +291,7 @@ describe('Client', function () {
       }
     });
     vit('2.0', 'should use pageState and fetchSize', function (done) {
-      var client = newInstance();
+      var client = newInstance({queryOptions: {consistency: types.consistencies.quorum}});
       var metaPageState;
       var pageState;
       async.series([
@@ -300,7 +300,7 @@ describe('Client', function () {
         },
         function insertData(seriesNext) {
           var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
-          async.times(131, function (n, next) {
+          helper.timesLimit(131, 100, function (n, next) {
             client.eachRow(query, [types.Uuid.random(), n.toString()], {prepare: 1}, noop, next);
           }, seriesNext);
         },
@@ -347,7 +347,7 @@ describe('Client', function () {
       ], done);
     });
     it('should retrieve the trace id when queryTrace flag is set', function (done) {
-      var client = newInstance();
+      var client = newInstance({queryOptions: {consistency: types.consistencies.quorum}});
       var id = types.Uuid.random();
       async.series([
         client.connect.bind(client),
@@ -399,6 +399,8 @@ describe('Client', function () {
 /**
  * @returns {Client}
  */
-function newInstance() {
-  return new Client(helper.baseOptions);
+function newInstance(options) {
+  options = options || {};
+  options = utils.extend(options, helper.baseOptions);
+  return new Client(options);
 }

--- a/test/integration/short/client-each-row-tests.js
+++ b/test/integration/short/client-each-row-tests.js
@@ -6,6 +6,7 @@ var helper = require('../../test-helper.js');
 var Client = require('../../../lib/client.js');
 var types = require('../../../lib/types');
 var utils = require('../../../lib/utils.js');
+var vit = helper.vit;
 
 describe('Client', function () {
   this.timeout(120000);
@@ -98,7 +99,7 @@ describe('Client', function () {
           });
         }], done);
     });
-    it('should autoPage @c2_0', function (done) {
+    vit('2.0', 'should autoPage', function (done) {
       var keyspace = helper.getRandomName('ks');
       var table = keyspace + '.' + helper.getRandomName('table');
       var client = newInstance();
@@ -224,7 +225,7 @@ describe('Client', function () {
           });
         }], done);
     });
-    it('should autoPage on parallel different tables @c2_0', function (done) {
+    vit('2.0', 'should autoPage on parallel different tables', function (done) {
       var keyspace = helper.getRandomName('ks');
       var table1 = keyspace + '.' + helper.getRandomName('table');
       var table2 = keyspace + '.' + helper.getRandomName('table');
@@ -289,7 +290,7 @@ describe('Client', function () {
         assert.strictEqual(result.rowLengthArray[1], fetchSize);
       }
     });
-    it('should use pageState and fetchSize @c2_0', function (done) {
+    vit('2.0', 'should use pageState and fetchSize', function (done) {
       var client = newInstance();
       var metaPageState;
       var pageState;

--- a/test/integration/short/client-pool-tests.js
+++ b/test/integration/short/client-pool-tests.js
@@ -488,7 +488,7 @@ describe('Client', function () {
           //3 hosts alive
           assert.strictEqual(Object.keys(hosts).length, 3);
           var counter = 0;
-          async.times(1000, function (i, next) {
+          helper.timesLimit(1000, 100, function (i, next) {
             client.execute('SELECT * FROM system.schema_keyspaces', function (err) {
               counter++;
               assert.ifError(err);

--- a/test/integration/short/client-stream-tests.js
+++ b/test/integration/short/client-stream-tests.js
@@ -129,7 +129,7 @@ describe('Client', function () {
         });
     });
     it('should prepare and emit the exact amount of rows', function (done) {
-      var client = newInstance();
+      var client = newInstance({queryOptions: {consistency: types.consistencies.quorum}})
       var keyspace = helper.getRandomName('ks');
       var table = keyspace + '.' + helper.getRandomName('table');
       var length = 1000;
@@ -142,7 +142,7 @@ describe('Client', function () {
           client.execute(helper.createTableCql(table), helper.waitSchema(client, next));
         },
         function (next) {
-          async.times(length, function (n, timesNext) {
+          helper.timesLimit(length, 100, function (n, timesNext) {
             var query = 'INSERT INTO %s (id, int_sample, bigint_sample) VALUES (%s, %d, %s)';
             query = util.format(query, table, types.Uuid.random(), n, new types.Long(n, 0x090807).toString());
             client.execute(query, timesNext);
@@ -151,7 +151,7 @@ describe('Client', function () {
         function (next) {
           var query = util.format('SELECT * FROM %s LIMIT 10000', table);
           var counter = 0;
-          var stream = client.stream(query, [], {prepare: 1, consistency: types.consistencies.quorum})
+          var stream = client.stream(query, [], {prepare: 1})
             .on('end', function () {
               assert.strictEqual(counter, length);
               done();
@@ -171,7 +171,7 @@ describe('Client', function () {
       ], done);
     });
     it('should prepare and fetch paging the exact amount of rows', function (done) {
-      var client = newInstance();
+      var client = newInstance({queryOptions: {consistency: types.consistencies.quorum}});
       var keyspace = helper.getRandomName('ks');
       var table = keyspace + '.' + helper.getRandomName('table');
       var length = 350;
@@ -184,7 +184,7 @@ describe('Client', function () {
           client.execute(helper.createTableCql(table), helper.waitSchema(client, next));
         },
         function (next) {
-          async.times(length, function (n, timesNext) {
+          helper.timesLimit(length, 100, function (n, timesNext) {
             var query = 'INSERT INTO %s (id, int_sample, bigint_sample) VALUES (%s, %d, %s)';
             query = util.format(query, table, types.Uuid.random(), n + 1, new types.Long(n, 0x090807).toString());
             client.execute(query, timesNext);
@@ -193,7 +193,7 @@ describe('Client', function () {
         function (next) {
           var query = util.format('SELECT * FROM %s LIMIT 10000', table);
           var counter = 0;
-          var stream = client.stream(query, [], {autoPage: true, fetchSize: 100, prepare: 1, consistency: types.consistencies.quorum})
+          var stream = client.stream(query, [], {autoPage: true, fetchSize: 100, prepare: 1})
             .on('end', function () {
               assert.strictEqual(counter, length);
               done();

--- a/test/integration/short/connection-tests.js
+++ b/test/integration/short/connection-tests.js
@@ -11,7 +11,7 @@ var helper = require('../../test-helper.js');
 var vit = helper.vit;
 
 describe('Connection', function () {
-  this.timeout(30000);
+  this.timeout(120000);
   describe('#open()', function () {
     before(helper.ccmHelper.start(1));
     after(helper.ccmHelper.remove);

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -366,6 +366,30 @@ var helper = {
     var address = typeof host == "string" ? host : host.address;
     var ipAddress = address.split(':')[0].split('.');
     return ipAddress[ipAddress.length-1];
+  },
+
+  /**
+   * The same as async.times, only no more than limit iterators will be
+   * simultaneously running at any time.
+   *
+   * Note that the items are not processed in batches, so there is no guarantee
+   * that the first limit iterator functions will complete before any others
+   * are started.
+   *
+   * Taken from https://github.com/caolan/async/pull/560.
+   *
+   * @param count The number of times to run the function.
+   * @param limit The maximum number of iterators to run at any time.
+   * @param iterator The function to call n times.
+   * @param callback The function to call on completion of iterators.
+   */
+  timesLimit: function(count, limit, iterator, callback) {
+    var counter = [];
+    for (var i = 0; i < count; i++) {
+      counter.push(i);
+    }
+
+    return async.mapLimit(counter, limit, iterator, callback);
   }
 };
 

--- a/test/unit/parser-tests.js
+++ b/test/unit/parser-tests.js
@@ -247,6 +247,7 @@ describe('Parser', function () {
       parser._transform(getBodyChunks(3, rowLength, 37, null), null, doneIfError(done));
     });
     it('should emit row with large row values', function (done) {
+      this.timeout(5000);
       //3mb value
       var cellValue = helper.fillArray(3 * 1024 * 1024, 74);
       //Add the length 0x00300000 of the value

--- a/test/unit/uuid-tests.js
+++ b/test/unit/uuid-tests.js
@@ -189,9 +189,10 @@ describe('TimeUuid', function () {
       assert.strictEqual(val.getNodeIdString(), 'h12345');
     });
     it('should use current date', function () {
-      var date = new Date();
-      var val = TimeUuid.now();
-      assert.strictEqual(val.getDate().getTime(), date.getTime());
+      var date = new Date().getTime();
+      var val = TimeUuid.now().getDate().getTime();
+      assert.ok([date-1, date, date+1].indexOf(val) > -1,
+        util.format("Expected %d to be within ± 1ms of %d.", val, date));
     });
   });
   describe('min()', function () {

--- a/test/unit/uuid-tests.js
+++ b/test/unit/uuid-tests.js
@@ -83,6 +83,7 @@ describe('Uuid', function () {
     });
   });
   describe('random()', function () {
+    this.timeout(5000);
     it('should return a Uuid instance', function () {
       helper.assertInstanceOf(Uuid.random(), Uuid);
     });
@@ -153,6 +154,7 @@ describe('TimeUuid', function () {
     });
   });
   describe('fromDate()', function () {
+    this.timeout(5000);
     it('should generate v1 uuids that do not collide', function () {
       var values = {};
       var length = 50000;


### PR DESCRIPTION
As we start setting up wider CI test coverage among platforms (node.js versions, cassandra versions) we've hit a few integration test resiliency issues.  This pull request is to work to make the tests a little more resilient by increasing consistency levels, reducing concurrency, etc.

Summary of changes thus far:

* Replace @c2_x indicator with 'vit' for rest of tests that weren't doing this yet.
* Reduce parallelism of some tests.
* Write and read at CL quorum in multi-node tests.
* Extend timeouts for tests that were pretty close to boundary of timing out.

Please do not merge until complete (will continue adding commits as I find new issues surface in CI).