### PR TITLE
Allow socket close event to be emitted before connection close calls back

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -604,7 +604,7 @@ Connection.prototype.close = function (callback) {
   }
   if (!this.connected) {
     this.netClient.destroy();
-    callback();
+    setImmediate(callback);
     return;
   }
   var self = this;
@@ -612,7 +612,7 @@ Connection.prototype.close = function (callback) {
     if (hadError) {
       self.log('info', 'The socket closed with a transmission error');
     }
-    callback();
+    setImmediate(callback);
   });
   this.netClient.end();
   this.streamHandlers = {};


### PR DESCRIPTION
https://datastax-oss.atlassian.net/browse/NODEJS-165