### PR TITLE
NODEJS-190 Don't apply useUndefinedAsUnset to UDT and Tuple fields.

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -160,14 +160,15 @@ Encoder.prototype.decode = function (buffer, type) {
 /**
  * @param value
  * @param {{code: number, info: *|Object}|String|Number} [typeInfo]
+ * @param nested Whether or not the value is nested in a type such as a UDT or tuple.
  * @returns {Buffer}
  * @throws {TypeError} When there is an encoding error
  */
-Encoder.prototype.encode = function (value, typeInfo) {
+Encoder.prototype.encode = function (value, typeInfo, nested) {
   if (value === undefined) {
     //defaults to null
     value = null;
-    if (this.encodingOptions.useUndefinedAsUnset) {
+    if (this.encodingOptions.useUndefinedAsUnset && !nested) {
       //use undefined as unset
       value = types.unset;
     }
@@ -937,7 +938,7 @@ Encoder.prototype.encodeUdt = function (value, udtInfo) {
   var totalLength = 0;
   for (var i = 0; i < udtInfo.fields.length; i++) {
     var field = udtInfo.fields[i];
-    var item = this.encode(value[field.name], field.type);
+    var item = this.encode(value[field.name], field.type, true);
     if (!item) {
       parts.push(nullValueBuffer);
       totalLength += 4;
@@ -957,7 +958,7 @@ Encoder.prototype.encodeTuple = function (value, tupleInfo) {
   var totalLength = 0;
   for (var i = 0; i < tupleInfo.length; i++) {
     var type = tupleInfo[i];
-    var item = this.encode(value.get(i), type);
+    var item = this.encode(value.get(i), type, true);
     if (!item) {
       parts.push(nullValueBuffer);
       totalLength += 4;


### PR DESCRIPTION
For [NODEJS-190](https://datastax-oss.atlassian.net/browse/NODEJS-190).

Currently if you have an undefined field in a Tuple or UDT, encodeUdt/encodeTuple would attempt to contact a list of Buffers with undefined values passed in as `{ unset: true }` rather than `<Buffer FF FF FF FE>` (-2).  Instead of setting undefined values as unset for Tuple and UDT fields, this checks a new `nested` flag to determine whether or not the value to encode is nested in one of those types.

One possible downside of this is that a user would not be able to use `cassandra.types.unset` in a UDT or Tuple field value.  We could fix that by handling unsets in `encodeUdt` and `encodeTuple` but wasn't sure if that was worth it.