### PR TITLE
support decoding timestamp as numeric value

### DIFF
--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -47,7 +47,8 @@ function defaultOptions () {
     maxPrepared: 500,
     encoding: {
       copyBuffer: true,
-      useUndefinedAsUnset: true
+      useUndefinedAsUnset: true,
+      useNumericTimestamp: false
     }
   });
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -93,6 +93,11 @@ var clientOptions = require('./client-options');
  * <p>
  *   Default: true.
  * </p>
+ * @property {Boolean} encoding.useNumericTimestamp Determines if decode the timestamp as a numeric or Date value
+ * <p>
+ *  Setting it to true will decode the timestamp types as numeric without converting it to its Date value.
+ *  Default: false.
+ * </p>
  */
 
 /**

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -140,7 +140,11 @@ function defineInstanceMembers() {
     return BigDecimal.fromBuffer(bytes);
   };
   this.decodeTimestamp = function(bytes) {
-    return new Date(this.decodeLong(bytes).toNumber());
+    var timestamp = this.decodeLong(bytes).toNumber();
+    if (this.encodingOptions.useNumericTimestamp) {
+      return timestamp;
+    }
+    return new Date(timestamp);
   };
   this.decodeDate = function (bytes) {
     return types.LocalDate.fromBuffer(bytes);


### PR DESCRIPTION
Add support to decode the timestamp type as its numeric value.
This option is required, when communicating with client side with the numeric timestamp value.