### PR TITLE
NODEJS-151 Keep separate index for each plan in Round Robin policies.

### DIFF
--- a/lib/host.js
+++ b/lib/host.js
@@ -318,6 +318,7 @@ HostConnectionPool.prototype.log = utils.log;
 /**
  * Represents an associative-array of {@link Host hosts} that can be iterated.
  * It creates an internal copy when adding or removing, making it safe to iterate using the values() method within async operations.
+ * @extends events.EventEmitter
  * @constructor
  */
 function HostMap() {

--- a/lib/policies/load-balancing.js
+++ b/lib/policies/load-balancing.js
@@ -175,7 +175,7 @@ DCAwareRoundRobinPolicy.prototype.newQueryPlan = function (keyspace, queryOption
   if (self.index >= utils.maxInt) {
     self.index = 0;
   }
-  var planRemoteIndex = undefined;
+  var planRemoteIndex;
 
   callback(null, {
     next: function () {

--- a/lib/policies/load-balancing.js
+++ b/lib/policies/load-balancing.js
@@ -70,17 +70,19 @@ RoundRobinPolicy.prototype.newQueryPlan = function (keyspace, queryOptions, call
   var hosts = this.hosts.values();
   var self = this;
   var counter = 0;
+
+  var planIndex = self.index % hosts.length;
+  self.index += 1;
+  if (self.index >= utils.maxInt) {
+    self.index = 0;
+  }
+
   callback(null, {
     next: function () {
       if (++counter > hosts.length) {
         return {done: true};
       }
-      self.index += 1;
-      //overflow protection
-      if (self.index >= utils.maxInt) {
-        self.index = 0;
-      }
-      return {value: hosts[self.index % hosts.length], done: false};
+      return {value: hosts[planIndex++ % hosts.length], done: false};
     }
   });
 };
@@ -167,6 +169,14 @@ DCAwareRoundRobinPolicy.prototype.newQueryPlan = function (keyspace, queryOption
   var self = this;
   var counter = 0;
   var remoteCounter = 0;
+
+  var planIndex = self.index % hosts.length;
+  self.index += 1;
+  if (self.index >= utils.maxInt) {
+    self.index = 0;
+  }
+  var planRemoteIndex = undefined;
+
   callback(null, {
     next: function () {
       var local = this.nextLocal();
@@ -174,24 +184,23 @@ DCAwareRoundRobinPolicy.prototype.newQueryPlan = function (keyspace, queryOption
         return local;
       }
       this.sliceRemoteHosts();
+      if(!planRemoteIndex) {
+        planRemoteIndex = self.remoteIndex % allRemoteHosts.length;
+        self.remoteIndex += 1;
+        if (self.remoteIndex >= utils.maxInt) {
+          self.remoteIndex = 0;
+        }
+      }
       if (++remoteCounter > allRemoteHosts.length) {
         return {done: true};
       }
-      self.remoteIndex++;
-      if (self.remoteIndex >= utils.maxInt) {
-        self.remoteIndex = 0;
-      }
-      return {value: allRemoteHosts[self.remoteIndex % allRemoteHosts.length], done: false};
+      return {value: allRemoteHosts[planRemoteIndex++ % allRemoteHosts.length], done: false};
     },
     nextLocal: function () {
       if (++counter > hosts.length) {
         return {done: true};
       }
-      self.index += 1;
-      if (self.index >= utils.maxInt) {
-        self.index = 0;
-      }
-      var host = hosts[self.index % hosts.length];
+      var host = hosts[planIndex++ % hosts.length];
       if (self.getDistance(host) === types.distance.remote) {
         var dcHosts = remoteHostsByDc[host.datacenter];
         if (!dcHosts) {

--- a/lib/policies/load-balancing.js
+++ b/lib/policies/load-balancing.js
@@ -105,7 +105,10 @@ function DCAwareRoundRobinPolicy(localDc, usedHostsPerRemoteDc) {
   this.localDc = localDc;
   this.usedHostsPerRemoteDc = usedHostsPerRemoteDc || 0;
   this.index = 0;
-  this.remoteIndex = 0;
+  /** @type {Array} */
+  this.localHostsArray = null;
+  /** @type {Array} */
+  this.remoteHostsArray = null;
 }
 
 util.inherits(DCAwareRoundRobinPolicy, LoadBalancingPolicy);
@@ -119,6 +122,8 @@ util.inherits(DCAwareRoundRobinPolicy, LoadBalancingPolicy);
 DCAwareRoundRobinPolicy.prototype.init = function (client, hosts, callback) {
   this.client = client;
   this.hosts = hosts;
+  hosts.on('add', this._cleanHostCache.bind(this));
+  hosts.on('remove', this._cleanHostCache.bind(this));
   if (!this.localDc) {
     //get the first alive local, it should be local on top
     var hostsArray = hosts.values();
@@ -151,6 +156,44 @@ DCAwareRoundRobinPolicy.prototype.getDistance = function (host) {
   return types.distance.remote;
 };
 
+DCAwareRoundRobinPolicy.prototype._cleanHostCache = function () {
+  this.localHostsArray = null;
+  this.remoteHostsArray = null;
+};
+
+DCAwareRoundRobinPolicy.prototype._sliceNodesByDc = function() {
+  var hosts = this.hosts.values();
+  if (this.remoteHostsArray) {
+    //there were already calculated
+    return;
+  }
+  //do a full lookup to cache the remote hosts by dc
+  var remoteHostsByDc = {};
+  this.localHostsArray = [];
+  this.remoteHostsArray = [];
+  hosts.forEach(function (h) {
+    if (!h.datacenter) {
+      //not a remote dc node
+      return;
+    }
+    if (h.datacenter === this.localDc) {
+      this.localHostsArray.push(h);
+      return;
+    }
+    if (this.usedHostsPerRemoteDc === 0) {
+      return;
+    }
+    var hostPerDc = remoteHostsByDc[h.datacenter];
+    if (!hostPerDc) {
+      remoteHostsByDc[h.datacenter] = hostPerDc = [];
+    }
+    if (hostPerDc.length < this.usedHostsPerRemoteDc) {
+      hostPerDc.push(h);
+      this.remoteHostsArray.push(h);
+    }
+  }, this);
+};
+
 /**
  * It returns an iterator that yields local nodes first and remotes nodes afterwards.
  * The amount of remote nodes returned will depend on the usedHostsPerRemoteDc
@@ -162,71 +205,28 @@ DCAwareRoundRobinPolicy.prototype.newQueryPlan = function (keyspace, queryOption
   if (!this.hosts) {
     callback(new Error('Load balancing policy not initialized'));
   }
-  var hosts = this.hosts.values();
-  var remoteHostsByDc = {};
-  var allRemoteHosts = null;
-
-  var self = this;
+  this.index += 1;
+  if (this.index >= utils.maxInt) {
+    this.index = 0;
+  }
+  this._sliceNodesByDc();
+  var planLocalIndex = this.index;
+  var planRemoteIndex = this.index;
   var counter = 0;
   var remoteCounter = 0;
-
-  var planIndex = self.index % hosts.length;
-  self.index += 1;
-  if (self.index >= utils.maxInt) {
-    self.index = 0;
-  }
-  var planRemoteIndex;
-
+  var self = this;
   callback(null, {
     next: function () {
-      var local = this.nextLocal();
-      if (!local.done) {
-        return local;
+      var host;
+      if (counter++ < self.localHostsArray.length) {
+        host = self.localHostsArray[planLocalIndex++ % self.localHostsArray.length];
+        return { value: host, done: false };
       }
-      this.sliceRemoteHosts();
-      if(!planRemoteIndex) {
-        planRemoteIndex = self.remoteIndex % allRemoteHosts.length;
-        self.remoteIndex += 1;
-        if (self.remoteIndex >= utils.maxInt) {
-          self.remoteIndex = 0;
-        }
+      if (remoteCounter++ < self.remoteHostsArray.length) {
+        host = self.remoteHostsArray[planRemoteIndex++ % self.remoteHostsArray.length];
+        return { value: host, done: false };
       }
-      if (++remoteCounter > allRemoteHosts.length) {
-        return {done: true};
-      }
-      return {value: allRemoteHosts[planRemoteIndex++ % allRemoteHosts.length], done: false};
-    },
-    nextLocal: function () {
-      if (++counter > hosts.length) {
-        return {done: true};
-      }
-      var host = hosts[planIndex++ % hosts.length];
-      if (self.getDistance(host) === types.distance.remote) {
-        var dcHosts = remoteHostsByDc[host.datacenter];
-        if (!dcHosts) {
-          dcHosts = [];
-          remoteHostsByDc[host.datacenter] = dcHosts;
-        }
-        dcHosts.push(host);
-        return this.nextLocal();
-      }
-      return {value: host, done: !host};
-    },
-    sliceRemoteHosts: function () {
-      if (allRemoteHosts) {
-        return;
-      }
-      allRemoteHosts = [];
-      if (self.usedHostsPerRemoteDc === 0) {
-        return;
-      }
-      for (var dc in remoteHostsByDc) {
-        if (!remoteHostsByDc.hasOwnProperty(dc)) {
-          continue;
-        }
-        var dcHosts = remoteHostsByDc[dc].slice(0, self.usedHostsPerRemoteDc);
-        allRemoteHosts.push.apply(allRemoteHosts, dcHosts);
-      }
+      return { done: true };
     }
   });
 };

--- a/test/unit/load-balancing-tests.js
+++ b/test/unit/load-balancing-tests.js
@@ -159,7 +159,7 @@ describe('DCAwareRoundRobinPolicy', function () {
       h.datacenter = (i % 2 === 0) ? 'dc1' : 'dc2';
       originalHosts.set(i.toString(), h);
     }
-    var localHosts = originalHosts.values().filter(function(element, index, arr) {
+    var localHosts = originalHosts.values().filter(function(element) {
       return element.datacenter == 'dc1';
     });
     var times = 50;
@@ -266,15 +266,15 @@ describe('DCAwareRoundRobinPolicy', function () {
       originalHosts.set(i.toString(), h);
     }
 
-    var localHosts = originalHosts.values().filter(function(element, index, arr) {
+    var localHosts = originalHosts.values().filter(function(element) {
       return element.datacenter == 'dc1';
     });
 
-    var dc2Hosts = originalHosts.values().filter(function(element, index, arr) {
+    var dc2Hosts = originalHosts.values().filter(function(element) {
       return element.datacenter == 'dc2';
     });
 
-    var dc3Hosts = originalHosts.values().filter(function(element, index, arr) {
+    var dc3Hosts = originalHosts.values().filter(function(element) {
       return element.datacenter == 'dc3';
     });
 
@@ -381,6 +381,16 @@ describe('DCAwareRoundRobinPolicy', function () {
             lastPlan = localOnlyPlanDesc;
           });
           assert.strictEqual(length, times / localPermutations.length);
+        });
+
+        // Ensure remote part of query plans is non-repeating among plans.
+        var lastPlan = null;
+        plans.forEach(function (item){
+          var remoteOnlyPlan = item.plan.slice(localHosts.length);
+          var remoteOnlyPlanDesc = JSON.stringify(remoteOnlyPlan);
+          assert.notEqual(lastPlan, remoteOnlyPlanDesc, "last encountered" +
+            " remote plan is the same as the previous one.\n" + lastPlan + "\n==\n" + remoteOnlyPlanDesc);
+          lastPlan = remoteOnlyPlanDesc;
         });
         done();
       });


### PR DESCRIPTION
An attempt to prevent separate query plans from affecting each other by maintaining a separate index for each generated query plan based off of the policy-based index.   This applies to both DCAwareRoundRobinPolicy and RoundRobinPolicy.