### PR TITLE
Performance: Use neo-async instead of async

### DIFF
--- a/examples/basic/basic-execute-flow.js
+++ b/examples/basic/basic-execute-flow.js
@@ -1,7 +1,7 @@
 "use strict";
 //replace by    require('cassandra-driver');
 var cassandra = require('../../');
-var async = require('async');
+var async = require('neo-async');
 var assert = require('assert');
 
 var client = new cassandra.Client({ contactPoints: ['127.0.0.1']});

--- a/examples/metadata/metadata-table.js
+++ b/examples/metadata/metadata-table.js
@@ -1,7 +1,7 @@
 "use strict";
 //replace by    require('cassandra-driver');
 var cassandra = require('../../');
-var async = require('async');
+var async = require('neo-async');
 var assert = require('assert');
 
 var client = new cassandra.Client({ contactPoints: ['127.0.0.1']});

--- a/examples/runner.js
+++ b/examples/runner.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var async = require('async');
+var async = require('neo-async');
 var exec = require('child_process').exec;
 var fs = require('fs');
 var path = require('path');

--- a/examples/tracing/retrieve-query-trace.js
+++ b/examples/tracing/retrieve-query-trace.js
@@ -1,7 +1,7 @@
 "use strict";
 //replace by    require('cassandra-driver');
 var cassandra = require('../../');
-var async = require('async');
+var async = require('neo-async');
 var assert = require('assert');
 
 var client = new cassandra.Client({ contactPoints: ['127.0.0.1']});

--- a/examples/tuple/tuple-insert-select.js
+++ b/examples/tuple/tuple-insert-select.js
@@ -1,7 +1,7 @@
 "use strict";
 //replace by    require('cassandra-driver');
 var cassandra = require('../../');
-var async = require('async');
+var async = require('neo-async');
 var assert = require('assert');
 
 var client = new cassandra.Client({ contactPoints: ['127.0.0.1']});

--- a/examples/udt/udt-insert-select.js
+++ b/examples/udt/udt-insert-select.js
@@ -1,7 +1,7 @@
 "use strict";
 //replace by    require('cassandra-driver');
 var cassandra = require('../../');
-var async = require('async');
+var async = require('neo-async');
 var assert = require('assert');
 
 var client = new cassandra.Client({ contactPoints: ['127.0.0.1']});

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,7 +1,7 @@
 "use strict";
 var events = require('events');
 var util = require('util');
-var async = require('async');
+var async = require('neo-async');
 
 var utils = require('./utils.js');
 var errors = require('./errors.js');

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -2,7 +2,7 @@
 var net = require('net');
 var events = require('events');
 var util = require('util');
-var async = require('async');
+var async = require('neo-async');
 var tls = require('tls');
 
 var Encoder = require('./encoder.js');

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -1,5 +1,5 @@
 "use strict";
-var async = require('async');
+var async = require('neo-async');
 var events = require('events');
 var util = require('util');
 var dns = require('dns');

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -1,6 +1,6 @@
 "use strict";
 var util = require('util');
-var async = require('async');
+var async = require('neo-async');
 
 var types = require('./types');
 var dataTypes = types.dataTypes;

--- a/lib/host.js
+++ b/lib/host.js
@@ -1,7 +1,7 @@
 "use strict";
 var util = require('util');
 var events = require('events');
-var async = require('async');
+var async = require('neo-async');
 
 var Connection = require('./connection');
 var utils = require('./utils');

--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -1,7 +1,7 @@
 "use strict";
 var events = require('events');
 var util = require('util');
-var async = require('async');
+var async = require('neo-async');
 /**
  * Module containing classes and fields related to metadata.
  * @module metadata

--- a/lib/metadata/schema-parser.js
+++ b/lib/metadata/schema-parser.js
@@ -1,6 +1,6 @@
 "use strict";
 var util = require('util');
-var async = require('async');
+var async = require('neo-async');
 var events = require('events');
 var types = require('../types');
 var utils = require('../utils');

--- a/lib/policies/address-resolution.js
+++ b/lib/policies/address-resolution.js
@@ -1,5 +1,5 @@
 "use strict";
-var async = require('async');
+var async = require('neo-async');
 var dns = require('dns');
 var util = require('util');
 /** @module policies/addressResolution */

--- a/lib/policies/load-balancing.js
+++ b/lib/policies/load-balancing.js
@@ -1,5 +1,5 @@
 var util = require('util');
-var async = require('async');
+var async = require('neo-async');
 
 var types = require('../types');
 var utils = require('../utils.js');

--- a/lib/policies/reconnection.js
+++ b/lib/policies/reconnection.js
@@ -1,5 +1,5 @@
 var util = require('util');
-var async = require('async');
+var async = require('neo-async');
 
 var types = require('../types');
 var utils = require('../utils.js');

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -1,6 +1,6 @@
 "use strict";
 var util = require('util');
