### PR TITLE
Use prepared meta partition keys for routing key

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -719,8 +719,8 @@ Client.prototype._setQueryOptions = function (options, params, meta, callback) {
           //The data is not there, maybe it is being recreated
           return next();
         }
-        options.routingIndexes = tableInfo.partitionKeys.map(function (key) {
-          return meta.columnsByName[key];
+        options.routingIndexes = tableInfo.partitionKeys.map(function (c) {
+          return meta.columnsByName[c.name];
         });
         //Skip parsing metadata next time
         meta.partitionKeys = options.routingIndexes;

--- a/lib/client.js
+++ b/lib/client.js
@@ -690,44 +690,80 @@ Client.prototype._getEncoder = function () {
  * @private
  */
 Client.prototype._setQueryOptions = function (options, params, meta, callback) {
-  var paramsInfo;
-  var self = this;
-  function adaptPageStateAndRouting(keys, params) {
-    if (typeof options.pageState === 'string') {
-      //pageState can be a hex string
-      options.pageState = new Buffer(options.pageState, 'hex');
-    }
-    self._getEncoder().setRoutingKey(params, options, keys);
-  }
-  if (!options.prepare && params && !util.isArray(params) && this.controlConnection.protocolVersion < 3) {
+  var protocolVersion = this.controlConnection.protocolVersion;
+  if (!options.prepare && params && !util.isArray(params) && protocolVersion < 3) {
     //Only Cassandra 2.1 and above supports named parameters
     return callback(new errors.ArgumentError('Named parameters for simple statements are not supported, use prepare flag'));
   }
-  try {
-    if (options.prepare) {
-      paramsInfo = utils.adaptNamedParamsPrepared(params, meta.columns);
-      //Add the type information provided by the prepared metadata
-      options.hints = meta.columns.map(function (c) { return c.type; });
-      adaptPageStateAndRouting(paramsInfo.keys, paramsInfo.params);
+  var paramsInfo;
+  var self = this;
+  async.series([
+    function fillRoutingKeys(next) {
+      if (options.routingKey || options.routingIndexes || options.routingNames || !meta) {
+        //it is filled by the user
+        //or it is not prepared
+        return next();
+      }
+      if (util.isArray(meta.partitionKeys)) {
+        //the partition keys are provided as part of the metadata
+        options.routingIndexes = meta.partitionKeys;
+        return next();
+      }
+      self.metadata.getTable(meta.keyspace, meta.table, function (err, tableInfo) {
+        if (err) {
+          self.log('warning', util.format('Table %s.%s metadata could not be retrieved', meta.keyspace, meta.table));
+          //execute without a routing key
+          return next();
+        }
+        if (!tableInfo) {
+          //The data is not there, maybe it is being recreated
+          return next();
+        }
+        options.routingIndexes = tableInfo.partitionKeys.map(function (key) {
+          return meta.columnsByName[key];
+        });
+        //Skip parsing metadata next time
+        meta.partitionKeys = options.routingIndexes;
+        next();
+      });
+    },
+    function adaptParameterNames(next) {
+      try {
+        if (options.prepare) {
+          paramsInfo = utils.adaptNamedParamsPrepared(params, meta.columns);
+          //Add the type information provided by the prepared metadata
+          options.hints = meta.columns.map(function (c) {
+            return c.type;
+          });
+        }
+        else {
+          paramsInfo = utils.adaptNamedParamsWithHints(params, options);
+        }
+      }
+      catch (err) {
+        return next(err);
+      }
+      next();
+    },
+    function adaptParameterTypes(next) {
+      if (options.prepare || !util.isArray(options.hints)) {
+        return next();
+      }
+      //Only not prepared with hints
+      //Adapting user hints is an async op
+      self.metadata.adaptUserHints(self.keyspace, options.hints, next);
     }
-    else {
-      paramsInfo = utils.adaptNamedParamsWithHints(params, options);
-      adaptPageStateAndRouting(paramsInfo.keys, paramsInfo.params);
+  ], function finishSettingOptions(err) {
+    if (err) {
+      //There was an error setting the query options
+      return callback(err);
     }
-  }
-  catch (err) {
-    return callback(err);
-  }
-  if (options.prepare || !util.isArray(options.hints)) {
-    //if we have all the information to execute
-    return callback(null, paramsInfo.params);
-  }
-  //Only not prepared with hints
-  //Adapting user hints is an async op
-  this.metadata.adaptUserHints(self.keyspace, options.hints, function (err) {
-    if (err) return callback(err);
     try {
-      adaptPageStateAndRouting(paramsInfo.keys, paramsInfo.params);
+      if (typeof options.pageState === 'string') {
+        //pageState can be a hex string
+        options.pageState = new Buffer(options.pageState, 'hex');
+      }
+      self._getEncoder().setRoutingKey(paramsInfo.params, options, paramsInfo.keys);
     }
     catch (err) {
       return callback(err);

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -316,14 +316,14 @@ Encoder.prototype.setRoutingKey = function (params, options, keys) {
   }
   var routingKeys = [];
   var hints = options.hints || utils.emptyArray;
-  if (options.routingNames && keys) {
-    options.routingNames.forEach(function (name) {
-      var paramIndex = keys[name];
+  if (options.routingIndexes) {
+    options.routingIndexes.forEach(function (paramIndex) {
       routingKeys.push(this.encode(params[paramIndex], hints[paramIndex]));
     }, this);
   }
-  else if (options.routingIndexes) {
-    options.routingIndexes.forEach(function (paramIndex) {
+  else if (options.routingNames && keys) {
+    options.routingNames.forEach(function (name) {
+      var paramIndex = keys[name];
       routingKeys.push(this.encode(params[paramIndex], hints[paramIndex]));
     }, this);
   }

--- a/lib/readers.js
+++ b/lib/readers.js
@@ -253,12 +253,14 @@ FrameReader.prototype.readFlagsInfo = function () {
  */
 FrameReader.prototype.readMetadata = function (kind) {
   var i;
+  //Determines if its a prepared metadata
+  var isPrepared = (kind === types.resultKind.prepared);
   var meta = {};
   //as used in Rows and Prepared responses
   var flags = this.readInt();
 
   var columnLength = this.readInt();
-  if (this.header.version > 3 && kind === types.resultKind.prepared) {
+  if (this.header.version > 3 && isPrepared) {
     //read the pk columns
     meta.partitionKeys = new Array(this.readInt());
     for (i = 0; i < meta.partitionKeys.length; i++) {
@@ -274,6 +276,11 @@ FrameReader.prototype.readMetadata = function (kind) {
     meta.table = this.readString();
   }
   meta.columns = new Array(columnLength);
+  meta.columnsByName = utils.emptyObject;
+  if (isPrepared) {
+    //for prepared metadata, we will need a index of the columns (param) by name
+    meta.columnsByName = {};
+  }
   for (i = 0; i < columnLength; i++) {
     var col = {};
     if(!meta.global_tables_spec) {
@@ -283,6 +290,9 @@ FrameReader.prototype.readMetadata = function (kind) {
     col.name = this.readString();
     col.type = this.readType();
     meta.columns[i] = col;
+    if (isPrepared) {
+      meta.columnsByName[col.name] = i;
+    }
   }
 
   return meta;

--- a/test/integration/long/load-balancing-tests.js
+++ b/test/integration/long/load-balancing-tests.js
@@ -11,7 +11,6 @@ var RoundRobinPolicy = loadBalancing.RoundRobinPolicy;
 var DCAwareRoundRobinPolicy = loadBalancing.DCAwareRoundRobinPolicy;
 var TokenAwarePolicy = loadBalancing.TokenAwarePolicy;
 
-
 describe('DCAwareRoundRobinPolicy', function () {
   this.timeout(180000);
   it('should never hit remote dc if not set', function (done) {
@@ -212,6 +211,46 @@ describe('TokenAwarePolicy', function () {
             assert.strictEqual(hosts[2].datacenter, localDc);
             assert.strictEqual(hosts[3].datacenter, localDc);
             timesNext();
+          });
+        }, next);
+      },
+      helper.ccmHelper.remove
+    ], done);
+  });
+  it('should target the correct partition', function (done) {
+    var keyspace = 'ks1';
+    var table = 'table1';
+    async.series([
+      helper.ccmHelper.start('3'),
+      function createKs(next) {
+        var client = new Client(helper.baseOptions);
+        client.execute(helper.createKeyspaceCql(keyspace, 1), helper.waitSchema(client, next));
+      },
+      function createTable(next) {
+        var client = new Client(helper.baseOptions);
+        var query = util.format('CREATE TABLE %s.%s (id int primary key, name int)', keyspace, table);
+        client.execute(query, helper.waitSchema(client, next));
+      },
+      function testCase(next) {
+        var client = new Client({
+          policies: { loadBalancing: new TokenAwarePolicy(new RoundRobinPolicy())},
+          keyspace: keyspace,
+          contactPoints: helper.baseOptions.contactPoints
+        });
+        async.timesSeries(10, function (n, timesNext) {
+          var id = (n % 10) + 1;
+          var query = util.format('INSERT INTO %s (id, name) VALUES (?, ?)', table);
+          client.execute(query, [id, id], { traceQuery: true, prepare: true}, function (err, result) {
+            assert.ifError(err);
+            var coordinator = result.info.queriedHost;
+            var traceId = result.info.traceId;
+            client.metadata.getTrace(traceId, function (err, trace) {
+              assert.ifError(err);
+              trace.events.forEach(function (event) {
+                assert.strictEqual(helper.lastOctetOf(event['source'].toString()), helper.lastOctetOf(coordinator.toString()));
+              });
+              timesNext();
+            });
           });
         }, next);
       },


### PR DESCRIPTION
Refactored `setQueryOptions()` to include the partition keys from the prepared metadata.

I've added a new `long` test to check that there are no networks hops when using TokenAwarePolicy using query trace events.