### PR TITLE
Read timeout at statement level

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -98,43 +98,60 @@ var clientOptions = require('./client-options');
 /**
  * Query options
  * @typedef {Object} QueryOptions
- * @property {Number} consistency Consistency level. Default: localOne.
- * @property {Number} fetchSize Amount of rows to retrieve per page.
- * @property {Boolean} prepare Determines if the query must be executed as a prepared statement.
- * @property {Boolean} autoPage Determines if the driver must retrieve the next pages.
- * @property {Buffer|Array} routingKey Partition key(s) to determine which coordinator should be used for the query.
- * @property {Array} routingIndexes Index of the parameters that are part of the partition key to determine the routing.
- * @property {Array} routingNames Array of the parameters names that are part of the partition key to determine the routing.
- * @property {Array|Array<Array>} hints Type hints for parameters given in the query, ordered as for the parameters.
- * <p>
- *   For batch queries, an array of such arrays, ordered as with the queries in the batch.
- * </p>
- * @property {Buffer|String} pageState Buffer or string token representing the paging state.
- * <p>
- *   Useful for manual paging, if provided, the query will be executed starting from a given paging state.
- * </p>
- * @property {RetryPolicy} retry Retry policy for the query.
- * <p>
- *   This property can be used to specify a different [retry policy]{@link module:policies/retry} to the one specified in the {@link ClientOptions}.policies.
- * </p>
- * @property {Number|Long} timestamp the default timestamp for the query in microseconds from the unix epoch (00:00:00, January 1st, 1970).
- * If provided, this will replace the server side assigned timestamp as default timestamp.
- * @property {Number} serialConsistency Serial consistency is the consistency level for the serial phase of conditional updates.
- * This option will be ignored for anything else that a conditional update/insert.
- * @property {Boolean} traceQuery Enable query tracing for the execution. Use query tracing to diagnose performance problems related to query executions. Default: false.
- * <p>
- *  To retrieve trace, you can call [Metadata.getTrace()]{@link Metadata} method.
- * </p>
- * @property {Boolean} retryOnTimeout Determines if the client should retry when it didn't hear back from a host within
- * <code>socketOptions.readTimeout</code>. Default: true.
- * @property {Object} customPayload Key-value payload to be passed to the server. On the Cassandra side, implementations of QueryHandler can use this data.
- * @property {Boolean} logged Determines if the batch should be written to the batchlog. Only for {@link Client.batch()}. Default: true.
- * @property {Boolean} captureStackTrace Determines if the stack trace before the query execution should be maintained.
+ * @property {Boolean} [autoPage] Determines if the driver must retrieve the following result pages automatically.
+ * @property {Boolean} [captureStackTrace] Determines if the stack trace before the query execution should be maintained.
  * <p>
  *   Useful for debugging purposes, it should be set to <code>false</code> under production environment as it adds an
  *   unnecessary overhead to each execution.
  * </p>
  * Default: false.
+ * @property {Number} [consistency] [Consistency level]{@link module:types~consistencies}. Default: localOne.
+ * @property {Object} [customPayload] Key-value payload to be passed to the server. On the Cassandra side, implementations
+ * of QueryHandler can use this data.
+ * @property {Number} [fetchSize] Amount of rows to retrieve per page.
+ * @property {Array|Array<Array>} hints Type hints for parameters given in the query, ordered as for the parameters.
+ * <p>
+ *   For batch queries, an array of such arrays, ordered as with the queries in the batch.
+ * </p>
+ * @property {Boolean} [logged] Determines if the batch should be written to the batchlog. Only valid for
+ * [Client#batch()]{@link Client#batch}, it will be ignored by other methods. Default: true.
+ * @property {Buffer|String} [pageState] Buffer or string token representing the paging state.
+ * <p>
+ *   Useful for manual paging, if provided, the query will be executed starting from a given paging state.
+ * </p>
+ * @property {Boolean} [prepare] Determines if the query must be executed as a prepared statement.
+ * @property {Number} [readTimeout] When defined, it overrides the default read timeout
+ * (<code>socketOptions.readTimeout</code>) in milliseconds for this execution per coordinator.
+ * <p>
+ *   Suitable for statements for which the coordinator may allow a longer server-side timeout, for example aggregation
+ *   queries.
+ * </p>
+ * <p>
+ *   A value of <code>0</code> disables client side read timeout for the execution. Default: <code>undefined</code>.
+ * </p>
+ * @property {RetryPolicy} [retry] Retry policy for the query.
+ * <p>
+ *   This property can be used to specify a different [retry policy]{@link module:policies/retry} to the one specified
+ *   in the {@link ClientOptions}.policies.
+ * </p>
+ * @property {Boolean} [retryOnTimeout] Determines if the client should retry when it didn't hear back from a host within
+ * <code>socketOptions.readTimeout</code>. Default: true.
+ * @property {Array} [routingIndexes] Index of the parameters that are part of the partition key to determine the routing.
+ * @property {Buffer|Array} [routingKey] Partition key(s) to determine which coordinator should be used for the query.
+ * @property {Array} [routingNames] Array of the parameters names that are part of the partition key to determine the
+ * routing.
+ * @property {Number} [serialConsistency] Serial consistency is the consistency level for the serial phase of conditional
+ * updates.
+ * This option will be ignored for anything else that a conditional update/insert.
+ * @property {Number|Long} [timestamp] The default timestamp for the query in microseconds from the unix epoch (00:00:00,
+ * January 1st, 1970).
+ * <p>If provided, this will replace the server side assigned timestamp as default timestamp.</p>
+ * <p>Use [generateTimestamp()]{@link module:types~generateTimestamp} utility method to generate a valid timestamp based on a Date and microseconds parts.</p>
+ * @property {Boolean} [traceQuery] Enable query tracing for the execution. Use query tracing to diagnose performance
+ * problems related to query executions. Default: false.
+ * <p>
+ *  To retrieve trace, you can call [Metadata.getTrace()]{@link module:metadata~Metadata#getTrace} method.
+ * </p>
  */
 
 /**

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -372,7 +372,7 @@ Connection.prototype.prepareOnce = function (query, callback) {
 /**
  * Uses the frame writer to write into the wire
  * @param request
- * @param options
+ * @param {QueryOptions} options
  * @param {function} callback Function to be called once the response has been received
  */
 Connection.prototype.sendStream = function (request, options, callback) {
@@ -394,6 +394,13 @@ Connection.prototype.sendStream = function (request, options, callback) {
   this.writeQueue.push(request, this.getWriteCallback(request, options, callback));
 };
 
+/**
+ * Returns the write callback
+ * @param request
+ * @param {QueryOptions} options
+ * @param {Function} callback
+ * @returns {Function}
+ */
 Connection.prototype.getWriteCallback = function (request, options, callback) {
   var self = this;
   return (function writeCallback (err) {
@@ -406,14 +413,8 @@ Connection.prototype.getWriteCallback = function (request, options, callback) {
       return callback(err);
     }
     self.log('verbose', 'Sent stream #' + request.streamId + ' to ' + self.endpoint);
-    //the request was successfully written, use a timer to set the readTimeout
-    var timeout;
-    if (self.options.socketOptions.readTimeout > 0) {
-      timeout = setTimeout(function () {
-        self.onTimeout(request.streamId);
-      }, self.options.socketOptions.readTimeout);
-    }
     if (request instanceof requests.ExecuteRequest || request instanceof requests.QueryRequest) {
+      //noinspection JSUnresolvedVariable
       if (options && options.byRow) {
         self.parser.setOptions(request.streamId, { byRow: true });
       }
@@ -431,7 +432,7 @@ Connection.prototype.getWriteCallback = function (request, options, callback) {
       callback: callback,
       rowCallback: options && options.rowCallback,
       options: options,
-      timeout: timeout
+      timeout: self.setRequestTimeout(request, options)
     };
   });
 };
@@ -578,6 +579,24 @@ Connection.prototype.invokeCallback = function (handler, err, response) {
   if (callback) {
     callback(err, response);
   }
+};
+
+/**
+ * Creates a timeout for the given request and returns the timeout object.
+ * @param request
+ * @param {QueryOptions} options
+ * @returns {Object} The timeout object
+ */
+Connection.prototype.setRequestTimeout = function (request, options) {
+  var millis = (options && options.readTimeout) || this.options.socketOptions.readTimeout;
+  if (!(millis > 0)) {
+    //read timeout disabled
+    return null;
+  }
+  var self = this;
+  return setTimeout(function () {
+    self.onTimeout(request.streamId);
+  }, millis);
 };
 
 /**


### PR DESCRIPTION
`readTimeout`:

> When defined, it overrides the default read timeout (`socketOptions.readTimeout`) in milliseconds for this execution per coordinator.
> 
> Suitable for statements for which the coordinator may allow a longer server-side timeout, for example aggregation queries.
> 
> A value of `0` disables client side read timeout for the execution. Default: `undefined`.

Also alphabetized and added more info on QueryOptions jsdocs.