### PR TITLE
expose encoder in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 exports.Client = require('./lib/client.js');
+exports.encoder = require('./lib/encoder.js');
 exports.types = require('./lib/types');
 exports.errors = require('./lib/errors.js');
 exports.policies = require('./lib/policies');


### PR DESCRIPTION
This will greatly help usage of the encoder since at present we need to create a hard link to a it as dependency of a dependency in node_modules. This should be exposed at the top level for consumption even when npm dedupe is used.