### PR TITLE
Generate monotonically increasing timeuuids for monotonically increasing dates

### DIFF
--- a/lib/types/time-uuid.js
+++ b/lib/types/time-uuid.js
@@ -24,8 +24,10 @@ var _ticksInMs = 10000;
 var _ticks = 0;
 /**
  * Remember the last time when a timeuuid tick was generated
+ * @private
+ * @type {number}
  */
-var _lastTickTime = 0;
+var _lastTimestamp = 0;
 /**
  * Creates a new instance of Uuid based on the parameters provided according to rfc4122.
  * If any of the arguments is not provided, it will be randomly generated, except for the date that will use the current date.
@@ -208,9 +210,9 @@ function getNodeId(nodeId) {
 function getTicks(time, ticks) {
   if (typeof ticks !== 'number'|| ticks >= _ticksInMs) {
     _ticks++;
-    if (_ticks >= _ticksInMs || time !== _lastTickTime) {
+    if (_ticks >= _ticksInMs || time > _lastTimestamp) {
       _ticks = 0;
-      _lastTickTime = time;
+      _lastTimestamp = time;
     }
     ticks = _ticks;
   }

--- a/lib/types/time-uuid.js
+++ b/lib/types/time-uuid.js
@@ -23,6 +23,10 @@ var _ticksInMs = 10000;
  */
 var _ticks = 0;
 /**
+ * Remember the last time when a timeuuid tick was generated
+ */
+var _lastTickTime = 0;
+/**
  * Creates a new instance of Uuid based on the parameters provided according to rfc4122.
  * If any of the arguments is not provided, it will be randomly generated, except for the date that will use the current date.
  * @class
@@ -201,11 +205,12 @@ function getNodeId(nodeId) {
   return buffer;
 }
 
-function getTicks(ticks) {
+function getTicks(time, ticks) {
   if (typeof ticks !== 'number'|| ticks >= _ticksInMs) {
     _ticks++;
-    if (_ticks >= _ticksInMs) {
+    if (_ticks >= _ticksInMs || time !== _lastTickTime) {
       _ticks = 0;
+      _lastTickTime = time;
     }
     ticks = _ticks;
   }
@@ -238,7 +243,7 @@ function getRandomBytes(length) {
  */
 function generateBuffer(date, ticks, nodeId, clockId) {
   var time = getTime(date);
-  ticks = getTicks(ticks);
+  ticks = getTicks(time, ticks);
   nodeId = getNodeId(nodeId);
   clockId = getClockId(clockId);
   var buffer = new Buffer(16);

--- a/lib/types/time-uuid.js
+++ b/lib/types/time-uuid.js
@@ -23,7 +23,13 @@ var _ticksInMs = 10000;
  */
 var _ticks = 0;
 /**
- * Remember the last time when a timeuuid tick was generated
+ * Counter used to generate ticks for the current time
+ * @private
+ * @type {number}
+ */
+var _ticksForCurrentTime = 0;
+/**
+ * Remember the last time when a ticks for the current time so that it can be reset
  * @private
  * @type {number}
  */
@@ -207,12 +213,17 @@ function getNodeId(nodeId) {
   return buffer;
 }
 
-function getTicks(time, ticks) {
+/**
+ * Returns the ticks portion of a timestamp.  If the ticks are not provided an internal counter is used that gets reset at 10000.
+ * @private
+ * @param {Number} [ticks] 
+ * @returns {Number} 
+ */
+function getTicks(ticks) {
   if (typeof ticks !== 'number'|| ticks >= _ticksInMs) {
     _ticks++;
-    if (_ticks >= _ticksInMs || time > _lastTimestamp) {
+    if (_ticks >= _ticksInMs) {
       _ticks = 0;
-      _lastTimestamp = time;
     }
     ticks = _ticks;
   }
@@ -220,14 +231,27 @@ function getTicks(time, ticks) {
 }
 
 /**
+ * Returns an object with the time representation of the date expressed in milliseconds since unix epoch 
+ * and a ticks property for the 100-nanoseconds precision.
  * @private
- * @returns {Number} Returns the time representation of the date expressed in milliseconds since unix epoch.
+ * @returns {{time: Number, ticks: Number}} 
  */
-function getTime(date) {
+function getTimeWithTicks(date, ticks) {
   if (!(date instanceof Date) || isNaN(date.getTime())) {
+    // time with ticks for the current time
     date = new Date();
+    var time = date.getTime();
+    _ticksForCurrentTime++;
+    if(_ticksForCurrentTime > _ticksInMs || time > _lastTimestamp) {
+      _ticksForCurrentTime = 0;
+      _lastTimestamp = time;
+    }
+    ticks = _ticksForCurrentTime;
   }
-  return date.getTime();
+  return {
+    time: date.getTime(),
+    ticks: getTicks(ticks)
+  }
 }
 
 function getRandomBytes(length) {
@@ -244,13 +268,12 @@ function getRandomBytes(length) {
  * @returns {Buffer}
  */
 function generateBuffer(date, ticks, nodeId, clockId) {
-  var time = getTime(date);
-  ticks = getTicks(time, ticks);
+  var timeWithTicks = getTimeWithTicks(date, ticks);
   nodeId = getNodeId(nodeId);
   clockId = getClockId(clockId);
   var buffer = new Buffer(16);
   //Positions 0-7 Timestamp
-  writeTime(buffer, time, ticks);
+  writeTime(buffer, timeWithTicks.time, timeWithTicks.ticks);
   //Position 8-9 Clock
   clockId.copy(buffer, 8, 0);
   //Positions 10-15 Node

--- a/test/unit/uuid-tests.js
+++ b/test/unit/uuid-tests.js
@@ -175,6 +175,24 @@ describe('TimeUuid', function () {
       //next should collide
       assert.strictEqual(values[TimeUuid.fromDate(date, null, 'host01', 'AA').toString()], true);
     });
+    it('should result in increasing time values if date changes every two steps', function () {
+      var timeUuidBefore = TimeUuid.fromDate(new Date(0), null, 'host01', 'AA');
+      var length = 10000;
+
+      for (var i = 1; i <= length; i++) {
+        var date = new Date(Math.ceil(i/2));
+        var timeUuid = TimeUuid.fromDate(date, null, 'host01', 'AA');
+
+        var datePrecision = timeUuid.getDatePrecision();
+        var datePrecisionBefore = timeUuidBefore.getDatePrecision();
+
+        assert.ok(datePrecisionBefore.date < datePrecision.date ||
+            (datePrecisionBefore.date.getTime() === datePrecision.date.getTime() &&
+            datePrecisionBefore.ticks < datePrecision.ticks));
+
+        timeUuidBefore = timeUuid;
+      }
+    });
   });
   describe('fromString()', function () {
     it('should parse the string representation', function () {

--- a/test/unit/uuid-tests.js
+++ b/test/unit/uuid-tests.js
@@ -175,32 +175,6 @@ describe('TimeUuid', function () {
       //next should collide
       assert.strictEqual(values[TimeUuid.fromDate(date, null, 'host01', 'AA').toString()], true);
     });
-    it('should result in increasing time values if date changes every two steps', function () {
-      var timeUuidBefore = TimeUuid.fromDate(new Date(0), null, 'host01', 'AA');
-      var length = 10000;
-
-      for (var i = 1; i <= length; i++) {
-        var date = new Date(Math.ceil(i/2));
-        var timeUuid = TimeUuid.fromDate(date, null, 'host01', 'AA');
-
-        var datePrecision = timeUuid.getDatePrecision();
-        var datePrecisionBefore = timeUuidBefore.getDatePrecision();
-
-        assert.ok(datePrecisionBefore.date < datePrecision.date ||
-            (datePrecisionBefore.date.getTime() === datePrecision.date.getTime() &&
-            datePrecisionBefore.ticks < datePrecision.ticks));
-
-        timeUuidBefore = timeUuid;
-      }
-    });
-    it('should generate non-colliding timeuuids for a fixed dates when generating timeuuids with interleaved dates', function () {
-        var values = {};
-        values[TimeUuid.fromDate(new Date(0), null, 'host01', 'AA').toString()] = true;
-        values[TimeUuid.fromDate(new Date(1), null, 'host01', 'AA').toString()] = true;
-        values[TimeUuid.fromDate(new Date(0), null, 'host01', 'AA').toString()] = true;
-        
-        assert.strictEqual(Object.keys(values).length, 3);
-    });
   });
   describe('fromString()', function () {
     it('should parse the string representation', function () {
@@ -222,6 +196,14 @@ describe('TimeUuid', function () {
       assert.ok([date-1, date, date+1].indexOf(val) > -1,
         util.format("Expected %d to be within ± 1ms of %d.", val, date));
     });
+    it('should reset the ticks portion of the TimeUuid to zero when the time progresses', function () {
+      var firstTimeUuid = TimeUuid.now();
+      var secondTimeUuid = TimeUuid.now();
+      while(firstTimeUuid.getDate().getTime() === secondTimeUuid.getDate().getTime()) {
+        secondTimeUuid = TimeUuid.now();
+      }
+      assert.strictEqual(secondTimeUuid.getDatePrecision().ticks, 0);
+    })  
   });
   describe('min()', function () {
     it('should generate uuid with the minimum node and clock id values', function () {

--- a/test/unit/uuid-tests.js
+++ b/test/unit/uuid-tests.js
@@ -193,6 +193,14 @@ describe('TimeUuid', function () {
         timeUuidBefore = timeUuid;
       }
     });
+    it('should generate non-colliding timeuuids for a fixed dates when generating timeuuids with interleaved dates', function () {
+        var values = {};
+        values[TimeUuid.fromDate(new Date(0), null, 'host01', 'AA').toString()] = true;
+        values[TimeUuid.fromDate(new Date(1), null, 'host01', 'AA').toString()] = true;
+        values[TimeUuid.fromDate(new Date(0), null, 'host01', 'AA').toString()] = true;
+        
+        assert.strictEqual(Object.keys(values).length, 3);
+    });
   });
   describe('fromString()', function () {
     it('should parse the string representation', function () {


### PR DESCRIPTION
We are having a problem with the current TimeUuid implementation of the nodejs driver: From time to time we generate two TimeUuids using the same date (especially when importing events from a different system). Most of the times, these will have the correct order, i.e. they have the same date component and increasing ticks.
However, every 10000 times these two TimeUuids are created when the internal tick counter flips from 9999 to 0. Then, they will have the same date component but the ticks decrease, and they will be stored in the wrong order.
The following pull requests adds a unit test for this problem and fixes it by remembering the time for which the last tick was created, such that it resets the _ticks not only if it reaches 10000 but also if time advances.