### PR TITLE
Update LocalDate to handle dates > ±100000000 days from epoch

### DIFF
--- a/lib/types/local-date.js
+++ b/lib/types/local-date.js
@@ -12,10 +12,6 @@ var millisecondsPerDay = 86400000;
  */
 var dateCenter = Math.pow(2,31);
 /**
- * @private
- */
-var twentiethCentury = new Date('1899-12-31') - new Date('0000-01-01');
-/**
  *
  * Creates a new instance of LocalDate.
  * @class
@@ -26,58 +22,85 @@ var twentiethCentury = new Date('1899-12-31') - new Date('0000-01-01');
  * <p>
  *   This class does not store or represent a time or time-zone. Instead, it is a description of the date, as used for birthdays. It cannot represent an instant on the time-line without additional information such as an offset or time-zone.
  * </p>
- * @param {Number} year The year.
+ * <p>
+ *   Note that this type can represent dates in the range [-5877641-06-23; 5881580-07-17] while the ES5 date type can only represent values in the range of [-271821-04-20; 275760-09-13].
+ *   In the event that year, month, day parameters do not fall within the ES5 date range an Error will be thrown.  If you wish to represent a date outside of this range, pass a single
+ *   parameter indicating the days since epoch.  For example, -1 represents 1969-12-31.
+ * </p>
+ * @param {Number} year The year or days since epoch.  If days since epoch, month and day should not be provided.
  * @param {Number} month Between 1 and 12 inclusive.
  * @param {Number} day Between 1 and the number of days in the given month of the given year.
+ *
+ * @property {Date} date The date representation if falls within a range of an ES5 data type, otherwise an invalid date.
+ *
  * @constructor
  */
 function LocalDate(year, month, day) {
   //implementation detail: internally uses a UTC based date
   if (typeof year === 'number' && typeof month === 'number' && typeof day === 'number') {
-    this.value = new Date(Date.UTC(year, month - 1, day));
-    if (year >= 0 && year < 100) {
-      //If there is a 2 digit year, Date.UTC() assumes that is the 20th century
-      //Thanks ECMAScript!
-      this.value = new Date(this.value.getTime() - twentiethCentury);
+    //Use setUTCFullYear as if there is a 2 digit year, Date.UTC() assumes
+    //that is the 20th century.  Thanks ECMAScript!
+    //noinspection JSValidateTypes
+    this.date = new Date();
+    this.date.setUTCHours(0, 0, 0, 0);
+    this.date.setUTCFullYear(year, month-1, day);
+    if(isNaN(this.date.getTime())) {
+      throw new Error(util.format('%d-%d-%d does not form a valid ES5 date!',
+        year, month, day));
     }
   }
   else if (typeof month === 'undefined' && typeof day === 'undefined') {
     if (typeof year === 'number') {
-      //in milliseconds since unix epoch
-      this.value = new Date(year);
+      //in days since epoch.
+      if(year < -2147483648 || year > 2147483647) {
+        throw new Error('You must provide a valid value for days since epoch (-2147483648 <= value <= 2147483647).')
+      }
+      //noinspection JSValidateTypes
+      this.date = new Date(year * millisecondsPerDay);
     }
   }
-  if (!this.value || isNaN(this.value.getTime())) {
+
+  if (typeof this.date === 'undefined') {
     throw new Error('You must provide a valid year, month and day');
   }
+
+  //If date cannot be represented yet given a valid days since epoch, track
+  //it internally.
+  var value = isNaN(this.date.getTime()) ? year : null;
+  Object.defineProperty(this, '_value', { enumerable: false, value: value });
+
   var self = this;
+
   /**
-   * A number representing the year.
+   * A number representing the year.  May return NaN if cannot be represented as
+   * a Date.
    * @name year
    * @type Number
    * @memberof module:types~LocalDate#
    */
   /**
-   * A number between 1 and 12 inclusive representing the month.
+   * A number between 1 and 12 inclusive representing the month.  May return
+   * NaN if cannot be represented as a Date.
    * @name month
    * @type Number
    * @memberof module:types~LocalDate#
    */
   /**
    * A number between 1 and the number of days in the given month of the given year (28, 29, 30, 31).
+   * May return NaN if cannot be represented as a Date.
    * @name day
    * @type Number
    * @memberof module:types~LocalDate#
    */
   Object.defineProperties(this, {
     'year': { enumerable: true, get: function () {
-      return self.value.getUTCFullYear();
+      return self.date.getUTCFullYear();
     }},
     'month': { enumerable: true, get: function () {
-      return self.value.getUTCMonth() + 1;
+      return self.date.getUTCMonth() + 1;
     }},
     'day': { enumerable: true, get: function () {
-      return self.value.getUTCDate();
+      return self.date.getUTCDate();
     }}
   });
 }
@@ -86,6 +109,7 @@ function LocalDate(year, month, day) {
  * Creates a new instance of LocalDate using the current year, month and day from the system clock in the default time-zone.
  */
 LocalDate.now = function () {
+  //noinspection JSCheckFunctionSignatures
   return LocalDate.fromDate(new Date());
 };
 
@@ -103,24 +127,34 @@ LocalDate.utcNow = function () {
  * @param {Date} date
  */
 LocalDate.fromDate = function (date) {
-  if (isNaN(date)) {
+  if (isNaN(date.getTime())) {
     throw new TypeError('Invalid date: ' + date);
   }
   return new LocalDate(date.getFullYear(), date.getMonth() + 1, date.getDate());
 };
 
 /**
- * Creates a new instance of LocalDate using the year, month and day provided in the form: yyyy-mm-dd.
+ * Creates a new instance of LocalDate using the year, month and day provided in the form: yyyy-mm-dd or
+ * days since epoch (i.e. -1 for Dec 31, 1969).
  * @param {String} value
  */
 LocalDate.fromString = function (value) {
-  var multiplier = 1;
-  if (value[0] === '-') {
-    value = value.substring(1);
-    multiplier = -1;
+  var dashCount = (value.match(/-/g) || []).length;
+  if(dashCount >= 2) {
+    var multiplier = 1;
+    if (value[0] === '-') {
+      value = value.substring(1);
+      multiplier = -1;
+    }
+    var parts = value.split('-');
+    return new LocalDate(multiplier * parseInt(parts[0], 10), parseInt(parts[1], 10), parseInt(parts[2], 10));
+  } else if(value.match(/^-?\d+$/)) {
+    // Parse as days since epoch.
+    //noinspection JSCheckFunctionSignatures
+    return new LocalDate(parseInt(value, 10));
+  } else {
+    throw new Error("Invalid input '" + value + "'.");
   }
-  var parts = value.split('-');
-  return new LocalDate(multiplier * parseInt(parts[0], 10), parseInt(parts[1], 10), parseInt(parts[2], 10));
 };
 
 /**
@@ -128,9 +162,9 @@ LocalDate.fromString = function (value) {
  * @param {Buffer} buffer
  */
 LocalDate.fromBuffer = function (buffer) {
-  //move to unix epoch: 0 and express it in milliseconds
+  //move to unix epoch: 0.
   //noinspection JSCheckFunctionSignatures
-  return new LocalDate((buffer.readUInt32BE(0) - dateCenter) * millisecondsPerDay);
+  return new LocalDate((buffer.readUInt32BE(0) - dateCenter));
 };
 
 /**
@@ -140,7 +174,9 @@ LocalDate.fromBuffer = function (buffer) {
  * if the given one is greater.
  */
 LocalDate.prototype.compare = function (other) {
-  var diff = this.value.getTime() - other.value.getTime();
+  var thisValue = isNaN(this.date.getTime()) ? this._value * millisecondsPerDay : this.date.getTime();
+  var otherValue = isNaN(other.date.getTime()) ? other._value * millisecondsPerDay : other.date.getTime();
+  var diff = thisValue - otherValue;
   if (diff < 0) {
     return -1;
   }
@@ -169,26 +205,37 @@ LocalDate.prototype.inspect = function () {
  */
 LocalDate.prototype.toBuffer = function () {
   //days since unix epoch
-  var value = Math.floor(this.value.getTime() / millisecondsPerDay) + dateCenter;
+  var daysSinceEpoch = isNaN(this.date.getTime()) ? this._value : Math.floor(this.date.getTime() / millisecondsPerDay);
+  var value = daysSinceEpoch + dateCenter;
   var buf = new Buffer(4);
   buf.writeUInt32BE(value, 0);
   return buf;
 };
 
 /**
- * Gets the string representation of the instance in the form: yyyy-mm-dd
+ * Gets the string representation of the instance in the form: yyyy-mm-dd if
+ * the value can be parsed as a Date, otherwise days since epoch.
  * @returns {String}
  */
 LocalDate.prototype.toString = function () {
   var result;
-  if (this.year < 0) {
-    result = '-' + fillZeros((this.year * -1).toString(), 4);
+  //if cannot be parsed as date, return days since epoch representation.
+  if(isNaN(this.date.getTime())) {
+    return this._value.toString();
   }
   else {
-    result = fillZeros(this.year.toString(), 4);
+    var year = this.date.getUTCFullYear();
+    var month = this.date.getUTCMonth() + 1;
+    var day = this.date.getUTCDate();
+    if (year < 0) {
+      result = '-' + fillZeros((year * -1).toString(), 4);
+    }
+    else {
+      result = fillZeros(year.toString(), 4);
+    }
+    result += '-' + fillZeros(month.toString(), 2) + '-' + fillZeros(day.toString(), 2);
+    return result;
   }
-  result += '-' + fillZeros(this.month.toString(), 2) + '-' + fillZeros(this.day.toString(), 2);
-  return result;
 };
 
 /**

--- a/test/integration/short/client-execute-prepared-tests.js
+++ b/test/integration/short/client-execute-prepared-tests.js
@@ -637,7 +637,7 @@ describe('Client', function () {
           [types.Uuid.random(), new LocalDate(2010, 4, 29), LocalTime.fromString('15:01:02.1234')],
           [types.Uuid.random(), new LocalDate(2005, 8, 5), LocalTime.fromString('01:56:03.000501')],
           [types.Uuid.random(), new LocalDate(1983, 2, 24), new LocalTime(types.Long.fromString('86399999999999'))],
-          [types.Uuid.random(), new LocalDate(1981, 9, 14), new LocalTime(types.Long.fromString('6311999549933'))]
+          [types.Uuid.random(), new LocalDate(-2147483648), new LocalTime(types.Long.fromString('6311999549933'))]
         ];
         var client = newInstance({ keyspace: commonKs });
         async.eachSeries(values, function (params, next) {

--- a/test/integration/short/client-execute-tests.js
+++ b/test/integration/short/client-execute-tests.js
@@ -724,7 +724,7 @@ describe('Client', function () {
           [types.Uuid.random(), new LocalDate(2010, 4, 29), LocalTime.fromString('15:01:02.1234')],
           [types.Uuid.random(), new LocalDate(2005, 8, 5), LocalTime.fromString('01:56:03.000501')],
           [types.Uuid.random(), new LocalDate(1983, 2, 24), new LocalTime(types.Long.fromString('86399999999999'))],
-          [types.Uuid.random(), new LocalDate(1981, 9, 14), new LocalTime(types.Long.fromString('6311999549933'))]
+          [types.Uuid.random(), new LocalDate(-2147483648), new LocalTime(types.Long.fromString('6311999549933'))]
         ];
         var client = newInstance({ keyspace: keyspace });
         async.eachSeries(values, function (params, next) {

--- a/test/unit/basic-tests.js
+++ b/test/unit/basic-tests.js
@@ -155,6 +155,13 @@ describe('types', function () {
       it('should refuse to create LocalDate from invalid values.', function () {
         assert.throws(function () { new types.LocalDate() }, Error);
         assert.throws(function () { new types.LocalDate(undefined) }, Error);
+        // Outside of ES5 Date range.
+        assert.throws(function () { new types.LocalDate(-271821, 4, 19) }, Error);
+        assert.throws(function () { new types.LocalDate(275760, 9, 14) }, Error);
+        // Outside of LocalDate range.
+        assert.throws(function () { new types.LocalDate(-2147483649) }, Error);
+        assert.throws(function () { new types.LocalDate(2147483648) }, Error);
+
       });
     });
     describe('#toString()', function () {
@@ -176,7 +183,7 @@ describe('types', function () {
       });
     });
     describe('#fromString()', function () {
-      it('should parse the string representation', function () {
+      it('should parse the string representation as yyyy-mm-dd', function () {
         [
           ['1200-12-30', 1200, 12, 30],
           ['1-1-1', 1, 1, 1],
@@ -185,18 +192,30 @@ describe('types', function () {
           ['2010-4-29', 2010, 4, 29],
           ['-199-06-30', -199, 6, 30],
           ['1201-04-03', 1201, 4, 3],
-          ['-1201-04-03', -1201, 4, 3]
+          ['-1201-04-03', -1201, 4, 3],
+          ['0-1-1', 0, 1, 1],
         ].forEach(function (item) {
             var value = LocalDate.fromString(item[0]);
             assert.strictEqual(value.year, item[1]);
             assert.strictEqual(value.month, item[2]);
             assert.strictEqual(value.day, item[3]);
-        })
+        });
+      });
+      it('should parse the string representation as since epoch days', function () {
+        [
+          ['0', '1970-01-01'],
+          ['1', '1970-01-02'],
+          ['2147483647', '2147483647'],
+          ['-2147483648', '-2147483648'],
+          ['-719162', '0001-01-01']
+        ].forEach(function (item) {
+            var value = LocalDate.fromString(item[0]);
+            assert.strictEqual(value.toString(), item[1]);
+        });
       });
       it('should throw when string representation is invalid', function () {
         [
           '',
-          '1',
           '1880-1',
           '1880-1-z',
           undefined,


### PR DESCRIPTION
* Changes LocalDate constructor to interpret 'year' as days from epoch instead of millis from epoch.
* LocalDate now keeps internal state 'value' as number representing days from epoch.
* Removed year, month, day properties.  Added 'date' property which returns date representation of LocalDate (or Invalid Date if not possible).
* Updated toString implementation to render as yyyy-mm-dd if can be represented as date, otherwise days from epoch.
* Updated tests to test for different dates.

This currently fails for 0000-01-01 as it is off by a day (thus tests will fail).  Will add a fix for that.
Will also improve documentation, validate 'date' object in tests.