### PR TITLE
Consider putting nodejs-driver types into a new repository

### DIFF
--- a/lib/auth/plain-text-auth-provider.js
+++ b/lib/auth/plain-text-auth-provider.js
@@ -7,6 +7,7 @@ var Authenticator = provider.Authenticator;
  * Creates a new instance of the Authenticator provider
  * @classdesc Provides plain text [Authenticator]{@link module:auth~Authenticator} instances to be used when
  * connecting to a host.
+ * @extends module:auth~AuthProvider
  * @example
  * var authProvider = new cassandra.auth.PlainTextAuthProvider('my_user', 'p@ssword1!');
  * //Set the auth provider in the clientOptions when creating the Client instance
@@ -24,7 +25,8 @@ function PlainTextAuthProvider(username, password) {
 util.inherits(PlainTextAuthProvider, AuthProvider);
 
 /**
- * Returns a new [Authenticator]{@link module:auth~Authenticator} instance to be for plain text authentication.
+ * Returns a new [Authenticator]{@link module:auth~Authenticator} instance to be used for plain text authentication.
+ * @override
  * @returns {Authenticator}
  */
 PlainTextAuthProvider.prototype.newAuthenticator = function () {

--- a/lib/auth/provider.js
+++ b/lib/auth/provider.js
@@ -1,6 +1,7 @@
 /**
  * @classdesc Provides [Authenticator]{@link module:auth~Authenticator} instances to be used when connecting to a host.
  * @constructor
+ * @abstract
  * @alias module:auth~AuthProvider
  */
 function AuthProvider() {
@@ -9,9 +10,12 @@ function AuthProvider() {
 
 /**
  * Returns an [Authenticator]{@link module:auth~Authenticator} instance to be used when connecting to a host.
+ * @param {String} endpoint The ip address and port number in the format ip:port
+ * @param {String} name Authenticator name
+ * @abstract
  * @returns {Authenticator}
  */
-AuthProvider.prototype.newAuthenticator = function () {
+AuthProvider.prototype.newAuthenticator = function (endpoint, name) {
   throw new Error('This is an abstract class, you must implement newAuthenticator method or ' +
     'use another auth provider that inherits from this class');
 };

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -20,19 +20,19 @@ var idleQuery = 'SELECT key from system.local';
 var maxProtocolVersion = 4;
 /**
  * Represents a connection to a Cassandra node
- * @param {String} endPoint An string containing ip address and port of the host
+ * @param {String} endpoint An string containing ip address and port of the host
  * @param {Number} protocolVersion
  * @param {ClientOptions} options
  * @constructor
  */
-function Connection(endPoint, protocolVersion, options) {
+function Connection(endpoint, protocolVersion, options) {
   events.EventEmitter.call(this);
   this.setMaxListeners(0);
-  if (!endPoint || endPoint.indexOf(':') <= 0) {
+  if (!endpoint || endpoint.indexOf(':') <= 0) {
     throw new Error('EndPoint must contain the ip address and port separated by : symbol');
   }
-  this.endPoint = endPoint;
-  var hostAndPort = endPoint.split(':');
+  this.endpoint = endpoint;
+  var hostAndPort = endpoint.split(':');
   this.address = hostAndPort[0];
   this.port = hostAndPort[1];
   Object.defineProperty(this, "options", { value: options, enumerable: false, writable: false});
@@ -142,7 +142,7 @@ Connection.prototype.startup = function (callback) {
     this.log('info', 'Trying to use protocol version ' + this.protocolVersion);
   }
   var self = this;
-  this.sendStream(new requests.StartupRequest(), null, function (err, response) {
+  this.sendStream(new requests.StartupRequest(), null, function responseCallback(err, response) {
     if (err && self.checkingVersion && self.protocolVersion > 1) {
       var invalidProtocol = (err instanceof errors.ResponseError &&
         err.code === types.responseErrorCodes.protocolError &&
@@ -158,8 +158,8 @@ Connection.prototype.startup = function (callback) {
         self.log('info', 'Protocol v' + self.protocolVersion + ' not supported, using v' + (self.protocolVersion-1));
         self.decreaseVersion();
         //The host closed the connection, close the socket
-        setImmediate(function () {
-          self.close(function () {
+        setImmediate(function decreasingVersionClosing() {
+          self.close(function decreasingVersionOpening() {
           //Retry
             self.open(callback);
           });
@@ -168,7 +168,7 @@ Connection.prototype.startup = function (callback) {
       }
     }
     if (response && response.mustAuthenticate) {
-      return self.authenticate(null, null, startupCallback);
+      return self.startAuthenticating(response.authenticatorName, startupCallback);
     }
     startupCallback(err);
   });
@@ -258,6 +258,24 @@ Connection.prototype.clearAndInvokePending = function (innerError) {
 };
 
 /**
+ * Starts the SASL flow
+ * @param {String} authenticatorName
+ * @param {Function} callback
+ */
+Connection.prototype.startAuthenticating = function (authenticatorName, callback) {
+  if (!this.options.authProvider) {
+    return callback(new errors.AuthenticationError('Authentication provider not set'));
+  }
+  var authenticator = this.options.authProvider.newAuthenticator(this.endpoint, authenticatorName);
+  var self = this;
+  authenticator.initialResponse(function initialResponseCallback(err, token) {
+    //Start the flow with the initial token
+    if (err) return callback(err);
+    self.authenticate(authenticator, token, callback);
+  });
+};
+
+/**
  * Handles authentication requests and responses.
  * @param {Authenticator} authenticator
  * @param {Buffer} token
@@ -265,19 +283,6 @@ Connection.prototype.clearAndInvokePending = function (innerError) {
  */
 Connection.prototype.authenticate = function(authenticator, token, callback) {
   var self = this;
-  if (authenticator === null) {
-    //initial token
-    if (!this.options.authProvider) {
-      return callback(new errors.AuthenticationError('Authentication provider not set'));
-    }
-    authenticator = this.options.authProvider.newAuthenticator();
-    authenticator.initialResponse(function (err, t) {
-      //let's start again with the correct args
-      if (err) return callback(err);
-      self.authenticate(authenticator, t, callback);
-    });
-    return;
-  }
   var request = new requests.AuthResponseRequest(token);
   if (this.protocolVersion === 1) {
     //No Sasl support, use CREDENTIALS
@@ -288,7 +293,7 @@ Connection.prototype.authenticate = function(authenticator, token, callback) {
     //noinspection JSUnresolvedVariable
     request = new requests.CredentialsRequest(authenticator.username, authenticator.password);
   }
-  this.sendStream(request, null, function (err, result) {
+  this.sendStream(request, null, function authResponseCallback(err, result) {
     if (err) {
       if (err instanceof errors.ResponseError && err.code === types.responseErrorCodes.badCredentials) {
         var authError = new errors.AuthenticationError(err.message);
@@ -302,7 +307,7 @@ Connection.prototype.authenticate = function(authenticator, token, callback) {
       return callback();
     }
     if (result.authChallenge) {
-      authenticator.evaluateChallenge(result.token, function (err, t) {
+      return authenticator.evaluateChallenge(result.token, function evaluateCallback(err, t) {
         if (err) {
           return callback(err);
         }
@@ -400,7 +405,7 @@ Connection.prototype.getWriteCallback = function (request, options, callback) {
       }
       return callback(err);
     }
-    self.log('verbose', 'Sent stream #' + request.streamId + ' to ' + self.endPoint);
+    self.log('verbose', 'Sent stream #' + request.streamId + ' to ' + self.endpoint);
     //the request was successfully written, use a timer to set the readTimeout
     var timeout;
     if (self.options.socketOptions.readTimeout > 0) {
@@ -507,7 +512,7 @@ Connection.prototype.handleResult = function (header, err, result) {
   if (!handler) {
     return this.log('error', 'The server replied with a wrong streamId #' + streamId);
   }
-  this.log('verbose', 'Received frame #' + streamId + ' from ' + this.endPoint);
+  this.log('verbose', 'Received frame #' + streamId + ' from ' + this.endpoint);
   this.invokeCallback(handler, err, result);
 };
 
@@ -592,7 +597,7 @@ Connection.prototype.onTimeout = function (streamId) {
   if (handler.options && handler.options.rowCallback) {
     handler.options.rowCallback = function noop() {};
   }
-  var message = util.format('The host %s did not reply before timeout %d ms', this.endPoint, this.options.socketOptions.readTimeout);
+  var message = util.format('The host %s did not reply before timeout %d ms', this.endpoint, this.options.socketOptions.readTimeout);
   originalCallback(new errors.OperationTimedOutError(message));
 };
 

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -329,7 +329,7 @@ ControlConnection.prototype.refreshHosts = function (newNodesUp, callback) {
     function getLocalInfo(next) {
       var request = new requests.QueryRequest(selectLocal, null, null);
       c.sendStream(request, {}, function (err, result) {
-        self.setLocalInfo(c.endPoint, result);
+        self.setLocalInfo(c.endpoint, result);
         next(err);
       });
     },

--- a/lib/policies/address-resolution.js
+++ b/lib/policies/address-resolution.js
@@ -40,8 +40,8 @@ function AddressTranslator() {
  * *not* <code>0.0.0.0</code>.
  * </p>
  * @param {Number} port The port number, as specified in the [protocolOptions]{@link ClientOptions} at Client instance creation (9042 by default).
- * @param {Function} callback Callback to invoke with endPoint as first parameter.
- * The endPoint is an string composed of the IP address and the port number in the format <code>ipAddress:port</code>.
+ * @param {Function} callback Callback to invoke with endpoint as first parameter.
+ * The endpoint is an string composed of the IP address and the port number in the format <code>ipAddress:port</code>.
  */
 AddressTranslator.prototype.translate = function (address, port, callback) {
   callback(address + ':' + port);

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -129,7 +129,8 @@ Parser.prototype._transform = function (item, encoding, callback) {
  * @param {{header: FrameHeader, chunk: Buffer}} item
  */
 Parser.prototype.parseBody = function (frameInfo, item) {
-  if (!frameInfo.byRow) {
+  if (!frameInfo.byRow || item.header.opcode !== types.opcodes.result) {
+    //Only RESULT operations are allowed to avoid buffering
     var currentLength = (frameInfo.bufferLength || 0) + item.chunk.length;
     if (currentLength < item.header.bodyLength) {
       //buffer until the message is completed
@@ -156,9 +157,11 @@ Parser.prototype.parseBody = function (frameInfo, item) {
     // cell value.
     if (frameInfo.buffers) {
       frameInfo.buffers.push(item.chunk);
-    } else if (frameInfo.buffer) {
+    }
+    else if (frameInfo.buffer) {
         frameInfo.buffers = [frameInfo.buffer, item.chunk];
-    } else {
+    }
+    else {
         frameInfo.buffers = [item.chunk];
     }
 
@@ -182,6 +185,8 @@ Parser.prototype.parseBody = function (frameInfo, item) {
     reader.unshift(frameInfo.buffer);
     frameInfo.buffer = null;
   }
+  //All the body for most operations is already buffered at this stage
+  //Except for RESULT
   switch (item.header.opcode) {
     case types.opcodes.result:
       return this.parseResult(frameInfo, reader);
@@ -189,58 +194,19 @@ Parser.prototype.parseBody = function (frameInfo, item) {
     case types.opcodes.authSuccess:
       return this.push({ header: frameInfo.header, ready: true });
     case types.opcodes.authChallenge:
-      return this.parseAuthChallenge(frameInfo, reader);
+      return this.push({ header: frameInfo.header, authChallenge: true, token: reader.readBytes()});
     case types.opcodes.authenticate:
-      return this.push({ header: frameInfo.header, mustAuthenticate: true });
+      return this.push({ header: frameInfo.header, mustAuthenticate: true, authenticatorName: reader.readString()});
     case types.opcodes.error:
-      return this.parseError(frameInfo, reader);
+      return this.push({ header: frameInfo.header, error: reader.readError()});
     case types.opcodes.supported:
       return this.push({ header: frameInfo.header });
     case types.opcodes.event:
-      return this.parseEvent(frameInfo, reader);
+      return this.push({ header: frameInfo.header, event: reader.readEvent()});
     default:
       return this.push({ header: frameInfo.header, error: new Error('Received invalid opcode: ' + item.header.opcode) });
   }
 };
-
-/**
- * Tries to read the error code and message.
- * If there is enough data to read, it pushes the header and error. If there isn't, it buffers it.
- * @param frameInfo information of the frame being parsed
- * @param {FrameReader} reader
- */
-Parser.prototype.parseError = function (frameInfo, reader) {
-  try {
-    this.push({ header: frameInfo.header, error: reader.readError()});
-  }
-  catch (e) {
-    if (e instanceof RangeError) {
-      frameInfo.buffer = reader.getBuffer();
-      return;
-    }
-    throw e;
-  }
-};
-
-/**
- * Tries to read the event from Cassandra
- * If there is enough data to read, it pushes the header and body. If there isn't, it buffers it.
- * @param frameInfo information of the frame being parsed
- * @param {FrameReader} reader
- */
-Parser.prototype.parseEvent = function (frameInfo, reader) {
-  try {
-    this.push({ header: frameInfo.header, event: reader.readEvent()});
-  }
-  catch (e) {
-    if (e instanceof RangeError) {
-      frameInfo.buffer = reader.getBuffer();
-      return;
-    }
-    throw e;
-  }
-};
-
 /**
  * Tries to read the result in the body of a message
  * @param frameInfo Frame information, header / metadata
@@ -350,24 +316,6 @@ Parser.prototype.parseRows = function (frameInfo, reader) {
       length: frameInfo.rowLength,
       flags: frameInfo.flagsInfo
     });
-  }
-};
-
-/**
- * @param frameInfo
- * @param {FrameReader} reader
- */
-Parser.prototype.parseAuthChallenge = function (frameInfo, reader) {
-  try {
-    //receives a token (can be empty or null)
-    this.push({ header: frameInfo.header, authChallenge: true, token: reader.readBytes()});
-  }
-  catch (e) {
-    if (e instanceof RangeError) {
-      frameInfo.buffer = reader.getBuffer();
-      return;
-    }
-    throw e;
   }
 };
 

--- a/lib/types/inet-address.js
+++ b/lib/types/inet-address.js
@@ -10,7 +10,7 @@ var utils = require('../utils');
  */
 function InetAddress(buffer) {
   if (!(buffer instanceof Buffer) || (buffer.length !== 4 && buffer.length !== 16)) {
-    throw new Error('The ip address must contain 4 or 16 bytes');
+    throw new TypeError('The ip address must contain 4 or 16 bytes');
   }
   this.buffer = buffer;
   /**
@@ -36,6 +36,10 @@ function InetAddress(buffer) {
 InetAddress.fromString = function (value) {
   if (!value) {
     return new InetAddress(new Buffer([0, 0, 0, 0]));
+  }
+  var pattern = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$|^[\da-f:]+$/i;
+  if (!pattern.test(value)) {
+    throw new TypeError('Value could not be parsed as InetAddress: ' + value);
   }
   var parts = value.split('.');
   if (parts.length === 4) {
@@ -68,7 +72,7 @@ InetAddress.fromString = function (value) {
     }
     return new InetAddress(buffer);
   }
-  throw new Error('Value could not be parsed as InetAddress: ' + value);
+  throw new TypeError('Value could not be parsed as InetAddress: ' + value);
 };
 
 /**
@@ -109,6 +113,7 @@ InetAddress.prototype.inspect = function () {
  *   In cases where there is more than one field of only zeros, it can be shortened. For example, 2001:0db8:0:0:0:1:0:1
  *   will be expressed as 2001:0db8::1:0:1.
  * </p>
+ * @param {String} [encoding]
  * @returns {String}
  */
 InetAddress.prototype.toString = function (encoding) {

--- a/test/unit/inet-address-tests.js
+++ b/test/unit/inet-address-tests.js
@@ -1,3 +1,4 @@
+'use strict';
 var assert = require('assert');
 var util = require('util');
 var events = require('events');
@@ -11,19 +12,19 @@ describe('InetAddress', function () {
     it('should validate the Buffer length', function () {
       assert.throws(function () {
         new InetAddress(new Buffer(10));
-      });
+      }, TypeError);
       assert.throws(function () {
         new InetAddress(null);
-      });
+      }, TypeError);
       assert.throws(function () {
         new InetAddress();
-      });
+      }, TypeError);
       assert.doesNotThrow(function () {
         new InetAddress(new Buffer(16));
-      });
+      }, TypeError);
       assert.doesNotThrow(function () {
         new InetAddress(new Buffer(4));
-      });
+      }, TypeError);
     });
   });
   describe('#toString()', function () {
@@ -93,10 +94,25 @@ describe('InetAddress', function () {
       helper.assertInstanceOf(val, InetAddress);
       assert.strictEqual(val.toString(), '10.11.12.13');
     });
-    it('should throw when can not parse to 4 or 16 bytes', function () {
+    it('should throw TypeError when the string is not a valid address', function () {
       assert.throws(function () {
         InetAddress.fromString('127.0.0.1.10');
-      }, Error);
+      }, TypeError);
+      assert.throws(function () {
+        InetAddress.fromString('127.0.');
+      }, TypeError);
+      assert.throws(function () {
+        InetAddress.fromString(' 127.10.0.1');
+      }, TypeError);
+      assert.throws(function () {
+        InetAddress.fromString('z');
+      }, TypeError);
+      assert.throws(function () {
+        InetAddress.fromString('::Z:11:2233:4455:aa:bb');
+      }, TypeError);
+      assert.throws(function () {
+        InetAddress.fromString(' ::a:11');
+      }, TypeError);
     });
   });
 });


### PR DESCRIPTION
Would be nice to create a CQL builder which supports the same type classes as the driver, and make this CQL builder only dependent of the types repository, not the driver itself. So the CQL builder could be used along with the driver, but not necessarily.