### PR TITLE
Manual paging

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -307,28 +307,38 @@ Client.prototype.eachRow = function () {
   });
   args.callback = utils.bindDomain(args.callback);
   var self = this;
+  function nextPage() {
+    self._innerExecute(args.query, args.params, args.options, pageCallback); 
+  }  
   function pageCallback (err, result) {
     if (err) {
       return args.callback(err);
     }
-    if (args.options.autoPage) {
-      //Next requests for auto-paging
-      args.options.rowLength = args.options.rowLength || 0;
-      args.options.rowLength += result.rowLength;
-      args.options.rowLengthArray = args.options.rowLengthArray || [];
-      args.options.rowLengthArray.push(result.rowLength);
+      
+    //Next requests in case paging (auto or explicit) is used
+    args.options.rowLength = args.options.rowLength || 0;
+    args.options.rowLength += result.rowLength;
+    args.options.rowLengthArray = args.options.rowLengthArray || [];
+    args.options.rowLengthArray.push(result.rowLength);
 
-      if (result.meta && result.meta.pageState) {
-        //Use new page state as next request page state
-        args.options.pageState = result.meta.pageState;
-        //Issue next request for the next page
-        self._innerExecute(args.query, args.params, args.options, pageCallback);
-        return;
+    if (result.meta && result.meta.pageState) {
+      //Use new page state as next request page state
+      args.options.pageState = result.meta.pageState;
+      //Issue next request for the next page
+      if (args.options.autoPage) {
+        //Next request for autopaging
+        nextPage(); 
+        return; 
       }
-      //finished auto-paging
-      result.rowLength = args.options.rowLength;
-      result.rowLengthArray = args.options.rowLengthArray;
+      else {
+        //Allows for explicit (manual) paging, in case the caller needs it 
+        result.nextPage = nextPage;
+      }
     }
+    //finished auto-paging
+    result.rowLength = args.options.rowLength;
+    result.rowLengthArray = args.options.rowLengthArray;
+
     args.callback(null, result);
   }
   this._innerExecute(args.query, args.params, args.options, pageCallback);
@@ -361,13 +371,33 @@ Client.prototype.stream = function () {
     args.push(function noop() {});
   }
   args = utils.parseCommonArgs.apply(null, args);
+  // NOTE: the nodejs stream maintains yet another internal buffer 
+  // we rely on the default stream implementation to keep memory 
+  // usage reasonable.
   var resultStream = new types.ResultStream({objectMode: 1});
   this.eachRow(args.query, args.params, args.options, function rowCallback(n, row) {
     resultStream.add(row);
-  }, function (err) {
+  }, function (err,result) {
     if (err) {
       resultStream.emit('error', err);
     }
+    if ( result && result.nextPage ) {
+      // allows for throttling as per the
+      // default nodejs stream implementation 
+      resultStream._valve( function( ) {
+          try {
+            result.nextPage(); 
+          }
+          catch( ex ) {
+            resultStream.emit('error', ex );
+          }
+        } );
+      return;
+    }
+    // not a bad idea explicitly dropping 
+    // the valve function + closure
+    resultStream._valve(null);
+    
     resultStream.add(null);
     args.callback(err);
   });

--- a/lib/types/result-stream.js
+++ b/lib/types/result-stream.js
@@ -1,5 +1,7 @@
 var util = require('util');
 var stream = require('stream');
+// var assert = require('assert');
+
 /** @module types */
 /**
  * Readable stream using to yield data from a result or a field
@@ -19,7 +21,32 @@ ResultStream.prototype._read = function() {
     this._readableState.reading = false;
   }
   while (!this.paused && this.buffer.length > 0) {
-    this.paused = this.push(this.buffer.shift());
+    this.paused = !this.push(this.buffer.shift());
+  }
+  if ( !this.paused && !this.buffer.length && this._readNext ) {
+    // console.log( "_read", this.paused, this.buffer.length );
+    this._readNext();
+    this._readNext = null;
+  }
+};
+
+/**
+ * Allows for throttling, helping nodejs keep the internal buffers reasonably sized.
+ * @param {function} function that triggers reading the next result chunk
+ * @constructor
+ */
+ResultStream.prototype._valve = function( readNext ) {
+  // assert( !this._readNext );
+  this._readNext = null;
+  if ( !readNext ) {
+    return;
+  }
+  if ( this.paused || this.buffer.length ) {
+    this._readNext = readNext;
+  }
+  else {
+    // console.log( "_valve", this.buffer.length );
+    readNext();
   }
 };
 


### PR DESCRIPTION
Hi Jorge,

Been time since the manual-paging in the eachRow. In addition, we now have throttling in stream.
Hopefully, this concludes the manual paging work.

Please review and make these part of the official driver release - tired of using two different driver versions in Peerbelt.

Let me know your thoughts, comments.

Thank you,
-Krassi

--
The manual-paging branch is too far behind and the Pull Request looked terrible with 90 or so files to be considered. Closed it and open this one instead.

Perhaps, you can recreate the branch if we need to work there?!

--
feat: support for manual paging:
	in eachRow via fetchSize option spec, resulting in a nextPage method attached to the resultStats in callback(err, resultStats)
	in stream, implicitly via the nodejs stream implementation, or again via fetchSize option spec

fix: according to https://nodejs.org/api/stream.html#stream_readable_push_chunk_encoding:
	"if push() returns false, then we need to stop reading from source", i.e. this.paused = !this.push(this.buffer.shift());