### PR TITLE
Schedule reconnection using setTimeout()

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -592,6 +592,9 @@ Connection.prototype.onTimeout = function (streamId) {
   originalCallback(new errors.OperationTimedOutError(message));
 };
 
+/**
+ * @param {Function} [callback]
+ */
 Connection.prototype.close = function (callback) {
   this.log('verbose', 'disconnecting');
   this.clearAndInvokePending();

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -12,6 +12,7 @@ var HostMap = require('./host').HostMap;
 var Metadata = require('./metadata');
 var requests = require('./requests');
 var utils = require('./utils');
+var types = require('./types');
 
 var selectPeers = "SELECT peer,data_center,rack,tokens,rpc_address,release_version FROM system.peers";
 var selectLocal = "SELECT * FROM system.local WHERE key='local'";
@@ -37,6 +38,16 @@ function ControlConnection(options) {
   this.metadata = new Metadata(this.options, this);
   this.addressTranslator = this.options.policies.addressResolution;
   this.initialized = false;
+  /**
+   * Host used by the control connection
+   * @type {Host|null}
+   */
+  this.host = null;
+  /**
+   * Connection used to retrieve metadata and subscribed to events
+   * @type {Connection|null}
+   */
+  this.connection = null;
 }
 
 util.inherits(ControlConnection, events.EventEmitter);
@@ -85,7 +96,7 @@ ControlConnection.prototype.init = function (callback) {
     },
     this.getConnection.bind(this),
     function tryInitOnConnection(next) {
-      self.initOnConnection(true, next);
+      self.refreshOnConnection(true, next);
     }
   ], function (err) {
     self.initialized = !err;
@@ -100,39 +111,132 @@ ControlConnection.prototype.init = function (callback) {
  */
 ControlConnection.prototype.getConnection = function (callback) {
   var self = this;
-  var handler = new RequestHandler(null, this.options);
-  if (!this.host) {
-    //it is the first time
-    this.log('info', 'Getting first connection');
-    handler.getFirstConnection(this.hosts, function (err, c, host) {
-      if (!err && c) {
-        self.protocolVersion = c.protocolVersion;
-        self.log('info', 'Control connection using protocol version ' + self.protocolVersion);
-      }
-      next(err, c, host);
-    });
-  }
-  else {
-    this.log('info', 'Getting a connection');
-    handler.getNextConnection(null, function (err, c, host) {
-      if (err) {
-        //it had an active connection, but now it failed to acquire a new one.
-        //lets retry in a couple seconds
-        setTimeout(function () {
-          self.getConnection.call(self, callback);
-        }, retryNewConnectionDelay);
-        return;
-      }
-      next(err, c, host);
-    });
-  }
-  function next(err, c, host) {
-    if (!err) {
+  function done(err, c, host) {
+    if (c) {
       self.connection = c;
       self.host = host;
     }
     callback(err);
   }
+  if (!this.initialized) {
+    //it is the first time
+    this.log('info', 'Getting first connection');
+    return this.getFirstConnection(function (err, c, host) {
+      if (!err && c) {
+        self.protocolVersion = c.protocolVersion;
+        self.log('info', 'Control connection using protocol version ' + self.protocolVersion);
+      }
+      done(err, c, host);
+    });
+  }
+  this.log('info', 'Trying to acquire a connection to a new host');
+  this.getConnectionToNewHost(done);
+};
+
+/**
+ * Gets an open connection to using the provided hosts Array, without using the load balancing policy.
+ * Invoked before the Client can access topology of the cluster.
+ * @param {Function} callback
+ */
+ControlConnection.prototype.getFirstConnection = function (callback) {
+  var connection = null;
+  var index = 0;
+  var openingErrors = {};
+  var hosts = this.hosts.values();
+  var host = null;
+  async.doWhilst(function iterator(next) {
+    host = hosts[index];
+    host.borrowConnection(function (err, c) {
+      if (err) {
+        openingErrors[host.address] = err;
+      }
+      else {
+        connection = c;
+      }
+      next();
+    });
+  }, function condition () {
+    return !connection && (++index < hosts.length);
+  }, function done(err) {
+    if (!connection) {
+      err = new errors.NoHostAvailableError(openingErrors);
+    }
+    callback(err, connection, host);
+  });
+};
+
+/**
+ * Acquires a connection to a host according to the load balancing policy.
+ * If its not possible to connect, it subscribes to the hosts UP event.
+ * @param {Function} callback
+ */
+ControlConnection.prototype.getConnectionToNewHost = function (callback) {
+  var self = this;
+  var host;
+  var connection = null;
+  var loadBalancingPolicy = this.options.policies.loadBalancing;
+  loadBalancingPolicy.newQueryPlan(null, null, function (err, iterator) {
+    if (err) {
+      var message = 'Control connection could not retrieve a query plan to determine which hosts to use, ' +
+        'using current hosts map';
+      self.log('error', message, err);
+      iterator = utils.arrayIterator(self.hosts.values());
+    }
+    //use iterator
+    async.whilst(
+      function condition() {
+        //while there isn't a valid connection
+        if (connection) {
+          return false;
+        }
+        var item = iterator.next();
+        host = item.value;
+        return (!item.done);
+      },
+      function whileIterator(next) {
+        if (!host.isUp()) {
+          return next();
+        }
+        var distance = loadBalancingPolicy.getDistance(host);
+        host.setDistance(distance);
+        if (distance === types.distance.ignored) {
+          return next();
+        }
+        host.borrowConnection(function (err, c) {
+          //move next if there was an error
+          connection = c;
+          next();
+        });
+      },
+      function whilstEnded() {
+        if (!connection) {
+          self.listenHostsForUp();
+          return callback();
+        }
+        callback(null, connection, host);
+      });
+  });
+};
+
+/**
+ * Subscribe to the UP event of all current hosts to reconnect when one
+ * of them are back up.
+ */
+ControlConnection.prototype.listenHostsForUp = function () {
+  var self = this;
+  var hostArray = this.hosts.values();
+  function onUp() {
+    //unsubscribe from all host
+    hostArray.forEach(function (host) {
+      host.removeListener('up', onUp);
+    });
+    self.refresh();
+  }
+  //All hosts are DOWN, we should subscribe to the UP event
+  //of each host as the HostConnectionPool is attempting to reconnect
+  hostArray.forEach(function (host) {
+    host.on('up', onUp);
+  });
 };
 
 /**
@@ -141,7 +245,7 @@ ControlConnection.prototype.getConnection = function (callback) {
  * it's the first time that trying to retrieve host information
  * @param {Function} callback
  */
-ControlConnection.prototype.initOnConnection = function (firstTime, callback) {
+ControlConnection.prototype.refreshOnConnection = function (firstTime, callback) {
   var c = this.connection;
   var self = this;
   self.log('info', 'Connection acquired, refreshing nodes list');
@@ -220,16 +324,32 @@ ControlConnection.prototype.refreshHosts = function (newNodesUp, callback) {
 
 ControlConnection.prototype.hostDownHandler = function () {
   this.log('warning', 'Host ' + this.host.address + ' used by the ControlConnection DOWN');
+  this.host = null;
+  this.connection = null;
+  this.refresh();
+};
+
+/**
+ * Acquires a connection and refreshes topology metadata.
+ * @param {Function} [callback]
+ */
+ControlConnection.prototype.refresh = function (callback) {
   var self = this;
   async.series([
       this.getConnection.bind(this),
       function (next) {
-        self.initOnConnection(false, next);
+        if (!self.connection) {
+          return next();
+        }
+        self.refreshOnConnection(false, next);
       }
     ],
-    function (err) {
-      if (err) {
-        self.log('error', 'Could not reconnect');
+    function doneRefreshing(err) {
+      if (err || !self.connection) {
+        self.log('error', 'ControlConnection was not able to reconnect');
+      }
+      if (callback) {
+        callback(err);
       }
     }
   );

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -17,7 +17,7 @@ var types = require('./types');
 var selectPeers = "SELECT peer,data_center,rack,tokens,rpc_address,release_version FROM system.peers";
 var selectLocal = "SELECT * FROM system.local WHERE key='local'";
 var newNodeDelay = 1000;
-var retryNewConnectionDelay = 5000;
+var metadataQueryAbortTimeout = 2000;
 var schemaChangeTypes = {
   created: 'CREATED',
   updated: 'UPDATED',
@@ -31,6 +31,8 @@ var schemaChangeTypes = {
 function ControlConnection(options) {
   this.protocolVersion = null;
   this.hosts = new HostMap();
+  //noinspection JSUnresolvedFunction
+  this.setMaxListeners(0);
   Object.defineProperty(this, "options", { value: options, enumerable: false, writable: false});
   /**
    * Cluster metadata that is going to be shared between the Client and ControlConnection
@@ -48,6 +50,11 @@ function ControlConnection(options) {
    * @type {Connection|null}
    */
   this.connection = null;
+  /**
+   * Reference to the encoder of the last valid connection
+   * @type {Encoder|null}
+   */
+  this.encoder = null;
 }
 
 util.inherits(ControlConnection, events.EventEmitter);
@@ -108,15 +115,18 @@ ControlConnection.prototype.init = function (callback) {
  * Gets a connection to any Host in the pool.
  * If its the first time, it will try to create a connection to a host present in the contactPoints in order.
  * @param {Function} callback
+ * @emits ControlConnection#newConnection When a new connection is acquired
  */
 ControlConnection.prototype.getConnection = function (callback) {
   var self = this;
   function done(err, c, host) {
     if (c) {
       self.connection = c;
+      self.encoder = c.encoder;
       self.host = host;
     }
     callback(err);
+    self.emit('newConnection', err, c, host);
   }
   if (!this.initialized) {
     //it is the first time
@@ -546,18 +556,52 @@ ControlConnection.prototype.getAddressForPeerHost = function (row, defaultPort, 
 };
 
 /**
+ * Waits for a connection to be available. If timeout expires before getting a connection it callbacks in error.
+ * @param {Function} callback
+ */
+ControlConnection.prototype.waitForReconnection = function (callback) {
+  var timeout;
+  function newConnectionListener(err) {
+    clearTimeout(timeout);
+    callback(err);
+  }
+  this.once('newConnection', newConnectionListener);
+  timeout = setTimeout(function waitTimeout() {
+    this.removeListener('newConnection', newConnectionListener);
+    callback(errors.OperationTimedOutError('A connection could not be acquired before timeout.'));
+  }, metadataQueryAbortTimeout);
+};
+
+/**
  * Executes a query using the active connection
  * @param {string} cqlQuery
  * @param {function} callback
  */
 ControlConnection.prototype.query = function (cqlQuery, callback) {
-  var request = new requests.QueryRequest(cqlQuery, null, null);
-  this.connection.sendStream(request, utils.emptyObject, callback);
+  var self = this;
+  function queryOnConnection() {
+    var request = new requests.QueryRequest(cqlQuery, null, null);
+    self.connection.sendStream(request, utils.emptyObject, callback);
+  }
+  if (!this.connection) {
+    //It's reconnecting
+    return this.waitForReconnection(function waitCallback(err) {
+      if (err) {
+        //it was not able to reconnect in time
+        return callback(err);
+      }
+      queryOnConnection();
+    });
+  }
+  queryOnConnection();
 };
 
 /** @returns {Encoder} The encoder used by the current connection */
 ControlConnection.prototype.getEncoder = function () {
-  return this.connection.encoder;
+  if (!this.encoder) {
+    throw new errors.DriverInternalError('Encoder is not defined');
+  }
+  return this.encoder;
 };
 
 module.exports = ControlConnection;

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -248,7 +248,7 @@ ControlConnection.prototype.listenHostsForUp = function () {
 ControlConnection.prototype.refreshOnConnection = function (firstTime, callback) {
   var c = this.connection;
   var self = this;
-  self.log('info', 'Connection acquired, refreshing nodes list');
+  self.log('info', 'Connection acquired to ' + self.host.address + ', refreshing nodes list');
   async.series([
     function subscribeHostEvents(next) {
       self.host.once('down', self.hostDownHandler.bind(self));
@@ -283,7 +283,7 @@ ControlConnection.prototype.refreshOnConnection = function (firstTime, callback)
         self.log('error', 'ControlConnection could not be initialized', err);
       }
       else {
-        self.log('info', 'ControlConnection connected and up to date');
+        self.log('info', 'ControlConnection connected to ' + self.host.address + ' and is up to date');
       }
       callback(err);
     });
@@ -298,6 +298,15 @@ ControlConnection.prototype.refreshHosts = function (newNodesUp, callback) {
   if (!callback) {
     callback = function () {};
   }
+
+  // it's possible that this was called as a result of a topology change, but the connection was lost
+  // between now and newNodeDelay.  In this case, simply return as this will be called again when there
+  // is a new connection.
+  if (!this.connection) {
+    callback();
+    return;
+  }
+
   var self = this;
   if (!this.host.protocolVersion) {
     this.hosts.forEach(function (h) {

--- a/lib/host.js
+++ b/lib/host.js
@@ -68,8 +68,13 @@ Host.prototype.setDown = function() {
   }
   this.reconnectionDelay = this.reconnectionSchedule.next().value;
   this.log('warning', util.format('Host %s considered as DOWN. Reconnection delay %dms.', this.address, this.reconnectionDelay));
+
+  var wasUp = this.isUp();
   this.unhealthyAt = new Date().getTime();
-  this.emit('down');
+  // Only emit a down event if was previously up.
+  if(wasUp) {
+    this.emit('down');
+  }
   this.pool.scheduleReconnection(this.reconnectionDelay);
 };
 
@@ -116,7 +121,7 @@ Host.prototype.isUp = function () {
 Host.prototype.canBeConsideredAsUp = function () {
   var self = this;
   function hasTimePassed() {
-    return new Date().getTime() - self.unhealthyAt > self.reconnectionDelay;
+    return new Date().getTime() - self.unhealthyAt >= self.reconnectionDelay;
   }
   return !this.unhealthyAt || hasTimePassed();
 };

--- a/lib/host.js
+++ b/lib/host.js
@@ -20,7 +20,10 @@ function Host(address, protocolVersion, options) {
   this.address = address;
   this.unhealthyAt = 0;
   Object.defineProperty(this, 'options', { value: options, enumerable: false, writable: false});
-  Object.defineProperty(this, 'pool', { value: new HostConnectionPool(address, protocolVersion, options), enumerable: false});
+  /**
+   * @type {HostConnectionPool}
+   */
+  Object.defineProperty(this, 'pool', { value: new HostConnectionPool(this, protocolVersion), enumerable: false});
   this.pool.on('idleRequestError', this.setDown.bind(this));
   /**
    * Gets string containing the Cassandra version.
@@ -63,11 +66,11 @@ Host.prototype.setDown = function() {
     //This host is not down, the pool is being shutdown
     return;
   }
-  this.log('warning', 'Setting host ' + this.address + ' as DOWN');
-  this.unhealthyAt = new Date().getTime();
   this.reconnectionDelay = this.reconnectionSchedule.next().value;
+  this.log('warning', util.format('Host %s considered as DOWN. Reconnection delay %dms.', this.address, this.reconnectionDelay));
+  this.unhealthyAt = new Date().getTime();
   this.emit('down');
-  this.pool.forceShutdown();
+  this.pool.scheduleReconnection(this.reconnectionDelay);
 };
 
 /**
@@ -84,6 +87,7 @@ Host.prototype.setUp = function () {
   this.unhealthyAt = 0;
   //if it was unhealthy and now it is not, lets reset the reconnection schedule.
   this.reconnectionSchedule = this.options.policies.reconnection.newSchedule();
+  this.pool.clearReconnection();
   this.emit('up');
 };
 
@@ -127,6 +131,11 @@ Host.prototype.canBeConsideredAsUp = function () {
 Host.prototype.setDistance = function (distance) {
   distance = distance || types.distance.local;
   this.pool.coreConnectionsLength = this.options.pooling.coreConnectionsPerHost[distance];
+  if (distance === types.distance.ignored && this.pool.connections.length > 0) {
+    //this host was local/remote and now must be ignored
+    //close all the connections to it
+    this.pool.shutdown(noop);
+  }
 };
 
 /**
@@ -180,7 +189,7 @@ Host.prototype.checkHealth = function (connection) {
  */
 Host.prototype.getCassandraVersion = function () {
   if (!this.cassandraVersion) return utils.emptyArray;
-  return this.cassandraVersion.split('-')[0].split('.').map(function (x) {
+  return this.cassandraVersion.split('-')[0].split('.').map(function eachMap(x) {
     return parseInt(x, 10);
   });
 };
@@ -189,18 +198,25 @@ Host.prototype.log = utils.log;
 
 /**
  * Represents a pool of connections to a host
+ * @param {Host} host
+ * @param {Number} protocolVersion Initial protocol version
  * @constructor
  * @ignore
  */
-function HostConnectionPool(address, protocolVersion, options) {
+function HostConnectionPool(host, protocolVersion) {
   events.EventEmitter.call(this);
-  this.address = address;
+  this.address = host.address;
+  this.options = host.options;
+  this.host = host;
   this.protocolVersion = protocolVersion;
-  Object.defineProperty(this, "options", { value: options, enumerable: false, writable: false});
-  Object.defineProperty(this, "connections", { value: null, enumerable: false, writable: true});
   this.coreConnectionsLength = 1;
   //Use like an immutable array
   this.connections = utils.emptyArray;
+  /**
+   * Timeout instance for next reconnection attempt, if any.
+   * @type {Object|null}
+   */
+  this.reconnectionTimeout = null;
   this.setMaxListeners(0);
 }
 
@@ -232,16 +248,21 @@ HostConnectionPool.prototype.borrowConnection = function (callback) {
  * Create the min amount of connections, if the pool is empty
  */
 HostConnectionPool.prototype._maybeCreatePool = function (callback) {
-  //The parameter this.coreConnectionsLength could change over time
-  //It can result of a created pool being resized (setting the distance).
-  if (!this.creating && this.connections.length >= this.coreConnectionsLength) {
+  //The value of this.coreConnectionsLength can change over time
+  //when an existing pool is being resized (by setting the distance).
+  if (this.connections.length >= this.coreConnectionsLength) {
     return callback();
   }
-  this.once('creation', callback);
   if (this.creating) {
-    //Its being created so it will emit after it finished
-    return;
+    if (this.connections.length > 0) {
+      //we already have a valid connection
+      //let the connection grow continue in the background
+      return callback();
+    }
+    //subscribe and move on
+    return this.once('creation', callback);
   }
+  this.once('creation', callback);
   this.creating = true;
   //Use a copy
   var connections = this.connections.slice(0);
@@ -251,15 +272,17 @@ HostConnectionPool.prototype._maybeCreatePool = function (callback) {
       return connections.length < self.coreConnectionsLength;
     },
     function iterator(next) {
-      var c = new Connection(self.address, self.protocolVersion, self.options);
-      //Relay the event idleRequestError
-      c.on('idleRequestError', function (err) {
-        //The pool will emit the event
-        self.emit('idleRequestError', err);
-      });
+      var c = self._createConnection();
       connections.push(c);
-      c.open(next);
-    }, function (err) {
+      c.open(function createOpenCallback(err) {
+        if (err) {
+          setImmediate(function createOpenError() {
+            c.close();
+          });
+        }
+        next(err);
+      });
+    }, function whilstEnded(err) {
       if (!err) {
         //set the new reference
         self.connections = connections;
@@ -267,6 +290,18 @@ HostConnectionPool.prototype._maybeCreatePool = function (callback) {
       self.creating = false;
       self.emit('creation', err);
   });
+};
+
+/** @returns {Connection} */
+HostConnectionPool.prototype._createConnection = function () {
+  var c = new Connection(this.address, this.protocolVersion, this.options);
+  var self = this;
+  //Relay the event idleRequestError
+  c.on('idleRequestError', function idleErrorCallback(err) {
+    //The pool will emit the event
+    self.emit('idleRequestError', err);
+  });
+  return c;
 };
 
 HostConnectionPool.prototype.checkHealth = function (connection) {
@@ -284,12 +319,12 @@ HostConnectionPool.prototype.checkHealth = function (connection) {
     this.connections = newConnections;
     //close the connection
     setImmediate(function checkHealthClose() {
-      connection.close(function () {});
+      connection.close(noop);
     });
   }
 };
 
-HostConnectionPool.prototype.forceShutdown = function () {
+HostConnectionPool.prototype._forceShutdown = function () {
   //kills all the connections
   if (!this.connections.length) {
     return;
@@ -297,15 +332,58 @@ HostConnectionPool.prototype.forceShutdown = function () {
   this.log('info', 'Closing force ' + this.connections.length + ' connections to ' + this.address);
   var activeConnections = this.connections;
   this.connections = utils.emptyArray;
-  async.each(activeConnections, function (c, next) {
-    c.close(function () {
+  async.each(activeConnections, function forceShutdownEachCallback(c, next) {
+    c.close(function forceShutdownCloseCallback() {
       //don't mind if there was an error
       next();
     });
   });
 };
 
+/**
+ * Closes all open connections and schedules reconnection
+ * @param {Number} delay
+ */
+HostConnectionPool.prototype.scheduleReconnection = function (delay) {
+  this._forceShutdown();
+  this.reconnectionTimeout = setTimeout(this._attemptReconnection.bind(this), delay);
+};
+
+/**
+ * Prevents reconnection timeout from triggering
+ */
+HostConnectionPool.prototype.clearReconnection = function () {
+  if (!this.reconnectionTimeout) {
+    return;
+  }
+  clearTimeout(this.reconnectionTimeout);
+  this.reconnectionTimeout = null;
+};
+
+HostConnectionPool.prototype._attemptReconnection = function () {
+  this.reconnectionTimeout = null;
+  var c = this._createConnection();
+  var self = this;
+  c.open(function attempOpenCallback(err) {
+    if (err) {
+      self.log('info', util.format('Reconnection attempt to host %s failed', self.address), err);
+      self.host.setDown();
+      return c.close();
+    }
+    self.host.setUp();
+    self.connections = [ c ];
+    setImmediate(function afterReconnectionSuccess() {
+      self._maybeCreatePool(noop);
+    });
+  });
+};
+
+/**
+ * @param {Function} callback
+ * @returns {*}
+ */
 HostConnectionPool.prototype.shutdown = function (callback) {
+  this.clearReconnection();
   if (!this.connections.length) {
     return callback();
   }
@@ -318,9 +396,9 @@ HostConnectionPool.prototype.shutdown = function (callback) {
   var connections = this.connections;
   //Create a new reference
   this.connections = utils.emptyArray;
-  async.each(connections, function (c, next) {
+  async.each(connections, function closeEach(c, next) {
     c.close(next);
-  }, function (err) {
+  }, function shutdownEachEnded(err) {
     self.shuttingDown = false;
     callback(err);
     self.emit('shutdown', err);
@@ -502,6 +580,8 @@ HostMap.prototype.inspect = function() {
 HostMap.prototype.toJSON = function() {
   return this._items;
 };
+
+function noop () {}
 
 exports.HostConnectionPool = HostConnectionPool;
 exports.Host = Host;

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -1,3 +1,4 @@
+"use strict";
 var util = require('util');
 var async = require('async');
 
@@ -75,7 +76,7 @@ RequestHandler.prototype.iterateThroughHosts = function (iterator, callback) {
       return (!item.done);
     },
     function whileIterator(next) {
-      if (!host.canBeConsideredAsUp()) {
+      if (!host.isUp()) {
         self.triedHosts[host.address] = 'Host considered as DOWN';
         return next();
       }
@@ -416,39 +417,6 @@ RequestHandler.prototype.prepareAndRetry = function (queryId, callback) {
     return;
   }
   return callback(new errors.DriverInternalError('Obtained unprepared from wrong request'));
-};
-
-/**
- * Gets an open connection to using the provided hosts Array, without using the load balancing policy.
- * Invoked before the Client can access topology of the cluster.
- * @param {HostMap} hostMap
- * @param {Function} callback
- */
-RequestHandler.prototype.getFirstConnection = function (hostMap, callback) {
-  var connection = null;
-  var index = 0;
-  var openingErrors = {};
-  var hosts = hostMap.values();
-  var host = null;
-  async.doWhilst(function iterator(next) {
-    host = hosts[index];
-    host.borrowConnection(function (err, c) {
-      if (err) {
-        openingErrors[host.address] = err;
-      }
-      else {
-        connection = c;
-      }
-      next();
-    });
-  }, function condition () {
-    return !connection && (++index < hosts.length);
-  }, function done(err) {
-    if (!connection) {
-      err = new errors.NoHostAvailableError(openingErrors);
-    }
-    callback(err, connection, host);
-  });
 };
 
 module.exports = RequestHandler;

--- a/test/integration/short/client-pool-tests.js
+++ b/test/integration/short/client-pool-tests.js
@@ -582,7 +582,7 @@ describe('Client', function () {
           //3 hosts alive
           assert.strictEqual(Object.keys(hosts).length, 3);
           var counter = 0;
-          async.times(1000, function (i, next) {
+          async.timesLimit(1000, 10, function (i, next) {
             client.execute(helper.queries.basic, function (err) {
               counter++;
               assert.ifError(err);
@@ -641,14 +641,14 @@ describe('Client', function () {
           var counter = 0;
           var issued = 0;
           var killed = false;
-          async.times(500, function (n, next) {
+          async.timesLimit(500, 20, function (n, next) {
             if (n === 10) {
               //kill a node when there are some outstanding requests
               helper.ccmHelper.exec(['node2', 'stop', '--not-gently'], function (err) {
                 killed = true;
                 assert.ifError(err);
                 //do a couple of more queries
-                async.times(10, function (n, next2) {
+                async.timesSeries(10, function (n, next2) {
                   client.execute(query, next2);
                 }, next);
               });

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -427,6 +427,42 @@ var helper = {
     var ipAddress = address.split(':')[0].split('.');
     return ipAddress[ipAddress.length-1];
   },
+
+  /**
+   * Given a {Client} and a {Number} returns the host whose last octet
+   * ends with the requested number.
+   * @param {Client|ControlConnection} client Client to lookup hosts from.
+   * @param {Number} number last octet of requested host.
+   * @returns {Host}
+   */
+  findHost: function(client, number) {
+    var host = null;
+    var self = this;
+    client.hosts.forEach(function(h) {
+      if(self.lastOctetOf(h) == number) {
+        host = h;
+      }
+    });
+    return host;
+  },
+
+  /**
+   * Waits indefinitely for a specific host to emit an event after a
+   * a given function has been called and invokes a callback on completion.
+   * @param {Function} f function to call
+   * @param {Client|ControlConnection} client client to inspect hosts from.
+   * @param {Number} number last octet of requested host.
+   * @param {String} event event to wait on, i.e. 'up'.
+   * @param {Function} cb function to call when event has been received.
+   */
+  waitOnHost: function(f, client, number, event, cb) {
+    var host = this.findHost(client, number);
+    host.once(event, function () {
+      cb();
+    });
+    f();
+  },
+
   /**
    * Returns a function, that when invoked shutdowns the client and callbacks
    * @param {Client} client


### PR DESCRIPTION
`HostConnectionPool` reconnects using `setTimeout()`.

When all the hosts go down, the `ControlConnection` listens to `Host`'s `up` event instead of actively trying to reconnect.