### PR TITLE
NODEJS-157 Subscribe to down event earlier on init of ControlConnection 

### DIFF
--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -148,6 +148,10 @@ ControlConnection.prototype.initOnConnection = function (firstTime, callback) {
   var self = this;
   self.log('info', 'Connection acquired, refreshing nodes list');
   async.series([
+    function subscribeHostEvents(next) {
+      self.host.once('down', self.hostDownHandler.bind(self));
+      next();
+    },
     function getLocalAndPeersInfo(next) {
       self.refreshHosts(firstTime, next);
     },
@@ -161,10 +165,6 @@ ControlConnection.prototype.initOnConnection = function (firstTime, callback) {
       else {
         self.log('warning', 'Tokenizer could not be determined');
       }
-      next();
-    },
-    function subscribeHostEvents(next) {
-      self.host.once('down', self.hostDownHandler.bind(self));
       next();
     },
     function subscribeConnectionEvents(next) {


### PR DESCRIPTION
For [NODEJS-157](https://datastax-oss.atlassian.net/browse/NODEJS-157), simply moving the subscribe on host down right after the connection is acquired will handle the case where an error is encountered during refreshHosts fixes the issue where the keyspace set up for the client no longer exists.