### PR TITLE
A better Client.stream() implementation to solve NODEJS-194

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -11,6 +11,8 @@ var RequestHandler = require('./request-handler');
 var requests = require('./requests');
 var clientOptions = require('./client-options');
 
+var ResponseStream = require('./response-stream');
+
 /**
  * Client options
  * @typedef {Object} ClientOptions
@@ -353,7 +355,7 @@ Client.prototype.eachRow = function () {
  * @param {Array|Object} [params] Array of parameter values or an associative array (object) containing parameter names as keys and its value
  * @param {QueryOptions} [options]
  * @param {function} [callback], executes callback(err) after all rows have been received or if there is an error
- * @returns {exports.ResultStream}
+ * @returns {ResponseStream}
  */
 Client.prototype.stream = function () {
   var args = Array.prototype.slice.call(arguments);
@@ -362,17 +364,8 @@ Client.prototype.stream = function () {
     args.push(function noop() {});
   }
   args = utils.parseCommonArgs.apply(null, args);
-  var resultStream = new types.ResultStream({objectMode: 1});
-  this.eachRow(args.query, args.params, args.options, function rowCallback(n, row) {
-    resultStream.add(row);
-  }, function (err) {
-    if (err) {
-      resultStream.emit('error', err);
-    }
-    resultStream.add(null);
-    args.callback(err);
-  });
-  return resultStream;
+
+  return new ResponseStream(this, args.query, args.params, args.options);
 };
 
 //noinspection JSValidateJSDoc,JSCommentMatchesSignature

