### PR TITLE
Missing return statement when calling callback

### DIFF
--- a/lib/policies/load-balancing.js
+++ b/lib/policies/load-balancing.js
@@ -65,7 +65,7 @@ util.inherits(RoundRobinPolicy, LoadBalancingPolicy);
  */
 RoundRobinPolicy.prototype.newQueryPlan = function (keyspace, queryOptions, callback) {
   if (!this.hosts) {
-    callback(new Error('Load balancing policy not initialized'));
+    return callback(new Error('Load balancing policy not initialized'));
   }
   var hosts = this.hosts.values();
   var self = this;
@@ -203,7 +203,7 @@ DCAwareRoundRobinPolicy.prototype._sliceNodesByDc = function() {
  */
 DCAwareRoundRobinPolicy.prototype.newQueryPlan = function (keyspace, queryOptions, callback) {
   if (!this.hosts) {
-    callback(new Error('Load balancing policy not initialized'));
+    return callback(new Error('Load balancing policy not initialized'));
   }
   this.index += 1;
   if (this.index >= utils.maxInt) {

--- a/test/unit/load-balancing-tests.js
+++ b/test/unit/load-balancing-tests.js
@@ -17,6 +17,14 @@ var DCAwareRoundRobinPolicy = loadBalancing.DCAwareRoundRobinPolicy;
 var WhiteListPolicy = loadBalancing.WhiteListPolicy;
 
 describe('RoundRobinPolicy', function () {
+  it('should yield an error when the hosts are not set', function(done) {
+    var policy = new RoundRobinPolicy();
+    policy.hosts = null;
+    policy.newQueryPlan(null, null, function(err, iterator) {
+      assert(err instanceof Error);
+      done();
+    });
+  });
   it('should yield nodes in a round robin manner even in parallel', function (done) {
     var policy = new RoundRobinPolicy();
     var hosts = [];
@@ -93,6 +101,14 @@ describe('RoundRobinPolicy', function () {
   });
 });
 describe('DCAwareRoundRobinPolicy', function () {
+  it('should yield an error when the hosts are not set', function(done) {
+    var policy = new DCAwareRoundRobinPolicy('dc1');
+    policy.hosts = null;
+    policy.newQueryPlan(null, null, function(err, iterator) {
+      assert(err instanceof Error);
+      done();
+    });
+  });
   it('should yield local nodes in a round robin manner in parallel', function (done) {
     //local datacenter: dc1
     //0 host per remote datacenter


### PR DESCRIPTION
Hi, there are bugs in error handling in Load balancing policies. The method `newQueryPlan` calls a callback with an error when the property `this.hosts` doesn't exists, but the method doesn't end and it continues to process the rest of the code and it eventually crashed because of TypeError: Cannot call method 'values' of null. I've added the return statement and unit tests. 

Ah, sorry for the misleading commit message. It is a commit message of another commit.  