### PR TITLE
Convert setImmediate to async.setImmediate

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -374,7 +374,7 @@ Client.prototype.shutdown = function (callback) {
  */
 Client.prototype.waitForSchemaAgreement = function (connection, callback) {
   if (this.hosts.length === 1) {
-    return setImmediate(callback);
+    return async.setImmediate(callback);
   }
   var self = this;
   var start = new Date();
@@ -560,7 +560,7 @@ Client.prototype._waitForPendingPrepares = function (queries, callback) {
         //There was IO between the last call
         //it is possible that queries marked to prepare are being prepared
         //iterate again until we have the filtered list of items to prepare
-        return setImmediate(function pendingIOCallback() {
+        return async.setImmediate(function pendingIOCallback() {
           doWait(toPrepare);
         });
       }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -151,7 +151,7 @@ Connection.prototype.startup = function (callback) {
         self.log('info', 'Protocol v' + self.protocolVersion + ' not supported, using v' + (self.protocolVersion-1));
         self.decreaseVersion();
         //The host closed the connection, close the socket
-        setImmediate(function () {
+        async.setImmediate(function () {
           self.close(function () {
           //Retry
             self.open(callback);
@@ -456,7 +456,7 @@ Connection.prototype.freeStreamId = function(header) {
 
 Connection.prototype.writeNext = function () {
   var self = this;
-  setImmediate(function writeNextPending() {
+  async.setImmediate(function writeNextPending() {
     var pending = self.pendingWrites.shift();
     if (!pending) {
       return;

--- a/lib/writers.js
+++ b/lib/writers.js
@@ -191,7 +191,7 @@ WriteQueue.prototype.process = function () {
         writeItem.callback(err);
         //it is better to queue it up on the event loop
         //to allow IO between writes
-        setImmediate(next);
+        async.setImmediate(next);
       }
     },
     function () {


### PR DESCRIPTION
Using async for this will let it fall through to the system setImmediate when it's defined, and shim in the functionality when it's not (falls back to `nextTick` (mainly for node <0.9), which falls back to `setInterval(..., 0)` when all else fails).

I know this isn't a super common issue, but it can make things nicer for older node versions and browserify, and being more supportive/having fallbacks seems like a good principle (plus async is already included, and it's a transparent fallthrough for 99% of cases, meaning there's minimal performance hit).