--- a/lib/response-stream.js
+++ b/lib/response-stream.js
@@ -90,6 +90,9 @@ ResponseStream.prototype._fetch = function()
                 // if an error occur during request notify it downstream
                 self.emit("error", err);
             }else{
+                // abort if no results
+                if(results === null || results === undefined) return self.push(null);;
+
                 // move result rows to the internal queue
                 self._rows.push.apply(self._rows, results.rows);
 

--- a/lib/response-stream.js
+++ b/lib/response-stream.js
@@ -41,6 +41,15 @@ function ResponseStream(client, query, params, options, streamOptions){
     // create the input queue
     this._recordQueue = [];
     this._recordQueueLowWatterMark = 250;
+
+    var self = this;
+
+    this._ended = false;
+    this.on("end", function(){
+        self._ended = true;
+    });
+
+    this._options.pageState = null;
 }
 
 /** Try to push all records on queue downstream.
@@ -48,9 +57,12 @@ function ResponseStream(client, query, params, options, streamOptions){
  * @private
  */
 ResponseStream.prototype._pushRecordQueue = function(){
-    var length = this._recordQueue.length;
-    for(var i = 0; i < length; i++){
-        if(!this.push(this._recordQueue.shift())) break;
+    // check if stream is ended
+    if(!this._ended){
+        var length = this._recordQueue.length;
+        for(var i = 0; i < length; i++){
+            if(!this.push(this._recordQueue.shift())) break;
+        }
     }
 };
 
@@ -62,10 +74,13 @@ ResponseStream.prototype._refill = function(){
     var self = this;
     this._client.execute(this._query, this._params, this._options, function(err, results){
         if(err !== null && err !== undefined){
-            this.emit("error", err);
-            this.push(null);
+            self.emit("error", err);
+            self.push(null);
         }else{
             self._recordQueue.push.apply(self._recordQueue, results.rows);
+
+            // update page state
+            self._options.pageState = results.meta.pageState;
 
             // try to push records downstream
             self._pushRecordQueue();

--- a/lib/response-stream.js
+++ b/lib/response-stream.js
@@ -71,6 +71,11 @@ ResponseStream.prototype._pushRows = function()
     while(this._rows.length > 0){
         if(this._end || !this.push(this._rows.shift())) break;
     }
+
+    // check the end condition
+    if(!this._more && this._rows.length === 0){
+        return this.push(null);
+    }
 };
 
 /** Fetch records.
@@ -91,7 +96,7 @@ ResponseStream.prototype._fetch = function()
                 self.emit("error", err);
             }else{
                 // abort if no results
-                if(results === null || results === undefined) return self.push(null);;
+                if(results === null || results === undefined) return self.push(null);
 
                 // move result rows to the internal queue
                 self._rows.push.apply(self._rows, results.rows);
@@ -123,11 +128,6 @@ ResponseStream.prototype._read = function()
 {
     // push as many rows as possible if any
     this._pushRows();
-
-    // check the end condition
-    if(!this._more && this._rows.length === 0){
-        return this.push(null);
-    }
 
     // if the internal row queue level is below the watermark request more
     // results from cassandra

--- a/lib/response-stream.js
+++ b/lib/response-stream.js
@@ -1,6 +1,3 @@
-/**
- * Created by yeiniel on 05/11/15.
- */
 
 'use strict';
 
@@ -9,106 +6,130 @@ var util = require('util');
 
 util.inherits(ResponseStream, Readable);
 
-/** Query response streamer.
+/** Response stream constructor.
  *
- * @param {Object} client Cassandra client.
- * @param {Object} query The query string.
- * @param {Array} params The parameter list.
- * @param {Object} options The Cassandra client options.
- * @param {Object} streamOptions The options used to build this stream object.
+ * @param client Cassandra client.
+ * @param {String} query SELECT query whose results are going to be streamed.
+ * @param {Array} params Array of query parameters.
+ * @param {Object} options Options map.
  * @constructor
  */
-function ResponseStream(client, query, params, options, streamOptions){
-    if(streamOptions === null || streamOptions === undefined){
-        streamOptions = {};
-    }
+function ResponseStream(client, query, params, options)
+{
+    var self = this;
 
-    if(!(this instanceof ResponseStream)){
-        return new ResponseStream(streamOptions);
-    }
+    // provide default value for the Stream base class constructor
+    options.stream = options.stream || {};
 
-    // force object mode
-    streamOptions.objectMode = true;
+    // force object mode on this stream
+    options.stream.objectMode = true;
 
-    Readable.call(this, streamOptions);
+    Readable.call(this, options.stream);
 
-    // store the cassandra client and op arguments for latter use
+    // store the cassandra client and execute() arguments for latter use
     this._client = client;
     this._query = query;
     this._params = params;
     this._options = options;
 
-    // create the input queue
-    this._recordQueue = [];
-    this._recordQueueLowWatterMark = 250;
+    // create the internal queue for buffering execute() calls
+    this._rows = [];
 
-    var self = this;
+    // provide default value for the low water mark on the internal queue
+    if(options.watermark === null || options.watermark === undefined){
+        options.watermark = 250;
+    }
 
-    this._ended = false;
-    this.on("end", function(){
-        self._ended = true;
-    });
-
-    this._options.pageState = null;
-
+    // provide default value for the fetchSize option
     if(options.fetchSize === null || options.fetchSize === undefined){
         options.fetchSize = 5000;
     }
+
+    // create the fetching flag to avoid duplicate calls to execute()
+    this._fetching = false;
+
+    // create the more flag to signal if there is more pages to fetch
+    this._more = true;
+
+    // create the end flag to signal once a null valua has been push
+    this._end = false;
+
+    // catch the end event to update the _end flag
+    // this signal the end to avoid any in-flight query to push a row
+    this.on("end", function(){ self._end = true; });
+
+    // start fetching rows
+    this._fetch();
 }
 
-/** Try to push all records on queue downstream.
+/** Push as many rows as possible downstream.
  *
  * @private
  */
-ResponseStream.prototype._pushRecordQueue = function(){
-    // check if stream is ended
-    if(!this._ended){
-        var length = this._recordQueue.length;
-        for(var i = 0; i < length; i++){
-            if(!this.push(this._recordQueue.shift())) break;
-        }
+ResponseStream.prototype._pushRows = function()
+{
+    while(this._rows.length > 0){
+        if(this._end || !this.push(this._rows.shift())) break;
     }
 };
 
-/** Refill the record queue.
+/** Fetch records.
  *
  * @private
  */
-ResponseStream.prototype._refill = function(){
+ResponseStream.prototype._fetch = function()
+{
     var self = this;
-    this._client.execute(this._query, this._params, this._options, function(err, results){
-        if(err !== null && err !== undefined){
-            self.emit("error", err);
-            self.push(null);
-        }else{
-            self._recordQueue.push.apply(self._recordQueue, results.rows);
 
-            // update page state
-            self._options.pageState = results.meta.pageState;
+    // signal fetching to avoid duplicate call to execute()
+    this._fetching = true;
 
-            // try to push records downstream
-            self._pushRecordQueue();
+    this._client.execute(this._query, this._params, this._options,
+        function(err, results){
+            if(err !== null && err !== undefined) {
+                // if an error occur during request notify it downstream
+                self.emit("error", err);
+            }else{
+                // move result rows to the internal queue
+                self._rows.push.apply(self._rows, results.rows);
 
-            // check stop conditions
-            if(results.rows.length < self._options.fetchSize){
-                self.push(null);
-                self.emit("end");
+                // update page state
+                self._options.pageState = results.meta.pageState;
+
+                // check if there is more pages to fetch
+                if(results.rows.length < self._options.fetchSize){
+                    self._more = false;
+                }
+
+                // re enable fetching
+                self._fetching = false;
+
+                // push as many rows as possible if any
+                self._pushRows();
             }
         }
-    });
+    );
 };
 
-ResponseStream.prototype._read = function(){
-    var self = this;
+/** Implement the _read() abstract method of the stream.Readable class.
+ *
+ * @override
+ * @private
+ */
+ResponseStream.prototype._read = function()
+{
+    // push as many rows as possible if any
+    this._pushRows();
 
-    this._pushRecordQueue();
+    // check the end condition
+    if(!this._more && this._rows.length === 0){
+        return this.push(null);
+    }
 
-    // check if queue size is below the low watter mark
-    if(this._recordQueue.length < this._recordQueueLowWatterMark){
-        // schedule queue refill
-        setImmediate(function(){
-            ResponseStream.prototype._refill.apply(self);
-        });
+    // if the internal row queue level is below the watermark request more
+    // results from cassandra
+    if(!this._fetching && this._rows.length < this._options.watermark){
+        this._fetch();
     }
 };
 

--- a/lib/response-stream.js
+++ b/lib/response-stream.js
@@ -50,6 +50,10 @@ function ResponseStream(client, query, params, options, streamOptions){
     });
 
     this._options.pageState = null;
+
+    if(options.fetchSize === null || options.fetchSize === undefined){
+        options.fetchSize = 5000;
+    }
 }
 
 /** Try to push all records on queue downstream.
@@ -84,6 +88,12 @@ ResponseStream.prototype._refill = function(){
 
             // try to push records downstream
             self._pushRecordQueue();
+
+            // check stop conditions
+            if(results.rows.length < self._options.fetchSize){
+                self.push(null);
+                self.emit("end");
+            }
         }
     });
 };

--- a/lib/response-stream.js
+++ b/lib/response-stream.js
@@ -1,0 +1,90 @@
+/**
+ * Created by yeiniel on 05/11/15.
+ */
+
+'use strict';
+
+var Readable = require('stream').Readable;
+var util = require('util');
+
+util.inherits(ResponseStream, Readable);
+
+/** Query response streamer.
+ *
+ * @param {Object} client Cassandra client.
+ * @param {Object} query The query string.
+ * @param {Array} params The parameter list.
+ * @param {Object} options The Cassandra client options.
+ * @param {Object} streamOptions The options used to build this stream object.
+ * @constructor
+ */
+function ResponseStream(client, query, params, options, streamOptions){
+    if(streamOptions === null || streamOptions === undefined){
+        streamOptions = {};
+    }
+
+    if(!(this instanceof ResponseStream)){
+        return new ResponseStream(streamOptions);
+    }
+
+    // force object mode
+    streamOptions.objectMode = true;
+
+    Readable.call(this, streamOptions);
+
+    // store the cassandra client and op arguments for latter use
+    this._client = client;
+    this._query = query;
+    this._params = params;
+    this._options = options;
+
+    // create the input queue
+    this._recordQueue = [];
+    this._recordQueueLowWatterMark = 250;
+}
+
+/** Try to push all records on queue downstream.
+ *
+ * @private
+ */
+ResponseStream.prototype._pushRecordQueue = function(){
+    var length = this._recordQueue.length;
+    for(var i = 0; i < length; i++){
+        if(!this.push(this._recordQueue.shift())) break;
+    }
+};
+
+/** Refill the record queue.
+ *
+ * @private
+ */
+ResponseStream.prototype._refill = function(){
+    var self = this;
+    this._client.execute(this._query, this._params, this._options, function(err, results){
+        if(err !== null && err !== undefined){
+            this.emit("error", err);
+            this.push(null);
+        }else{
+            self._recordQueue.push.apply(self._recordQueue, results.rows);
+
+            // try to push records downstream
+            self._pushRecordQueue();
+        }
+    });
+};
+
+ResponseStream.prototype._read = function(){
+    var self = this;
+
+    this._pushRecordQueue();
+
+    // check if queue size is below the low watter mark
+    if(this._recordQueue.length < this._recordQueueLowWatterMark){
+        // schedule queue refill
+        setImmediate(function(){
+            ResponseStream.prototype._refill.apply(self);
+        });
+    }
+};
+
+module.exports = ResponseStream;


### PR DESCRIPTION
NODEJS-194 is caused by the fact that the Client.stream() API is based on the Client.eachRow() API and therefore back pressure cant be handled. This pull request provide a Client.stream() API implementation based on Client.execute(). 