### PR TITLE
Add capability to specify cassandra version and git branch separately.

### DIFF
--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -472,6 +472,10 @@ Ccm.prototype.startAll = function (nodeLength, options, callback) {
         create = ['create', 'test', '--install-dir=' + process.env.TEST_CASSANDRA_DIR];
         helper.trace('With', create[2]);
       }
+      else if (process.env.TEST_CASSANDRA_BRANCH) {
+        create = ['create', 'test', '-v', process.env.TEST_CASSANDRA_BRANCH];
+        helper.trace('With branch', create[3]);
+      }
       if (options.ssl) {
         create.push('--ssl', self.getPath('ssl'));
       }


### PR DESCRIPTION
This adds a support for providing git/github branch via setting the TEST_CASSANDRA_BRANCH environment variable along with TEST_CASSANDRA_VERSION.   TEST_CASSANDRA_VERSION will still be used for determining what version we are on (which is useful for `vit`/`vdescribe`) and will still be passed in to CCM if TEST_CASSANDRA_BRANCH is not set.

i.e.:

```
TEST_CASSANDRA_VERSION=3.0.0
TEST_CASSANDRA_BRANCH=git:cassandra-3.0
```

Will test against apache git branch cassandra-3.o.

```
TEST_CASSANDRA_VERSION=3.0.0
TEST_CASSANDRA_BRANCH=github:tolbertam/experimental
```

Will test against github branch tolbertam/experimental.