### PR TITLE
Fix #NODEJS-217 - Add encoding option for tuples encoded/decoded as Array

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -73,6 +73,8 @@ var clientOptions = require('./client-options');
  * If not set, it will default to Javascript Object with map keys as property names.
  * @property {Function} encoding.set Set constructor to use for Cassandra set<k> type encoding and decoding.
  * If not set, it will default to Javascript Array.
+ * @property {Function} encoding.tuple Tuple constructor to use for Cassandra tuple<> type encoding and decoding.
+ * The only supported option, other than the default [Tuple]{@link module:types~Tuple} type, is Javascript Array.
  * @property {Boolean} encoding.copyBuffer Determines if the network buffer should be copied for buffer based data types (blob, uuid, timeuuid and inet).
  * <p>
  *   Setting it to true will cause that the network buffer is copied for each row value of those types,

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -256,6 +256,9 @@ function defineInstanceMembers() {
       elements[i] = this.decode(bytes.slice(offset, offset+length), tupleInfo[i]);
       offset += length;
     }
+    if (this.encodingOptions.tuple === Array) {
+      return elements;
+    }
     return new types.Tuple(elements);
   };
   //Encoding methods
@@ -627,6 +630,11 @@ function defineInstanceMembers() {
   this.encodeTuple = function (value, tupleInfo) {
     var parts = [];
     var totalLength = 0;
+
+    if (this.encodingOptions.tuple === Array) {
+      value = new types.Tuple(value);
+    }
+
     for (var i = 0; i < tupleInfo.length; i++) {
       var type = tupleInfo[i];
       var item = this.encode(value.get(i), type);

--- a/test/unit/encoder-tests.js
+++ b/test/unit/encoder-tests.js
@@ -522,6 +522,20 @@ describe('encoder', function () {
       assert.strictEqual(decoded.get(0), 'one');
       assert.strictEqual(decoded.get(1).getTime(), 1429259123607);
     });
+    it('should encode/decode tuples as Array if encoding option for tuple = Array', function () {
+      var encoder = new Encoder(3, {
+        encoding: {
+          tuple: Array
+        }
+      });
+      var type = { code: dataTypes.tuple, info: [ { code: dataTypes.text}, { code: dataTypes.timestamp }]};
+      var encoded = encoder.encode(['one', new Date(1429259123607)], type);
+      var decoded = encoder.decode(encoded, type);
+      assert(decoded instanceof Array, true);
+      assert.strictEqual(decoded.length, 2);
+      assert.strictEqual(decoded[0], 'one');
+      assert.strictEqual(decoded[1].getTime(), 1429259123607);
+    });
     it('should encode/decode LocalDate as date', function () {
       var encoder = new Encoder(4, {});
       var type = {code: dataTypes.date};


### PR DESCRIPTION
Add `tuple` encoding option for encoding/decoding tuple type as Array

[JIRA link](https://datastax-oss.atlassian.net/browse/NODEJS-217)