### PR TITLE
Fix: Use pool connection length to check before switching to a keyspace

### DIFF
--- a/lib/host.js
+++ b/lib/host.js
@@ -154,7 +154,7 @@ Host.prototype.borrowConnection = function (callback) {
  * @ignore
  */
 Host.prototype.getActiveConnection = function () {
-  if (!this.isUp() || !this.pool.connections) {
+  if (!this.isUp() || !this.pool.connections.length) {
     return null;
   }
   return this.pool.connections[0];

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -188,7 +188,7 @@ RequestHandler.prototype.setKeyspace = function (callback) {
   for (var i = 0; i < hosts.length; i++) {
     this.host = hosts[i];
     connection = this.host.getActiveConnection();
-    if (connection !== null) {
+    if (connection) {
       break;
     }
   }

--- a/test/integration/short/client-pool-tests.js
+++ b/test/integration/short/client-pool-tests.js
@@ -168,6 +168,16 @@ describe('Client', function () {
         });
       });
     });
+    it('should not fail when switching keyspace and a contact point is not valid', function (done) {
+      var client = new Client({
+        contactPoints: ['1.1.1.1', helper.baseOptions.contactPoints[0]],
+        keyspace: 'system'
+      });
+      client.connect(function (err) {
+        assert.ifError(err);
+        done();
+      });
+    });
   });
   describe('#connect() with auth', function () {
     before(function (done) {

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -107,7 +107,7 @@ var helper = {
      * @param {Function} callback
      */
     startNode: function (nodeIndex, callback) {
-      new Ccm().exec(['node' + nodeIndex, 'start'], callback);
+      new Ccm().exec(['node' + nodeIndex, 'start', '--wait-for-binary-proto'], callback);
     },
     exec: function (params, callback) {
       new Ccm().exec(params, callback);
@@ -608,21 +608,21 @@ function RetryMultipleTimes(times) {
   this.times = times;
 }
 
-RetryMultipleTimes.prototype.onReadTimeout = function (requestInfo, consistency, received, blockFor, isDataPresent) {
+RetryMultipleTimes.prototype.onReadTimeout = function (requestInfo) {
   if (requestInfo.nbRetry > this.times) {
     return this.rethrowResult();
   }
   return this.retryResult();
 };
 
-RetryMultipleTimes.prototype.onUnavailable = function (requestInfo, consistency, required, alive) {
+RetryMultipleTimes.prototype.onUnavailable = function (requestInfo) {
   if (requestInfo.nbRetry > this.times) {
     return this.rethrowResult();
   }
   return this.retryResult();
 };
 
-RetryMultipleTimes.prototype.onWriteTimeout = function (requestInfo, consistency, received, blockFor, writeType) {
+RetryMultipleTimes.prototype.onWriteTimeout = function (requestInfo) {
   if (requestInfo.nbRetry > this.times) {
     return this.rethrowResult();
   }

--- a/test/unit/host-tests.js
+++ b/test/unit/host-tests.js
@@ -249,6 +249,16 @@ describe('Host', function () {
       host.setDown();
     });
   });
+  describe('#getActiveConnection()', function () {
+    it('should return null if a the pool is initialized', function () {
+      var options = {
+        policies: {
+          reconnection: new reconnection.ConstantReconnectionPolicy(100)
+        }};
+      var h = newHostInstance(options);
+      assert.strictEqual(h.getActiveConnection(), null);
+    });
+  });
 });
 describe('HostMap', function () {
   describe('#values()', function () {


### PR DESCRIPTION
After connecting the control connection, use pool connection length to check before switching to a keyspace.