### PR TITLE
Custom payload using bytes instead of short bytes NODEJS-123

### DIFF
--- a/lib/readers.js
+++ b/lib/readers.js
@@ -163,7 +163,7 @@ FrameReader.prototype.readBytesMap = function () {
   }
   var map = {};
   for (var i = 0; i < length; i++) {
-    map[this.readString()] = this.readShortBytes();
+    map[this.readString()] = this.readBytes();
   }
   return map;
 };

--- a/lib/writers.js
+++ b/lib/writers.js
@@ -115,7 +115,7 @@ FrameWriter.prototype.writeCustomPayload = function (payload) {
   this.writeShort(keys.length);
   keys.forEach(function (k) {
     this.writeString(k);
-    this.writeShortBytes(payload[k]);
+    this.writeBytes(payload[k]);
   }, this);
 };
 


### PR DESCRIPTION
For upcoming Cassandra 2.2 beta or rc version, for the [CASSANDRA-9515](https://issues.apache.org/jira/browse/CASSANDRA-9515) fix.

To run the test, include the env variable: `TEST_CASSANDRA_DIR`, for example:
```bash
export TEST_CASSANDRA_DIR=/path/to/cassandra-2.2/src/
```

We should not merge this until the C* version is released AND ci uses the latest C* 2.2.