### PR TITLE
Defer removal of error listener until connection is ready.  NODEJS-146

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -67,7 +67,6 @@ Connection.prototype.log = utils.log;
  */
 Connection.prototype.bindSocketListeners = function() {
   //Remove listeners that were used for connecting
-  this.netClient.removeAllListeners('error');
   this.netClient.removeAllListeners('connect');
   this.netClient.removeAllListeners('timeout');
   var self = this;
@@ -193,6 +192,8 @@ Connection.prototype.connectionReady = function (callback) {
   this.emit('connected');
   this.connected = true;
   this.connecting = false;
+  // Remove existing error handlers as the connection is now ready.
+  this.netClient.removeAllListeners('error');
   this.netClient.on('error', this.handleSocketError.bind(this));
   callback();
 };


### PR DESCRIPTION
This change defers the removal of any error handlers until the startup request has be successfully processed and the connection is ready.  Should ensure that there is always an 'error' handler on a connection, which prevents an ```Unhandled 'error' event``` error.   

Included test that reproduces the error condition if ```this.netClient.removeAllListeners('error');``` is added back to line 70.

[NODEJS-146](https://datastax-oss.atlassian.net/browse/NODEJS-146)