-var async = require('async');
+var async = require('neo-async');
 
 var errors = require('./errors');
 var types = require('./types');

--- a/lib/requests.js
+++ b/lib/requests.js
@@ -1,4 +1,4 @@
-var async = require('async');
+var async = require('neo-async');
 var events = require('events');
 var util = require('util');
 

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -1,5 +1,5 @@
 var util = require('util');
-var async = require('async');
+var async = require('neo-async');
 
 var types = require('./types');
 var utils = require('./utils.js');

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -1,5 +1,5 @@
 var util = require('util');
-var async = require('async');
+var async = require('neo-async');
 
 var utils = require('../utils');
 var errors = require('../errors');

--- a/lib/writers.js
+++ b/lib/writers.js
@@ -1,4 +1,4 @@
-var async = require('async');
+var async = require('neo-async');
 var events = require('events');
 var util = require('util');
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     }
   ],
   "dependencies": {
-    "async": "^1.5.0",
-    "long": "^2.2.0"
+    "long": "^2.2.0",
+    "neo-async": "1.7.5"
   },
   "devDependencies": {
     "mocha": ">= 1.14.0",
@@ -30,17 +30,17 @@
     "mocha-jenkins-reporter": ">= 0.1.9"
   },
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/datastax/nodejs-driver.git"
+    "type": "git",
+    "url": "https://github.com/datastax/nodejs-driver.git"
   },
   "bugs": {
     "url": "https://groups.google.com/a/lists.datastax.com/forum/#!forum/nodejs-driver-user"
   },
-  "scripts":  {
+  "scripts": {
     "test": "mocha test/unit -R spec -t 5000",
     "ci": "mocha test/unit test/integration/short -R mocha-jenkins-reporter"
   },
   "engines": {
-    "node" : ">=0.10.0"
-   }
+    "node": ">=0.10.0"
+  }
 }

--- a/test/integration/long/client-metadata-tests.js
+++ b/test/integration/long/client-metadata-tests.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 
 var helper = require('../../test-helper');

--- a/test/integration/long/error-tests.js
+++ b/test/integration/long/error-tests.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 
 var helper = require('../../test-helper');

--- a/test/integration/long/load-balancing-tests.js
+++ b/test/integration/long/load-balancing-tests.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 
 var helper = require('../../test-helper.js');

--- a/test/integration/long/reconnection-tests.js
+++ b/test/integration/long/reconnection-tests.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 
 var helper = require('../../test-helper.js');

--- a/test/integration/long/stress-tests.js
+++ b/test/integration/long/stress-tests.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 
 var helper = require('../../test-helper.js');

