### PR TITLE
Parse cql type names

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -1,5 +1,6 @@
 "use strict";
 var util = require('util');
+var async = require('async');
 
 var types = require('./types');
 var dataTypes = types.dataTypes;
@@ -30,6 +31,15 @@ var complexTypeNames = Object.freeze({
   collection: 'org.apache.cassandra.db.marshal.ColumnToCollectionType'
 });
 /** @const */
+var cqlNames = Object.freeze({
+  frozen: 'frozen',
+  list: 'list',
+  'set': 'set',
+  map: 'map',
+  tuple: 'tuple',
+  empty: 'empty'
+});
+/** @const */
 var singleTypeNames = Object.freeze({
   'org.apache.cassandra.db.marshal.UTF8Type':           dataTypes.varchar,
   'org.apache.cassandra.db.marshal.AsciiType':          dataTypes.ascii,
@@ -52,7 +62,7 @@ var singleTypeNames = Object.freeze({
   'org.apache.cassandra.db.marshal.IntegerType':        dataTypes.varint,
   'org.apache.cassandra.db.marshal.CounterColumnType':  dataTypes.counter
 });
-var singleTypeNamesLength = Object.keys(singleTypeNames).reduce(function (previous, current) {
+var singleFqTypeNamesLength = Object.keys(singleTypeNames).reduce(function (previous, current) {
   return current.length > previous ? current.length : previous;
 }, 0);
 var nullValueBuffer = new Buffer([255, 255, 255, 255]);
@@ -1043,14 +1053,147 @@ Encoder.prototype.handleBufferRef = function (buffer) {
 };
 
 /**
- * Parses a given Cassandra type name to get the data type information
+ * Parses a CQL name string into data type information
+ * @param {String} keyspace
+ * @param {String} typeName
+ * @param {Number} startIndex
+ * @param {Number|null} length
+ * @param {Function} udtResolver
+ * @param {Function} callback Callback invoked with err and  {{code: number, info: Object|Array|null, options: {frozen: Boolean}}}
+ */
+Encoder.prototype.parseTypeName = function (keyspace, typeName, startIndex, length, udtResolver, callback) {
+  var dataType = {
+    code: 0,
+    info: null,
+    options: {
+      frozen: false
+    }
+  };
+  startIndex = startIndex || 0;
+  var innerTypes;
+  if (!length) {
+    length = typeName.length;
+  }
+  if (typeName.indexOf(cqlNames.frozen, startIndex) === startIndex) {
+    //Remove the frozen token
+    startIndex += cqlNames.frozen.length + 1;
+    length -= cqlNames.frozen.length + 2;
+    dataType.options.frozen = true;
+  }
+  if (typeName.indexOf(cqlNames.list, startIndex) === startIndex) {
+    //move cursor across the name and bypass the angle brackets
+    startIndex += cqlNames.list.length + 1;
+    length -= cqlNames.list.length + 2;
+    innerTypes = parseParams(typeName, startIndex, length);
+    if (innerTypes.length != 1) {
+      return callback(new TypeError('Not a valid type ' + typeName));
+    }
+    dataType.code = dataTypes.list;
+    return this.parseTypeName(keyspace, innerTypes[0], 0, null, udtResolver, function (err, childType) {
+      if (err) {
+        return callback(err);
+      }
+      dataType.info = childType;
+      callback(null, dataType);
+    });
+  }
+  if (typeName.indexOf(cqlNames.set, startIndex) === startIndex) {
+    //move cursor across the name and bypass the angle brackets
+    startIndex += cqlNames.set.length + 1;
+    length -= cqlNames.set.length + 2;
+    innerTypes = parseParams(typeName, startIndex, length);
+    if (innerTypes.length != 1) {
+      return callback(new TypeError('Not a valid type ' + typeName));
+    }
+    dataType.code = dataTypes.set;
+    return this.parseTypeName(keyspace, innerTypes[0], 0, null, udtResolver, function (err, childType) {
+      if (err) {
+        return callback(err);
+      }
+      dataType.info = childType;
+      callback(null, dataType);
+    });
+  }
+  if (typeName.indexOf(cqlNames.map, startIndex) === startIndex) {
+    //move cursor across the name and bypass the angle brackets
+    startIndex += cqlNames.map.length + 1;
+    length -= cqlNames.map.length + 2;
+    innerTypes = parseParams(typeName, startIndex, length);
+    //It should contain the key and value types
+    if (innerTypes.length != 2) {
+      return callback(new TypeError('Not a valid type ' + typeName));
+    }
+    dataType.code = dataTypes.map;
+    return this._parseChildTypes(keyspace, dataType, innerTypes, udtResolver, callback);
+  }
+  if (typeName.indexOf(cqlNames.tuple, startIndex) === startIndex) {
+    //move cursor across the name and bypass the angle brackets
+    startIndex += cqlNames.tuple.length + 1;
+    length -= cqlNames.tuple.length + 2;
+    innerTypes = parseParams(typeName, startIndex, length);
+    if (innerTypes.length < 1) {
+      throw new TypeError('Not a valid type ' + typeName);
+    }
+    dataType.code = dataTypes.tuple;
+    return this._parseChildTypes(keyspace, dataType, innerTypes, udtResolver, callback);
+  }
+  //Quick check if its a single type
+  if (startIndex > 0) {
+    typeName = typeName.substr(startIndex, length);
+  }
+  var typeCode = dataTypes[typeName];
+  if (typeof typeCode === 'number') {
+    dataType.code = typeCode;
+    return callback(null, dataType);
+  }
+  if (typeName === cqlNames.empty) {
+    //set as custom
+    dataType.info = 'empty';
+    return callback(null, dataType);
+  }
+  udtResolver(keyspace, typeName, function (err, udtInfo) {
+    if (err) {
+      return callback(err);
+    }
+    if (udtInfo) {
+      dataType.code = dataTypes.udt;
+      dataType.info = udtInfo;
+      return callback(null, dataType);
+    }
+    callback(new TypeError('Not a valid type "' + typeName + '"'));
+  });
+};
+
+/**
+ * @param {String} keyspace
+ * @param dataType
+ * @param {Array} typeNames
+ * @param {Function} udtResolver
+ * @param {Function} callback
+ * @private
+ */
+Encoder.prototype._parseChildTypes = function (keyspace, dataType, typeNames, udtResolver, callback) {
+  var self = this;
+  async.mapSeries(typeNames, function (name, next) {
+    self.parseTypeName(keyspace, name.trim(), 0, null, udtResolver, next);
+  }, function (err, childTypes) {
+    if (err) {
+      return callback(err);
+    }
+    dataType.info = childTypes;
+    callback(null, dataType);
+  });
+};
+
+/**
+ * Parses a Cassandra fully-qualified class name string into data type information
  * @param {String} typeName
  * @param {Number} [startIndex]
  * @param {Number} [length]
  * @throws TypeError
  * @returns {{code: number, info: Object|Array|null, options: {frozen: Boolean, reversed: Boolean}}}
  */
-Encoder.prototype.parseTypeName = function (typeName, startIndex, length) {
+Encoder.prototype.parseFqTypeName = function (typeName, startIndex, length) {
   var dataType = {
     code: 0,
     info: null,
@@ -1064,13 +1207,13 @@ Encoder.prototype.parseTypeName = function (typeName, startIndex, length) {
   if (!length) {
     length = typeName.length;
   }
-  if (length > complexTypeNames.reversed.length && typeName.substr(startIndex, complexTypeNames.reversed.length) === complexTypeNames.reversed) {
+  if (length > complexTypeNames.reversed.length && typeName.indexOf(complexTypeNames.reversed) === startIndex) {
     //Remove the reversed token
     startIndex += complexTypeNames.reversed.length + 1;
     length -= complexTypeNames.reversed.length + 2;
     dataType.options.reversed = true;
   }
-  if (length > complexTypeNames.frozen.length && typeName.substr(startIndex, complexTypeNames.frozen.length) == complexTypeNames.frozen) {
+  if (length > complexTypeNames.frozen.length && typeName.indexOf(complexTypeNames.frozen, startIndex) == startIndex) {
     //Remove the frozen token
     startIndex += complexTypeNames.frozen.length + 1;
     length -= complexTypeNames.frozen.length + 2;
@@ -1082,7 +1225,7 @@ Encoder.prototype.parseTypeName = function (typeName, startIndex, length) {
     return dataType;
   }
   //Quick check if its a single type
-  if (length <= singleTypeNamesLength) {
+  if (length <= singleFqTypeNamesLength) {
     if (startIndex > 0) {
       typeName = typeName.substr(startIndex, length);
     }
@@ -1091,9 +1234,9 @@ Encoder.prototype.parseTypeName = function (typeName, startIndex, length) {
       dataType.code = typeCode;
       return dataType;
     }
-    throw new TypeError('Not a valid type ' + typeName);
+    throw new TypeError('Not a valid type "' + typeName + '"');
   }
-  if (typeName.substr(startIndex, complexTypeNames.list.length) === complexTypeNames.list) {
+  if (typeName.indexOf(complexTypeNames.list, startIndex) === startIndex) {
     //Its a list
     //org.apache.cassandra.db.marshal.ListType(innerType)
     //move cursor across the name and bypass the parenthesis
@@ -1104,10 +1247,10 @@ Encoder.prototype.parseTypeName = function (typeName, startIndex, length) {
       throw new TypeError('Not a valid type ' + typeName);
     }
     dataType.code = dataTypes.list;
-    dataType.info = this.parseTypeName(innerTypes[0]);
+    dataType.info = this.parseFqTypeName(innerTypes[0]);
     return dataType;
   }
-  if (typeName.substr(startIndex, complexTypeNames.set.length) === complexTypeNames.set) {
+  if (typeName.indexOf(complexTypeNames.set, startIndex) === startIndex) {
     //Its a set
     //org.apache.cassandra.db.marshal.SetType(innerType)
     //move cursor across the name and bypass the parenthesis
@@ -1119,10 +1262,10 @@ Encoder.prototype.parseTypeName = function (typeName, startIndex, length) {
       throw new TypeError('Not a valid type ' + typeName);
     }
     dataType.code = dataTypes.set;
-    dataType.info = this.parseTypeName(innerTypes[0]);
+    dataType.info = this.parseFqTypeName(innerTypes[0]);
     return dataType;
   }
-  if (typeName.substr(startIndex, complexTypeNames.map.length) === complexTypeNames.map) {
+  if (typeName.indexOf(complexTypeNames.map, startIndex) === startIndex) {
     //org.apache.cassandra.db.marshal.MapType(keyType,valueType)
     //move cursor across the name and bypass the parenthesis
     startIndex += complexTypeNames.map.length + 1;
@@ -1133,16 +1276,16 @@ Encoder.prototype.parseTypeName = function (typeName, startIndex, length) {
       throw new TypeError('Not a valid type ' + typeName);
     }
     dataType.code = dataTypes.map;
-    dataType.info = [this.parseTypeName(innerTypes[0]), this.parseTypeName(innerTypes[1])];
+    dataType.info = [this.parseFqTypeName(innerTypes[0]), this.parseFqTypeName(innerTypes[1])];
     return dataType;
   }
-  if (typeName.substr(startIndex, complexTypeNames.udt.length) === complexTypeNames.udt) {
+  if (typeName.indexOf(complexTypeNames.udt, startIndex) === startIndex) {
     //move cursor across the name and bypass the parenthesis
     startIndex += complexTypeNames.udt.length + 1;
     length -= complexTypeNames.udt.length + 2;
     return this._parseUdtName(typeName, startIndex, length);
   }
-  if (typeName.substr(startIndex, complexTypeNames.tuple.length) === complexTypeNames.tuple) {
+  if (typeName.indexOf(complexTypeNames.tuple, startIndex) === startIndex) {
     //move cursor across the name and bypass the parenthesis
     startIndex += complexTypeNames.tuple.length + 1;
     length -= complexTypeNames.tuple.length + 2;
@@ -1152,7 +1295,7 @@ Encoder.prototype.parseTypeName = function (typeName, startIndex, length) {
     }
     dataType.code = dataTypes.tuple;
     dataType.info = innerTypes.map(function (x) {
-      return this.parseTypeName(x);
+      return this.parseFqTypeName(x);
     }, this);
     return dataType;
   }
@@ -1215,7 +1358,7 @@ Encoder.prototype.parseKeyTypes = function (typesString) {
   }
   return {
     types: types.map(function (name) {
-      return this.parseTypeName(name);
+      return this.parseFqTypeName(name);
     }, this),
     hasCollections: hasCollections,
     isComposite: isComposite
@@ -1241,7 +1384,7 @@ Encoder.prototype._parseUdtName = function (typeName, startIndex, length) {
   for (var i = 2; i < udtParams.length; i++) {
     var p = udtParams[i];
     var separatorIndex = p.indexOf(':');
-    var fieldType = this.parseTypeName(p, separatorIndex + 1, p.length - (separatorIndex + 1));
+    var fieldType = this.parseFqTypeName(p, separatorIndex + 1, p.length - (separatorIndex + 1));
     udtInfo.fields.push({
       name: new Buffer(p.substr(0, separatorIndex), 'hex').toString(),
       type: fieldType

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -1084,7 +1084,7 @@ Encoder.prototype.parseTypeName = function (keyspace, typeName, startIndex, leng
     //move cursor across the name and bypass the angle brackets
     startIndex += cqlNames.list.length + 1;
     length -= cqlNames.list.length + 2;
-    innerTypes = parseParams(typeName, startIndex, length);
+    innerTypes = parseParams(typeName, startIndex, length, '<', '>');
     if (innerTypes.length != 1) {
       return callback(new TypeError('Not a valid type ' + typeName));
     }
@@ -1101,7 +1101,7 @@ Encoder.prototype.parseTypeName = function (keyspace, typeName, startIndex, leng
     //move cursor across the name and bypass the angle brackets
     startIndex += cqlNames.set.length + 1;
     length -= cqlNames.set.length + 2;
-    innerTypes = parseParams(typeName, startIndex, length);
+    innerTypes = parseParams(typeName, startIndex, length, '<', '>');
     if (innerTypes.length != 1) {
       return callback(new TypeError('Not a valid type ' + typeName));
     }
@@ -1118,7 +1118,7 @@ Encoder.prototype.parseTypeName = function (keyspace, typeName, startIndex, leng
     //move cursor across the name and bypass the angle brackets
     startIndex += cqlNames.map.length + 1;
     length -= cqlNames.map.length + 2;
-    innerTypes = parseParams(typeName, startIndex, length);
+    innerTypes = parseParams(typeName, startIndex, length, '<', '>');
     //It should contain the key and value types
     if (innerTypes.length != 2) {
       return callback(new TypeError('Not a valid type ' + typeName));
@@ -1130,7 +1130,7 @@ Encoder.prototype.parseTypeName = function (keyspace, typeName, startIndex, leng
     //move cursor across the name and bypass the angle brackets
     startIndex += cqlNames.tuple.length + 1;
     length -= cqlNames.tuple.length + 2;
-    innerTypes = parseParams(typeName, startIndex, length);
+    innerTypes = parseParams(typeName, startIndex, length, '<', '>');
     if (innerTypes.length < 1) {
       throw new TypeError('Not a valid type ' + typeName);
     }
@@ -1398,18 +1398,22 @@ Encoder.prototype._parseUdtName = function (typeName, startIndex, length) {
  * @param {String} value
  * @param {Number} startIndex
  * @param {Number} length
+ * @param {String} [open]
+ * @param {String} [close]
  * @returns {Array}
  */
-function parseParams(value, startIndex, length) {
+function parseParams(value, startIndex, length, open, close) {
+  open = open || '(';
+  close = close || ')';
   var types = [];
   var paramStart = startIndex;
   var level = 0;
   for (var i = startIndex; i < startIndex + length; i++) {
     var c = value[i];
-    if (c == '(') {
+    if (c == open) {
       level++;
     }
-    if (c == ')') {
+    if (c == close) {
       level--;
     }
     if (level == 0 && c == ',') {

--- a/lib/metadata/aggregate.js
+++ b/lib/metadata/aggregate.js
@@ -45,13 +45,13 @@ function Aggregate() {
    */
   this.finalFunction = null;
   /**
-   * Initial state value of this aggregate.
-   * @type {Buffer}
+   * Raw value value of the initial state of this aggregate.
+   * @type {Buffer|String}
    */
   this.initConditionRaw = null;
   /**
    * Initial state value of this aggregate.
-   * @type {Object}
+   * @type {String}
    */
   this.initCondition = null;
   /**

--- a/lib/metadata/data-collection.js
+++ b/lib/metadata/data-collection.js
@@ -127,7 +127,7 @@ function DataCollection(name) {
    * Array describing the table columns.
    * @type {Array}
    */
-  this.columns = [];
+  this.columns = null;
   /**
    * An associative Array of columns by name.
    * @type {Object}

--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -9,7 +9,7 @@ var utils = require('../utils');
 var errors = require('../errors');
 var types = require('../types');
 var requests = require('../requests');
-var getSchemaParserByVersion = require('./schema-parser').getByVersion;
+var schemaParserFactory = require('./schema-parser');
 
 /**
  * @const
@@ -51,14 +51,10 @@ var _traceAttemptDelay = 200;
  */
 function Metadata (options, controlConnection) {
   Object.defineProperty(this, 'options', { value: options, enumerable: false, writable: false});
-  this.controlConnection = controlConnection;
+  Object.defineProperty(this, 'controlConnection', { value: controlConnection, enumerable: false, writable: false});
   this.keyspaces = {};
   this.clearPrepared();
-  /**
-   * @type {SchemaParser}
-   * @private
-   */
-  this._schemaParser = getSchemaParserByVersion(1);
+  this._schemaParser = schemaParserFactory.getByVersion(controlConnection, this.getUdt.bind(this));
 }
 
 /**
@@ -68,7 +64,8 @@ function Metadata (options, controlConnection) {
  * @param {Array.<Number>} version
  */
 Metadata.prototype.setCassandraVersion = function (version) {
-  this._schemaParser = getSchemaParserByVersion(version);
+  this._schemaParser = schemaParserFactory.getByVersion(
+    this.controlConnection, this.getUdt.bind(this), version, this._schemaParser);
 };
 
 /**
@@ -130,7 +127,7 @@ Metadata.prototype.refreshKeyspace = function (name, callback) {
     callback = function () {};
   }
   var self = this;
-  this._schemaParser.getKeyspace(this.controlConnection, name, function (err, ksInfo) {
+  this._schemaParser.getKeyspace(name, function (err, ksInfo) {
     if (err) {
       self.log('error', 'There was an error while trying to retrieve keyspace information', err);
       return callback(err);
@@ -154,7 +151,7 @@ Metadata.prototype.refreshKeyspaces = function (callback) {
   if (!callback) {
     callback = function () {};
   }
-  this._schemaParser.getKeyspaces(this.controlConnection, function (err, keyspaces) {
+  this._schemaParser.getKeyspaces(function (err, keyspaces) {
     if (err) {
       self.log('error', 'There was an error while trying to retrieve keyspaces information', err);
       return callback(err);
@@ -255,7 +252,7 @@ Metadata.prototype.getUdt = function (keyspaceName, name, callback) {
   if (!keyspace) {
     return callback(null, null);
   }
-  this._schemaParser.getUdt(this.controlConnection, keyspace, name, callback);
+  this._schemaParser.getUdt(keyspace, name, callback);
 };
 
 /**
@@ -273,7 +270,7 @@ Metadata.prototype.getTable = function (keyspaceName, name, callback) {
   if (!keyspace) {
     return callback(null, null);
   }
-  this._schemaParser.getTable(this.controlConnection, keyspace, name, callback);
+  this._schemaParser.getTable(keyspace, name, callback);
 };
 
 /**
@@ -388,7 +385,7 @@ Metadata.prototype._getFunctions = function (keyspaceName, name, aggregate, call
   if (!keyspace) {
     return callback(null, null);
   }
-  this._schemaParser.getFunctions(this.controlConnection, keyspace, name, aggregate, callback);
+  this._schemaParser.getFunctions(keyspace, name, aggregate, callback);
 };
 
 /**

--- a/lib/metadata/schema-parser.js
+++ b/lib/metadata/schema-parser.js
@@ -33,7 +33,13 @@ var _selectAggregatesV1 = "SELECT * FROM system.schema_aggregates WHERE keyspace
 var _selectAggregatesV2 = "SELECT * FROM system_schema.aggregates WHERE keyspace_name = '%s' AND aggregate_name = '%s'";
 var _selectMaterializedViewV2 = "SELECT * FROM system_schema.views WHERE keyspace_name = '%s' AND view_name = '%s'";
 
-function SchemaParser() {
+/**
+ * @abstract
+ * @param {ControlConnection} cc
+ * @constructor
+ */
+function SchemaParser(cc) {
+  this.cc = cc;
   this.selectTable = null;
   this.selectColumns = null;
   this.selectIndexes = null;
@@ -69,28 +75,25 @@ SchemaParser.prototype._createKeyspace = function (name, durableWrites, strategy
 
 /**
  * @abstract
- * @param {ControlConnection} cc
  * @param {String} name
  * @param {Function} callback
  */
-SchemaParser.prototype.getKeyspace = function (cc, name, callback) {
+SchemaParser.prototype.getKeyspace = function (name, callback) {
 };
 
 /**
  * @abstract
- * @param {ControlConnection} cc
  * @param {Function} callback
  */
-SchemaParser.prototype.getKeyspaces = function (cc, callback) {
+SchemaParser.prototype.getKeyspaces = function (callback) {
 };
 
 /**
- * @param {ControlConnection} cc
  * @param keyspace
  * @param {String} name
  * @param {Function} callback
  */
-SchemaParser.prototype.getTable = function (cc, keyspace, name, callback) {
+SchemaParser.prototype.getTable = function (keyspace, name, callback) {
   var tableInfo = keyspace.tables[name];
   if (!tableInfo) {
     keyspace.tables[name] = tableInfo = new TableMetadata(name);
@@ -109,7 +112,7 @@ SchemaParser.prototype.getTable = function (cc, keyspace, name, callback) {
   async.waterfall([
     function getTableRow(next) {
       var query = util.format(self.selectTable, keyspace.name, name);
-      cc.query(query, function (err, response) {
+      self.cc.query(query, function (err, response) {
         if (err) return next(err);
         next(null, response.rows[0]);
       });
@@ -117,7 +120,7 @@ SchemaParser.prototype.getTable = function (cc, keyspace, name, callback) {
     function getColumnRows (tableRow, next) {
       if (!tableRow) return next(null, null, null);
       var query = util.format(self.selectColumns, keyspace.name, name);
-      cc.query(query, function (err, response) {
+      self.cc.query(query, function (err, response) {
         if (err) return next(err);
         next(null, tableRow, response.rows);
       });
@@ -128,33 +131,30 @@ SchemaParser.prototype.getTable = function (cc, keyspace, name, callback) {
         return next(null, tableRow, columnRows);
       }
       var query = util.format(self.selectIndexes, keyspace.name, name);
-      cc.query(query, function (err, response) {
+      self.cc.query(query, function (err, response) {
         if (err) return next(err);
         next(null, tableRow, columnRows, response.rows);
       });
     }
   ], function afterQuery (err, tableRow, columnRows, indexRows) {
-    tableInfo.loading = false;
     if (err || !tableRow) {
+      tableInfo.loading = false;
       return tableInfo.emit('load', err, null);
     }
-    try {
-      self._parseTableOrView(tableInfo, cc.getEncoder(), tableRow, columnRows, indexRows);
-    }
-    catch (parseError) {
-      err = parseError;
-    }
-    tableInfo.emit('load', err, tableInfo);
+    self._parseTableOrView(tableInfo, tableRow, columnRows, indexRows, function (err) {
+      tableInfo.loading = false;
+      tableInfo.loaded = !err;
+      tableInfo.emit('load', err, tableInfo);
+    });
   });
 };
 
 /**
- * @param {ControlConnection} cc
  * @param keyspace
  * @param {String} name
  * @param {Function} callback
  */
-SchemaParser.prototype.getUdt = function (cc, keyspace, name, callback) {
+SchemaParser.prototype.getUdt = function (keyspace, name, callback) {
   var udtInfo = keyspace.udts[name];
   if (!udtInfo) {
     keyspace.udts[name] = udtInfo = new events.EventEmitter();
@@ -175,48 +175,46 @@ SchemaParser.prototype.getUdt = function (cc, keyspace, name, callback) {
   //it is not cached, try to query for it
   var query = util.format(this.selectUdt, keyspace.name, name);
   var self = this;
-  cc.query(query, function (err, response) {
-    udtInfo.loading = false;
+  this.cc.query(query, function (err, response) {
     if (err) {
       return udtInfo.emit('load', err);
     }
     var row = response.rows[0];
-    udtInfo.emit('load', null, self._parseUdt(udtInfo, cc.getEncoder(), row));
+    if (!row) {
+      udtInfo.loading = false;
+      return udtInfo.emit('load', null, null);
+    }
+    self._parseUdt(udtInfo, row, function (err) {
+      udtInfo.loading = false;
+      if (err) {
+        return udtInfo.emit('load', err);
+      }
+      return udtInfo.emit('load', null, udtInfo);
+    });
   });
 };
 
 /**
+ * @abstract
  * Parses the udt information from the row
- * @returns {{fields: Array}}|null
+ * @param udtInfo
+ * @param {Row} row
+ * @param {Function} callback Callback to be invoked with the err and {{fields: Array}}|null
  */
-SchemaParser.prototype._parseUdt = function (udtInfo, encoder, row) {
-  if (!row) {
-    return null;
-  }
-  var fieldNames = row['field_names'];
-  var fieldTypes = row['field_types'];
-  var fields = new Array(fieldNames.length);
-  for (var i = 0; i < fieldNames.length; i++) {
-    fields[i] = {
-      name: fieldNames[i],
-      type: encoder.parseTypeName(fieldTypes[i])
-    };
-  }
-  udtInfo.fields = fields;
-  return udtInfo;
+SchemaParser.prototype._parseUdt = function (udtInfo, row, callback) {
 };
 
 /**
  * Builds the metadata based on the table and column rows
  * @abstract
  * @param {TableMetadata} tableInfo
- * @param {Encoder} encoder
  * @param {Row} tableRow
  * @param {Array.<Row>} columnRows
  * @param {Array.<Row>} indexRows
+ * @param {Function} callback
  * @throws {Error}
  */
-SchemaParser.prototype._parseTableOrView = function (tableInfo, encoder, tableRow, columnRows, indexRows) {
+SchemaParser.prototype._parseTableOrView = function (tableInfo, tableRow, columnRows, indexRows, callback) {
 };
 
 
@@ -232,22 +230,19 @@ SchemaParser.prototype.getMaterializedView = function (cc, keyspace, name, callb
 };
 
 /**
- * @param {ControlConnection} cc
  * @param keyspace
  * @param {String} name
  * @param {Boolean} aggregate
  * @param {Function} callback
  */
-SchemaParser.prototype.getFunctions = function (cc, keyspace, name, aggregate, callback) {
+SchemaParser.prototype.getFunctions = function (keyspace, name, aggregate, callback) {
   var cache = keyspace.functions;
   var query = this.selectFunctions;
-  var Constructor = SchemaFunction;
-  var parser = this._parseFunction;
+  var parser = this._parseFunction.bind(this);
   if (aggregate) {
     cache = keyspace.aggregates;
     query = this.selectAggregates;
-    Constructor = Aggregate;
-    parser = this._parseAggregate;
+    parser = this._parseAggregate.bind(this);
   }
   //if not already loaded
   //get all functions with that name
@@ -268,7 +263,7 @@ SchemaParser.prototype.getFunctions = function (cc, keyspace, name, aggregate, c
   functionsInfo.loading = true;
   //it is not cached, try to query for it
   query = util.format(query, keyspace.name, name);
-  cc.query(query, function (err, response) {
+  this.cc.query(query, function (err, response) {
     functionsInfo.loading = false;
     if (err || response.rows.length === 0) {
       return functionsInfo.emit('load', err, null);
@@ -276,57 +271,46 @@ SchemaParser.prototype.getFunctions = function (cc, keyspace, name, aggregate, c
     if (response.rows.length > 0) {
       functionsInfo.values = {};
     }
-    try {
-      response.rows.forEach(function (row) {
-        var func = new Constructor();
-        parser(cc.getEncoder(), func, row);
+    async.each(response.rows, function (row, next) {
+      parser(row, function (err, func) {
+        if (err) {
+          return next(err);
+        }
         functionsInfo.values['(' + func.signature.join(',') + ')'] = func;
+        next();
       });
-    }
-    catch (buildErr) {
-      err = buildErr;
-    }
-    if (err) {
-      functionsInfo.values = null;
-    }
-    functionsInfo.emit('load', err, functionsInfo.values);
+    }, function (err) {
+      if (err) {
+        return functionsInfo.emit('load', err);
+      }
+      functionsInfo.emit('load', null, functionsInfo.values);
+    });
   });
 };
 
-SchemaParser.prototype._parseAggregate = function (encoder, aggregate, row) {
-  aggregate.name = row['aggregate_name'];
-  aggregate.keyspaceName = row['keyspace_name'];
-  aggregate.signature = row['signature'] || utils.emptyArray;
-  aggregate.argumentTypes = (row['argument_types'] || utils.emptyArray).map(function (name) {
-    return encoder.parseTypeName(name);
-  });
-  aggregate.stateFunction = row['state_func'];
-  aggregate.stateType = encoder.parseTypeName(row['state_type']);
-  aggregate.finalFunction = row['final_func'];
-  aggregate.initConditionRaw = row['initcond'];
-  aggregate.initCondition = encoder.decode(aggregate.initConditionRaw, aggregate.stateType);
-  aggregate.returnType = encoder.parseTypeName(row['return_type']);
+/**
+ * @abstract
+ * @param {Row} row
+ * @param {Function} callback
+ */
+SchemaParser.prototype._parseAggregate = function (row, callback) {
 };
 
-SchemaParser.prototype._parseFunction = function (encoder, func, row) {
-  func.name = row['function_name'];
-  func.keyspaceName = row['keyspace_name'];
-  func.signature = row['signature'] || utils.emptyArray;
-  func.argumentNames = row['argument_names'] || utils.emptyArray;
-  func.argumentTypes = (row['argument_types'] || utils.emptyArray).map(function (name) {
-    return encoder.parseTypeName(name);
-  });
-  func.body = row['body'];
-  func.calledOnNullInput = row['called_on_null_input'];
-  func.language = row['language'];
-  func.returnType = encoder.parseTypeName(row['return_type']);
+/**
+ * @abstract
+ * @param {Row} row
+ * @param {Function} callback
+ */
+SchemaParser.prototype._parseFunction = function (row, callback) {
 };
 
 /**
  * Used to parse schema information for Cassandra versions 1.2.x, and 2.x
+ * @param {ControlConnection} cc
  * @constructor
  */
-function SchemaParserV1() {
+function SchemaParserV1(cc) {
+  SchemaParser.call(this, cc);
   this.selectTable = _selectTableV1;
   this.selectColumns = _selectColumnsV1;
   this.selectUdt = _selectUdtV1;
@@ -337,10 +321,10 @@ function SchemaParserV1() {
 util.inherits(SchemaParserV1, SchemaParser);
 
 /** @override */
-SchemaParserV1.prototype.getKeyspaces = function (cc, callback) {
+SchemaParserV1.prototype.getKeyspaces = function (callback) {
   var self = this;
   var keyspaces = {};
-  cc.query(_selectAllKeyspacesV1, function (err, result) {
+  this.cc.query(_selectAllKeyspacesV1, function (err, result) {
     if (err) return callback(err);
     for (var i = 0; i < result.rows.length; i++) {
       var row = result.rows[i];
@@ -356,9 +340,9 @@ SchemaParserV1.prototype.getKeyspaces = function (cc, callback) {
 };
 
 /** @override */
-SchemaParserV1.prototype.getKeyspace = function (cc, name, callback) {
+SchemaParserV1.prototype.getKeyspace = function (name, callback) {
   var self = this;
-  cc.query(util.format(_selectSingleKeyspaceV1, name), function (err, result) {
+  this.cc.query(util.format(_selectSingleKeyspaceV1, name), function (err, result) {
     if (err) {
       return callback(err);
     }
@@ -376,12 +360,12 @@ SchemaParserV1.prototype.getKeyspace = function (cc, name, callback) {
 
 //noinspection JSUnusedLocalSymbols
 /** @override */
-SchemaParserV1.prototype._parseTableOrView = function (tableInfo, encoder, tableRow, columnRows, indexRows) {
+SchemaParserV1.prototype._parseTableOrView = function (tableInfo, tableRow, columnRows, indexRows, callback) {
   var i, c, name, types;
+  var encoder = this.cc.getEncoder();
   var columnsKeyed = {};
   var partitionKeys = [];
   var clusteringKeys = [];
-  tableInfo.loaded = true;
   tableInfo.bloomFilterFalsePositiveChance = tableRow['bloom_filter_fp_chance'];
   tableInfo.caching = tableRow['caching'];
   tableInfo.comment = tableRow['comment'];
@@ -410,101 +394,113 @@ SchemaParserV1.prototype._parseTableOrView = function (tableInfo, encoder, table
     //leave the default otherwise
     tableInfo.replicateOnWrite = tableRow['replicate_on_write'];
   }
-  (function parseColumns() {
-    //function context
-    for (i = 0; i < columnRows.length; i++) {
-      var row = columnRows[i];
-      var type = encoder.parseTypeName(row['validator']);
+  tableInfo.columns = [];
+  try {
+    (function parseColumns() {
+      //function context
+      for (i = 0; i < columnRows.length; i++) {
+        var row = columnRows[i];
+        var type = encoder.parseFqTypeName(row['validator']);
+        c = {
+          name: row['column_name'],
+          type: type
+        };
+        tableInfo.columns.push(c);
+        columnsKeyed[c.name] = c;
+        switch (row['type']) {
+          case 'partition_key':
+            partitionKeys.push({c: c, index: (row['component_index'] || 0)});
+            break;
+          case 'clustering_key':
+            clusteringKeys.push({
+              c: c,
+              index: (row['component_index'] || 0),
+              order: c.type.options.reversed ? 'DESC' : 'ASC'
+            });
+            break;
+        }
+      }
+    })();
+    if (partitionKeys.length > 0) {
+      tableInfo.partitionKeys = partitionKeys.sort(utils.propCompare('index')).map(function (item) {
+        return item.c;
+      });
+      clusteringKeys.sort(utils.propCompare('index'));
+      tableInfo.clusteringKeys = clusteringKeys.map(function (item) {
+        return item.c;
+      });
+      tableInfo.clusteringOrder = clusteringKeys.map(function (item) {
+        return item.order;
+      });
+    }
+    //In C* 1.2, keys are not stored on the schema_columns table
+    var keysStoredInTableRow = (tableInfo.partitionKeys.length === 0);
+    if (keysStoredInTableRow && tableRow['key_aliases']) {
+      //In C* 1.2, keys are not stored on the schema_columns table
+      partitionKeys = JSON.parse(tableRow['key_aliases']);
+      types = encoder.parseKeyTypes(tableRow['key_validator']).types;
+      for (i = 0; i < partitionKeys.length; i++) {
+        name = partitionKeys[i];
+        c = columnsKeyed[name];
+        if (!c) {
+          c = {
+            name: name,
+            type: types[i]
+          };
+          tableInfo.columns.push(c);
+        }
+        tableInfo.partitionKeys.push(c);
+      }
+    }
+    var comparator = encoder.parseKeyTypes(tableRow['comparator']);
+    if (keysStoredInTableRow && tableRow['column_aliases']) {
+      clusteringKeys = JSON.parse(tableRow['column_aliases']);
+      for (i = 0; i < clusteringKeys.length; i++) {
+        name = clusteringKeys[i];
+        c = columnsKeyed[name];
+        if (!c) {
+          c = {
+            name: name,
+            type: comparator.types[i]
+          };
+          tableInfo.columns.push(c);
+        }
+        tableInfo.clusteringKeys.push(c);
+        tableInfo.clusteringOrder.push(c.type.options.reversed ? 'DESC' : 'ASC');
+      }
+    }
+    tableInfo.isCompact = !!tableRow['is_dense'];
+    if (!tableInfo.isCompact) {
+      //is_dense column does not exist in previous versions of Cassandra
+      //also, compact pk, ck and val appear as is_dense false
+      // clusteringKeys != comparator types - 1
+      // or not composite (comparator)
+      tableInfo.isCompact = (
+        //clustering keys are not marked as composite
+        !comparator.isComposite ||
+          //only 1 column not part of the partition or clustering keys
+        (!comparator.hasCollections && tableInfo.clusteringKeys.length !== comparator.types.length - 1)
+      );
+    }
+    name = tableRow['value_alias'];
+    if (tableInfo.isCompact && name && !columnsKeyed[name]) {
+      //additional column in C* 1.2 as value_alias
       c = {
-        name: row['column_name'],
-        type: type
+        name: name,
+        type: encoder.parseFqTypeName(tableRow['default_validator'])
       };
       tableInfo.columns.push(c);
-      columnsKeyed[c.name] = c;
-      switch (row['type']) {
-        case 'partition_key':
-          partitionKeys.push({ c: c, index: (row['component_index'] || 0)});
-          break;
-        case 'clustering_key':
-          clusteringKeys.push({ c: c, index: (row['component_index'] || 0), order: c.type.options.reversed ? 'DESC' : 'ASC'});
-          break;
-      }
+      columnsKeyed[name] = c;
     }
-  })();
-  if (partitionKeys.length > 0) {
-    tableInfo.partitionKeys = partitionKeys.sort(utils.propCompare('index')).map(function (item) {
-      return item.c;
-    });
-    clusteringKeys.sort(utils.propCompare('index'));
-    tableInfo.clusteringKeys = clusteringKeys.map(function (item) {
-      return item.c;
-    });
-    tableInfo.clusteringOrder = clusteringKeys.map(function (item) {
-      return item.order;
-    });
+    tableInfo.columnsByName = columnsKeyed;
+    tableInfo.indexes = Index.fromColumnRows(columnRows, tableInfo.columnsByName);
   }
-  //In C* 1.2, keys are not stored on the schema_columns table
-  var keysStoredInTableRow = (tableInfo.partitionKeys.length === 0);
-  if (keysStoredInTableRow && tableRow['key_aliases']) {
-    //In C* 1.2, keys are not stored on the schema_columns table
-    partitionKeys = JSON.parse(tableRow['key_aliases']);
-    types = encoder.parseKeyTypes(tableRow['key_validator']).types;
-    for (i = 0; i < partitionKeys.length; i++) {
-      name = partitionKeys[i];
-      c = columnsKeyed[name];
-      if (!c) {
-        c = {
-          name: name,
-          type: types[i]
-        };
-        tableInfo.columns.push(c);
-      }
-      tableInfo.partitionKeys.push(c);
-    }
+  catch (err) {
+    return callback(err);
   }
-  var comparator = encoder.parseKeyTypes(tableRow['comparator']);
-  if (keysStoredInTableRow && tableRow['column_aliases']) {
-    clusteringKeys = JSON.parse(tableRow['column_aliases']);
-    for (i = 0; i < clusteringKeys.length; i++) {
-      name = clusteringKeys[i];
-      c = columnsKeyed[name];
-      if (!c) {
-        c = {
-          name: name,
-          type: comparator.types[i]
-        };
-        tableInfo.columns.push(c);
-      }
-      tableInfo.clusteringKeys.push(c);
-      tableInfo.clusteringOrder.push(c.type.options.reversed ? 'DESC' : 'ASC');
-    }
-  }
-  tableInfo.isCompact = !!tableRow['is_dense'];
-  if (!tableInfo.isCompact) {
-    //is_dense column does not exist in previous versions of Cassandra
-    //also, compact pk, ck and val appear as is_dense false
-    // clusteringKeys != comparator types - 1
-    // or not composite (comparator)
-    tableInfo.isCompact = (
-      //clustering keys are not marked as composite
-      !comparator.isComposite ||
-      //only 1 column not part of the partition or clustering keys
-      (!comparator.hasCollections && tableInfo.clusteringKeys.length !== comparator.types.length - 1)
-    );
-  }
-  name = tableRow['value_alias'];
-  if (tableInfo.isCompact && name && !columnsKeyed[name]) {
-    //additional column in C* 1.2 as value_alias
-    c = {
-      name: name,
-      type: encoder.parseTypeName(tableRow['default_validator'])
-    };
-    tableInfo.columns.push(c);
-    columnsKeyed[name] = c;
-  }
-  tableInfo.columnsByName = columnsKeyed;
-  tableInfo.indexes = Index.fromColumnRows(columnRows, tableInfo.columnsByName);
-  return tableInfo;
+  //All the tableInfo parsing in V1 is sync, it uses a callback because the super defines one
+  //to support other versions.
+  callback();
 };
 
 /** @override */
@@ -512,11 +508,86 @@ SchemaParserV1.prototype.getMaterializedView = function (cc, keyspace, name, cal
   callback(new errors.NotSupportedError('Materialized views are not supported on Cassandra versions below 3.0'));
 };
 
+/** @override */
+SchemaParserV1.prototype._parseAggregate = function (row, callback) {
+  var encoder = this.cc.getEncoder();
+  var aggregate = new Aggregate();
+  aggregate.name = row['aggregate_name'];
+  aggregate.keyspaceName = row['keyspace_name'];
+  aggregate.signature = row['signature'] || utils.emptyArray;
+  aggregate.stateFunction = row['state_func'];
+  aggregate.finalFunction = row['final_func'];
+  aggregate.initConditionRaw = row['initcond'];
+  try {
+    aggregate.argumentTypes = (row['argument_types'] || utils.emptyArray).map(function (name) {
+      return encoder.parseFqTypeName(name);
+    });
+    aggregate.stateType = encoder.parseFqTypeName(row['state_type']);
+    var initConditionValue = encoder.decode(aggregate.initConditionRaw, aggregate.stateType);
+    if (initConditionValue !== null && typeof initConditionValue !== 'undefined') {
+      aggregate.initCondition = initConditionValue.toString();
+    }
+    aggregate.returnType = encoder.parseFqTypeName(row['return_type']);
+  }
+  catch (err) {
+    return callback(err);
+  }
+  callback(null, aggregate);
+};
+
+/** @override */
+SchemaParserV1.prototype._parseFunction = function (row, callback) {
+  var encoder = this.cc.getEncoder();
+  var func = new SchemaFunction();
+  func.name = row['function_name'];
+  func.keyspaceName = row['keyspace_name'];
+  func.signature = row['signature'] || utils.emptyArray;
+  func.argumentNames = row['argument_names'] || utils.emptyArray;
+  func.body = row['body'];
+  func.calledOnNullInput = row['called_on_null_input'];
+  func.language = row['language'];
+  try {
+    func.argumentTypes = (row['argument_types'] || utils.emptyArray).map(function (name) {
+      return encoder.parseFqTypeName(name);
+    });
+    func.returnType = encoder.parseFqTypeName(row['return_type']);
+  }
+  catch (err) {
+    return callback(err);
+  }
+  callback(null, func);
+};
+
+/** @override */
+SchemaParserV1.prototype._parseUdt = function (udtInfo, row, callback) {
+  var encoder = this.cc.getEncoder();
+  var fieldNames = row['field_names'];
+  var fieldTypes = row['field_types'];
+  var fields = new Array(fieldNames.length);
+  try {
+    for (var i = 0; i < fieldNames.length; i++) {
+      fields[i] = {
+        name: fieldNames[i],
+        type: encoder.parseFqTypeName(fieldTypes[i])
+      };
+    }
+  }
+  catch (err) {
+    return callback(err);
+  }
+  udtInfo.fields = fields;
+  callback(null, udtInfo);
+};
+
 /**
  * Used to parse schema information for Cassandra versions 3.x and above
+ * @param {ControlConnection} cc The control connection to be used
+ * @param {Function} udtResolver The function to be used to retrieve the udts.
  * @constructor
  */
-function SchemaParserV2() {
+function SchemaParserV2(cc, udtResolver) {
+  SchemaParser.call(this, cc);
+  this.udtResolver = udtResolver;
   this.selectTable = _selectTableV2;
   this.selectColumns = _selectColumnsV2;
   this.selectUdt = _selectUdtV2;
@@ -528,10 +599,10 @@ function SchemaParserV2() {
 util.inherits(SchemaParserV2, SchemaParser);
 
 /** @override */
-SchemaParserV2.prototype.getKeyspaces = function (cc, callback) {
+SchemaParserV2.prototype.getKeyspaces = function (callback) {
   var self = this;
   var keyspaces = {};
-  cc.query(_selectAllKeyspacesV2, function (err, result) {
+  this.cc.query(_selectAllKeyspacesV2, function (err, result) {
     if (err) return callback(err);
     for (var i = 0; i < result.rows.length; i++) {
       var ksInfo = self._parseKeyspace(result.rows[i]);
@@ -542,9 +613,9 @@ SchemaParserV2.prototype.getKeyspaces = function (cc, callback) {
 };
 
 /** @override */
-SchemaParserV2.prototype.getKeyspace = function (cc, name, callback) {
+SchemaParserV2.prototype.getKeyspace = function (name, callback) {
   var self = this;
-  cc.query(util.format(_selectSingleKeyspaceV2, name), function (err, result) {
+  this.cc.query(util.format(_selectSingleKeyspaceV2, name), function (err, result) {
     if (err) {
       return callback(err);
     }
@@ -594,13 +665,11 @@ SchemaParserV2.prototype.getMaterializedView = function (cc, keyspace, name, cal
     if (err || !tableRow) {
       return viewInfo.emit('load', err, null);
     }
-    try {
-      self._parseTableOrView(viewInfo, cc.getEncoder(), tableRow, columnRows);
-    }
-    catch (parseError) {
-      err = parseError;
-    }
-    viewInfo.emit('load', err, viewInfo);
+    self._parseTableOrView(viewInfo, tableRow, columnRows, null, function (err) {
+      viewInfo.loading = false;
+      viewInfo.loaded = !err;
+      viewInfo.emit('load', err, viewInfo);
+    });
   });
 
 };
@@ -627,13 +696,12 @@ SchemaParserV2.prototype._parseKeyspace = function (row) {
 };
 
 /** @override */
-SchemaParserV2.prototype._parseTableOrView = function (tableInfo, encoder, tableRow, columnRows, indexRows) {
-  var i, c;
+SchemaParserV2.prototype._parseTableOrView = function (tableInfo, tableRow, columnRows, indexRows, callback) {
+  var encoder = this.cc.getEncoder();
   var columnsKeyed = {};
   var partitionKeys = [];
   var clusteringKeys = [];
   var isView = tableInfo instanceof MaterializedView;
-  tableInfo.loaded = true;
   tableInfo.bloomFilterFalsePositiveChance = tableRow['bloom_filter_fp_chance'];
   tableInfo.caching = JSON.stringify(tableRow['caching']);
   tableInfo.comment = tableRow['comment'];
@@ -659,20 +727,17 @@ SchemaParserV2.prototype._parseTableOrView = function (tableInfo, encoder, table
   tableInfo.speculativeRetry = tableRow['speculative_retry'] || tableInfo.speculativeRetry;
   tableInfo.minIndexInterval = tableRow['min_index_interval'] || tableInfo.minIndexInterval;
   tableInfo.maxIndexInterval = tableRow['max_index_interval'] || tableInfo.maxIndexInterval;
-
-  (function parseColumns() {
-    //function context
-    var row;
-    var type;
-    for (i = 0; i < columnRows.length; i++) {
-      row = columnRows[i];
-      type = encoder.parseTypeName(row['type']);
-      c = {
+  var self = this;
+  async.map(columnRows, function (row, next) {
+    encoder.parseTypeName(tableRow['keyspace_name'], row['type'], 0, null, self.udtResolver, function (err, type) {
+      if (err) {
+        return next(err);
+      }
+      var c = {
         name: row['column_name'],
         type: type,
         isStatic: false
       };
-      tableInfo.columns.push(c);
       columnsKeyed[c.name] = c;
       switch (row['kind']) {
         case 'partition_key':
@@ -685,9 +750,14 @@ SchemaParserV2.prototype._parseTableOrView = function (tableInfo, encoder, table
           c.isStatic = true;
           break;
       }
+      next(null, c);
+    });
+  }, function (err, columns) {
+    if (err) {
+      return callback(err);
     }
-  })();
-  if (partitionKeys.length > 0) {
+    tableInfo.columns = columns;
+    tableInfo.columnsByName = columnsKeyed;
     tableInfo.partitionKeys = partitionKeys.sort(utils.propCompare('index')).map(function (item) {
       return item.c;
     });
@@ -698,29 +768,131 @@ SchemaParserV2.prototype._parseTableOrView = function (tableInfo, encoder, table
     tableInfo.clusteringOrder = clusteringKeys.map(function (item) {
       return item.order;
     });
-  }
-  tableInfo.columnsByName = columnsKeyed;
-  if (isView) {
-    tableInfo.tableName = tableRow['base_table_name'];
-    tableInfo.whereClause = tableRow['where_clause'];
-    tableInfo.includeAllColumns = tableRow['include_all_columns'];
-    return tableInfo;
-  }
-  tableInfo.indexes = Index.fromRows(indexRows);
-  var flags = tableRow['flags'];
-  var isDense = flags.indexOf('dense') >= 0;
-  var isSuper = flags.indexOf('super') >= 0;
-  var isCompound = flags.indexOf('compound') >= 0;
-  tableInfo.isCompact = isSuper || isDense || !isCompound;
-  //remove the columns related to Thrift
-  var isStaticCompact = !isSuper && !isDense && !isCompound;
-  if(isStaticCompact) {
-    pruneStaticCompactTableColumns(tableInfo);
-  }
-  else if (isDense) {
-    pruneDenseTableColumns(tableInfo)
-  }
-  return tableInfo;
+    if (isView) {
+      tableInfo.tableName = tableRow['base_table_name'];
+      tableInfo.whereClause = tableRow['where_clause'];
+      tableInfo.includeAllColumns = tableRow['include_all_columns'];
+      return callback();
+    }
+    tableInfo.indexes = Index.fromRows(indexRows);
+    var flags = tableRow['flags'];
+    var isDense = flags.indexOf('dense') >= 0;
+    var isSuper = flags.indexOf('super') >= 0;
+    var isCompound = flags.indexOf('compound') >= 0;
+    tableInfo.isCompact = isSuper || isDense || !isCompound;
+    //remove the columns related to Thrift
+    var isStaticCompact = !isSuper && !isDense && !isCompound;
+    if(isStaticCompact) {
+      pruneStaticCompactTableColumns(tableInfo);
+    }
+    else if (isDense) {
+      pruneDenseTableColumns(tableInfo)
+    }
+    callback();
+  });
+};
+
+/** @override */
+SchemaParserV2.prototype._parseAggregate = function (row, callback) {
+  var encoder = this.cc.getEncoder();
+  var aggregate = new Aggregate();
+  aggregate.name = row['aggregate_name'];
+  aggregate.keyspaceName = row['keyspace_name'];
+  aggregate.signature = row['argument_types'] || utils.emptyArray;
+  aggregate.stateFunction = row['state_func'];
+  aggregate.finalFunction = row['final_func'];
+  aggregate.initConditionRaw = row['initcond'];
+  aggregate.initCondition = aggregate.initConditionRaw;
+  var self = this;
+  async.series([
+    function parseArguments(next) {
+      async.map(row['argument_types'] || utils.emptyArray, function (name, mapNext) {
+        encoder.parseTypeName(row['keyspace_name'], name, 0, null, self.udtResolver, mapNext);
+      }, function (err, result) {
+        aggregate.argumentTypes = result;
+        next(err);
+      });
+    },
+    function parseStateType(next) {
+      encoder.parseTypeName(row['keyspace_name'], row['state_type'], 0, null, self.udtResolver, function (err, type) {
+        aggregate.stateType = type;
+        next(err);
+      });
+    },
+    function parseReturnType(next) {
+      encoder.parseTypeName(row['keyspace_name'], row['return_type'], 0, null, self.udtResolver, function (err, type) {
+        aggregate.returnType = type;
+        next(err);
+      });
+    }
+  ], function (err) {
+    if (err) {
+      return callback(err);
+    }
+    callback(null, aggregate);
+  });
+};
+
+/** @override */
+SchemaParserV2.prototype._parseFunction = function (row, callback) {
+  var encoder = this.cc.getEncoder();
+  var func = new SchemaFunction();
+  func.name = row['function_name'];
+  func.keyspaceName = row['keyspace_name'];
+  func.signature = row['argument_types'] || utils.emptyArray;
+  func.argumentNames = row['argument_names'] || utils.emptyArray;
+  func.body = row['body'];
+  func.calledOnNullInput = row['called_on_null_input'];
+  func.language = row['language'];
+  var self = this;
+  async.series([
+    function parseArguments(next) {
+      async.map(row['argument_types'] || utils.emptyArray, function (name, mapNext) {
+        encoder.parseTypeName(row['keyspace_name'], name, 0, null, self.udtResolver, mapNext);
+      }, function (err, result) {
+        func.argumentTypes = result;
+        next(err);
+      });
+    },
+    function parseReturnType(next) {
+      encoder.parseTypeName(row['keyspace_name'], row['return_type'], 0, null, self.udtResolver, function (err, type) {
+        func.returnType = type;
+        next(err);
+      });
+    }
+  ], function (err) {
+    if (err) {
+      return callback(err);
+    }
+    callback(null, func);
+  });
+};
+
+/** @override */
+SchemaParserV2.prototype._parseUdt = function (udtInfo, row, callback) {
+  var encoder = this.cc.getEncoder();
+  var fieldTypes = row['field_types'];
+  var keyspace = row['keyspace_name'];
+  var fields = new Array(fieldTypes.length);
+  var self = this;
+  async.forEachOf(row['field_names'], function (name, i, next) {
+    encoder.parseTypeName(keyspace, fieldTypes[i], 0, null, self.udtResolver, function (err, type) {
+      if (err) {
+        return next(err);
+      }
+      fields[i] = {
+        name: name,
+        type: type
+      };
+      next();
+    });
+  }, function (err) {
+    if (err) {
+      return callback(err);
+    }
+    udtInfo.fields = fields;
+    callback(null, udtInfo);
+  });
 };
 
 /**
@@ -892,18 +1064,24 @@ function getTokenToReplicaNetworkMapper(replicationFactors) {
   });
 }
 
-//singletons
-var schemaParserV1Instance = new SchemaParserV1();
-var schemaParserV2Instance = new SchemaParserV2();
 /**
- * @param {Array.<Number>} version
+ * Creates a new instance if the currentInstance is not valid for the
+ * provided Cassandra version
+ * @param {ControlConnection} cc The control connection to be used
+ * @param {Function} udtResolver The function to be used to retrieve the udts.
+ * @param {Array.<Number>} [version] The cassandra version
+ * @param {SchemaParser} [currentInstance] The current instance
  * @returns {SchemaParser}
  */
-function getByVersion(version) {
-  if (version[0] >= 3) {
-    return schemaParserV2Instance;
+function getByVersion(cc, udtResolver, version, currentInstance) {
+  var parserConstructor = SchemaParserV1;
+  if (version && version[0] >= 3) {
+    parserConstructor = SchemaParserV2;
   }
-  return schemaParserV1Instance;
+  if (!currentInstance || !(currentInstance instanceof parserConstructor)){
+    return new parserConstructor(cc, udtResolver);
+  }
+  return currentInstance;
 }
 
 exports.getByVersion = getByVersion;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     }
   ],
   "dependencies": {
-    "async": "^0.9.0",
+    "async": "^1.5.0",
     "long": "^2.2.0"
   },
   "devDependencies": {

--- a/test/integration/short/metadata-tests.js
+++ b/test/integration/short/metadata-tests.js
@@ -112,9 +112,9 @@ describe('Metadata', function () {
             assert.ok(udtInfo.fields);
             assert.strictEqual(udtInfo.fields.length, 3);
             assert.strictEqual(udtInfo.fields[0].name, 'alias');
-            assert.strictEqual(udtInfo.fields[0].type.code, types.dataTypes.varchar);
+            assert.ok(udtInfo.fields[0].type.code === types.dataTypes.varchar || udtInfo.fields[0].type.code === types.dataTypes.text);
             assert.strictEqual(udtInfo.fields[1].name, 'number');
-            assert.strictEqual(udtInfo.fields[1].type.code, types.dataTypes.varchar);
+            assert.ok(udtInfo.fields[1].type.code === types.dataTypes.varchar || udtInfo.fields[1].type.code === types.dataTypes.text);
             assert.strictEqual(udtInfo.fields[2].name, 'country_code');
             assert.strictEqual(udtInfo.fields[2].type.code, types.dataTypes.int);
             next();
@@ -128,7 +128,7 @@ describe('Metadata', function () {
             assert.strictEqual(udtInfo.name, 'address');
             assert.strictEqual(udtInfo.fields.length, 3);
             assert.strictEqual(udtInfo.fields[0].name, 'street');
-            assert.strictEqual(udtInfo.fields[0].type.code, types.dataTypes.varchar);
+            assert.ok(udtInfo.fields[0].type.code === types.dataTypes.varchar || udtInfo.fields[0].type.code === types.dataTypes.text);
             assert.strictEqual(udtInfo.fields[1].name, 'ZIP');
             assert.strictEqual(udtInfo.fields[1].type.code, types.dataTypes.int);
             assert.strictEqual(udtInfo.fields[2].name, 'phones');

--- a/test/integration/short/udf-tests.js
+++ b/test/integration/short/udf-tests.js
@@ -260,7 +260,7 @@ vdescribe('2.2', 'Metadata', function () {
             assert.strictEqual(aggregate.argumentTypes[0].code, types.dataTypes.int);
             assert.strictEqual(aggregate.returnType.code, types.dataTypes.int);
             assert.strictEqual(aggregate.stateFunction, 'plus');
-            assert.strictEqual(aggregate.initCondition, 1);
+            assert.strictEqual(aggregate.initCondition, '1');
             next();
           });
         },
@@ -319,7 +319,7 @@ vdescribe('2.2', 'Metadata', function () {
             assert.ifError(err);
             assert.ok(func);
             assert.strictEqual(func.name, 'sum2');
-            assert.strictEqual(func.initCondition, 0);
+            assert.strictEqual(func.initCondition, '0');
             next();
           });
         },
@@ -333,7 +333,7 @@ vdescribe('2.2', 'Metadata', function () {
             assert.ok(func);
             assert.strictEqual(func.name, 'sum2');
             //changed
-            assert.strictEqual(func.initCondition, 200);
+            assert.strictEqual(func.initCondition, '200');
             next();
           });
         },

--- a/test/unit/encoder-tests.js
+++ b/test/unit/encoder-tests.js
@@ -940,6 +940,27 @@ describe('encoder', function () {
         });
       }, done);
     });
+    it('should parse nested subtypes', function (done) {
+      var encoder = new Encoder(4, {});
+      async.series([
+        function (next) {
+          var name = 'map<text,frozen<list<frozen<map<text,frozen<list<int>>>>>>>';
+          encoder.parseTypeName('ks1', name, 0, null, throwIfCalled, function (err, type) {
+            assert.ifError(err);
+            assert.ok(type);
+            assert.strictEqual(type.code, dataTypes.map);
+            assert.strictEqual(type.info[0].code, dataTypes.text);
+            assert.strictEqual(type.info[1].code, dataTypes.list);
+            var subType1 = type.info[1];
+            assert.strictEqual(subType1.info.code, dataTypes.map);
+            var subType2 = subType1.info.info[1];
+            assert.strictEqual(subType2.code, dataTypes.list);
+            assert.strictEqual(subType2.info.code, dataTypes.int);
+            next();
+          });
+        }
+      ], done);
+    });
   });
   describe('#parseKeyTypes', function () {
     var encoder = new Encoder(1, {});

--- a/test/unit/encoder-tests.js
+++ b/test/unit/encoder-tests.js
@@ -743,66 +743,66 @@ describe('encoder', function () {
       }, TypeError);
     });
   });
-  describe('#parseTypeName()', function () {
+  describe('#parseFqTypeName()', function () {
     it('should parse single type names', function () {
       var encoder = new Encoder(2, {});
-      var type = encoder.parseTypeName('org.apache.cassandra.db.marshal.Int32Type');
+      var type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.Int32Type');
       assert.strictEqual(dataTypes.int, type.code);
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.UUIDType');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.UUIDType');
       assert.strictEqual(dataTypes.uuid, type.code);
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.UTF8Type');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.UTF8Type');
       assert.strictEqual(dataTypes.varchar, type.code);
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.BytesType');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.BytesType');
       assert.strictEqual(dataTypes.blob, type.code);
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.FloatType');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.FloatType');
       assert.strictEqual(dataTypes.float, type.code);
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.DoubleType');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.DoubleType');
       assert.strictEqual(dataTypes.double, type.code);
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.BooleanType');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.BooleanType');
       assert.strictEqual(dataTypes.boolean, type.code);
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.InetAddressType');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.InetAddressType');
       assert.strictEqual(dataTypes.inet, type.code);
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.DateType');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.DateType');
       assert.strictEqual(dataTypes.timestamp, type.code);
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.TimestampType');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.TimestampType');
       assert.strictEqual(dataTypes.timestamp, type.code);
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.LongType');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.LongType');
       assert.strictEqual(dataTypes.bigint, type.code);
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.DecimalType');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.DecimalType');
       assert.strictEqual(dataTypes.decimal, type.code);
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.IntegerType');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.IntegerType');
       assert.strictEqual(dataTypes.varint, type.code);
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.CounterColumnType');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.CounterColumnType');
       assert.strictEqual(dataTypes.counter, type.code);
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.TimeUUIDType');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.TimeUUIDType');
       assert.strictEqual(dataTypes.timeuuid, type.code);
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.AsciiType');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.AsciiType');
       assert.strictEqual(dataTypes.ascii, type.code);
     });
     it('should parse complex type names', function () {
       var encoder = new Encoder(2, {});
-      var type = encoder.parseTypeName('org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)');
+      var type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)');
       assert.strictEqual(dataTypes.list, type.code);
       assert.ok(type.info);
       assert.strictEqual(dataTypes.int, type.info.code);
 
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UUIDType)');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.UUIDType)');
       assert.strictEqual(dataTypes.set, type.code);
       assert.ok(type.info);
       assert.strictEqual(dataTypes.uuid, type.info.code);
 
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.TimeUUIDType)');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.SetType(org.apache.cassandra.db.marshal.TimeUUIDType)');
       assert.strictEqual(dataTypes.set, type.code);
       assert.ok(type.info);
       assert.strictEqual(dataTypes.timeuuid, type.info.code);
 
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.LongType)');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.LongType)');
       assert.strictEqual(dataTypes.map, type.code);
       assert.ok(util.isArray(type.info));
       assert.strictEqual(dataTypes.varchar, type.info[0].code);
       assert.strictEqual(dataTypes.bigint, type.info[1].code);
 
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.Int32Type)');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.TupleType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.Int32Type)');
       assert.strictEqual(dataTypes.tuple, type.code);
       assert.ok(util.isArray(type.info));
       assert.strictEqual(dataTypes.varchar, type.info[0].code);
@@ -810,12 +810,12 @@ describe('encoder', function () {
     });
     it('should parse frozen types', function () {
       var encoder = new Encoder(2, {});
-      var type = encoder.parseTypeName('org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.TimeUUIDType))');
+      var type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.TimeUUIDType))');
       assert.strictEqual(dataTypes.list, type.code);
       assert.ok(type.info);
       assert.strictEqual(dataTypes.timeuuid, type.info.code);
 
-      type = encoder.parseTypeName('org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)))');
+      type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)))');
       assert.strictEqual(dataTypes.map, type.code);
       assert.ok(util.isArray(type.info));
       assert.strictEqual(dataTypes.varchar, type.info[0].code);
@@ -830,7 +830,7 @@ describe('encoder', function () {
         'org.apache.cassandra.db.marshal.UserType(' +
         'tester,70686f6e65,616c696173:org.apache.cassandra.db.marshal.UTF8Type,6e756d626572:org.apache.cassandra.db.marshal.UTF8Type' +
         ')';
-      var dataType = encoder.parseTypeName(typeText);
+      var dataType = encoder.parseFqTypeName(typeText);
       assert.strictEqual(dataTypes.udt, dataType.code);
       //Udt name
       assert.ok(dataType.info);
@@ -856,7 +856,7 @@ describe('encoder', function () {
         '616c696173:org.apache.cassandra.db.marshal.UTF8Type,' +
         '6e756d626572:org.apache.cassandra.db.marshal.UTF8Type))' +
         ')';
-      var dataType = encoder.parseTypeName(typeText);
+      var dataType = encoder.parseFqTypeName(typeText);
       assert.strictEqual(dataTypes.udt, dataType.code);
       assert.strictEqual('address', dataType.info.name);
       assert.strictEqual('tester', dataType.info.keyspace);
@@ -875,6 +875,70 @@ describe('encoder', function () {
       assert.strictEqual(2, phonesSubType.info.fields.length);
       assert.strictEqual('alias', phonesSubType.info.fields[0].name);
       assert.strictEqual('number', phonesSubType.info.fields[1].name);
+    });
+  });
+  describe('#parseTypeName()', function () {
+    function throwIfCalled() {
+      throw new Error('This function should not be called');
+    }
+    it('should parse single type names', function (done) {
+      var encoder = new Encoder(4, {});
+      var items = [
+        ['int',        dataTypes.int],
+        ['uuid',       dataTypes.uuid],
+        ['text',       dataTypes.text],
+        ['varchar',    dataTypes.varchar],
+        ['blob',       dataTypes.blob],
+        ['float',      dataTypes.float],
+        ['double',     dataTypes.double],
+        ['boolean',    dataTypes.boolean],
+        ['inet',       dataTypes.inet],
+        ['timestamp',  dataTypes.timestamp],
+        ['bigint',     dataTypes.bigint],
+        ['decimal',    dataTypes.decimal],
+        ['varint',     dataTypes.varint],
+        ['counter',    dataTypes.counter],
+        ['timeuuid',   dataTypes.timeuuid],
+        ['ascii',      dataTypes.ascii]
+      ];
+      async.eachSeries(items, function eachCb(item, next) {
+        encoder.parseTypeName('ks1', item[0], 0, null, throwIfCalled, function (err, dataType) {
+          assert.ifError(err);
+          assert.ok(dataType);
+          assert.strictEqual(dataType.code, item[1]);
+          next();
+        });
+      }, done);
+    });
+    it('should parse complex type names', function (done) {
+      var encoder = new Encoder(4, {});
+      var items = [
+        ['list<int>', dataTypes.list, dataTypes.int],
+        ['set<uuid>', dataTypes.set, dataTypes.uuid],
+        ['set<timeuuid>', dataTypes.set, dataTypes.timeuuid],
+        ['map<varchar,bigint>', dataTypes.map, [dataTypes.varchar, dataTypes.bigint]],
+        ['tuple<varchar,int>', dataTypes.tuple, [dataTypes.varchar, dataTypes.int]],
+        ['frozen<list<timeuuid>>', dataTypes.list, dataTypes.timeuuid],
+        ['map<text,frozen<list<int>>>', dataTypes.map, [dataTypes.text, dataTypes.list]]
+      ];
+      async.eachSeries(items, function eachCb(item, next) {
+        encoder.parseTypeName('ks1', item[0], 0, null, throwIfCalled, function (err, dataType) {
+          assert.ifError(err);
+          assert.ok(dataType);
+          assert.strictEqual(dataType.code, item[1]);
+          assert.notEqual(dataType.info, null);
+          if (util.isArray(item[2])) {
+            assert.strictEqual(dataType.info.length, item[2].length);
+            dataType.info.forEach(function (childType, i) {
+              assert.strictEqual(childType.code, item[2][i]);
+            });
+          }
+          else {
+            assert.strictEqual(dataType.info.code, item[2]);
+          }
+          next();
+        });
+      }, done);
     });
   });
   describe('#parseKeyTypes', function () {

--- a/test/unit/metadata-tests.js
+++ b/test/unit/metadata-tests.js
@@ -12,6 +12,7 @@ var TableMetadata = require('../../lib/metadata/table-metadata');
 var MaterializedView = require('../../lib/metadata/materialized-view');
 var tokenizer = require('../../lib/tokenizer');
 var types = require('../../lib/types');
+var dataTypes = types.dataTypes;
 var utils = require('../../lib/utils');
 var errors = require('../../lib/errors');
 var Encoder = require('../../lib/encoder');
@@ -812,7 +813,7 @@ describe('Metadata', function () {
           var tableRow = {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","bloom_filter_fp_chance":0.01,"caching":"{\"keys\":\"ALL\", \"rows_per_partition\":\"NONE\"}","cf_id":"609f53a0-038b-11e5-be48-0d419bfb85c8","column_aliases":"[]","comment":"","compaction_strategy_class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy","compaction_strategy_options":"{}","comparator":"org.apache.cassandra.db.marshal.UTF8Type","compression_parameters":"{\"sstable_compression\":\"org.apache.cassandra.io.compress.LZ4Compressor\"}","default_time_to_live":0,"default_validator":"org.apache.cassandra.db.marshal.BytesType","dropped_columns":null,"gc_grace_seconds":864000,"index_interval":null,"is_dense":false,"key_aliases":"[\"id\"]","key_validator":"org.apache.cassandra.db.marshal.UUIDType","local_read_repair_chance":0.1,"max_compaction_threshold":32,"max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_compaction_threshold":4,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99.0PERCENTILE","subcomparator":null,"type":"Standard","value_alias":null};
           var columnRows = [
             {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"id","component_index":null,"index_name":null,"index_options":"null","index_type":null,"type":"partition_key","validator":"org.apache.cassandra.db.marshal.UUIDType"},
-            {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"text1","component_index":null,"index_name":"custom_index","index_options":'{"foo":"bar", "class_name":"dummy.DummyIndex"}',"index_type":"CUSTOM","type":"regular","validator":"org.apache.cassandra.db.marshal.UTF8Type"},
+            {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"text1","component_index":null,"index_name":"custom_index","index_options":'{"foo":"bar", "class_name":"dummy.DummyIndex"}',"index_type":"CUSTOM","type":"regular","validator":"org.apache.cassandra.db.marshal.UTF8Type"}
           ];
           var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
           metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
@@ -838,7 +839,7 @@ describe('Metadata', function () {
         var tableRow = {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","bloom_filter_fp_chance":0.01,"caching":"{\"keys\":\"ALL\", \"rows_per_partition\":\"NONE\"}","cf_id":"609f53a0-038b-11e5-be48-0d419bfb85c8","column_aliases":"[]","comment":"","compaction_strategy_class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy","compaction_strategy_options":"{}","comparator":"org.apache.cassandra.db.marshal.UTF8Type","compression_parameters":"{\"sstable_compression\":\"org.apache.cassandra.io.compress.LZ4Compressor\"}","default_time_to_live":0,"default_validator":"org.apache.cassandra.db.marshal.BytesType","dropped_columns":null,"gc_grace_seconds":864000,"index_interval":null,"is_dense":false,"key_aliases":"[\"id\"]","key_validator":"org.apache.cassandra.db.marshal.UUIDType","local_read_repair_chance":0.1,"max_compaction_threshold":32,"max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_compaction_threshold":4,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99.0PERCENTILE","subcomparator":null,"type":"Standard","value_alias":null};
         var columnRows = [
           {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"id","component_index":null,"index_name":null,"index_options":"null","index_type":null,"type":"partition_key","validator":"org.apache.cassandra.db.marshal.UUIDType"},
-          {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"text1","component_index":null,"index_name":"custom_index","index_options":'{"index_keys": ""}',"index_type":"KEYS","type":"regular","validator":"org.apache.cassandra.db.marshal.UTF8Type"},
+          {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"text1","component_index":null,"index_name":"custom_index","index_options":'{"index_keys": ""}',"index_type":"KEYS","type":"regular","validator":"org.apache.cassandra.db.marshal.UTF8Type"}
         ];
         var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
@@ -867,7 +868,7 @@ describe('Metadata', function () {
         var tableRow = {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","bloom_filter_fp_chance":0.01,"caching":"{\"keys\":\"ALL\", \"rows_per_partition\":\"NONE\"}","cf_id":"609f53a0-038b-11e5-be48-0d419bfb85c8","column_aliases":"[]","comment":"","compaction_strategy_class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy","compaction_strategy_options":"{}","comparator":"org.apache.cassandra.db.marshal.UTF8Type","compression_parameters":"{\"sstable_compression\":\"org.apache.cassandra.io.compress.LZ4Compressor\"}","default_time_to_live":0,"default_validator":"org.apache.cassandra.db.marshal.BytesType","dropped_columns":null,"gc_grace_seconds":864000,"index_interval":null,"is_dense":false,"key_aliases":"[\"id\"]","key_validator":"org.apache.cassandra.db.marshal.UUIDType","local_read_repair_chance":0.1,"max_compaction_threshold":32,"max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_compaction_threshold":4,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99.0PERCENTILE","subcomparator":null,"type":"Standard","value_alias":null};
         var columnRows = [
           {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"id","component_index":null,"index_name":null,"index_options":"null","index_type":null,"type":"partition_key","validator":"org.apache.cassandra.db.marshal.UUIDType"},
-          {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"b@706172656e745f70617468","component_index":null,"index_name":"cfs_archive_parent_path","index_options":"\"null\"","index_type":"KEYS","type":"regular","validator":"org.apache.cassandra.db.marshal.UTF8Type"},
+          {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"b@706172656e745f70617468","component_index":null,"index_name":"cfs_archive_parent_path","index_options":"\"null\"","index_type":"KEYS","type":"regular","validator":"org.apache.cassandra.db.marshal.UTF8Type"}
         ];
         var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
@@ -1044,7 +1045,7 @@ describe('Metadata', function () {
       });
     });
     describe('with C*3.0+ metadata rows', function () {
-      it('should parse partition and clustering keys @debug', function (done) {
+      it('should parse partition and clustering keys', function (done) {
         var tableRow = {
           "keyspace_name":"ks_tbl_meta",
           "table_name":"tbl4",
@@ -1063,11 +1064,11 @@ describe('Metadata', function () {
           "crc_check_chance": 0.8,
           "memtable_flush_period_in_ms":0,"min_index_interval":64,"read_repair_chance":0,"speculative_retry":"99PERCENTILE"};
         var columnRows = [
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl4", "column_name": "apk2", "clustering_order": "none", "column_name_bytes": "0x61706b32", "kind": "partition_key", "position": 1, "type": "org.apache.cassandra.db.marshal.UTF8Type"},
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl4", "column_name": "pk1", "clustering_order": "none", "column_name_bytes": "0x706b31", "kind": "partition_key", "position": 0, "type": "org.apache.cassandra.db.marshal.UUIDType"},
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl4", "column_name": "val2", "clustering_order": "none", "column_name_bytes": "0x76616c32", "kind": "regular", "position": -1, "type": "org.apache.cassandra.db.marshal.BytesType"},
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl4", "column_name": "valz1", "clustering_order": "none", "column_name_bytes": "0x76616c7a31", "kind": "regular", "position": -1, "type": "org.apache.cassandra.db.marshal.Int32Type"},
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl4", "column_name": "zck", "clustering_order": "asc", "column_name_bytes": "0x7a636b", "kind": "clustering", "position": 0, "type": "org.apache.cassandra.db.marshal.TimeUUIDType"}
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl4", "column_name": "apk2", "clustering_order": "none", "column_name_bytes": "0x61706b32", "kind": "partition_key", "position": 1, "type": "text"},
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl4", "column_name": "pk1", "clustering_order": "none", "column_name_bytes": "0x706b31", "kind": "partition_key", "position": 0, "type": "uuid"},
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl4", "column_name": "val2", "clustering_order": "none", "column_name_bytes": "0x76616c32", "kind": "regular", "position": -1, "type": "blob"},
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl4", "column_name": "valz1", "clustering_order": "none", "column_name_bytes": "0x76616c7a31", "kind": "regular", "position": -1, "type": "int"},
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl4", "column_name": "zck", "clustering_order": "asc", "column_name_bytes": "0x7a636b", "kind": "clustering", "position": 0, "type": "timeuuid"}
         ];
         var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.setCassandraVersion([3, 0]);
@@ -1087,6 +1088,8 @@ describe('Metadata', function () {
           //not present, default
           assert.strictEqual(table.populateCacheOnFlush, false);
           assert.strictEqual(table.columns.length, 5);
+          assert.deepEqual(table.columns.map(function (x) { return x.type.code; }),
+            [dataTypes.text, dataTypes.uuid, dataTypes.blob, dataTypes.int, dataTypes.timeuuid]);
           assert.strictEqual(table.partitionKeys.length, 2);
           assert.strictEqual(table.partitionKeys[0].name, 'pk1');
           assert.strictEqual(table.partitionKeys[1].name, 'apk2');
@@ -1098,20 +1101,20 @@ describe('Metadata', function () {
       it('should parse with no clustering keys', function (done) {
         var tableRow = {"keyspace_name":"ks_tbl_meta","table_name":"tbl1","bloom_filter_fp_chance":0.01,"caching":{"keys":"ALL","rows_per_partition":"NONE"},"comment":"","compaction":{"min_threshold":"4","max_threshold":"32","class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy"},"compression":{"chunk_length_in_kb":"64","class":"org.apache.cassandra.io.compress.LZ4Compressor"},"dclocal_read_repair_chance":0.1,"default_time_to_live":0,"extensions":{},"flags":["compound"],"gc_grace_seconds":864000,"id":"7e0e8bf0-5862-11e5-84f8-c7d0c38d1d8d","max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99PERCENTILE"};
         var columnRows = [
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl1", "column_name": "id", "clustering_order": "none", "column_name_bytes": "0x6964", "kind": "partition_key", "position": -1, "type": "org.apache.cassandra.db.marshal.UUIDType"},
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl1", "column_name": "text_sample", "clustering_order": "none", "column_name_bytes": "0x746578745f73616d706c65", "kind": "regular", "position": -1, "type": "org.apache.cassandra.db.marshal.UTF8Type"}
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl1", "column_name": "id", "clustering_order": "none", "column_name_bytes": "0x6964", "kind": "partition_key", "position": -1, "type": "uuid"},
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl1", "column_name": "text_sample", "clustering_order": "none", "column_name_bytes": "0x746578745f73616d706c65", "kind": "regular", "position": -1, "type": "text"}
         ];
         var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.setCassandraVersion([3, 0]);
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
-          assert.ifError(err);
-          assert.ok(table);
-          assert.strictEqual(table.columns.length, 2);
-          assert.strictEqual(table.partitionKeys.length, 1);
-          assert.strictEqual(table.partitionKeys[0].name, 'id');
-          assert.strictEqual(table.partitionKeys[0].type.code, types.dataTypes.uuid);
-          assert.strictEqual(table.clusteringKeys.length, 0);
+            assert.ifError(err);
+            assert.ok(table);
+            assert.strictEqual(table.columns.length, 2);
+            assert.strictEqual(table.partitionKeys.length, 1);
+            assert.strictEqual(table.partitionKeys[0].name, 'id');
+            assert.strictEqual(table.partitionKeys[0].type.code, types.dataTypes.uuid);
+            assert.strictEqual(table.clusteringKeys.length, 0);
           done();
         });
       });
@@ -1121,9 +1124,9 @@ describe('Metadata', function () {
           "keyspace_name":"ks_tbl_meta","table_name":"tbl5","bloom_filter_fp_chance":0.01,"caching":{"keys":"ALL","rows_per_partition":"NONE"},"comment":"","compaction":{"min_threshold":"4","max_threshold":"32","class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy"},"compression":{"chunk_length_in_kb":"64","class":"org.apache.cassandra.io.compress.LZ4Compressor"},"dclocal_read_repair_chance":0.1,"default_time_to_live":0,"extensions":{},
           "flags":["dense"],"gc_grace_seconds":864000,"id":"80fd9590-5862-11e5-84f8-c7d0c38d1d8d","max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99PERCENTILE"};
         var columnRows = [
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "id1", "clustering_order": "none", "column_name_bytes": "0x696431", "kind": "partition_key", "position": -1, "type": "org.apache.cassandra.db.marshal.UUIDType"},
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "id2", "clustering_order": "asc", "column_name_bytes": "0x696432", "kind": "clustering", "position": 0, "type": "org.apache.cassandra.db.marshal.TimeUUIDType"},
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "text1", "clustering_order": "none", "column_name_bytes": "0x7465787431", "kind": "regular", "position": -1, "type": "org.apache.cassandra.db.marshal.UTF8Type"}
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "id1", "clustering_order": "none", "column_name_bytes": "0x696431", "kind": "partition_key", "position": -1, "type": "uuid"},
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "id2", "clustering_order": "asc", "column_name_bytes": "0x696432", "kind": "clustering", "position": 0, "type": "timeuuid"},
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "text1", "clustering_order": "none", "column_name_bytes": "0x7465787431", "kind": "regular", "position": -1, "type": "text"}
         ];
         var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.setCassandraVersion([3, 0]);
@@ -1146,9 +1149,9 @@ describe('Metadata', function () {
           "keyspace_name":"ks_tbl_meta","table_name":"tbl5","bloom_filter_fp_chance":0.01,"caching":{"keys":"ALL","rows_per_partition":"NONE"},"comment":"","compaction":{"min_threshold":"4","max_threshold":"32","class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy"},"compression":{"chunk_length_in_kb":"64","class":"org.apache.cassandra.io.compress.LZ4Compressor"},"dclocal_read_repair_chance":0.1,"default_time_to_live":0,"extensions":{},
           "flags":["dense"],"gc_grace_seconds":864000,"id":"80fd9590-5862-11e5-84f8-c7d0c38d1d8d","max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99PERCENTILE"};
         var columnRows = [
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "id1", "clustering_order": "none", "column_name_bytes": "0x696431", "kind": "partition_key", "position": -1, "type": "org.apache.cassandra.db.marshal.UUIDType"},
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "id2", "clustering_order": "asc", "column_name_bytes": "0x696432", "kind": "clustering", "position": 0, "type": "org.apache.cassandra.db.marshal.TimeUUIDType"},
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "text1", "clustering_order": "none", "column_name_bytes": "0x7465787431", "kind": "regular", "position": -1, "type": "org.apache.cassandra.db.marshal.UTF8Type"}
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "id1", "clustering_order": "none", "column_name_bytes": "0x696431", "kind": "partition_key", "position": -1, "type": "uuid"},
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "id2", "clustering_order": "asc", "column_name_bytes": "0x696432", "kind": "clustering", "position": 0, "type": "timeuuid"},
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "text1", "clustering_order": "none", "column_name_bytes": "0x7465787431", "kind": "regular", "position": -1, "type": "text"}
         ];
         var indexRows = [
           {"index_name": "custom_index", "kind": "CUSTOM", "options": {"foo":"bar","class_name":"dummy.DummyIndex","target":"a, b, keys(c)"}}
@@ -1180,11 +1183,11 @@ describe('Metadata', function () {
           "keyspace_name":"ks_tbl_meta","table_name":"tbl6","bloom_filter_fp_chance":0.01,"caching":{"keys":"ALL","rows_per_partition":"NONE"},"comment":"","compaction":{"min_threshold":"4","max_threshold":"32","class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy"},"compression":{"chunk_length_in_kb":"64","class":"org.apache.cassandra.io.compress.LZ4Compressor"},"dclocal_read_repair_chance":0.1,"default_time_to_live":0,"extensions":{},
           "flags":[],"gc_grace_seconds":864000,"id":"81a32460-5862-11e5-b0ce-c7d0c38d1d8d","max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99PERCENTILE"};
         var columnRows = [
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl6", "column_name": "column1", "clustering_order": "asc", "column_name_bytes": "0x636f6c756d6e31", "kind": "clustering", "position": 0, "type": "org.apache.cassandra.db.marshal.UTF8Type"},
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl6", "column_name": "id", "clustering_order": "none", "column_name_bytes": "0x6964", "kind": "partition_key", "position": -1, "type": "org.apache.cassandra.db.marshal.UUIDType"},
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl6", "column_name": "text1", "clustering_order": "none", "column_name_bytes": "0x7465787431", "kind": "static", "position": -1, "type": "org.apache.cassandra.db.marshal.UTF8Type"},
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl6", "column_name": "text2", "clustering_order": "none", "column_name_bytes": "0x7465787432", "kind": "static", "position": -1, "type": "org.apache.cassandra.db.marshal.UTF8Type"},
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl6", "column_name": "value", "clustering_order": "none", "column_name_bytes": "0x76616c7565", "kind": "regular", "position": -1, "type": "org.apache.cassandra.db.marshal.BytesType"}
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl6", "column_name": "column1", "clustering_order": "asc", "column_name_bytes": "0x636f6c756d6e31", "kind": "clustering", "position": 0, "type": "text"},
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl6", "column_name": "id", "clustering_order": "none", "column_name_bytes": "0x6964", "kind": "partition_key", "position": -1, "type": "uuid"},
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl6", "column_name": "text1", "clustering_order": "none", "column_name_bytes": "0x7465787431", "kind": "static", "position": -1, "type": "text"},
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl6", "column_name": "text2", "clustering_order": "none", "column_name_bytes": "0x7465787432", "kind": "static", "position": -1, "type": "text"},
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl6", "column_name": "value", "clustering_order": "none", "column_name_bytes": "0x76616c7565", "kind": "regular", "position": -1, "type": "blob"}
         ];
         var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.setCassandraVersion([3, 0]);
@@ -1206,10 +1209,10 @@ describe('Metadata', function () {
           "keyspace_name": "ks1", "table_name": "tbl10", "bloom_filter_fp_chance": 0.01, "caching": {"keys": "ALL", "rows_per_partition": "NONE"}, "comment": "", "compaction": {"min_threshold": "4", "max_threshold": "32", "class": "org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy"}, "compression": {"chunk_length_in_kb": "64", "class": "org.apache.cassandra.io.compress.LZ4Compressor"}, "dclocal_read_repair_chance": 0.1, "default_time_to_live": 0, "extensions": {},
           "flags": ["compound", "dense"], "gc_grace_seconds": 864000, "id": "b4d56ea0-5881-11e5-8326-c7d0c38d1d8d", "max_index_interval": 2048, "memtable_flush_period_in_ms": 0, "min_index_interval": 128, "read_repair_chance": 0.0, "speculative_retry": "99PERCENTILE"};
         var columnRows = [
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl10", "column_name": "id1", "clustering_order": "none", "column_name_bytes": "0x696431", "kind": "partition_key", "position": -1, "type": "org.apache.cassandra.db.marshal.UUIDType"},
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl10", "column_name": "id2", "clustering_order": "asc", "column_name_bytes": "0x696432", "kind": "clustering", "position": 0, "type": "org.apache.cassandra.db.marshal.TimeUUIDType"},
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl10", "column_name": "text1", "clustering_order": "asc", "column_name_bytes": "0x7465787431", "kind": "clustering", "position": 1, "type": "org.apache.cassandra.db.marshal.UTF8Type"},
-          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl10", "column_name": "value", "clustering_order": "none", "column_name_bytes": "0x76616c7565", "kind": "regular", "position": -1, "type": "org.apache.cassandra.db.marshal.EmptyType"}
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl10", "column_name": "id1", "clustering_order": "none", "column_name_bytes": "0x696431", "kind": "partition_key", "position": -1, "type": "uuid"},
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl10", "column_name": "id2", "clustering_order": "asc", "column_name_bytes": "0x696432", "kind": "clustering", "position": 0, "type": "timeuuid"},
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl10", "column_name": "text1", "clustering_order": "asc", "column_name_bytes": "0x7465787431", "kind": "clustering", "position": 1, "type": "text"},
+          {"keyspace_name": "ks_tbl_meta", "table_name": "tbl10", "column_name": "value", "clustering_order": "none", "column_name_bytes": "0x76616c7565", "kind": "regular", "position": -1, "type": "empty"}
         ];
         var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.setCassandraVersion([3, 0]);
@@ -1229,63 +1232,6 @@ describe('Metadata', function () {
     });
   });
   describe('#getFunctions()', function () {
-    it('should query once when called in parallel', function (done) {
-      var called = 0;
-      var rows = [
-        {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
-      ];
-      var cc = {
-        query: function (q, cb) {
-          called++;
-          setImmediate(function () {
-            cb(null, {rows: rows});
-          });
-        },
-        getEncoder: function () { return new Encoder(4, {}); }
-      };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
-      metadata.keyspaces['ks_udf'] = { functions: {}};
-      async.times(10, function (n, next) {
-        metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
-          assert.ifError(err);
-          assert.ok(funcArray);
-          next();
-        });
-      }, function (err) {
-        assert.ifError(err);
-        assert.strictEqual(called, 1);
-        done();
-      });
-    });
-    it('should query once when called serially', function (done) {
-      var called = 0;
-      var rows = [
-        {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
-      ];
-      var cc = {
-        query: function (q, cb) {
-          called++;
-          setImmediate(function () {
-            cb(null, {rows: rows});
-          });
-        },
-        getEncoder: function () { return new Encoder(4, {}); }
-      };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
-      metadata.keyspaces['ks_udf'] = { functions: {}};
-      async.timesSeries(10, function (n, next) {
-        metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
-          assert.ifError(err);
-          assert.ok(funcArray);
-          assert.strictEqual(funcArray.length, 1);
-          next();
-        });
-      }, function (err) {
-        assert.ifError(err);
-        assert.strictEqual(called, 1);
-        done();
-      });
-    });
     it('should return an empty array when not found', function (done) {
       var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
       metadata.keyspaces['ks_udf'] = { functions: {}};
@@ -1296,139 +1242,225 @@ describe('Metadata', function () {
         done();
       });
     });
-    it('should query the following times if was previously not found', function (done) {
-      var called = 0;
-      var rows = [
-        {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
-      ];
-      var cc = {
-        query: function (q, cb) {
-          if (called++ < 5) {
-            return setImmediate(function () {
-              cb(null, {rows: []});
+    describe('with C* 2.2 metadata rows', function () {
+      it('should query once when called in parallel', function (done) {
+        var called = 0;
+        var rows = [
+          {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
+        ];
+        var cc = {
+          query: function (q, cb) {
+            called++;
+            setImmediate(function () {
+              cb(null, {rows: rows});
             });
-          }
-          setImmediate(function () {
-            cb(null, {rows: rows});
+          },
+          getEncoder: function () { return new Encoder(4, {}); }
+        };
+        var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        metadata.keyspaces['ks_udf'] = { functions: {}};
+        async.times(10, function (n, next) {
+          metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
+            assert.ifError(err);
+            assert.ok(funcArray);
+            next();
           });
-        },
-        getEncoder: function () { return new Encoder(4, {}); }
-      };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
-      metadata.keyspaces['ks_udf'] = { functions: {}};
-      async.timesSeries(10, function (n, next) {
-        metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
+        }, function (err) {
           assert.ifError(err);
-          assert.ok(funcArray);
-          if (n < 5) {
-            assert.strictEqual(funcArray.length, 0);
-          }
-          else {
-            //there should be a row
-            assert.strictEqual(funcArray.length, 1);
-          }
-          next();
+          assert.strictEqual(called, 1);
+          done();
         });
-      }, function (err) {
-        assert.ifError(err);
-        assert.strictEqual(called, 6);
-        done();
       });
-    });
-    it('should query the following times if there was an error previously', function (done) {
-      var called = 0;
-      var rows = [
-        {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
-      ];
-      var cc = {
-        query: function (q, cb) {
-          if (called++ < 5) {
-            return setImmediate(function () {
-              cb(new Error('Dummy'));
+      it('should query once when called serially', function (done) {
+        var called = 0;
+        var rows = [
+          {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
+        ];
+        var cc = {
+          query: function (q, cb) {
+            called++;
+            setImmediate(function () {
+              cb(null, {rows: rows});
             });
-          }
-          setImmediate(function () {
-            cb(null, {rows: rows});
-          });
-        },
-        getEncoder: function () { return new Encoder(4, {}); }
-      };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
-      metadata.keyspaces['ks_udf'] = { functions: {}};
-      async.timesSeries(10, function (n, next) {
-        metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
-          if (n < 5) {
-            assert.ok(err);
-            assert.strictEqual(err.message, 'Dummy');
-          }
-          else {
+          },
+          getEncoder: function () { return new Encoder(4, {}); }
+        };
+        var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        metadata.keyspaces['ks_udf'] = { functions: {}};
+        async.timesSeries(10, function (n, next) {
+          metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
             assert.ifError(err);
             assert.ok(funcArray);
             assert.strictEqual(funcArray.length, 1);
-          }
-          next();
+            next();
+          });
+        }, function (err) {
+          assert.ifError(err);
+          assert.strictEqual(called, 1);
+          done();
         });
-      }, function (err) {
-        assert.ifError(err);
-        assert.strictEqual(called, 6);
-        done();
       });
-    });
-    it('should parse function metadata with 2 parameters', function (done) {
-      var rows = [
-        {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"},
-        {"keyspace_name":"ks_udf","function_name":"plus","signature":["int","int"],"argument_names":["arg1","arg2"],"argument_types":["org.apache.cassandra.db.marshal.Int32Type","org.apache.cassandra.db.marshal.Int32Type"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.Int32Type"}
-      ];
-      var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
-      metadata.keyspaces['ks_udf'] = { functions: {}};
-      metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
-        assert.ifError(err);
-        assert.ok(funcArray);
-        assert.strictEqual(funcArray.length, 2);
-        assert.strictEqual(funcArray[0].name, 'plus');
-        assert.strictEqual(funcArray[0].keyspaceName, 'ks_udf');
-        assert.strictEqual(funcArray[0].signature.join(', '), ['bigint', 'bigint'].join(', '));
-        assert.strictEqual(funcArray[0].argumentNames.join(', '), ['s', 'v'].join(', '));
-        assert.ok(funcArray[0].argumentTypes[0]);
-        assert.strictEqual(funcArray[0].argumentTypes[0].code, types.dataTypes.bigint);
-        assert.ok(funcArray[0].argumentTypes[1]);
-        assert.strictEqual(funcArray[0].argumentTypes[1].code, types.dataTypes.bigint);
-        assert.strictEqual(funcArray[0].language, 'java');
-        assert.ok(funcArray[0].returnType);
-        assert.strictEqual(funcArray[0].returnType.code, types.dataTypes.bigint);
+      it('should query the following times if was previously not found', function (done) {
+        var called = 0;
+        var rows = [
+          {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
+        ];
+        var cc = {
+          query: function (q, cb) {
+            if (called++ < 5) {
+              return setImmediate(function () {
+                cb(null, {rows: []});
+              });
+            }
+            setImmediate(function () {
+              cb(null, {rows: rows});
+            });
+          },
+          getEncoder: function () { return new Encoder(4, {}); }
+        };
+        var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        metadata.keyspaces['ks_udf'] = { functions: {}};
+        async.timesSeries(10, function (n, next) {
+          metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
+            assert.ifError(err);
+            assert.ok(funcArray);
+            if (n < 5) {
+              assert.strictEqual(funcArray.length, 0);
+            }
+            else {
+              //there should be a row
+              assert.strictEqual(funcArray.length, 1);
+            }
+            next();
+          });
+        }, function (err) {
+          assert.ifError(err);
+          assert.strictEqual(called, 6);
+          done();
+        });
+      });
+      it('should query the following times if there was an error previously', function (done) {
+        var called = 0;
+        var rows = [
+          {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
+        ];
+        var cc = {
+          query: function (q, cb) {
+            if (called++ < 5) {
+              return setImmediate(function () {
+                cb(new Error('Dummy'));
+              });
+            }
+            setImmediate(function () {
+              cb(null, {rows: rows});
+            });
+          },
+          getEncoder: function () { return new Encoder(4, {}); }
+        };
+        var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        metadata.keyspaces['ks_udf'] = { functions: {}};
+        async.timesSeries(10, function (n, next) {
+          metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
+            if (n < 5) {
+              assert.ok(err);
+              assert.strictEqual(err.message, 'Dummy');
+            }
+            else {
+              assert.ifError(err);
+              assert.ok(funcArray);
+              assert.strictEqual(funcArray.length, 1);
+            }
+            next();
+          });
+        }, function (err) {
+          assert.ifError(err);
+          assert.strictEqual(called, 6);
+          done();
+        });
+      });
+      it('should parse function metadata with 2 parameters', function (done) {
+        var rows = [
+          {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"},
+          {"keyspace_name":"ks_udf","function_name":"plus","signature":["int","int"],"argument_names":["arg1","arg2"],"argument_types":["org.apache.cassandra.db.marshal.Int32Type","org.apache.cassandra.db.marshal.Int32Type"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.Int32Type"}
+        ];
+        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+        metadata.keyspaces['ks_udf'] = { functions: {}};
+        metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
+          assert.ifError(err);
+          assert.ok(funcArray);
+          assert.strictEqual(funcArray.length, 2);
+          assert.strictEqual(funcArray[0].name, 'plus');
+          assert.strictEqual(funcArray[0].keyspaceName, 'ks_udf');
+          assert.strictEqual(funcArray[0].signature.join(', '), ['bigint', 'bigint'].join(', '));
+          assert.strictEqual(funcArray[0].argumentNames.join(', '), ['s', 'v'].join(', '));
+          assert.ok(funcArray[0].argumentTypes[0]);
+          assert.strictEqual(funcArray[0].argumentTypes[0].code, types.dataTypes.bigint);
+          assert.ok(funcArray[0].argumentTypes[1]);
+          assert.strictEqual(funcArray[0].argumentTypes[1].code, types.dataTypes.bigint);
+          assert.strictEqual(funcArray[0].language, 'java');
+          assert.ok(funcArray[0].returnType);
+          assert.strictEqual(funcArray[0].returnType.code, types.dataTypes.bigint);
 
-        assert.strictEqual(funcArray[1].name, 'plus');
-        assert.strictEqual(funcArray[0].keyspaceName, 'ks_udf');
-        assert.strictEqual(funcArray[1].signature.join(', '), ['int', 'int'].join(', '));
-        assert.strictEqual(funcArray[1].argumentNames.join(', '), ['arg1', 'arg2'].join(', '));
-        assert.ok(funcArray[1].argumentTypes[0]);
-        assert.strictEqual(funcArray[1].argumentTypes[0].code, types.dataTypes.int);
-        assert.ok(funcArray[1].argumentTypes[1]);
-        assert.strictEqual(funcArray[1].argumentTypes[1].code, types.dataTypes.int);
-        assert.strictEqual(funcArray[1].language, 'java');
-        assert.ok(funcArray[1].returnType);
-        assert.strictEqual(funcArray[1].returnType.code, types.dataTypes.int);
-        done();
+          assert.strictEqual(funcArray[1].name, 'plus');
+          assert.strictEqual(funcArray[0].keyspaceName, 'ks_udf');
+          assert.strictEqual(funcArray[1].signature.join(', '), ['int', 'int'].join(', '));
+          assert.strictEqual(funcArray[1].argumentNames.join(', '), ['arg1', 'arg2'].join(', '));
+          assert.ok(funcArray[1].argumentTypes[0]);
+          assert.strictEqual(funcArray[1].argumentTypes[0].code, types.dataTypes.int);
+          assert.ok(funcArray[1].argumentTypes[1]);
+          assert.strictEqual(funcArray[1].argumentTypes[1].code, types.dataTypes.int);
+          assert.strictEqual(funcArray[1].language, 'java');
+          assert.ok(funcArray[1].returnType);
+          assert.strictEqual(funcArray[1].returnType.code, types.dataTypes.int);
+          done();
+        });
+      });
+      it('should parse a function metadata with no parameters', function (done) {
+        var rows = [
+          {"keyspace_name":"ks_udf","function_name":"return_one","signature":[],"argument_names":null,"argument_types":null,"body":"return 1;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.Int32Type"}
+        ];
+        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+        metadata.keyspaces['ks_udf'] = { functions: {}};
+        metadata.getFunctions('ks_udf', 'return_one', function (err, funcArray) {
+          assert.ifError(err);
+          assert.ok(funcArray);
+          assert.strictEqual(funcArray.length, 1);
+          assert.strictEqual(funcArray[0].name, 'return_one');
+          assert.strictEqual(funcArray[0].signature.length, 0);
+          assert.strictEqual(funcArray[0].argumentNames, utils.emptyArray);
+          assert.strictEqual(funcArray[0].argumentTypes.length, 0);
+          assert.strictEqual(funcArray[0].language, 'java');
+          assert.ok(funcArray[0].returnType);
+          assert.strictEqual(funcArray[0].returnType.code, types.dataTypes.int);
+          done();
+        });
       });
     });
-    it('should parse a function metadata with no parameters', function (done) {
-      var rows = [
-        {"keyspace_name":"ks_udf","function_name":"return_one","signature":[],"argument_names":null,"argument_types":null,"body":"return 1;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.Int32Type"}
-      ];
-      var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
-      metadata.keyspaces['ks_udf'] = { functions: {}};
-      metadata.getFunctions('ks_udf', 'return_one', function (err, funcArray) {
-        assert.ifError(err);
-        assert.ok(funcArray);
-        assert.strictEqual(funcArray.length, 1);
-        assert.strictEqual(funcArray[0].name, 'return_one');
-        assert.strictEqual(funcArray[0].signature.length, 0);
-        assert.strictEqual(funcArray[0].argumentNames, utils.emptyArray);
-        assert.strictEqual(funcArray[0].argumentTypes.length, 0);
-        assert.strictEqual(funcArray[0].language, 'java');
-        assert.ok(funcArray[0].returnType);
-        assert.strictEqual(funcArray[0].returnType.code, types.dataTypes.int);
-        done();
+    describe('with C* 3.0+ metadata rows', function () {
+      it('should parse function metadata with 2 parameters', function (done) {
+        var rows = [
+          {"keyspace_name": "ks_udf", "function_name": "plus", "argument_types": ["int", "int"], "argument_names": ["s", "v"], "body": "return s+v;", "called_on_null_input": false, "language": "java", "return_type": "int"}
+        ];
+        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+        metadata.setCassandraVersion([3, 0]);
+        metadata.keyspaces['ks_udf'] = { functions: {}};
+        metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
+          assert.ifError(err);
+          assert.ok(funcArray);
+          assert.strictEqual(funcArray.length, 1);
+          assert.strictEqual(funcArray[0].name, 'plus');
+          assert.strictEqual(funcArray[0].keyspaceName, 'ks_udf');
+          assert.strictEqual(funcArray[0].signature.join(', '), ['int', 'int'].join(', '));
+          assert.strictEqual(funcArray[0].argumentNames.join(', '), ['s', 'v'].join(', '));
+          assert.ok(funcArray[0].argumentTypes[0]);
+          assert.strictEqual(funcArray[0].argumentTypes[0].code, types.dataTypes.int);
+          assert.ok(funcArray[0].argumentTypes[1]);
+          assert.strictEqual(funcArray[0].argumentTypes[1].code, types.dataTypes.int);
+          assert.strictEqual(funcArray[0].language, 'java');
+          assert.ok(funcArray[0].returnType);
+          assert.strictEqual(funcArray[0].returnType.code, types.dataTypes.int);
+          done();
+        });
       });
     });
   });
@@ -1578,64 +1610,6 @@ describe('Metadata', function () {
     });
   });
   describe('#getAggregates()', function () {
-    it('should query once when called in parallel', function (done) {
-      var called = 0;
-      var rows = [
-        {"keyspace_name":"ks_udf","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":new Buffer([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"}
-      ];
-      var cc = {
-        query: function (q, cb) {
-          called++;
-          helper.assertContains(q, 'system.schema_aggregates');
-          setImmediate(function () {
-            cb(null, {rows: rows});
-          });
-        },
-        getEncoder: function () { return new Encoder(4, {}); }
-      };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
-      metadata.keyspaces['ks_udf'] = { aggregates: {}};
-      async.times(10, function (n, next) {
-        metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
-          assert.ifError(err);
-          assert.ok(funcArray);
-          next();
-        });
-      }, function (err) {
-        assert.ifError(err);
-        assert.strictEqual(called, 1);
-        done();
-      });
-    });
-    it('should query once when called serially', function (done) {
-      var called = 0;
-      var rows = [
-        {"keyspace_name":"ks_udf","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":new Buffer([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"}
-      ];
-      var cc = {
-        query: function (q, cb) {
-          called++;
-          setImmediate(function () {
-            cb(null, {rows: rows});
-          });
-        },
-        getEncoder: function () { return new Encoder(4, {}); }
-      };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
-      metadata.keyspaces['ks_udf'] = { aggregates: {}};
-      async.timesSeries(10, function (n, next) {
-        metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
-          assert.ifError(err);
-          assert.ok(funcArray);
-          assert.strictEqual(funcArray.length, 1);
-          next();
-        });
-      }, function (err) {
-        assert.ifError(err);
-        assert.strictEqual(called, 1);
-        done();
-      });
-    });
     it('should return an empty array when not found', function (done) {
       var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
       metadata.keyspaces['ks_udf'] = { aggregates: {}};
@@ -1646,127 +1620,229 @@ describe('Metadata', function () {
         done();
       });
     });
-    it('should query the following times if was previously not found', function (done) {
-      var called = 0;
-      var rows = [
-        {"keyspace_name":"ks_udf","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":new Buffer([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"}
-      ];
-      var cc = {
-        query: function (q, cb) {
-          if (called++ < 5) {
-            return setImmediate(function () {
-              cb(null, {rows: []});
+    describe('with C* 2.2 metadata rows', function () {
+      it('should query once when called in parallel', function (done) {
+        var called = 0;
+        var rows = [
+          {"keyspace_name":"ks_udf","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":new Buffer([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"}
+        ];
+        var cc = {
+          query: function (q, cb) {
+            called++;
+            helper.assertContains(q, 'system.schema_aggregates');
+            setImmediate(function () {
+              cb(null, {rows: rows});
             });
-          }
-          setImmediate(function () {
-            cb(null, {rows: rows});
+          },
+          getEncoder: function () { return new Encoder(4, {}); }
+        };
+        var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        metadata.keyspaces['ks_udf'] = { aggregates: {}};
+        async.times(10, function (n, next) {
+          metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
+            assert.ifError(err);
+            assert.ok(funcArray);
+            next();
           });
-        },
-        getEncoder: function () { return new Encoder(4, {}); }
-      };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
-      metadata.keyspaces['ks_udf'] = { aggregates: {}};
-      async.timesSeries(10, function (n, next) {
-        metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
+        }, function (err) {
           assert.ifError(err);
-          assert.ok(funcArray);
-          if (n < 5) {
-            assert.strictEqual(funcArray.length, 0);
-          }
-          else {
-            //there should be a row
-            assert.strictEqual(funcArray.length, 1);
-          }
-          next();
+          assert.strictEqual(called, 1);
+          done();
         });
-      }, function (err) {
-        assert.ifError(err);
-        assert.strictEqual(called, 6);
-        done();
       });
-    });
-    it('should query the following times if there was an error previously', function (done) {
-      var called = 0;
-      var rows = [
-        {"keyspace_name":"ks_udf","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":new Buffer([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"}
-      ];
-      var cc = {
-        query: function (q, cb) {
-          helper.assertContains(q, 'system.schema_aggregates');
-          if (called++ < 5) {
-            return setImmediate(function () {
-              cb(new Error('Dummy'));
+      it('should query once when called serially', function (done) {
+        var called = 0;
+        var rows = [
+          {"keyspace_name":"ks_udf","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":new Buffer([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"}
+        ];
+        var cc = {
+          query: function (q, cb) {
+            called++;
+            setImmediate(function () {
+              cb(null, {rows: rows});
             });
-          }
-          setImmediate(function () {
-            cb(null, {rows: rows});
-          });
-        },
-        getEncoder: function () { return new Encoder(4, {}); }
-      };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
-      metadata.keyspaces['ks_udf'] = { aggregates: {}};
-      async.timesSeries(10, function (n, next) {
-        metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
-          if (n < 5) {
-            assert.ok(err);
-            assert.strictEqual(err.message, 'Dummy');
-          }
-          else {
+          },
+          getEncoder: function () { return new Encoder(4, {}); }
+        };
+        var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        metadata.keyspaces['ks_udf'] = { aggregates: {}};
+        async.timesSeries(10, function (n, next) {
+          metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
             assert.ifError(err);
             assert.ok(funcArray);
             assert.strictEqual(funcArray.length, 1);
-          }
-          next();
+            next();
+          });
+        }, function (err) {
+          assert.ifError(err);
+          assert.strictEqual(called, 1);
+          done();
         });
-      }, function (err) {
-        assert.ifError(err);
-        assert.strictEqual(called, 6);
-        done();
+      });
+      it('should query the following times if was previously not found', function (done) {
+        var called = 0;
+        var rows = [
+          {"keyspace_name":"ks_udf","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":new Buffer([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"}
+        ];
+        var cc = {
+          query: function (q, cb) {
+            if (called++ < 5) {
+              return setImmediate(function () {
+                cb(null, {rows: []});
+              });
+            }
+            setImmediate(function () {
+              cb(null, {rows: rows});
+            });
+          },
+          getEncoder: function () { return new Encoder(4, {}); }
+        };
+        var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        metadata.keyspaces['ks_udf'] = { aggregates: {}};
+        async.timesSeries(10, function (n, next) {
+          metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
+            assert.ifError(err);
+            assert.ok(funcArray);
+            if (n < 5) {
+              assert.strictEqual(funcArray.length, 0);
+            }
+            else {
+              //there should be a row
+              assert.strictEqual(funcArray.length, 1);
+            }
+            next();
+          });
+        }, function (err) {
+          assert.ifError(err);
+          assert.strictEqual(called, 6);
+          done();
+        });
+      });
+      it('should query the following times if there was an error previously', function (done) {
+        var called = 0;
+        var rows = [
+          {"keyspace_name":"ks_udf","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":new Buffer([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"}
+        ];
+        var cc = {
+          query: function (q, cb) {
+            helper.assertContains(q, 'system.schema_aggregates');
+            if (called++ < 5) {
+              return setImmediate(function () {
+                cb(new Error('Dummy'));
+              });
+            }
+            setImmediate(function () {
+              cb(null, {rows: rows});
+            });
+          },
+          getEncoder: function () { return new Encoder(4, {}); }
+        };
+        var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        metadata.keyspaces['ks_udf'] = { aggregates: {}};
+        async.timesSeries(10, function (n, next) {
+          metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
+            if (n < 5) {
+              assert.ok(err);
+              assert.strictEqual(err.message, 'Dummy');
+            }
+            else {
+              assert.ifError(err);
+              assert.ok(funcArray);
+              assert.strictEqual(funcArray.length, 1);
+            }
+            next();
+          });
+        }, function (err) {
+          assert.ifError(err);
+          assert.strictEqual(called, 6);
+          done();
+        });
+      });
+      it('should parse aggregate metadata with 1 parameter', function (done) {
+        var rows = [
+          {"keyspace_name":"ks_udf1","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":new Buffer([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"},
+          {"keyspace_name":"ks_udf1","aggregate_name":"sum","signature":["int"],"argument_types":["org.apache.cassandra.db.marshal.Int32Type"],"final_func":null,"initcond":new Buffer([0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.Int32Type","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.Int32Type"}
+        ];
+        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+        metadata.keyspaces['ks_udf1'] = { aggregates: {}};
+        metadata.getAggregates('ks_udf1', 'sum', function (err, aggregatesArray) {
+          assert.ifError(err);
+          assert.ok(aggregatesArray);
+          assert.strictEqual(aggregatesArray.length, 2);
+          assert.strictEqual(aggregatesArray[0].name, 'sum');
+          assert.strictEqual(aggregatesArray[0].keyspaceName, 'ks_udf1');
+          assert.strictEqual(aggregatesArray[0].signature.join(', '), ['bigint'].join(', '));
+          assert.strictEqual(aggregatesArray[0].argumentTypes.length, 1);
+          assert.ok(aggregatesArray[0].argumentTypes[0]);
+          assert.strictEqual(aggregatesArray[0].argumentTypes[0].code, types.dataTypes.bigint);
+          assert.ok(aggregatesArray[0].returnType);
+          assert.strictEqual(aggregatesArray[0].returnType.code, types.dataTypes.bigint);
+          assert.strictEqual(aggregatesArray[0].finalFunction, null);
+          assert.ok(aggregatesArray[0].stateType);
+          assert.strictEqual(aggregatesArray[0].stateType.code, types.dataTypes.bigint);
+          assert.strictEqual(aggregatesArray[0].stateFunction, 'plus');
+          assert.strictEqual(aggregatesArray[0].initCondition, '0');
+
+          assert.strictEqual(aggregatesArray[1].name, 'sum');
+          assert.strictEqual(aggregatesArray[0].keyspaceName, 'ks_udf1');
+          assert.strictEqual(aggregatesArray[1].signature.join(', '), ['int'].join(', '));
+          assert.strictEqual(aggregatesArray[1].argumentTypes.length, 1);
+          assert.ok(aggregatesArray[1].argumentTypes[0]);
+          assert.strictEqual(aggregatesArray[1].argumentTypes[0].code, types.dataTypes.int);
+          assert.ok(aggregatesArray[1].returnType);
+          assert.strictEqual(aggregatesArray[1].returnType.code, types.dataTypes.int);
+          assert.strictEqual(aggregatesArray[1].finalFunction, null);
+          assert.ok(aggregatesArray[1].stateType);
+          assert.strictEqual(aggregatesArray[1].stateType.code, types.dataTypes.int);
+          assert.strictEqual(aggregatesArray[1].stateFunction, 'plus');
+          assert.strictEqual(aggregatesArray[1].initCondition, '0');
+          done();
+        });
       });
     });
-    it('should parse function metadata with 2 parameters', function (done) {
-      var rows = [
-        {"keyspace_name":"ks_udf1","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":new Buffer([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"},
-        {"keyspace_name":"ks_udf1","aggregate_name":"sum","signature":["int"],"argument_types":["org.apache.cassandra.db.marshal.Int32Type"],"final_func":null,"initcond":new Buffer([0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.Int32Type","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.Int32Type"}
-      ];
-      var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
-      metadata.keyspaces['ks_udf1'] = { aggregates: {}};
-      metadata.getAggregates('ks_udf1', 'sum', function (err, aggregatesArray) {
-        assert.ifError(err);
-        assert.ok(aggregatesArray);
-        assert.strictEqual(aggregatesArray.length, 2);
-        assert.strictEqual(aggregatesArray[0].name, 'sum');
-        assert.strictEqual(aggregatesArray[0].keyspaceName, 'ks_udf1');
-        assert.strictEqual(aggregatesArray[0].signature.join(', '), ['bigint'].join(', '));
-        assert.strictEqual(aggregatesArray[0].argumentTypes.length, 1);
-        assert.ok(aggregatesArray[0].argumentTypes[0]);
-        assert.strictEqual(aggregatesArray[0].argumentTypes[0].code, types.dataTypes.bigint);
-        assert.ok(aggregatesArray[0].returnType);
-        assert.strictEqual(aggregatesArray[0].returnType.code, types.dataTypes.bigint);
-        assert.strictEqual(aggregatesArray[0].finalFunction, null);
-        assert.ok(aggregatesArray[0].stateType);
-        assert.strictEqual(aggregatesArray[0].stateType.code, types.dataTypes.bigint);
-        assert.strictEqual(aggregatesArray[0].stateFunction, 'plus');
-        helper.assertInstanceOf(aggregatesArray[0].initConditionRaw, Buffer);
-        helper.assertInstanceOf(aggregatesArray[0].initCondition, types.Long);
-        assert.ok(aggregatesArray[0].initCondition.equals(types.Long.ZERO));
+    describe('with C* 3.0+ metadata rows', function () {
+      it('should parse aggregate metadata with 1 parameter', function (done) {
+        var rows = [
+          {"keyspace_name": "ks_udf1", "aggregate_name": "sum", "argument_types": ["bigint"], "final_func": null, "initcond": '2', "return_type": "bigint", "state_func": "plus", "state_type": "bigint"},
+          {"keyspace_name": "ks_udf1", "aggregate_name": "sum", "argument_types": ["int"], "final_func": null, "initcond": '1', "return_type": "int", "state_func": "plus", "state_type": "int"}
+        ];
+        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+        metadata.setCassandraVersion([3, 0]);
+        metadata.keyspaces['ks_udf1'] = { aggregates: {}};
+        metadata.getAggregates('ks_udf1', 'sum', function (err, aggregatesArray) {
+          assert.ifError(err);
+          assert.ok(aggregatesArray);
+          assert.strictEqual(aggregatesArray.length, 2);
+          assert.strictEqual(aggregatesArray[0].name, 'sum');
+          assert.strictEqual(aggregatesArray[0].keyspaceName, 'ks_udf1');
+          assert.strictEqual(aggregatesArray[0].signature.join(', '), ['bigint'].join(', '));
+          assert.strictEqual(aggregatesArray[0].argumentTypes.length, 1);
+          assert.ok(aggregatesArray[0].argumentTypes[0]);
+          assert.strictEqual(aggregatesArray[0].argumentTypes[0].code, types.dataTypes.bigint);
+          assert.ok(aggregatesArray[0].returnType);
+          assert.strictEqual(aggregatesArray[0].returnType.code, types.dataTypes.bigint);
+          assert.strictEqual(aggregatesArray[0].finalFunction, null);
+          assert.ok(aggregatesArray[0].stateType);
+          assert.strictEqual(aggregatesArray[0].stateType.code, types.dataTypes.bigint);
+          assert.strictEqual(aggregatesArray[0].stateFunction, 'plus');
+          assert.strictEqual(aggregatesArray[0].initCondition, '2');
 
-        assert.strictEqual(aggregatesArray[1].name, 'sum');
-        assert.strictEqual(aggregatesArray[0].keyspaceName, 'ks_udf1');
-        assert.strictEqual(aggregatesArray[1].signature.join(', '), ['int'].join(', '));
-        assert.strictEqual(aggregatesArray[1].argumentTypes.length, 1);
-        assert.ok(aggregatesArray[1].argumentTypes[0]);
-        assert.strictEqual(aggregatesArray[1].argumentTypes[0].code, types.dataTypes.int);
-        assert.ok(aggregatesArray[1].returnType);
-        assert.strictEqual(aggregatesArray[1].returnType.code, types.dataTypes.int);
-        assert.strictEqual(aggregatesArray[1].finalFunction, null);
-        assert.ok(aggregatesArray[1].stateType);
-        assert.strictEqual(aggregatesArray[1].stateType.code, types.dataTypes.int);
-        assert.strictEqual(aggregatesArray[1].stateFunction, 'plus');
-        assert.strictEqual(typeof aggregatesArray[1].initCondition, 'number');
-        assert.strictEqual(aggregatesArray[1].initCondition, 0);
-        done();
+          assert.strictEqual(aggregatesArray[1].name, 'sum');
+          assert.strictEqual(aggregatesArray[0].keyspaceName, 'ks_udf1');
+          assert.strictEqual(aggregatesArray[1].signature.join(', '), ['int'].join(', '));
+          assert.strictEqual(aggregatesArray[1].argumentTypes.length, 1);
+          assert.ok(aggregatesArray[1].argumentTypes[0]);
+          assert.strictEqual(aggregatesArray[1].argumentTypes[0].code, types.dataTypes.int);
+          assert.ok(aggregatesArray[1].returnType);
+          assert.strictEqual(aggregatesArray[1].returnType.code, types.dataTypes.int);
+          assert.strictEqual(aggregatesArray[1].finalFunction, null);
+          assert.ok(aggregatesArray[1].stateType);
+          assert.strictEqual(aggregatesArray[1].stateType.code, types.dataTypes.int);
+          assert.strictEqual(aggregatesArray[1].stateFunction, 'plus');
+          assert.strictEqual(typeof aggregatesArray[1].initCondition, 'string');
+          assert.strictEqual(aggregatesArray[1].initCondition, '1');
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
Use `TEST_CASSANDRA_DIR` env variable to test against latest CASSANDRA-10365 branch. 

Handles UDT resolution.
Updated async dependency to ~1.5.

`SchemaParser` instances are not longer singletons.
Not tested with nested udt, waiting for dev branch to be updated.