### PR TITLE
Appveyor enablement

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Enterprise (3.1+) using exclusively Cassandra's binary protocol and Cassandra Qu
 $ npm install cassandra-driver
 ```
 
-[![Build Status](https://travis-ci.org/datastax/nodejs-driver.svg?branch=master)](https://travis-ci.org/datastax/nodejs-driver)
+[![Build Status](https://travis-ci.org/datastax/nodejs-driver.svg?branch=master)](https://travis-ci.org/datastax/nodejs-driver) [![Build status](https://ci.appveyor.com/api/projects/status/m21t2tfdpmkjex1l/branch/master?svg=true)](https://ci.appveyor.com/project/datastax/nodejs-driver/branch/master)
+
 
 ## Features
 

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -1,0 +1,61 @@
+$env:JAVA_HOME="C:\Program Files\Java\jdk1.8.0"
+$env:PYTHON="C:\Python27-x64"
+$env:PATH="$($env:PYTHON);$($env:PYTHON)\Scripts;$($env:JAVA_HOME)\bin;$($env:PATH)"
+$env:CCM_PATH="C:\Users\appveyor\ccm"
+
+# Install Ant and Maven
+$packages = "ant", "maven"
+Start-Process cinst -ArgumentList @("-y","$packages") -Wait -NoNewWindow
+# Workaround for ccm, link ant.exe -> ant.bat
+If (!(Test-Path C:\ProgramData\chocolatey\bin\ant.bat)) {
+  cmd /c mklink C:\ProgramData\chocolatey\bin\ant.bat C:\ProgramData\chocolatey\bin\ant.exe
+}
+
+# Install Java Cryptographic Extensions, needed for SSL.
+$target = "$($env:JAVA_HOME)\jre\lib\security"
+# If this file doesn't exist we know JCE hasn't been installed.
+$jce_indicator = "$target\README.txt"
+$zip = "C:\Users\appveyor\jce_policy-8.zip"
+If (!(Test-Path $jce_indicator)) {
+  # Download zip to staging area if it doesn't exist, we do this because
+  # we extract it to the directory based on the platform and we want to cache
+  # this file so it can apply to all platforms.
+  if(!(Test-Path $zip)) {
+    $url = "https://www.dropbox.com/s/al1e6e92cjdv7m7/jce_policy-8.zip?dl=1"
+    (new-object System.Net.WebClient).DownloadFile($url, $zip)
+  }
+
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  [System.IO.Compression.ZipFile]::ExtractToDirectory($zip, $target)
+
+  $jcePolicyDir = "$target\UnlimitedJCEPolicyJDK8"
+  Move-Item $jcePolicyDir\* $target\ -force
+  Remove-Item $jcePolicyDir
+}
+
+# Install Python Dependencies for CCM.
+Start-Process python -ArgumentList "-m pip install psutil pyYaml six" -Wait -NoNewWindow
+
+# Clone ccm from git and use master.
+If (!(Test-Path $env:CCM_PATH)) {
+  Start-Process git -ArgumentList "clone https://github.com/pcmanus/ccm.git $($env:CCM_PATH)" -Wait -NoNewWindow
+}
+
+# Copy ccm -> ccm.py so windows knows to run it.
+If (!(Test-Path $env:CCM_PATH\ccm.py)) {
+  Copy-Item "$env:CCM_PATH\ccm" "$env:CCM_PATH\ccm.py"
+}
+$env:PYTHONPATH="$($env:CCM_PATH);$($env:PYTHONPATH)"
+$env:PATH="$($env:CCM_PATH);$($env:PATH)"
+
+# Predownload cassandra version for CCM if it isn't already downloaded.
+If (!(Test-Path C:\Users\appveyor\.ccm\repository\$env:TEST_CASSANDRA_VERSION)) {
+  Start-Process python -ArgumentList "$($env:CCM_PATH)\ccm.py create -v $($env:TEST_CASSANDRA_VERSION) -n 1 predownload" -Wait -NoNewWindow
+  Start-Process python -ArgumentList "$($env:CCM_PATH)\ccm.py remove predownload" -Wait -NoNewWindow
+}
+
+# Activate the proper nodejs version.
+Install-Product node $env:nodejs_version $env:PLATFORM
+
+# Enable appveyor reporter
+$env:multi="spec=- mocha-appveyor-reporter=-"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+environment:
+  ci_type: ci_unit
+  matrix:
+    - nodejs_version: 5
+      TEST_CASSANDRA_VERSION: 3.0.5
+      ci_type: ci
+    - nodejs_version: 4
+    - nodejs_version: 0.12
+    - nodejs_version: 0.10
+platform:
+  - x64
+install:
+  - ps: .\appveyor.ps1
+  - npm install
+build: off
+test_script:
+  - "npm run %ci_type%"
+cache:
+  - node_modules -> package.json
+  - C:\ProgramData\chocolatey\bin
+  - C:\ProgramData\chocolatey\lib
+  - C:\Users\appveyor\jce_policy-8.zip
+  - C:\Users\appveyor\.ccm\repository
+  - C:\Users\appveyor\ccm

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,8 @@
 nodejs:
   - "0.10"
   - "0.12"
-  - "4.3"
-  - "5.6"
+  - "4"
+  - "5"
 os:
   - ubuntu/trusty64
 cassandra:

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,8 @@
 nodejs:
   - "0.10"
   - "0.12"
-  - "iojs-3"
-  - "4.0"
+  - "4.3"
+  - "5.6"
 os:
   - ubuntu/trusty64
 cassandra:
@@ -19,6 +19,7 @@ build:
       CCM_PATH=$HOME/ccm
       JUNIT_REPORT_STACK=1
       JUNIT_REPORT_PATH=.
+      multi=mocha-jenkins-reporter=-
   - npm: install
   - npm: run-script ci
     graceful: true

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,8 @@
 nodejs:
   - "0.10"
   - "0.12"
-  - "4"
-  - "5"
+  - "4.3"
+  - "5.6"
 os:
   - ubuntu/trusty64
 cassandra:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   "devDependencies": {
     "mocha": ">= 1.14.0",
     "rewire": ">= 2.1.0",
-    "mocha-jenkins-reporter": ">= 0.1.9"
+    "mocha-jenkins-reporter": ">= 0.1.9",
+    "mocha-appveyor-reporter": ">= 0.2.1",
+    "mocha-multi": ">= 0.8.0"
   },
   "repository": {
     "type" : "git",
@@ -36,8 +38,9 @@
     "url": "https://groups.google.com/a/lists.datastax.com/forum/#!forum/nodejs-driver-user"
   },
   "scripts":  {
-    "test": "mocha test/unit -R spec -t 5000",
-    "ci": "mocha test/unit test/integration/short -R mocha-jenkins-reporter"
+    "test": "./node_modules/.bin/mocha test/unit -R spec -t 5000",
+    "ci": "./node_modules/.bin/mocha test/unit test/integration/short -R mocha-multi",
+    "ci_unit": "./node_modules/.bin/mocha test/unit -R mocha-multi"
   },
   "engines": {
     "node" : ">=0.10.0"

--- a/test/integration/long/client-metadata-tests.js
+++ b/test/integration/long/client-metadata-tests.js
@@ -73,7 +73,7 @@ describe('Client', function () {
   describe('#getReplicas() with ByteOrderPartitioner', function () {
     var ccmOptions = {
       vnodes: true,
-      yaml: ['partitioner: org.apache.cassandra.dht.ByteOrderedPartitioner']
+      yaml: ['partitioner:org.apache.cassandra.dht.ByteOrderedPartitioner']
     };
     before(helper.ccmHelper.start('2', ccmOptions));
     after(helper.ccmHelper.remove);
@@ -101,7 +101,7 @@ describe('Client', function () {
   describe('#getReplicas() with RandomPartitioner', function () {
     var ccmOptions = {
       vnodes: true,
-      yaml: ['partitioner: org.apache.cassandra.dht.RandomPartitioner']
+      yaml: ['partitioner:org.apache.cassandra.dht.RandomPartitioner']
     };
     before(helper.ccmHelper.start('2', ccmOptions));
     after(helper.ccmHelper.remove);

--- a/test/integration/long/error-tests.js
+++ b/test/integration/long/error-tests.js
@@ -17,7 +17,7 @@ describe('Client', function () {
       policies: { loadBalancing: new helper.WhiteListPolicy(['2'])}
     });
     utils.series([
-      helper.ccmHelper.start(2, { yaml: ['tombstone_failure_threshold: 1000']}),
+      helper.ccmHelper.start(2, { yaml: ['tombstone_failure_threshold:1000']}),
       client.connect.bind(client),
       helper.toTask(client.execute, client, "CREATE KEYSPACE test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}"),
       helper.toTask(client.execute, client, "CREATE TABLE test.foo(pk int, cc int, v int, primary key (pk, cc))"),
@@ -74,7 +74,7 @@ describe('Client', function () {
   vit('2.2', 'should callback with functionFailure error when the cql function throws an error', function (done) {
     var client = newInstance({});
     utils.series([
-      helper.ccmHelper.start(1, { yaml: ['enable_user_defined_functions: true']}),
+      helper.ccmHelper.start(1, { yaml: ['enable_user_defined_functions:true']}),
       client.connect.bind(client),
       helper.toTask(client.execute, client, helper.createKeyspaceCql('ks_func')),
       helper.toTask(client.execute, client, 'CREATE TABLE ks_func.tbl1 (id int PRIMARY KEY, v1 int, v2 int)'),

--- a/test/integration/long/event-tests.js
+++ b/test/integration/long/event-tests.js
@@ -1,0 +1,119 @@
+var assert = require('assert');
+var domain = require('domain');
+
+var helper = require('../../test-helper');
+var Host = require('../../../lib/host').Host;
+var utils = require('../../../lib/utils');
+var errors = require('../../../lib/errors');
+var types = require('../../../lib/types');
+var policies = require('../../../lib/policies');
+
+var Client = require('../../../lib/client');
+
+describe('Client', function () {
+  describe('events', function () {
+    //noinspection JSPotentiallyInvalidUsageOfThis
+    this.timeout(600000);
+    var is1x = helper.getCassandraVersion().charAt(0) === '1';
+    beforeEach(helper.ccmHelper.start(2));
+    afterEach(helper.ccmHelper.remove);
+    it('should emit hostUp hostDown', function (done) {
+      var client = newInstance();
+      var hostsWentUp = [];
+      var hostsWentDown = [];
+      utils.series([
+        client.connect.bind(client),
+        function addListeners(next) {
+          client.on('hostUp', hostsWentUp.push.bind(hostsWentUp));
+          client.on('hostDown', hostsWentDown.push.bind(hostsWentDown));
+          next();
+        },
+        helper.toTask(helper.ccmHelper.stopNode, null, 2),
+        helper.toTask(helper.ccmHelper.startNode, null, 2),
+        function waitForUp(next) {
+          // We wait slightly before checking host states
+          // because the node is marked UP just before the listeners are
+          // called since CCM considers the node up as soon as other nodes
+          // have seen it up, at which point they would send the
+          // notification on the control connection so there is a very small
+          // race here (evident in both 1.2 and 2.2).
+          // If the host was already marked up, we simply proceed.
+          if(hostsWentUp.length >= 1) {
+            next();
+          } else {
+            // Set a timeout of 10 seconds to call next at which point
+            // things will likely fail if the hostUp event has not been
+            // surfaced yet.
+            var timeout = setTimeout(next, 10000);
+            client.on('hostUp', function() {
+              // Call next on a timeout since this callback may be invoked
+              // before the one that adds to hostsWentUp.
+              setTimeout(next, 1);
+              clearTimeout(timeout);
+            });
+          }
+        },
+        function checkResults(next) {
+          assert.strictEqual(hostsWentUp.length, 1);
+          helper.assertInstanceOf(hostsWentUp[0], Host);
+          assert.strictEqual(helper.lastOctetOf(hostsWentUp[0]), '2');
+
+          // Special exception for C* 1.x, as it may send duplicate down events
+          // for a single host.
+          if(!is1x) {
+            assert.strictEqual(hostsWentDown.length, 1);
+          }
+          hostsWentDown.forEach(function(downHost) {
+            helper.assertInstanceOf(downHost, Host);
+            assert.strictEqual(helper.lastOctetOf(downHost), '2');
+          });
+          next();
+        },
+        client.shutdown.bind(client)
+      ], done);
+    });
+    it('should emit hostAdd hostRemove', function (done) {
+      var client = newInstance();
+      var hostsAdded = [];
+      var hostsRemoved = [];
+      function trace(message) {
+        return (function (next) {
+          helper.trace(message);
+          next();
+        });
+      }
+      utils.series([
+        client.connect.bind(client),
+        function addListeners(next) {
+          client.on('hostAdd', hostsAdded.push.bind(hostsAdded));
+          client.on('hostRemove', hostsRemoved.push.bind(hostsRemoved));
+          next();
+        },
+        trace('Bootstrapping node 3'),
+        helper.toTask(helper.ccmHelper.bootstrapNode, null, 3),
+        trace('Starting newly bootstrapped node 3'),
+        helper.toTask(helper.ccmHelper.startNode, null, 3),
+        trace('Decommissioning node 2'),
+        helper.toTask(helper.ccmHelper.decommissionNode, null, 2),
+        trace('Stopping node 2'),
+        helper.toTask(helper.ccmHelper.stopNode, null, 2),
+        function checkResults(next) {
+          helper.trace('Checking results');
+          assert.strictEqual(hostsAdded.length, 1);
+          assert.strictEqual(hostsRemoved.length, 1);
+          helper.assertInstanceOf(hostsAdded[0], Host);
+          helper.assertInstanceOf(hostsRemoved[0], Host);
+          assert.strictEqual(helper.lastOctetOf(hostsAdded[0]), '3');
+          assert.strictEqual(helper.lastOctetOf(hostsRemoved[0]), '2');
+          next();
+        },
+        client.shutdown.bind(client)
+      ], done);
+    });
+  });
+});
+
+/** @returns {Client}  */
+function newInstance(options) {
+  return new Client(utils.extend({}, helper.baseOptions, options));
+}

--- a/test/integration/short/client-batch-tests.js
+++ b/test/integration/short/client-batch-tests.js
@@ -371,7 +371,7 @@ describe('Client', function () {
       var client = newInstance();
       utils.parallel([
         function (next) {
-          utils.timesLimit(1000, 25, function (n, eachNext) {
+          utils.timesLimit(120, 100, function (n, eachNext) {
             var queries = [{
               query: query1Table1,
               params: [id1Tbl1, types.timeuuid(), types.BigDecimal.fromNumber(new Date().getTime())]
@@ -383,7 +383,7 @@ describe('Client', function () {
           }, next);
         },
         function (next) {
-          utils.timesLimit(1000, 25, function (n, eachNext) {
+          utils.timesLimit(120, 100, function (n, eachNext) {
             var queries = [{
               query: query2Table1,
               params: [id2Tbl1, types.timeuuid(), types.BigDecimal.fromNumber(new Date().getTime())]
@@ -406,7 +406,7 @@ describe('Client', function () {
             client.execute(query, [], { consistency: consistency }, function (err, result) {
               assert.ifError(err);
               var rows1 = result.rows;
-              assert.strictEqual(rows1.length, 2000);
+              assert.strictEqual(rows1.length, 240);
               next();
             });
           },
@@ -415,7 +415,7 @@ describe('Client', function () {
             client.execute(query, [], { consistency: consistency }, function (err, result) {
               assert.ifError(err);
               var rows2 = result.rows;
-              assert.strictEqual(rows2.length, 2000);
+              assert.strictEqual(rows2.length, 240);
               next();
             });
           }

--- a/test/integration/short/client-batch-tests.js
+++ b/test/integration/short/client-batch-tests.js
@@ -371,7 +371,7 @@ describe('Client', function () {
       var client = newInstance();
       utils.parallel([
         function (next) {
-          utils.timesLimit(1000, 100, function (n, eachNext) {
+          utils.timesLimit(1000, 25, function (n, eachNext) {
             var queries = [{
               query: query1Table1,
               params: [id1Tbl1, types.timeuuid(), types.BigDecimal.fromNumber(new Date().getTime())]
@@ -383,7 +383,7 @@ describe('Client', function () {
           }, next);
         },
         function (next) {
-          utils.timesLimit(1000, 100, function (n, eachNext) {
+          utils.timesLimit(1000, 25, function (n, eachNext) {
             var queries = [{
               query: query2Table1,
               params: [id2Tbl1, types.timeuuid(), types.BigDecimal.fromNumber(new Date().getTime())]
@@ -395,7 +395,9 @@ describe('Client', function () {
           }, next);
         }
       ], function (err) {
-        assert.ifError(err);
+        if(err) {
+          return done(err);
+        }
         //verify results in both tables
         var q = 'SELECT * FROM %s where id IN (%s, %s)';
         utils.series([

--- a/test/integration/short/client-each-row-tests.js
+++ b/test/integration/short/client-each-row-tests.js
@@ -282,13 +282,13 @@ describe('Client', function () {
         },
         function insertData(seriesNext) {
           var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table1);
-          utils.timesLimit(200, 100, function (n, next) {
+          utils.timesLimit(200, 25, function (n, next) {
             client.eachRow(query, [types.Uuid.random(), n.toString()], {prepare: 1}, noop, next);
           }, seriesNext);
         },
         function insertData(seriesNext) {
           var query = util.format('INSERT INTO %s (id, int_sample) VALUES (?, ?)', table2);
-          utils.timesLimit(135, 100, function (n, next) {
+          utils.timesLimit(135, 25, function (n, next) {
             client.eachRow(query, [types.Uuid.random(), n+1], {prepare: 1}, noop, next);
           }, seriesNext);
         },

--- a/test/integration/short/client-pool-tests.js
+++ b/test/integration/short/client-pool-tests.js
@@ -227,32 +227,8 @@ describe('Client', function () {
     });
   });
   describe('#connect() with auth', function () {
-    before(function (done) {
-      utils.series([
-        function (next) {
-          //it wont hurt to remove
-          helper.ccmHelper.exec(['remove'], function () {
-            //ignore error
-            next();
-          });
-        },
-        function (next) {
-          helper.ccmHelper.exec(['create', 'test', '-v', helper.getCassandraVersion()], next);
-        },
-        function (next) {
-          helper.ccmHelper.exec(['updateconf', "authenticator: PasswordAuthenticator"], next);
-        },
-        function (next) {
-          helper.ccmHelper.exec(['populate', '-n', '2'], next);
-        },
-        function (next) {
-          helper.ccmHelper.exec(['start'], function () {
-            //It takes a while for Cassandra to create the default user account
-            setTimeout(function () {next();}, 25000);
-          });
-        }
-      ], done)
-    });
+    before(helper.ccmHelper.start(2, { yaml: ['authenticator:PasswordAuthenticator'],
+      jvmArgs: ['-Dcassandra.superuser_setup_delay_ms=0'], sleep: 5000 }));
     after(helper.ccmHelper.remove);
     var PlainTextAuthProvider = require('../../../lib/auth/plain-text-auth-provider.js');
     it('should connect using the plain text authenticator', function (done) {

--- a/test/integration/short/client-pool-tests.js
+++ b/test/integration/short/client-pool-tests.js
@@ -4,7 +4,6 @@ var domain = require('domain');
 
 var helper = require('../../test-helper');
 var Client = require('../../../lib/client');
-var Host = require('../../../lib/host').Host;
 var clientOptions = require('../../../lib/client-options');
 var utils = require('../../../lib/utils');
 var errors = require('../../../lib/errors');
@@ -730,106 +729,6 @@ describe('Client', function () {
           client.hosts.forEach(function (host) {
             assert.strictEqual(host.isUp(), helper.lastOctetOf(host) === '3');
           });
-          next();
-        },
-        client.shutdown.bind(client)
-      ], done);
-    });
-  });
-  describe('events', function () {
-    //noinspection JSPotentiallyInvalidUsageOfThis
-    this.timeout(600000);
-    var is1x = helper.getCassandraVersion().charAt(0) === '1';
-    beforeEach(helper.ccmHelper.start(2));
-    afterEach(helper.ccmHelper.remove);
-    it('should emit hostUp hostDown', function (done) {
-      var client = newInstance();
-      var hostsWentUp = [];
-      var hostsWentDown = [];
-      utils.series([
-        client.connect.bind(client),
-        function addListeners(next) {
-          client.on('hostUp', hostsWentUp.push.bind(hostsWentUp));
-          client.on('hostDown', hostsWentDown.push.bind(hostsWentDown));
-          next();
-        },
-        helper.toTask(helper.ccmHelper.stopNode, null, 2),
-        helper.toTask(helper.ccmHelper.startNode, null, 2),
-        function waitForUp(next) {
-          // We wait slightly before checking host states
-          // because the node is marked UP just before the listeners are
-          // called since CCM considers the node up as soon as other nodes
-          // have seen it up, at which point they would send the
-          // notification on the control connection so there is a very small
-          // race here (evident in both 1.2 and 2.2).
-          // If the host was already marked up, we simply proceed.
-          if(hostsWentUp.length >= 1) {
-            next();
-          } else {
-            // Set a timeout of 10 seconds to call next at which point
-            // things will likely fail if the hostUp event has not been
-            // surfaced yet.
-            var timeout = setTimeout(next, 10000);
-            client.on('hostUp', function() {
-              // Call next on a timeout since this callback may be invoked
-              // before the one that adds to hostsWentUp.
-              setTimeout(next, 1);
-              clearTimeout(timeout);
-            });
-          }
-        },
-        function checkResults(next) {
-          assert.strictEqual(hostsWentUp.length, 1);
-          helper.assertInstanceOf(hostsWentUp[0], Host);
-          assert.strictEqual(helper.lastOctetOf(hostsWentUp[0]), '2');
-
-          // Special exception for C* 1.x, as it may send duplicate down events
-          // for a single host.
-          if(!is1x) {
-            assert.strictEqual(hostsWentDown.length, 1);
-          }
-          hostsWentDown.forEach(function(downHost) {
-            helper.assertInstanceOf(downHost, Host);
-            assert.strictEqual(helper.lastOctetOf(downHost), '2');
-          });
-          next();
-        },
-        client.shutdown.bind(client)
-      ], done);
-    });
-    it('should emit hostAdd hostRemove', function (done) {
-      var client = newInstance();
-      var hostsAdded = [];
-      var hostsRemoved = [];
-      function trace(message) {
-        return (function (next) {
-          helper.trace(message);
-          next();
-        });
-      }
-      utils.series([
-        client.connect.bind(client),
-        function addListeners(next) {
-          client.on('hostAdd', hostsAdded.push.bind(hostsAdded));
-          client.on('hostRemove', hostsRemoved.push.bind(hostsRemoved));
-          next();
-        },
-        trace('Bootstrapping node 3'),
-        helper.toTask(helper.ccmHelper.bootstrapNode, null, 3),
-        trace('Starting newly bootstrapped node 3'),
-        helper.toTask(helper.ccmHelper.startNode, null, 3),
-        trace('Decommissioning node 2'),
-        helper.toTask(helper.ccmHelper.decommissionNode, null, 2),
-        trace('Stopping node 2'),
-        helper.toTask(helper.ccmHelper.stopNode, null, 2),
-        function checkResults(next) {
-          helper.trace('Checking results');
-          assert.strictEqual(hostsAdded.length, 1);
-          assert.strictEqual(hostsRemoved.length, 1);
-          helper.assertInstanceOf(hostsAdded[0], Host);
-          helper.assertInstanceOf(hostsRemoved[0], Host);
-          assert.strictEqual(helper.lastOctetOf(hostsAdded[0]), '3');
-          assert.strictEqual(helper.lastOctetOf(hostsRemoved[0]), '2');
           next();
         },
         client.shutdown.bind(client)

--- a/test/integration/short/udf-tests.js
+++ b/test/integration/short/udf-tests.js
@@ -9,7 +9,7 @@ var vdescribe = helper.vdescribe;
 
 vdescribe('2.2', 'Metadata', function () {
   this.timeout(60000);
-  before(helper.ccmHelper.start(1, { yaml: ['enable_user_defined_functions: true']}));
+  before(helper.ccmHelper.start(1, { yaml: ['enable_user_defined_functions:true']}));
   var keyspace = 'ks_udf';
   before(function createSchema(done) {
     var client = newInstance();


### PR DESCRIPTION
Adds appveyor support to enable CI on windows.  Had to make a few tweaks to tests to make them run well on windows, but didn't take much.  Currently runs all short+unit tests.

Some things to determine:

* Do we want to run short tests all the time?  We have the bandwidth to do it.  Takes 30-35 minutes to run through all short tests.
* What combinations to test against?  Currently set up to test with nodejs driver 5.X and C* 3.0.4.  C* 2.2+ run reliably enough on windows.  Might be able to find a way to run against more combinations on master only on a weekly basis or something like that.

https://ci.appveyor.com/project/datastax/nodejs-driver