### PR TITLE
Switch to container-based infrastructure for travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,7 @@ node_js:
   - "0.12"
   - "0.10"
   - "iojs"
+sudo: false
+cache:
+  directories:
+    - node_modules


### PR DESCRIPTION
See:
http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/

Also sets up caching for the node_modules directory, which should speed up build times by not downloading dependencies on every build.