### PR TITLE
Initial build.yaml for jenkins builds.

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,24 @@
+nodejs:
+  - "0.10"
+  - "0.12"
+  - "iojs-3"
+  - "4.0"
+os:
+  - ubuntu/trusty64
+cassandra:
+  - 1.2
+  - 2.0
+  - 2.1
+  - 2.2
+build:
+  - type: envinject
+    properties: |
+      TEST_CASSANDRA_VERSION=$CCM_CASSANDRA_VERSION
+      JAVA_HOME=$CCM_JAVA_HOME
+      CCM_PATH=$HOME/ccm
+      JUNIT_REPORT_STACK=1
+      JUNIT_REPORT_PATH=.
+  - npm: install
+  - npm: run-script ci
+    graceful: true
+  - xunit: "*.xml"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "devDependencies": {
     "mocha": ">= 1.14.0",
-    "rewire": ">= 2.1.0"
+    "rewire": ">= 2.1.0",
+    "mocha-jenkins-reporter": ">= 0.1.9"
   },
   "repository": {
     "type" : "git",
@@ -36,7 +37,8 @@
     "url": "https://groups.google.com/a/lists.datastax.com/forum/#!forum/nodejs-driver-user"
   },
   "scripts":  {
-    "test": "mocha test/unit -R spec -t 5000"
+    "test": "mocha test/unit -R spec -t 5000",
+    "ci": "mocha test/unit test/integration/short -R mocha-jenkins-reporter"
   },
   "engines": {
     "node" : ">=0.10.0"


### PR DESCRIPTION
This adds a build.yaml for internal jenkins builds against latest C* versions (1.2.x, 2.0.x, 2.1.x, 2.2.x) with latest nodejs versions (0.10.x, 0.12.x, iojs-3.x, 4.0.x) on linux.  Windows support will be added in the coming weeks.