--- a/test/integration/short/_infrastructure-tests.js
+++ b/test/integration/short/_infrastructure-tests.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var helper = require('../../test-helper.js');
 
 describe('Test infrastructure', function () {

--- a/test/integration/short/client-batch-tests.js
+++ b/test/integration/short/client-batch-tests.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 
 var helper = require('../../test-helper.js');

--- a/test/integration/short/client-each-row-tests.js
+++ b/test/integration/short/client-each-row-tests.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 
 var helper = require('../../test-helper.js');

--- a/test/integration/short/client-execute-prepared-tests.js
+++ b/test/integration/short/client-execute-prepared-tests.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 
 var helper = require('../../test-helper');

--- a/test/integration/short/client-execute-tests.js
+++ b/test/integration/short/client-execute-tests.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 
 var helper = require('../../test-helper.js');

--- a/test/integration/short/client-pool-tests.js
+++ b/test/integration/short/client-pool-tests.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var domain = require('domain');
 
 var helper = require('../../test-helper');

--- a/test/integration/short/client-stream-tests.js
+++ b/test/integration/short/client-stream-tests.js
@@ -1,6 +1,6 @@
 "use strict";
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 
 var helper = require('../../test-helper.js');

--- a/test/integration/short/connection-tests.js
+++ b/test/integration/short/connection-tests.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 var util = require('util');
-var async = require('async');
+var async = require('neo-async');
 
 var Connection = require('../../../lib/connection.js');
 var defaultOptions = require('../../../lib/client-options.js').defaultOptions();

--- a/test/integration/short/control-connection-tests.js
+++ b/test/integration/short/control-connection-tests.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 
 var helper = require('../../test-helper');
 var ControlConnection = require('../../../lib/control-connection');

--- a/test/integration/short/custom-payload-tests.js
+++ b/test/integration/short/custom-payload-tests.js
@@ -1,6 +1,6 @@
 "use strict";
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 
 var helper = require('../../test-helper');

--- a/test/integration/short/metadata-tests.js
+++ b/test/integration/short/metadata-tests.js
@@ -1,6 +1,6 @@
 "use strict";
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 
 var helper = require('../../test-helper');
 var Client = require('../../../lib/client');

--- a/test/integration/short/timeout-tests.js
+++ b/test/integration/short/timeout-tests.js
@@ -1,6 +1,6 @@
 "use strict";
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 
 var helper = require('../../test-helper');
 var Client = require('../../../lib/client');

--- a/test/integration/short/udf-tests.js
+++ b/test/integration/short/udf-tests.js
@@ -1,6 +1,6 @@
 "use strict";
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 
 var helper = require('../../test-helper');
 var Client = require('../../../lib/client');

--- a/test/other/memory/basic-profile.js
+++ b/test/other/memory/basic-profile.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 var fs = require('fs');
 var heapdump;

--- a/test/other/memory/profile-keeping-ref.js
+++ b/test/other/memory/profile-keeping-ref.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 var fs = require('fs');
 var heapdump;

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -1,4 +1,4 @@
-var async = require('async');
+var async = require('neo-async');
 var assert = require('assert');
 var util = require('util');
 var path = require('path');

--- a/test/unit/address-resolution-tests.js
+++ b/test/unit/address-resolution-tests.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var util = require('util');
 var events = require('events');
-var async = require('async');
+var async = require('neo-async');
 var dns = require('dns');
 
 var addressResolution = require('../../lib/policies/address-resolution');

--- a/test/unit/basic-tests.js
+++ b/test/unit/basic-tests.js
@@ -2,7 +2,7 @@
 var assert = require('assert');
 var util = require('util');
 var events = require('events');
-var async = require('async');
+var async = require('neo-async');
 
 var Client = require('../../lib/client.js');
 var clientOptions = require('../../lib/client-options.js');

--- a/test/unit/big-decimal-tests.js
+++ b/test/unit/big-decimal-tests.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var util = require('util');
 var events = require('events');
-var async = require('async');
+var async = require('neo-async');
 var utils = require('../../lib/utils.js');
 
 var types = require('../../lib/types');

--- a/test/unit/client-tests.js
+++ b/test/unit/client-tests.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 var rewire = require('rewire');
 

--- a/test/unit/connection-tests.js
+++ b/test/unit/connection-tests.js
@@ -1,6 +1,6 @@
 "use strict";
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 var events = require('events');
 var rewire = require('rewire');

--- a/test/unit/control-connection-tests.js
+++ b/test/unit/control-connection-tests.js
@@ -1,6 +1,6 @@
 "use strict";
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var events = require('events');
 
 var helper = require('../test-helper.js');

--- a/test/unit/encoder-tests.js
+++ b/test/unit/encoder-tests.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 var util = require('util');
-var async = require('async');
+var async = require('neo-async');
 var utils = require('../../lib/utils');
 
 var Encoder = require('../../lib/encoder');

--- a/test/unit/host-tests.js
+++ b/test/unit/host-tests.js
@@ -1,6 +1,6 @@
 "use strict";
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 var events = require('events');
 

--- a/test/unit/load-balancing-tests.js
+++ b/test/unit/load-balancing-tests.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 
 var helper = require('../test-helper.js');

--- a/test/unit/metadata-tests.js
+++ b/test/unit/metadata-tests.js
@@ -1,6 +1,6 @@
 "use strict";
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 
 var helper = require('../test-helper.js');

--- a/test/unit/parser-tests.js
+++ b/test/unit/parser-tests.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 var util = require('util');
-var async = require('async');
+var async = require('neo-async');
 
 var Encoder = require('../../lib/encoder');
 var streams = require('../../lib/streams');

--- a/test/unit/reconnection-test.js
+++ b/test/unit/reconnection-test.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 //project modules
 var reconnection = require('../../lib/policies/reconnection.js');

--- a/test/unit/request-handler-tests.js
+++ b/test/unit/request-handler-tests.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var async = require('async');
+var async = require('neo-async');
 var util = require('util');
 var rewire = require('rewire');
 


### PR DESCRIPTION
The node cassandra driver uses https://github.com/caolan/async for much of its
control flow. As a result, the `async` library shows up prominently in cpu
profiles, typically using most cpu time of all driver components.

The neo-async library (https://github.com/suguru03/neo-async) promises a
light-weight drop-in replacement, with lower memory and cpu consumption. After
seeing promising results in bluebird's micro-benchmark suite, I was curious
whether those results would translate to real-world applications.

To test this, I replaced `async` with `neo-async`, and ran a single-threaded
web server benchmark:

- using https://github.com/wikimedia/restbase: `node server.js -c
  config.example.wikimedia.yaml -n 1`
- Each request involves two simple Cassandra read queries.
- Test run: `wrk -H'Accept-encoding: gzip' --latency -d60
  http://localhost:7231/en.wikipedia.org/v1/page/html/FOO`
- First run for warm-up, second run for actual measurement.

Results:

library | throughput | memory
---------|----------------|--------------
async     | 670 req/s | 320m RSS
neo-async | 788 req/s | 222m RSS

So, it looks like neo-async does indeed improve performance significantly in
this benchmark.

Out of an abundance of caution, this patch pulls in a fixed version of
neo-async. This way, new versions of neo-async can be tested with the driver
before being officially pulled in.