### PR TITLE
Replace async dependency

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,7 +1,6 @@
 "use strict";
 var events = require('events');
 var util = require('util');
-var async = require('async');
 
 var utils = require('./utils.js');
 var errors = require('./errors.js');
@@ -251,7 +250,7 @@ Client.prototype.connect = function (callback) {
   }
   this.connecting = true;
   var self = this;
-  async.series([
+  utils.series([
     function initControlConnection(next) {
       self.controlConnection.init(next);
     },
@@ -278,7 +277,7 @@ Client.prototype.connect = function (callback) {
       }
       self._warmup(next);
     }
-  ], function (err) {
+  ], function connectFinished(err) {
     self.connected = !err;
     self.connecting = false;
     self.emit('connected', err);
@@ -494,7 +493,7 @@ Client.prototype.shutdown = function (callback) {
   this.isShuttingDown = true;
   var self = this;
   var hosts = this.hosts.values();
-  async.each(hosts, function (h, next) {
+  utils.each(hosts, function (h, next) {
     h.shutdown(next);
   }, function(err) {
     self.connected = !!err;
@@ -517,20 +516,25 @@ Client.prototype.waitForSchemaAgreement = function (connection, callback) {
   var maxWaitTime = this.options.protocolOptions.maxSchemaAgreementWaitSeconds * 1000;
   this.log('info', 'Waiting for schema agreement');
   var versionsMatch;
-  async.doWhilst(function (next) {
-    async.series([
+  var peerVersions;
+  utils.whilst(function condition() {
+    return !versionsMatch && (new Date() - start) < maxWaitTime;
+  }, function fn(next) {
+    utils.series([
       function (next) {
-        self.metadata.getPeersSchemaVersions(connection, next);
+        self.metadata.getPeersSchemaVersions(connection, function (err, result) {
+          peerVersions = result;
+          next(err);
+        });
       },
       function (next) {
         self.metadata.getLocalSchemaVersion(connection, next);
       }
-    ], function (err, results) {
+    ], function seriesEnded(err, localVersion) {
       if (err) return next(err);
       //check the different versions
       versionsMatch = true;
-      var localVersion = results[1].toString();
-      var peerVersions = results[0];
+      localVersion = localVersion.toString();
       for (var i = 0; i < peerVersions.length; i++) {
         if (peerVersions[i].toString() !== localVersion) {
           versionsMatch = false;
@@ -543,8 +547,6 @@ Client.prototype.waitForSchemaAgreement = function (connection, callback) {
       //let some time pass before the next check
       setTimeout(next, 500);
     });
-  }, function () {
-    return !versionsMatch && (new Date() - start) < maxWaitTime;
   }, callback);
 };
 
@@ -561,14 +563,17 @@ Client.prototype._innerExecute = function (query, params, options, callback) {
     return this._executeAsPrepared(query, params, options, callback);
   }
   var self = this;
-  async.waterfall([
+  utils.series([
     function connecting(next) {
       self.connect(next);
     },
     function settingOptions(next) {
-      self._setQueryOptions(options, params, null, next);
+      self._setQueryOptions(options, params, null, function setOptionsCallback(err, p) {
+        params = p;
+        next(err);
+      });
     },
-    function sendingQuery(params, next) {
+    function sendingQuery(next) {
       var request = new requests.QueryRequest(
         query,
         params,
@@ -588,20 +593,27 @@ Client.prototype._innerExecute = function (query, params, options, callback) {
  * @private
  */
 Client.prototype._executeAsPrepared = function (query, params, options, callback) {
+  var queryId;
+  var meta;
   var self = this;
-  async.waterfall([
+  utils.series([
     function connecting(next) {
       self.connect(next);
     },
     function preparing(next) {
-      self._getPrepared(query, next);
-    },
-    function settingOptions(queryId, meta, next) {
-      self._setQueryOptions(options, params, meta, function (err, params) {
-        next(err, queryId, params)
+      self._getPrepared(query, function (err, id, m) {
+        queryId = id;
+        meta = m;
+        next(err);
       });
     },
-    function sendingExecute(queryId, params, next) {
+    function settingOptions(next) {
+      self._setQueryOptions(options, params, meta, function (err, p) {
+        params = p;
+        next(err);
+      });
+    },
+    function sendingExecute(next) {
       var request = new requests.ExecuteRequest(
         queryId,
         params,
@@ -674,7 +686,7 @@ Client.prototype._waitForPendingPrepares = function (queries, callback) {
   function doWait(queriesMap) {
     var toPrepare = {};
     var pendingIO = false;
-    async.each(Object.keys(queriesMap), function waitIterator(query, next) {
+    utils.each(Object.keys(queriesMap), function waitIterator(query, next) {
       var info = queriesMap[query];
       if (info.queryId) {
         //Its already prepared
@@ -833,7 +845,8 @@ Client.prototype._warmup = function (callback) {
   loadBalancingPolicy.newQueryPlan(this.keyspace, utils.emptyObject, function (err, iterator) {
     if (err) return callback(err);
     var hosts = utils.iteratorToArray(iterator);
-    async.eachLimit(hosts, 32, function (h, next) {
+    utils.timesLimit(hosts.length, 32, function (i, next) {
+      var h = hosts[i];
       var distance = loadBalancingPolicy.getDistance(h);
       h.setDistance(distance);
       if (distance !== types.distance.local) {
@@ -881,7 +894,7 @@ Client.prototype._setQueryOptions = function (options, params, meta, callback) {
   }
   var paramsInfo;
   var self = this;
-  async.series([
+  utils.series([
     function fillRoutingKeys(next) {
       if (options.routingKey || options.routingIndexes || options.routingNames || !meta) {
         //it is filled by the user

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -2,7 +2,6 @@
 var net = require('net');
 var events = require('events');
 var util = require('util');
-var async = require('async');
 var tls = require('tls');
 
 var Encoder = require('./encoder.js');
@@ -244,14 +243,14 @@ Connection.prototype.clearAndInvokePending = function (innerError) {
   }
   var self = this;
   //invoke all handlers
-  async.each(handlers, function (item, next) {
+  utils.each(handlers, function (item, next) {
     self.invokeCallback(item, err);
     next();
   });
 
   var pendingWritesCopy = this.pendingWrites;
   this.pendingWrites = [];
-  async.each(pendingWritesCopy, function (item, next) {
+  utils.each(pendingWritesCopy, function (item, next) {
     if (!item.callback) return;
     item.callback(err);
     next();
@@ -429,6 +428,7 @@ Connection.prototype.getWriteCallback = function (request, options, callback) {
         self.idleTimeoutHandler();
       }, self.options.pooling.heartBeatInterval);
     }
+    //noinspection JSUnresolvedVariable
     self.streamHandlers[request.streamId] = {
       callback: callback,
       rowCallback: options && options.rowCallback,

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -1,12 +1,10 @@
 "use strict";
-var async = require('async');
 var events = require('events');
 var util = require('util');
 var dns = require('dns');
 var net = require('net');
 
 var errors = require('./errors');
-var RequestHandler = require('./request-handler');
 var Host = require('./host').Host;
 var HostMap = require('./host').HostMap;
 var Metadata = require('./metadata');
@@ -77,9 +75,9 @@ ControlConnection.prototype.init = function (callback) {
     self.log('info', 'Adding host ' + endPoint);
     cb();
   }
-  async.series([
+  utils.series([
     function resolveNames(next) {
-      async.each(self.options.contactPoints, function (name, eachNext) {
+      utils.each(self.options.contactPoints, function (name, eachNext) {
         if (name.indexOf(':') > 0) {
           var parts = name.split(':');
           return addHost(parts[0], parts[1], eachNext);
@@ -150,11 +148,13 @@ ControlConnection.prototype.getConnection = function (callback) {
  */
 ControlConnection.prototype.getFirstConnection = function (callback) {
   var connection = null;
-  var index = 0;
+  var index = -1;
   var openingErrors = {};
   var hosts = this.hosts.values();
   var host = null;
-  async.doWhilst(function iterator(next) {
+  utils.whilst(function condition () {
+    return !connection && (++index < hosts.length);
+  }, function iterator(next) {
     host = hosts[index];
     host.borrowConnection(function (err, c) {
       if (err) {
@@ -165,8 +165,6 @@ ControlConnection.prototype.getFirstConnection = function (callback) {
       }
       next();
     });
-  }, function condition () {
-    return !connection && (++index < hosts.length);
   }, function done(err) {
     if (!connection) {
       err = new errors.NoHostAvailableError(openingErrors);
@@ -193,7 +191,7 @@ ControlConnection.prototype.getConnectionToNewHost = function (callback) {
       iterator = utils.arrayIterator(self.hosts.values());
     }
     //use iterator
-    async.whilst(
+    utils.whilst(
       function condition() {
         //while there isn't a valid connection
         if (connection) {
@@ -259,12 +257,9 @@ ControlConnection.prototype.refreshOnConnection = function (firstTime, callback)
   var c = this.connection;
   var self = this;
   self.log('info', 'Connection acquired to ' + self.host.address + ', refreshing nodes list');
-  async.series([
-    function subscribeHostEvents(next) {
-      self.host.once('down', self.hostDownHandler.bind(self));
-      next();
-    },
+  utils.series([
     function getLocalAndPeersInfo(next) {
+      self.host.once('down', self.hostDownHandler.bind(self));
       self.refreshHosts(firstTime, next);
     },
     function getKeyspaces(next) {
@@ -325,7 +320,7 @@ ControlConnection.prototype.refreshHosts = function (newNodesUp, callback) {
   }
   this.log('info', 'Refreshing local and peers info');
   var c = this.connection;
-  async.series([
+  utils.series([
     function getLocalInfo(next) {
       var request = new requests.QueryRequest(selectLocal, null, null);
       c.sendStream(request, {}, function (err, result) {
@@ -354,7 +349,7 @@ ControlConnection.prototype.hostDownHandler = function () {
  */
 ControlConnection.prototype.refresh = function (callback) {
   var self = this;
-  async.series([
+  utils.series([
       this.getConnection.bind(this),
       function (next) {
         if (!self.connection) {
@@ -489,7 +484,7 @@ ControlConnection.prototype.setPeersInfo = function (newNodesUp, result, callbac
   //A map of peers, could useful for in case there are discrepancies
   var peers = {};
   var port = this.options.protocolOptions.port;
-  async.eachSeries(result.rows, function (row, next) {
+  utils.eachSeries(result.rows, function (row, next) {
     self.getAddressForPeerHost(row, port, function (endPoint) {
       if (!endPoint) {
         return next();

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -1,6 +1,5 @@
 "use strict";
 var util = require('util');
-var async = require('async');
 
 var types = require('./types');
 var dataTypes = types.dataTypes;
@@ -881,7 +880,7 @@ function defineInstanceMembers() {
    */
   this._parseChildTypes = function (keyspace, dataType, typeNames, udtResolver, callback) {
     var self = this;
-    async.mapSeries(typeNames, function (name, next) {
+    utils.mapSeries(typeNames, function (name, next) {
       self.parseTypeName(keyspace, name.trim(), 0, null, udtResolver, next);
     }, function (err, childTypes) {
       if (err) {

--- a/lib/host.js
+++ b/lib/host.js
@@ -1,7 +1,6 @@
 "use strict";
 var util = require('util');
 var events = require('events');
-var async = require('async');
 
 var Connection = require('./connection');
 var utils = require('./utils');
@@ -237,7 +236,7 @@ util.inherits(HostConnectionPool, events.EventEmitter);
 HostConnectionPool.prototype.borrowConnection = function (callback) {
   var c;
   var self = this;
-  async.series([
+  utils.series([
     function createPoolIfNeeded(next) {
       self._maybeCreatePool(next)
     },
@@ -302,7 +301,7 @@ HostConnectionPool.prototype._maybeCreatePool = function (callback) {
   //Use a copy
   var connections = this.connections.slice(0);
   var self = this;
-  async.whilst(
+  utils.whilst(
     function condition() {
       return connections.length < self.coreConnectionsLength;
     },
@@ -367,7 +366,7 @@ HostConnectionPool.prototype._forceShutdown = function () {
   this.log('info', 'Closing force ' + this.connections.length + ' connections to ' + this.address);
   var activeConnections = this.connections;
   this.connections = utils.emptyArray;
-  async.each(activeConnections, function forceShutdownEachCallback(c, next) {
+  utils.each(activeConnections, function forceShutdownEachCallback(c, next) {
     c.close(function forceShutdownCloseCallback() {
       //don't mind if there was an error
       next();
@@ -431,7 +430,7 @@ HostConnectionPool.prototype.shutdown = function (callback) {
   var connections = this.connections;
   //Create a new reference
   this.connections = utils.emptyArray;
-  async.each(connections, function closeEach(c, next) {
+  utils.each(connections, function closeEach(c, next) {
     c.close(next);
   }, function shutdownEachEnded(err) {
     self.shuttingDown = false;

--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -1,7 +1,6 @@
 "use strict";
 var events = require('events');
 var util = require('util');
-var async = require('async');
 /**
  * Module containing classes and fields related to metadata.
  * @module metadata
@@ -454,7 +453,7 @@ Metadata.prototype.getTrace = function (traceId, callback) {
   var selectSession = util.format(_selectTraceSession, traceId);
   var selectEvents = util.format(_selectTraceEvents, traceId);
   var self = this;
-  async.whilst(function condition() {
+  utils.whilst(function condition() {
     return !trace && (attempts++  < _traceMaxAttemps);
   }, function iterator(next) {
     self.controlConnection.query(selectSession, function (err, result) {
@@ -549,7 +548,7 @@ Metadata.prototype.adaptUserHints = function (keyspace, hints, callback) {
     }
   }
   var self = this;
-  async.each(udts, function (type, next) {
+  utils.each(udts, function (type, next) {
     self.getUdt(type.info.keyspace, type.info.name, function (err, udtInfo) {
       if (err) return next(err);
       if (!udtInfo) {

--- a/lib/metadata/schema-parser.js
+++ b/lib/metadata/schema-parser.js
@@ -1,6 +1,5 @@
 "use strict";
 var util = require('util');
-var async = require('async');
 var events = require('events');
 var types = require('../types');
 var utils = require('../utils');
@@ -107,36 +106,40 @@ SchemaParser.prototype.getTable = function (keyspace, name, callback) {
     return;
   }
   tableInfo.loading = true;
+  var tableRow, columnRows, indexRows;
   //it is not cached, try to query for it
   var self = this;
-  async.waterfall([
+  utils.series([
     function getTableRow(next) {
       var query = util.format(self.selectTable, keyspace.name, name);
       self.cc.query(query, function (err, response) {
         if (err) return next(err);
-        next(null, response.rows[0]);
+        tableRow = response.rows[0];
+        next();
       });
     },
-    function getColumnRows (tableRow, next) {
+    function getColumnRows (next) {
       if (!tableRow) return next(null, null, null);
       var query = util.format(self.selectColumns, keyspace.name, name);
       self.cc.query(query, function (err, response) {
         if (err) return next(err);
-        next(null, tableRow, response.rows);
+        columnRows = response.rows;
+        next();
       });
     },
-    function getIndexes(tableRow, columnRows, next) {
+    function getIndexes(next) {
       if (!tableRow || !self.selectIndexes) {
         //either the table does not exists or it does not support indexes schema table
-        return next(null, tableRow, columnRows);
+        return next();
       }
       var query = util.format(self.selectIndexes, keyspace.name, name);
       self.cc.query(query, function (err, response) {
         if (err) return next(err);
-        next(null, tableRow, columnRows, response.rows);
+        indexRows = response.rows;
+        next();
       });
     }
-  ], function afterQuery (err, tableRow, columnRows, indexRows) {
+  ], function afterQuery (err) {
     if (err || !tableRow) {
       tableInfo.loading = false;
       return tableInfo.emit('load', err, null);
@@ -273,7 +276,7 @@ SchemaParser.prototype.getFunctions = function (keyspace, name, aggregate, callb
     if (response.rows.length > 0) {
       functionsInfo.values = {};
     }
-    async.each(response.rows, function (row, next) {
+    utils.each(response.rows, function (row, next) {
       parser(row, function (err, func) {
         if (err) {
           return next(err);
@@ -646,25 +649,28 @@ SchemaParserV2.prototype.getMaterializedView = function (cc, keyspace, name, cal
     return;
   }
   viewInfo.loading = true;
+  var tableRow, columnRows;
   //it is not cached, try to query for it
   var self = this;
-  async.waterfall([
+  utils.series([
     function getTableRow(next) {
       var query = util.format(_selectMaterializedViewV2, keyspace.name, name);
       cc.query(query, function (err, response) {
         if (err) return next(err);
-        next(null, response.rows[0]);
+        tableRow = response.rows[0];
+        next();
       });
     },
-    function getColumnRows (tableRow, next) {
+    function getColumnRows (next) {
       if (!tableRow) return next();
       var query = util.format(self.selectColumns, keyspace.name, name);
       cc.query(query, function (err, response) {
         if (err) return next(err);
-        next(null, tableRow, response.rows);
+        columnRows = response.rows;
+        next();
       });
     }
-  ], function afterQuery (err, tableRow, columnRows) {
+  ], function afterQuery (err) {
     viewInfo.loading = false;
     if (err || !tableRow) {
       return viewInfo.emit('load', err, null);
@@ -732,7 +738,7 @@ SchemaParserV2.prototype._parseTableOrView = function (tableInfo, tableRow, colu
   tableInfo.minIndexInterval = tableRow['min_index_interval'] || tableInfo.minIndexInterval;
   tableInfo.maxIndexInterval = tableRow['max_index_interval'] || tableInfo.maxIndexInterval;
   var self = this;
-  async.map(columnRows, function (row, next) {
+  utils.map(columnRows, function (row, next) {
     encoder.parseTypeName(tableRow['keyspace_name'], row['type'], 0, null, self.udtResolver, function (err, type) {
       if (err) {
         return next(err);
@@ -808,9 +814,9 @@ SchemaParserV2.prototype._parseAggregate = function (row, callback) {
   aggregate.initConditionRaw = row['initcond'];
   aggregate.initCondition = aggregate.initConditionRaw;
   var self = this;
-  async.series([
+  utils.series([
     function parseArguments(next) {
-      async.map(row['argument_types'] || utils.emptyArray, function (name, mapNext) {
+      utils.map(row['argument_types'] || utils.emptyArray, function (name, mapNext) {
         encoder.parseTypeName(row['keyspace_name'], name, 0, null, self.udtResolver, mapNext);
       }, function (err, result) {
         aggregate.argumentTypes = result;
@@ -849,9 +855,9 @@ SchemaParserV2.prototype._parseFunction = function (row, callback) {
   func.calledOnNullInput = row['called_on_null_input'];
   func.language = row['language'];
   var self = this;
-  async.series([
+  utils.series([
     function parseArguments(next) {
-      async.map(row['argument_types'] || utils.emptyArray, function (name, mapNext) {
+      utils.map(row['argument_types'] || utils.emptyArray, function (name, mapNext) {
         encoder.parseTypeName(row['keyspace_name'], name, 0, null, self.udtResolver, mapNext);
       }, function (err, result) {
         func.argumentTypes = result;
@@ -879,7 +885,7 @@ SchemaParserV2.prototype._parseUdt = function (udtInfo, row, callback) {
   var keyspace = row['keyspace_name'];
   var fields = new Array(fieldTypes.length);
   var self = this;
-  async.forEachOf(row['field_names'], function (name, i, next) {
+  utils.forEachOf(row['field_names'], function (name, i, next) {
     encoder.parseTypeName(keyspace, fieldTypes[i], 0, null, self.udtResolver, function (err, type) {
       if (err) {
         return next(err);

--- a/lib/policies/address-resolution.js
+++ b/lib/policies/address-resolution.js
@@ -1,7 +1,7 @@
 "use strict";
-var async = require('async');
 var dns = require('dns');
 var util = require('util');
+var utils = require('../utils');
 /** @module policies/addressResolution */
 /**
  * @class
@@ -76,15 +76,17 @@ util.inherits(EC2MultiRegionTranslator, AddressTranslator);
 EC2MultiRegionTranslator.prototype.translate = function (address, port, callback) {
   var newAddress = address;
   var self = this;
-  async.waterfall([
+  var name;
+  utils.series([
     function resolve(next) {
       dns.reverse(address, function (err, hostNames) {
         if (err) return next(err);
         if (!hostNames) return next();
-        next(null, hostNames[0]);
+        name = hostNames[0];
+        next();
       });
     },
-    function lookup(name, next) {
+    function lookup(next) {
       if (!name) return next();
       dns.lookup(name, function (err, lookupAddress) {
         if (err) return next(err);

--- a/lib/policies/load-balancing.js
+++ b/lib/policies/load-balancing.js
@@ -1,5 +1,4 @@
 var util = require('util');
-var async = require('async');
 
 var types = require('../types');
 var utils = require('../utils.js');

--- a/lib/policies/reconnection.js
+++ b/lib/policies/reconnection.js
@@ -1,5 +1,4 @@
 var util = require('util');
-var async = require('async');
 
 var types = require('../types');
 var utils = require('../utils.js');

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -1,6 +1,5 @@
 "use strict";
 var util = require('util');
-var async = require('async');
 
 var errors = require('./errors');
 var types = require('./types');
@@ -65,7 +64,7 @@ RequestHandler.prototype.iterateThroughHosts = function (iterator, callback) {
   var host;
   var connection = null;
   var self = this;
-  async.whilst(
+  utils.whilst(
     function condition() {
       //while there isn't a valid connection
       if (connection) {
@@ -87,19 +86,23 @@ RequestHandler.prototype.iterateThroughHosts = function (iterator, callback) {
         //If its marked as ignore by the load balancing policy, move on.
         return next();
       }
-      async.waterfall([
+      var c;
+      utils.series([
         function borrowingConnection(next) {
-          host.borrowConnection(next);
-        },
-        function changingKeyspace(c, waterfallNext) {
-          //There isn't a client, so there isn't an active keyspace
-          if (!self.client) return waterfallNext(null, c);
-          //Try to change, if the connection is on the same connection it wont change it.
-          c.changeKeyspace(self.client.keyspace, function (err) {
-            waterfallNext(err, c);
+          host.borrowConnection(function (err, pooledConnection) {
+            c = pooledConnection;
+            next(err);
           });
+        },
+        function changingKeyspace(next) {
+          if (!self.client) {
+            //There isn't a client, so there isn't an active keyspace
+            return next();
+          }
+          //Try to change, if the connection is on the same connection it wont change it.
+          c.changeKeyspace(self.client.keyspace, next);
         }
-      ], function (err, c) {
+      ], function (err) {
         if (err) {
           //Cannot get a connection
           //Its a bad host
@@ -273,7 +276,7 @@ RequestHandler.prototype.prepareMultiple = function (queries, callbacksArray, op
 RequestHandler.prototype.prepareOnConnection = function (queries, callbacksArray, callback) {
   var self = this;
   var index = 0;
-  async.eachSeries(queries, function (query, next) {
+  utils.eachSeries(queries, function (query, next) {
     self.connection.prepareOnce(query, function (err, response) {
       if (callbacksArray) {
         callbacksArray[index++](err, response);

--- a/lib/requests.js
+++ b/lib/requests.js
@@ -1,4 +1,3 @@
-var async = require('async');
 var events = require('events');
 var util = require('util');
 

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -1,5 +1,4 @@
 var util = require('util');
-var async = require('async');
 
 var types = require('./types');
 var utils = require('./utils.js');

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -1,5 +1,4 @@
 var util = require('util');
-var async = require('async');
 
 var utils = require('../utils');
 var errors = require('../errors');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,11 +4,14 @@ var errors = require('./errors');
 var utils = require('./utils');
 
 /**
+ * Max int that can be accurately represented with 64-bit Number (2^53)
+ * @type {number}
  * @const
- * @type {string}
- * @private
  */
-var _hex = '0123456789abcdef';
+var maxInt = 9007199254740992;
+
+function noop() {}
+
 /**
  * Creates a copy of a buffer
  */
@@ -36,9 +39,11 @@ function fixStack(stackTrace, error) {
  */
 function log(type, info, furtherInfo) {
   if (!this.logEmitter) {
+    //noinspection JSUnresolvedVariable
     if (!this.options || !this.options.logEmitter) {
       throw new Error('Log emitter not defined');
     }
+    //noinspection JSUnresolvedVariable
     this.logEmitter = this.options.logEmitter;
   }
   this.logEmitter('log', type, this.constructor.name, info, furtherInfo || '');
@@ -105,6 +110,7 @@ function deepExtend(target) {
       // a native single type
       // or not existent
       // or is not an anonymous object (not class instance)
+      //noinspection JSUnresolvedVariable
       if (!targetProp ||
         targetType === 'number' ||
         targetType === 'string' ||
@@ -121,36 +127,6 @@ function deepExtend(target) {
     }
   });
   return target;
-}
-
-/**
- * Sync events: executes the callback when the event (with the same parameters) have been called in all emitters.
- */
-function syncEvent(emitters, eventName, context, callback) {
-  var thisKey = '';
-  var eventListener = getListener(eventName, context);
-  emitters.forEach(function (item) {
-    thisKey += '_' + item.constructor.name;
-    item.on(eventName, eventListener);
-  });
-  context[thisKey] = {emittersLength: emitters.length};
-  
-  function getListener(eventName, context) {
-    return function listener () {
-      var argsKey = '_' + eventName + Array.prototype.slice.call(arguments).join('_');
-      var elements = context[thisKey];
-      if (typeof elements[argsKey] === 'undefined') {
-        elements[argsKey] = 0;
-        return;
-      }
-      else if (elements[argsKey] < elements.emittersLength-2){
-        elements[argsKey] = elements[argsKey] + 1;
-        return;
-      }
-      delete elements[argsKey];
-      callback.apply(context, Array.prototype.slice.call(arguments));
-    };
-  }
 }
 
 /**
@@ -427,6 +403,402 @@ HashSet.prototype.toArray = function () {
   return Object.keys(this.items);
 };
 
+/**
+ * @param {Array} arr
+ * @param {Function} fn
+ * @param {Function} [callback]
+ */
+function each(arr, fn, callback) {
+  if (!Array.isArray(arr)) {
+    throw new TypeError('First parameter is not an Array');
+  }
+  callback = callback || noop;
+  var length = arr.length;
+  if (length === 0) {
+    return callback();
+  }
+  var completed = 0;
+  for (var i = 0; i < length; i++) {
+    fn(arr[i], next);
+  }
+  function next(err) {
+    if (err) {
+      var cb = callback;
+      callback = noop;
+      cb(err);
+      return;
+    }
+    if (++completed !== length) {
+      return;
+    }
+    callback();
+  }
+}
+
+/**
+ * @param {Array} arr
+ * @param {Function} fn
+ * @param {Function} [callback]
+ */
+function eachSeries(arr, fn, callback) {
+  if (!Array.isArray(arr)) {
+    throw new TypeError('First parameter is not an Array');
+  }
+  callback = callback || noop;
+  var length = arr.length;
+  if (length === 0) {
+    return callback();
+  }
+  var sync;
+  var index = 1;
+  fn(arr[0], next);
+  if (sync === undefined) {
+    sync = false;
+  }
+
+  function next(err) {
+    if (err) {
+      return callback(err);
+    }
+    if (index >= length) {
+      return callback();
+    }
+    if (sync === undefined) {
+      sync = true;
+    }
+    if (sync) {
+      return process.nextTick(function () {
+        fn(arr[index++], next);
+      });
+    }
+    fn(arr[index++], next);
+  }
+}
+
+/**
+ * @param {Array} arr
+ * @param {Function} fn
+ * @param {Function} [callback]
+ */
+function forEachOf(arr, fn, callback) {
+  return mapEach(arr, fn, true, callback);
+}
+
+/**
+ * @param {Array} arr
+ * @param {Function} fn
+ * @param {Function} [callback]
+ */
+function map(arr, fn, callback) {
+  return mapEach(arr, fn, false, callback);
+}
+
+function mapEach(arr, fn, useIndex, callback) {
+  if (!Array.isArray(arr)) {
+    throw new TypeError('First parameter must be an Array');
+  }
+  callback = callback || noop;
+  var length = arr.length;
+  if (length === 0) {
+    return callback(null, []);
+  }
+  var result = new Array(length);
+  var completed = 0;
+  var invoke = useIndex ? invokeWithIndex : invokeWithoutIndex;
+  for (var i = 0; i < length; i++) {
+    invoke(i);
+  }
+
+  function invokeWithoutIndex(i) {
+    fn(arr[i], function mapItemCallback(err, transformed) {
+      result[i] = transformed;
+      next(err);
+    });
+  }
+
+  function invokeWithIndex(i) {
+    fn(arr[i], i, function mapItemCallback(err, transformed) {
+      result[i] = transformed;
+      next(err);
+    });
+  }
+
+  function next(err) {
+    if (err) {
+      var cb = callback;
+      callback = noop;
+      cb(err);
+      return;
+    }
+    if (++completed !== length) {
+      return;
+    }
+    callback(null, result);
+  }
+}
+
+/**
+ * @param {Array} arr
+ * @param {Function} fn
+ * @param {Function} [callback]
+ */
+function mapSeries(arr, fn, callback) {
+  if (!Array.isArray(arr)) {
+    throw new TypeError('First parameter must be an Array');
+  }
+  callback = callback || noop;
+  var length = arr.length;
+  if (length === 0) {
+    return callback(null, []);
+  }
+  var result = new Array(length);
+  var index = 0;
+  var sync;
+  invoke(0);
+  if (sync === undefined) {
+    sync = false;
+  }
+
+  function invoke(i) {
+    fn(arr[i], function mapItemCallback(err, transformed) {
+      result[i] = transformed;
+      next(err);
+    });
+  }
+
+  function next(err) {
+    if (err) {
+      return callback(err);
+    }
+    if (++index === length) {
+      return callback(null, result);
+    }
+    if (sync === undefined) {
+      sync = true;
+    }
+    var i = index;
+    if (sync) {
+      return process.nextTick(function () {
+        invoke(i);
+      });
+    }
+    invoke(index);
+  }
+}
+
+/**
+ * @param {Array.<Function>} arr
+ * @param {Function} [callback]
+ */
+function parallel(arr, callback) {
+  if (!Array.isArray(arr)) {
+    throw new TypeError('First parameter must be an Array');
+  }
+  callback = callback || noop;
+  var length = arr.length;
+  var completed = 0;
+  for (var i = 0; i < length; i++) {
+    arr[i](next);
+  }
+  function next(err) {
+    if (err) {
+      var cb = callback;
+      callback = noop;
+      return cb(err);
+    }
+    if (++completed !== length) {
+      return;
+    }
+    callback();
+  }
+}
+
+/**
+ * Similar to async.series(), but instead accumulating the result in an Array, it callbacks with the result of the last
+ * function in the array.
+ * @param {Array.<Function>} arr
+ * @param {Function} [callback]
+ */
+function series(arr, callback) {
+  if (!Array.isArray(arr)) {
+    throw new TypeError('First parameter must be an Array');
+  }
+  callback = callback || noop;
+  var index = 0;
+  var sync;
+  next();
+  function next(err, result) {
+    if (err) {
+      return callback(err);
+    }
+    if (index === arr.length) {
+      return callback(null, result);
+    }
+    if (sync) {
+      return process.nextTick(function () {
+        //noinspection JSUnusedAssignment
+        sync = true;
+        arr[index++](next);
+        sync = false;
+      });
+    }
+    sync = true;
+    arr[index++](next);
+    sync = false;
+  }
+}
+
+/**
+ * @param {Number} count
+ * @param {Function} iteratorFunc
+ * @param {Function} [callback]
+ */
+function times(count, iteratorFunc, callback) {
+  callback = callback || noop;
+  count = +count;
+  if (isNaN(count) || count === 0) {
+    return callback();
+  }
+  var completed = 0;
+  for (var i = 0; i < count; i++) {
+    iteratorFunc(i, next);
+  }
+  function next(err) {
+    if (err) {
+      var cb = callback;
+      callback = noop;
+      return cb(err);
+    }
+    if (++completed !== count) {
+      return;
+    }
+    callback();
+  }
+}
+
+/**
+ * @param {Number} count
+ * @param {Number} limit
+ * @param {Function} iteratorFunc
+ * @param {Function} [callback]
+ */
+function timesLimit(count, limit, iteratorFunc, callback) {
+  callback = callback || noop;
+  limit = Math.min(limit, count);
+  var index = limit - 1;
+  var i;
+  var completed = 0;
+  for (i = 0; i < limit; i++) {
+    iteratorFunc(i, next);
+  }
+  i = -1;
+  var sync = undefined;
+  function next(err) {
+    if (err) {
+      var cb = callback;
+      callback = noop;
+      cb(err);
+      return;
+    }
+    if (++completed === count) {
+      return callback();
+    }
+    index++;
+    if (index >= count) {
+      return;
+    }
+    if (sync === undefined) {
+      sync = (i >= 0);
+    }
+    if (sync) {
+      var captureIndex = index;
+      return process.nextTick(function () {
+        iteratorFunc(captureIndex, next);
+      });
+    }
+    iteratorFunc(index, next);
+  }
+}
+
+/**
+ * @param {Number} count
+ * @param {Function} iteratorFunction
+ * @param {Function} callback
+ */
+function timesSeries(count, iteratorFunction, callback) {
+  count = +count;
+  if (isNaN(count) || count < 1) {
+    return callback();
+  }
+  var index = 1;
+  var sync;
+  iteratorFunction(0, next);
+  if (sync === undefined) {
+    sync = false;
+  }
+  function next(err) {
+    if (err) {
+      return callback(err);
+    }
+    if (index === count) {
+      return callback();
+    }
+    if (sync === undefined) {
+      sync = true;
+    }
+    var i = index++;
+    if (sync) {
+      //Prevent "Maximum call stack size exceeded"
+      return process.nextTick(function () {
+        iteratorFunction(i, next);
+      });
+    }
+    //do a sync call as the callback is going to call on a future tick
+    iteratorFunction(i, next);
+  }
+}
+
+/**
+ * @param {Function} condition
+ * @param {Function} fn
+ * @param {Function} callback
+ */
+function whilst(condition, fn, callback) {
+  var sync = 0;
+  next();
+  function next(err) {
+    if (err) {
+      return callback(err);
+    }
+    if (!condition()) {
+      return callback();
+    }
+    if (sync === 0) {
+      sync = 1;
+      fn(function (err) {
+        if (sync === 1) {
+          //sync function
+          sync = 4;
+        }
+        next(err);
+      });
+      if (sync === 1) {
+        //async function
+        sync = 2;
+      }
+      return;
+    }
+    if (sync === 4) {
+      //Prevent "Maximum call stack size exceeded"
+      return process.nextTick(function () {
+        fn(next);
+      });
+    }
+    //do a sync call as the callback is going to call on a future tick
+    fn(next);
+  }
+}
+
 exports.adaptNamedParamsPrepared = adaptNamedParamsPrepared;
 exports.adaptNamedParamsWithHints = adaptNamedParamsWithHints;
 exports.arrayIterator = arrayIterator;
@@ -434,25 +806,31 @@ exports.binarySearch = binarySearch;
 exports.bindDomain = bindDomain;
 exports.copyBuffer = copyBuffer;
 exports.deepExtend = deepExtend;
+exports.each = each;
+exports.eachSeries = eachSeries;
 /** @const */
 exports.emptyArray = Object.freeze([]);
 /** @const */
 exports.emptyObject = Object.freeze({});
 exports.extend = extend;
 exports.fixStack = fixStack;
+exports.forEachOf = forEachOf;
 exports.funcCompare = funcCompare;
 exports.insertSorted = insertSorted;
 exports.iteratorToArray = iteratorToArray;
 exports.log = log;
-/**
- * Max int that can be accurately represented with 64-bit Number (2^53)
- * @type {number}
- */
-exports.maxInt = 9007199254740992;
+exports.map = map;
+exports.mapSeries = mapSeries;
+exports.maxInt = maxInt;
 exports.objectValues = objectValues;
+exports.parallel = parallel;
 exports.parseCommonArgs = parseCommonArgs;
 exports.propCompare = propCompare;
+exports.series = series;
 exports.stringRepeat = stringRepeat;
-exports.syncEvent = syncEvent;
+exports.times = times;
+exports.timesLimit = timesLimit;
+exports.timesSeries = timesSeries;
 exports.totalLength = totalLength;
+exports.whilst = whilst;
 exports.HashSet = HashSet;

--- a/lib/writers.js
+++ b/lib/writers.js
@@ -1,4 +1,3 @@
-var async = require('async');
 var events = require('events');
 var util = require('util');
 
@@ -184,7 +183,7 @@ WriteQueue.prototype.run = function () {
 
 WriteQueue.prototype.process = function () {
   var self = this;
-  async.whilst(
+  utils.whilst(
     function () {
       return self.queue.length > 0;
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     }
   ],
   "dependencies": {
-    "async": "^1.5.0",
     "long": "^2.2.0"
   },
   "devDependencies": {

--- a/test/integration/long/client-metadata-tests.js
+++ b/test/integration/long/client-metadata-tests.js
@@ -1,5 +1,5 @@
+"use strict";
 var assert = require('assert');
-var async = require('async');
 var util = require('util');
 
 var helper = require('../../test-helper');
@@ -7,10 +7,6 @@ var Client = require('../../../lib/client');
 var types = require('../../../lib/types');
 var utils = require('../../../lib/utils');
 var tokenizer = require('../../../lib/tokenizer');
-var loadBalancing = require('../../../lib/policies/load-balancing');
-var RoundRobinPolicy = loadBalancing.RoundRobinPolicy;
-var DCAwareRoundRobinPolicy = loadBalancing.DCAwareRoundRobinPolicy;
-var TokenAwarePolicy = loadBalancing.TokenAwarePolicy;
 
 describe('Client', function () {
   this.timeout(240000);
@@ -18,7 +14,7 @@ describe('Client', function () {
     before(function (done) {
       var client = new Client(helper.baseOptions);
       var createQuery = "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1' : %d, 'dc2' : %d}";
-      async.series([
+      utils.series([
         helper.ccmHelper.start('4:4', {sleep: 1000}),
         function (next) {
           client.execute(util.format(createQuery, 'sampleks1', 2, 2), next);

--- a/test/integration/long/error-tests.js
+++ b/test/integration/long/error-tests.js
@@ -1,5 +1,5 @@
+"use strict";
 var assert = require('assert');
-var async = require('async');
 var util = require('util');
 
 var helper = require('../../test-helper');
@@ -16,14 +16,14 @@ describe('Client', function () {
       contactPoints: ['127.0.0.2'],
       policies: { loadBalancing: new helper.WhiteListPolicy(['2'])}
     });
-    async.series([
+    utils.series([
       helper.ccmHelper.start(2, { yaml: ['tombstone_failure_threshold: 1000']}),
       client.connect.bind(client),
       helper.toTask(client.execute, client, "CREATE KEYSPACE test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}"),
       helper.toTask(client.execute, client, "CREATE TABLE test.foo(pk int, cc int, v int, primary key (pk, cc))"),
       function generateTombstones(next) {
         // The rest of the test relies on the fact that the PK '1' will be placed on node1 with MurmurPartitioner
-        async.timesSeries(2000, function (n, timesNext) {
+        utils.timesSeries(2000, function (n, timesNext) {
           client.execute('INSERT INTO test.foo (pk, cc, v) VALUES (1, ?, null)', [n], {prepare: true}, function (err, result) {
             if (err) return next(err);
             assert.strictEqual(helper.lastOctetOf(result.info.queriedHost), '2');
@@ -48,7 +48,7 @@ describe('Client', function () {
     var client = newInstance();
     var keyspace = 'ks_wfail';
     var table = keyspace + '.tbl1';
-    async.series([
+    utils.series([
       helper.ccmHelper.removeIfAny,
       helper.toTask(helper.ccmHelper.exec, null, ['create', 'test', '-v', helper.getCassandraVersion()]),
       helper.toTask(helper.ccmHelper.exec, null, ['populate', '-n', 2]),
@@ -73,7 +73,7 @@ describe('Client', function () {
   });
   vit('2.2', 'should callback with functionFailure error when the cql function throws an error', function (done) {
     var client = newInstance({});
-    async.series([
+    utils.series([
       helper.ccmHelper.start(1, { yaml: ['enable_user_defined_functions: true']}),
       client.connect.bind(client),
       helper.toTask(client.execute, client, helper.createKeyspaceCql('ks_func')),

--- a/test/integration/long/stress-tests.js
+++ b/test/integration/long/stress-tests.js
@@ -1,5 +1,5 @@
+"use strict";
 var assert = require('assert');
-var async = require('async');
 var util = require('util');
 
 var helper = require('../../test-helper.js');
@@ -18,7 +18,7 @@ describe('Client', function () {
     var selectQuery = 'SELECT * FROM ' + table;
     var insertQuery = util.format('INSERT INTO %s (id, text_sample, timestamp_sample) VALUES (?, ?, ?)', table);
     var times = 2000;
-    async.series([
+    utils.series([
       helper.ccmHelper.start(3),
       function createKs(next) {
         client.execute(helper.createKeyspaceCql(keyspace, 3), [], helper.waitSchema(client, next));
@@ -27,11 +27,11 @@ describe('Client', function () {
         client.execute(helper.createTableCql(table), [], helper.waitSchema(client, next));
       },
       function testCase(next) {
-        async.parallel([insert, select], next);
+        utils.parallel([insert, select], next);
       }
     ], done);
     function insert(callback) {
-      async.eachLimit(new Array(times), 500, function (i, next) {
+      utils.timesLimit(times, 500, function (i, next) {
         var options = {
           prepare: 1,
           consistency: types.consistencies.quorum};
@@ -40,7 +40,7 @@ describe('Client', function () {
     }
     function select(callback) {
       var resultCount = 0;
-      async.eachLimit(new Array(Math.floor(times / 5)), 200, function (i, next) {
+      utils.timesLimit(Math.floor(times / 5), 200, function (i, next) {
         var options = {
           prepare: 1,
           consistency: types.consistencies.one};
@@ -64,7 +64,7 @@ describe('Client', function () {
     var selectQuery = 'SELECT * FROM ' + table;
     var insertQuery = util.format('INSERT INTO %s (id, text_sample, timestamp_sample) VALUES (?, ?, ?)', table);
     var times = 2000;
-    async.series([
+    utils.series([
       helper.ccmHelper.start(3),
       function createKs(next) {
         client.execute(helper.createKeyspaceCql(keyspace, 3), [], helper.waitSchema(client, next));
@@ -73,11 +73,11 @@ describe('Client', function () {
         client.execute(helper.createTableCql(table), [], helper.waitSchema(client, next));
       },
       function testCase(next) {
-        async.parallel([insert, select, killANode], next);
+        utils.parallel([insert, select, killANode], next);
       }
     ], done);
     function insert(callback) {
-      async.eachLimit(new Array(times), 500, function (i, next) {
+      utils.timesLimit(times, 500, function (i, next) {
         var options = {
           prepare: 1,
           consistency: types.consistencies.quorum};
@@ -86,7 +86,7 @@ describe('Client', function () {
     }
     function select(callback) {
       var resultCount = 0;
-      async.eachLimit(new Array(Math.floor(times / 5)), 100, function (i, next) {
+      utils.timesLimit(Math.floor(times / 5), 100, function (i, next) {
         var options = {
           prepare: 1,
           consistency: types.consistencies.one};
@@ -117,7 +117,7 @@ describe('Client', function () {
     var selectQuery = 'SELECT * FROM ' + table + ' LIMIT 10';
     var insertQuery = util.format('INSERT INTO %s (id, double_sample, blob_sample) VALUES (?, ?, ?)', table);
     var times = 500;
-    async.series([
+    utils.series([
       helper.ccmHelper.start(3),
       function createKs(next) {
         client.execute(helper.createKeyspaceCql(keyspace, 3), [], helper.waitSchema(client, next));
@@ -126,12 +126,12 @@ describe('Client', function () {
         client.execute(helper.createTableCql(keyspace + '.' + table), [], helper.waitSchema(client, next));
       },
       function testCase(next) {
-        async.parallel([insert, select], next);
+        utils.parallel([insert, select], next);
       }
     ], done);
     function insert(callback) {
       var n = 0;
-      async.eachLimit(new Array(times), 100, function (i, next) {
+      utils.timesLimit(times, 100, function (i, next) {
         i = ++n;
         var options = {
           prepare: 1,
@@ -143,7 +143,7 @@ describe('Client', function () {
     }
     function select(callback) {
       var resultCount = 0;
-      async.eachLimit(new Array(times*10), 2, function (i, next) {
+      utils.timesLimit(times*10, 2, function (i, next) {
         var options = {
           prepare: 1,
           consistency: types.consistencies.one,

--- a/test/integration/short/_infrastructure-tests.js
+++ b/test/integration/short/_infrastructure-tests.js
@@ -1,17 +1,17 @@
 var assert = require('assert');
-var async = require('async');
 var helper = require('../../test-helper.js');
+var utils = require('../../../lib/utils');
 
 describe('Test infrastructure', function () {
   this.timeout(120000);
   it('should be able to run ccm', function (done) {
     var ccm = new helper.Ccm();
-    ccm.exec(['list'], function (err, info) {
+    ccm.exec(['list'], function (err) {
       done(err);
     });
   });
   it('should be able to create and destroy a cluster', function (done) {
-    async.timesSeries(2, function (n, next) {
+    utils.timesSeries(2, function (n, next) {
       var ccm = new helper.Ccm();
       ccm.startAll(2, null, function (err) {
         assert.equal(err, null);

--- a/test/integration/short/connection-tests.js
+++ b/test/integration/short/connection-tests.js
@@ -1,6 +1,6 @@
+"use strict";
 var assert = require('assert');
 var util = require('util');
-var async = require('async');
 
 var Connection = require('../../../lib/connection.js');
 var defaultOptions = require('../../../lib/client-options.js').defaultOptions();
@@ -48,7 +48,7 @@ describe('Connection', function () {
       var minProtocolVersionSupported = getMinProtocolVersion();
       if(helper.getCassandraVersion())
       var protocolVersion = minProtocolVersionSupported - 1;
-      async.whilst(function condition() {
+      utils.whilst(function condition() {
         return (++protocolVersion) <= maxProtocolVersionSupported;
       }, function iterator (next) {
         var localCon = newInstance(null, protocolVersion);
@@ -121,7 +121,7 @@ describe('Connection', function () {
     it('should change active keyspace', function (done) {
       var localCon = newInstance();
       var keyspace = helper.getRandomName();
-      async.series([
+      utils.series([
         localCon.open.bind(localCon),
         function creating(next) {
           var query = 'CREATE KEYSPACE ' + keyspace + ' WITH replication = {\'class\': \'SimpleStrategy\', \'replication_factor\' : 1};';
@@ -140,7 +140,7 @@ describe('Connection', function () {
       var localCon = newInstance();
       var keyspace = helper.getRandomName().toUpperCase();
       assert.notStrictEqual(keyspace, keyspace.toLowerCase());
-      async.series([
+      utils.series([
         localCon.open.bind(localCon),
         function creating(next) {
           var query = 'CREATE KEYSPACE "' + keyspace + '" WITH replication = {\'class\': \'SimpleStrategy\', \'replication_factor\' : 1};';
@@ -165,10 +165,10 @@ describe('Connection', function () {
       options.policies.retry = new helper.RetryMultipleTimes(3);
       var connection = newInstance(null, null, options);
       var maxRequests = connection.protocolVersion < 3 ? 128 : Math.pow(2, 15);
-      async.series([
+      utils.series([
         connection.open.bind(connection),
         function asserting(seriesNext) {
-          async.times(maxRequests + 10, function (n, next) {
+          utils.times(maxRequests + 10, function (n, next) {
             var request = getRequest(helper.queries.basic);
             connection.sendStream(request, null, next);
           }, seriesNext);
@@ -182,10 +182,10 @@ describe('Connection', function () {
       var connection = newInstance(null, null, options);
       var maxRequests = connection.protocolVersion < 3 ? 128 : Math.pow(2, 15);
       var killed = false;
-      async.series([
+      utils.series([
         connection.open.bind(connection),
         function asserting(seriesNext) {
-          async.times(maxRequests + 10, function (n, next) {
+          utils.times(maxRequests + 10, function (n, next) {
             if (n === maxRequests + 9) {
               connection.netClient.destroy();
               killed = true;

--- a/test/integration/short/control-connection-tests.js
+++ b/test/integration/short/control-connection-tests.js
@@ -1,5 +1,5 @@
+"use strict";
 var assert = require('assert');
-var async = require('async');
 
 var helper = require('../../test-helper');
 var ControlConnection = require('../../../lib/control-connection');
@@ -29,7 +29,7 @@ describe('ControlConnection', function () {
     });
     it('should subscribe to SCHEMA_CHANGE events and refresh keyspace information', function (done) {
       var cc = newInstance();
-      async.series([
+      utils.series([
         cc.init.bind(cc),
         function createKeyspace(next) {
           var query = "CREATE KEYSPACE sample_change_1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}";
@@ -66,7 +66,7 @@ describe('ControlConnection', function () {
     });
     it('should subscribe to STATUS_CHANGE events', function (done) {
       var cc = newInstance();
-      async.series([
+      utils.series([
         cc.init.bind(cc),
         function (next) {
           //wait for all initial events
@@ -97,7 +97,7 @@ describe('ControlConnection', function () {
       options.pooling.coreConnectionsPerHost[types.distance.remote] = 1;
       options.policies.reconnection = new policies.reconnection.ConstantReconnectionPolicy(1000);
       var cc = new ControlConnection(options);
-      async.series([
+      utils.series([
         cc.init.bind(cc),
         function (next) {
           //add a node
@@ -130,7 +130,7 @@ describe('ControlConnection', function () {
     });
     it('should subscribe to TOPOLOGY_CHANGE remove events and refresh ring info', function (done) {
       var cc = newInstance();
-      async.series([
+      utils.series([
         cc.init.bind(cc),
         function (next) {
           //decommission node
@@ -173,7 +173,7 @@ describe('ControlConnection', function () {
       options.pooling.coreConnectionsPerHost[types.distance.remote] = 1;
       options.policies.reconnection = new policies.reconnection.ConstantReconnectionPolicy(1000);
       var cc = new ControlConnection(options);
-      async.series([
+      utils.series([
         cc.init.bind(cc),
         function initLbp(next) {
           assert.ok(cc.host);

--- a/test/integration/short/custom-payload-tests.js
+++ b/test/integration/short/custom-payload-tests.js
@@ -1,6 +1,5 @@
 "use strict";
 var assert = require('assert');
-var async = require('async');
 var util = require('util');
 
 var helper = require('../../test-helper');
@@ -18,7 +17,7 @@ describe('custom payload', function () {
   }));
   before(function (done) {
     var client = newInstance();
-    async.series([
+    utils.series([
       client.connect.bind(client),
       helper.toTask(client.execute, client, helper.createKeyspaceCql(keyspace)),
       helper.toTask(client.execute, client, helper.createTableCql(table)),
@@ -32,7 +31,7 @@ describe('custom payload', function () {
       var payload = {
         'key1': new Buffer('val1')
       };
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function execute(next) {
           client.execute('SELECT key FROM system.local', [], { customPayload: payload}, function (err, result) {
@@ -52,7 +51,7 @@ describe('custom payload', function () {
       var payload = {
         'key2': new Buffer('val2')
       };
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function insert(next) {
           var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
@@ -73,7 +72,7 @@ describe('custom payload', function () {
       var payload = {
         'key3': new Buffer('val3')
       };
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function insert(next) {
           var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
@@ -98,7 +97,7 @@ describe('custom payload', function () {
         'key-prep1': new Buffer('val-prep1'),
         'key-prep2': new Buffer('val-prep2')
       };
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function execute(next) {
           client.execute('SELECT key FROM system.local', [], { prepare: 1, customPayload: payload}, function (err, result) {
@@ -122,7 +121,7 @@ describe('custom payload', function () {
       var payload = {
         'key-batch1': new Buffer('val-batch1')
       };
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function executeBatch(next) {
           var q = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
@@ -147,7 +146,7 @@ describe('custom payload', function () {
       var payload = {
         'key-batch2': new Buffer('val-batch2')
       };
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function executeBatch(next) {
           var q = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
@@ -177,7 +176,7 @@ describe('custom payload', function () {
       var payload = {
         'key-batch-prep1': new Buffer('val-batch-prep1')
       };
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function executeBatch(next) {
           var q = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);

--- a/test/integration/short/load-balancing-tests.js
+++ b/test/integration/short/load-balancing-tests.js
@@ -1,6 +1,5 @@
-'use strict';
+"use strict";
 var assert = require('assert');
-var async = require('async');
 var util = require('util');
 
 var helper = require('../../test-helper.js');
@@ -9,7 +8,6 @@ var types = require('../../../lib/types');
 var utils = require('../../../lib/utils.js');
 var loadBalancing = require('../../../lib/policies/load-balancing.js');
 var RoundRobinPolicy = loadBalancing.RoundRobinPolicy;
-var DCAwareRoundRobinPolicy = loadBalancing.DCAwareRoundRobinPolicy;
 var TokenAwarePolicy = loadBalancing.TokenAwarePolicy;
 var WhiteListPolicy = loadBalancing.WhiteListPolicy;
 
@@ -20,7 +18,7 @@ describe('TokenAwarePolicy', function () {
     var keyspace = 'ks1';
     var table = 'table1';
     var testClient = new Client(helper.baseOptions);
-    async.series([
+    utils.series([
       helper.ccmHelper.start('3'),
       testClient.connect.bind(testClient),
       function createKs(next) {
@@ -51,7 +49,7 @@ describe('TokenAwarePolicy', function () {
           keyspace: keyspace,
           contactPoints: helper.baseOptions.contactPoints
         });
-        async.times(100, function (n, timesNext) {
+        utils.times(100, function (n, timesNext) {
           var id = (n % 10) + 1;
           var query = util.format('INSERT INTO %s (id, name) VALUES (%s, %s)', table, id, id);
           client.execute(query, null, { routingKey: new Buffer([0, 0, 0, id])}, function (err, result) {
@@ -77,7 +75,7 @@ describe('TokenAwarePolicy', function () {
         keyspace: ks,
         contactPoints: helper.baseOptions.contactPoints
       });
-      async.timesSeries(10, function (n, timesNext) {
+      utils.timesSeries(10, function (n, timesNext) {
         var id = (n % 10) + 1;
         var query = util.format('INSERT INTO %s (id, name) VALUES (?, ?)', table);
         client.execute(query, [id, id], { traceQuery: true, prepare: true}, function (err, result) {
@@ -99,7 +97,7 @@ describe('TokenAwarePolicy', function () {
     }
 
     var testClient = new Client(helper.baseOptions);
-    async.series([
+    utils.series([
       helper.ccmHelper.start('3'),
       testClient.connect.bind(testClient),
       function createKs1(next) {
@@ -137,7 +135,7 @@ describe('WhiteListPolicy', function () {
   it('should use the hosts in the white list only', function (done) {
     var policy = new WhiteListPolicy(new RoundRobinPolicy(), ['127.0.0.1:9042', '127.0.0.2:9042']);
     var client = newInstance(policy);
-    helper.timesLimit(100, 20, function (n, next) {
+    utils.timesLimit(100, 20, function (n, next) {
       client.execute('SELECT * FROM system.local', function (err, result) {
         assert.ifError(err);
         var lastOctet = helper.lastOctetOf(result.info.queriedHost);

--- a/test/integration/short/timeout-tests.js
+++ b/test/integration/short/timeout-tests.js
@@ -1,6 +1,5 @@
 "use strict";
 var assert = require('assert');
-var async = require('async');
 
 var helper = require('../../test-helper');
 var Client = require('../../../lib/client');
@@ -26,10 +25,10 @@ describe('client read timeouts', function () {
       var client = newInstance({ socketOptions: { readTimeout: 3000 } });
       var coordinators = {};
       var errorsReceived = [];
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function warmup(next) {
-          async.timesSeries(10, function (n, timesNext) {
+          utils.timesSeries(10, function (n, timesNext) {
             client.execute('SELECT key FROM system.local', function (err, result) {
               if (err) return timesNext(err);
               coordinators[helper.lastOctetOf(result.info.queriedHost)] = true;
@@ -43,7 +42,7 @@ describe('client read timeouts', function () {
           assert.strictEqual(coordinators['1'], true);
           assert.strictEqual(coordinators['2'], true);
           coordinators = {};
-          async.times(10, function (n, timesNext) {
+          utils.times(10, function (n, timesNext) {
             client.execute('SELECT key FROM system.local', [], { retryOnTimeout: false }, function (err, result) {
               if (err) {
                 errorsReceived.push(err);
@@ -86,10 +85,10 @@ describe('client read timeouts', function () {
       });
       var coordinators = {};
       var connection;
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function warmup(next) {
-          async.times(10, function (n, timesNext) {
+          utils.times(10, function (n, timesNext) {
             client.execute('SELECT key FROM system.local', function (err, result) {
               if (err) return timesNext(err);
               coordinators[helper.lastOctetOf(result.info.queriedHost)] = true;
@@ -114,7 +113,7 @@ describe('client read timeouts', function () {
           assert.strictEqual(coordinators['1'], true);
           assert.strictEqual(coordinators['2'], true);
           coordinators = {};
-          async.times(500, function (n, timesNext) {
+          utils.times(500, function (n, timesNext) {
             client.execute('SELECT key FROM system.local', function (err, result) {
               if (err) return timesNext(err);
               coordinators[helper.lastOctetOf(result.info.queriedHost)] = true;
@@ -137,10 +136,10 @@ describe('client read timeouts', function () {
     it('should move to next host for eachRow() executions', function (done) {
       var client = newInstance({ socketOptions: { readTimeout: 3000 } });
       var coordinators = {};
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function warmup(next) {
-          async.timesSeries(10, function (n, timesNext) {
+          utils.timesSeries(10, function (n, timesNext) {
             var counter = 0;
             client.eachRow('SELECT key FROM system.local', [], function () {
               counter++;
@@ -158,7 +157,7 @@ describe('client read timeouts', function () {
           assert.strictEqual(coordinators['1'], true);
           assert.strictEqual(coordinators['2'], true);
           coordinators = {};
-          async.times(10, function (n, timesNext) {
+          utils.times(10, function (n, timesNext) {
             var counter = 0;
             client.eachRow('SELECT key FROM system.local', [], function () {
               counter++;
@@ -222,10 +221,10 @@ function getMoveNextHostTest(prepare, prepareWarmup, readTimeout, queryOptions) 
       timeoutLogs.push(info);
     });
     var coordinators = {};
-    async.series([
+    utils.series([
       client.connect.bind(client),
       function warmup(next) {
-        async.timesSeries(10, function (n, timesNext) {
+        utils.timesSeries(10, function (n, timesNext) {
           client.execute('SELECT key FROM system.local', [], { prepare: prepareWarmup }, function (err, result) {
             if (err) return timesNext(err);
             coordinators[helper.lastOctetOf(result.info.queriedHost)] = true;
@@ -242,7 +241,7 @@ function getMoveNextHostTest(prepare, prepareWarmup, readTimeout, queryOptions) 
         var testAbortTimeout = setTimeout(function () {
           throw new Error('It should have been executed in the next (not paused) host.');
         }, testTimeoutMillis * 4);
-        async.times(10, function (n, timesNext) {
+        utils.times(10, function (n, timesNext) {
           queryOptions = utils.extend({ }, queryOptions, { prepare: prepare});
           client.execute('SELECT key FROM system.local', [], queryOptions, function (err, result) {
             if (err) return timesNext(err);
@@ -276,10 +275,10 @@ function getTimeoutErrorExpectedTest(prepare, prepareWarmup, readTimeout, queryO
   return (function timeoutErrorExpectedTest(done) {
     var client = newInstance({ socketOptions: { readTimeout: readTimeout } });
     var coordinators = {};
-    async.series([
+    utils.series([
       client.connect.bind(client),
       function warmup(next) {
-        async.timesSeries(10, function (n, timesNext) {
+        utils.timesSeries(10, function (n, timesNext) {
           client.execute('SELECT key FROM system.local', [], { prepare: prepareWarmup }, function (err, result) {
             if (err) return timesNext(err);
             coordinators[helper.lastOctetOf(result.info.queriedHost)] = true;

--- a/test/integration/short/udf-tests.js
+++ b/test/integration/short/udf-tests.js
@@ -1,6 +1,5 @@
 "use strict";
 var assert = require('assert');
-var async = require('async');
 
 var helper = require('../../test-helper');
 var Client = require('../../../lib/client');
@@ -22,13 +21,13 @@ vdescribe('2.2', 'Metadata', function () {
       "CREATE AGGREGATE ks_udf.sum(int) SFUNC plus STYPE int INITCOND 1",
       "CREATE AGGREGATE ks_udf.sum(bigint) SFUNC plus STYPE bigint INITCOND 2"
     ];
-    async.eachSeries(queries, client.execute.bind(client), helper.finish(client, done));
+    utils.eachSeries(queries, client.execute.bind(client), helper.finish(client, done));
   });
   after(helper.ccmHelper.remove);
   describe('#getFunctions()', function () {
     it('should retrieve the metadata of cql functions', function (done) {
       var client = newInstance();
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
           client.metadata.getFunctions(keyspace, 'plus', function (err, funcArray) {
@@ -43,7 +42,7 @@ vdescribe('2.2', 'Metadata', function () {
     });
     it('should retrieve the metadata for a cql function without arguments', function (done) {
       var client = newInstance();
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
           client.metadata.getFunctions(keyspace, 'return_one', function (err, funcArray) {
@@ -58,7 +57,7 @@ vdescribe('2.2', 'Metadata', function () {
     });
     it('should return an empty array when not found', function (done) {
       var client = newInstance();
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
           client.metadata.getFunctions(keyspace, 'func_does_not_exists', function (err, funcArray) {
@@ -72,7 +71,7 @@ vdescribe('2.2', 'Metadata', function () {
     });
     it('should return an empty array when the keyspace does not exists', function (done) {
       var client = newInstance();
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
           client.metadata.getFunctions('ks_does_not_exists', 'func1', function (err, funcArray) {
@@ -88,7 +87,7 @@ vdescribe('2.2', 'Metadata', function () {
   describe('#getFunction()', function () {
     it('should retrieve the metadata of a cql function', function (done) {
       var client = newInstance();
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
           client.metadata.getFunction(keyspace, 'plus', ['int', 'int'], function (err, func) {
@@ -108,7 +107,7 @@ vdescribe('2.2', 'Metadata', function () {
     });
     it('should retrieve the metadata for a cql function without arguments', function (done) {
       var client = newInstance();
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
           client.metadata.getFunction(keyspace, 'return_one', [], function (err, func) {
@@ -127,7 +126,7 @@ vdescribe('2.2', 'Metadata', function () {
     });
     it('should return null when not found', function (done) {
       var client = newInstance();
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
           client.metadata.getFunction(keyspace, 'func_does_not_exists', [], function (err, func) {
@@ -141,7 +140,7 @@ vdescribe('2.2', 'Metadata', function () {
     });
     it('should return null when not found by signature', function (done) {
       var client = newInstance();
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
           client.metadata.getFunction(keyspace, 'plus', ['int'], function (err, func) {
@@ -155,7 +154,7 @@ vdescribe('2.2', 'Metadata', function () {
     });
     it('should return null when the keyspace does not exists', function (done) {
       var client = newInstance();
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
           client.metadata.getFunction('ks_does_not_exists', 'func1', ['int'], function (err, func) {
@@ -169,7 +168,7 @@ vdescribe('2.2', 'Metadata', function () {
     });
     it('should retrieve the most up to date metadata', function (done) {
       var client = newInstance({ keyspace: keyspace });
-      async.series([
+      utils.series([
         client.connect.bind(client),
         helper.toTask(client.execute, client, "CREATE FUNCTION stringify(i int) RETURNS NULL ON NULL INPUT RETURNS text LANGUAGE java AS 'return Integer.toString(i);'"),
         function checkMetaInit(next) {
@@ -201,7 +200,7 @@ vdescribe('2.2', 'Metadata', function () {
   describe('#getAggregates()', function () {
     it('should retrieve the metadata of cql aggregates', function (done) {
       var client = newInstance();
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
           client.metadata.getAggregates(keyspace, 'sum', function (err, aggregatesArray) {
@@ -218,7 +217,7 @@ vdescribe('2.2', 'Metadata', function () {
     });
     it('should return an empty array when not found', function (done) {
       var client = newInstance();
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
           client.metadata.getAggregates(keyspace, 'aggregate_does_not_exists', function (err, funcArray) {
@@ -232,7 +231,7 @@ vdescribe('2.2', 'Metadata', function () {
     });
     it('should return an empty array when the keyspace does not exists', function (done) {
       var client = newInstance();
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
           client.metadata.getAggregates('ks_does_not_exists', 'aggr1', function (err, funcArray) {
@@ -248,7 +247,7 @@ vdescribe('2.2', 'Metadata', function () {
   describe('#getAggregate()', function () {
     it('should retrieve the metadata of a cql aggregate', function (done) {
       var client = newInstance();
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
           client.metadata.getAggregate(keyspace, 'sum', ['int'], function (err, aggregate) {
@@ -269,7 +268,7 @@ vdescribe('2.2', 'Metadata', function () {
     });
     it('should return null when not found', function (done) {
       var client = newInstance();
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
           client.metadata.getAggregate(keyspace, 'aggregate_does_not_exists', [], function (err, func) {
@@ -283,7 +282,7 @@ vdescribe('2.2', 'Metadata', function () {
     });
     it('should return null when not found by signature', function (done) {
       var client = newInstance();
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
           client.metadata.getAggregate(keyspace, 'sum', ['text'], function (err, func) {
@@ -297,7 +296,7 @@ vdescribe('2.2', 'Metadata', function () {
     });
     it('should return null when the keyspace does not exists', function (done) {
       var client = newInstance();
-      async.series([
+      utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
           client.metadata.getAggregate('ks_does_not_exists', 'func1', ['int'], function (err, func) {
@@ -311,7 +310,7 @@ vdescribe('2.2', 'Metadata', function () {
     });
     it('should retrieve the most up to date metadata', function (done) {
       var client = newInstance({ keyspace: keyspace });
-      async.series([
+      utils.series([
         client.connect.bind(client),
         helper.toTask(client.execute, client, "CREATE AGGREGATE ks_udf.sum2(int) SFUNC plus STYPE int INITCOND 0"),
         function checkMetaInit(next) {

--- a/test/other/memory/basic-profile.js
+++ b/test/other/memory/basic-profile.js
@@ -1,5 +1,4 @@
 var assert = require('assert');
-var async = require('async');
 var util = require('util');
 var fs = require('fs');
 var heapdump;
@@ -29,7 +28,7 @@ if (!global.gc) {
 var insertOnly = process.argv.indexOf('--insert-only') > 0;
 var heapUsed = process.memoryUsage().heapUsed;
 
-async.series([
+utils.series([
   helper.ccmHelper.removeIfAny,
   helper.ccmHelper.start(2),
   client.connect.bind(client),
@@ -45,7 +44,7 @@ async.series([
     var counter = 0;
     var callbackCounter = 0;
     global.gc();
-    async.eachLimit(new Array(10000), 500, function (v, timesNext) {
+    utils.timesLimit(10000, 500, function (v, timesNext) {
       var n = counter++;
       client.execute(query, [types.Uuid.random(), n, new Buffer(generateAsciiString(1024), 'utf8')], {prepare: true}, function (err) {
         if ((callbackCounter++) % 1000 === 0) {

--- a/test/other/memory/profile-keeping-ref.js
+++ b/test/other/memory/profile-keeping-ref.js
@@ -1,5 +1,4 @@
 var assert = require('assert');
-var async = require('async');
 var util = require('util');
 var fs = require('fs');
 var heapdump;
@@ -31,7 +30,7 @@ var heapUsed = process.memoryUsage().heapUsed;
 var totalByteLength = 0;
 var values = [];
 
-async.series([
+utils.series([
   helper.ccmHelper.removeIfAny,
   helper.ccmHelper.start(2),
   client.connect.bind(client),
@@ -47,7 +46,7 @@ async.series([
     var counter = 0;
     var callbackCounter = 0;
     global.gc();
-    async.eachLimit(new Array(totalLength), 500, function (v, timesNext) {
+    utils.timesLimit(totalLength, 500, function (v, timesNext) {
       var n = counter++;
       client.execute(query, [types.uuid(), n, types.Long.fromNumber(n), new Buffer(generateAsciiString(1024))], {prepare: 1}, function (err) {
         if ((callbackCounter++) % 1000 === 0) {

--- a/test/unit/address-resolution-tests.js
+++ b/test/unit/address-resolution-tests.js
@@ -1,7 +1,6 @@
 var assert = require('assert');
 var util = require('util');
 var events = require('events');
-var async = require('async');
 var dns = require('dns');
 
 var addressResolution = require('../../lib/policies/address-resolution');

--- a/test/unit/basic-tests.js
+++ b/test/unit/basic-tests.js
@@ -2,7 +2,6 @@
 var assert = require('assert');
 var util = require('util');
 var events = require('events');
-var async = require('async');
 
 var Client = require('../../lib/client.js');
 var clientOptions = require('../../lib/client-options.js');
@@ -522,24 +521,6 @@ describe('types', function () {
   });
 });
 describe('utils', function () {
-  describe('#syncEvent()', function () {
-    it('should execute callback once for all emitters', function () {
-      var emitter1 = new events.EventEmitter();
-      var emitter2 = new events.EventEmitter(); 
-      var emitter3 = new events.EventEmitter(); 
-      var callbackCounter = 0;
-      utils.syncEvent([emitter1, emitter2, emitter3], 'dummy', this, function (text){
-        assert.strictEqual(text, 'bop');
-        callbackCounter = callbackCounter + 1;
-      });
-      assert.ok(emitter1.emit('dummy', 'bip'));
-      emitter1.emit('dummy', 'bop');
-      emitter2.emit('dummy', 'bip');
-      emitter2.emit('dummy', 'bop');
-      emitter3.emit('dummy', 'bop');
-      assert.strictEqual(callbackCounter, 1);
-    });
-  });
   describe('#parseCommonArgs()', function () {
     it('parses args and can be retrieved by name', function () {
       function testArgs(args, expectedLength) {

--- a/test/unit/big-decimal-tests.js
+++ b/test/unit/big-decimal-tests.js
@@ -1,7 +1,6 @@
 var assert = require('assert');
 var util = require('util');
 var events = require('events');
-var async = require('async');
 var utils = require('../../lib/utils.js');
 
 var types = require('../../lib/types');

--- a/test/unit/connection-tests.js
+++ b/test/unit/connection-tests.js
@@ -1,6 +1,5 @@
 "use strict";
 var assert = require('assert');
-var async = require('async');
 var util = require('util');
 var events = require('events');
 var rewire = require('rewire');
@@ -31,7 +30,7 @@ describe('Connection', function () {
           cb(null, r.query);
         });
       };
-      async.parallel([
+      utils.parallel([
         prepareAndAssert(connection, 'QUERY1'),
         prepareAndAssert(connection, 'QUERY2'),
         prepareAndAssert(connection, 'QUERY3')
@@ -49,7 +48,7 @@ describe('Connection', function () {
           cb(null, r.query);
         });
       };
-      async.parallel([
+      utils.parallel([
         prepareAndAssert(connection, 'QUERY1'),
         prepareAndAssert(connection, 'QUERY2'),
         prepareAndAssert(connection, 'QUERY3')
@@ -68,7 +67,7 @@ describe('Connection', function () {
           cb(null, r.query);
         });
       };
-      async.parallel([
+      utils.parallel([
         prepareAndAssert(connection, 'QUERY1'),
         prepareAndAssert(connection, 'QUERY1'),
         prepareAndAssert(connection, 'QUERY1')
@@ -89,7 +88,7 @@ describe('Connection', function () {
           cb(null, r.query);
         });
       };
-      async.parallel([
+      utils.parallel([
         prepareAndAssert(connection, 'QUERY1'),
         prepareAndAssert(connection, 'QUERY1'),
         prepareAndAssert(connection, 'QUERY1')

--- a/test/unit/control-connection-tests.js
+++ b/test/unit/control-connection-tests.js
@@ -1,6 +1,5 @@
 "use strict";
 var assert = require('assert');
-var async = require('async');
 var events = require('events');
 
 var helper = require('../test-helper.js');
@@ -74,7 +73,7 @@ describe('ControlConnection', function () {
       cc.host = new Host('2.2.2.2', 1, options);
       cc.log = helper.noop;
       var peer = getInet([100, 100, 100, 100]);
-      async.series([
+      utils.series([
         function (next) {
           var row = {'rpc_address': getInet([1, 2, 3, 4]), peer: peer};
           cc.getAddressForPeerHost(row, 9042, function (endPoint) {

--- a/test/unit/encoder-tests.js
+++ b/test/unit/encoder-tests.js
@@ -1,6 +1,5 @@
 var assert = require('assert');
 var util = require('util');
-var async = require('async');
 var utils = require('../../lib/utils');
 
 var Encoder = require('../../lib/encoder');
@@ -901,7 +900,7 @@ describe('encoder', function () {
         ['timeuuid',   dataTypes.timeuuid],
         ['ascii',      dataTypes.ascii]
       ];
-      async.eachSeries(items, function eachCb(item, next) {
+      utils.eachSeries(items, function eachCb(item, next) {
         encoder.parseTypeName('ks1', item[0], 0, null, throwIfCalled, function (err, dataType) {
           assert.ifError(err);
           assert.ok(dataType);
@@ -921,7 +920,7 @@ describe('encoder', function () {
         ['frozen<list<timeuuid>>', dataTypes.list, dataTypes.timeuuid],
         ['map<text,frozen<list<int>>>', dataTypes.map, [dataTypes.text, dataTypes.list]]
       ];
-      async.eachSeries(items, function eachCb(item, next) {
+      utils.eachSeries(items, function eachCb(item, next) {
         encoder.parseTypeName('ks1', item[0], 0, null, throwIfCalled, function (err, dataType) {
           assert.ifError(err);
           assert.ok(dataType);
@@ -942,7 +941,7 @@ describe('encoder', function () {
     });
     it('should parse nested subtypes', function (done) {
       var encoder = new Encoder(4, {});
-      async.series([
+      utils.series([
         function (next) {
           var name = 'map<text,frozen<list<frozen<map<text,frozen<list<int>>>>>>>';
           encoder.parseTypeName('ks1', name, 0, null, throwIfCalled, function (err, type) {
@@ -963,7 +962,7 @@ describe('encoder', function () {
     });
     it('should parse udts', function (done) {
       var encoder = new Encoder(4, {});
-      async.series([
+      utils.series([
         function (next) {
           var called = 0;
           function udtResolver(ks, udtName, callback) {
@@ -1008,7 +1007,7 @@ describe('encoder', function () {
     });
     it('should parse quoted udts', function (done) {
       var encoder = new Encoder(4, {});
-      async.series([
+      utils.series([
         function (next) {
           var called = 0;
           function udtResolver(ks, udtName, callback) {

--- a/test/unit/host-tests.js
+++ b/test/unit/host-tests.js
@@ -1,6 +1,5 @@
 "use strict";
 var assert = require('assert');
-var async = require('async');
 var util = require('util');
 var events = require('events');
 
@@ -25,7 +24,7 @@ describe('HostConnectionPool', function () {
         }};
       };
       hostPool.coreConnectionsLength = 10;
-      async.times(5, function (n, next) {
+      utils.times(5, function (n, next) {
         //even though it is called multiple times in parallel
         //it should only create a pool with 10 connections
         hostPool._maybeCreatePool(function (err) {
@@ -46,7 +45,7 @@ describe('HostConnectionPool', function () {
           }
         };
       };
-      async.times(5, function(n, next) {
+      utils.times(5, function(n, next) {
         setTimeout(function () {
           hostPool._maybeCreatePool(function (err) {
             assert.ifError(err);
@@ -75,7 +74,7 @@ describe('HostConnectionPool', function () {
         };
       };
       var counter = 0;
-      async.timesLimit(10, 4, function(n, next) {
+      utils.timesLimit(10, 4, function(n, next) {
         counter++;
         hostPool._maybeCreatePool(function (err) {
           setImmediate(function () {
@@ -320,7 +319,7 @@ describe('Host', function () {
         c.open = helper.callbackNoop;
         return c;
       };
-      async.series([
+      utils.series([
         function (next) {
           host.borrowConnection(function (err, c) {
             assert.equal(err, null);
@@ -340,7 +339,7 @@ describe('Host', function () {
         },
         function (next) {
           //Check multiple times in parallel
-          async.times(10, function (n, timesNext) {
+          utils.times(10, function (n, timesNext) {
             host.borrowConnection(function (err, c) {
               assert.equal(err, null);
               assert.notEqual(c, null);

--- a/test/unit/metadata-tests.js
+++ b/test/unit/metadata-tests.js
@@ -1,6 +1,5 @@
 "use strict";
 var assert = require('assert');
-var async = require('async');
 var util = require('util');
 var rewire = require('rewire');
 
@@ -506,7 +505,7 @@ describe('Metadata', function () {
       //no keyspace named ks1 in metadata
       metadata.keyspaces = { ks1: { udts: {}}};
       //Invoke multiple times in parallel
-      async.times(50, function (n, next) {
+      utils.times(50, function (n, next) {
         metadata.getUdt('ks1', 'udt5', function (err, udtInfo) {
           if (err) return next(err);
           assert.ok(udtInfo);
@@ -539,7 +538,7 @@ describe('Metadata', function () {
       //no keyspace named ks1 in metadata
       metadata.keyspaces = { ks1: { udts: {}}};
       //Invoke multiple times in parallel
-      async.timesSeries(50, function (n, next) {
+      utils.timesSeries(50, function (n, next) {
         metadata.getUdt('ks1', 'udt10', function (err, udtInfo) {
           if (err) return next(err);
           assert.ok(udtInfo);
@@ -565,7 +564,7 @@ describe('Metadata', function () {
       };
       var metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks1: { udts: {}}};
-      async.timesSeries(20, function (n, next) {
+      utils.timesSeries(20, function (n, next) {
         metadata.getUdt('ks1', 'udt20', function (err, udtInfo) {
           if (err) return next(err);
           assert.strictEqual(udtInfo, null);
@@ -814,7 +813,7 @@ describe('Metadata', function () {
       };
       var metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
-      async.times(100, function (n, next) {
+      utils.map(new Array(100), function (n, next) {
         metadata.getTable('ks_tbl_meta', 'tbl1', next);
       }, function (err, results) {
         assert.ifError(err);
@@ -854,7 +853,7 @@ describe('Metadata', function () {
       };
       var metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
-      async.timesSeries(100, function (n, next) {
+      utils.mapSeries(new Array(100), function (n, next) {
         metadata.getTable('ks_tbl_meta', 'tbl1', next);
       }, function (err, results) {
         assert.ifError(err);
@@ -885,7 +884,7 @@ describe('Metadata', function () {
       };
       var metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
-      async.timesSeries(100, function (n, next) {
+      utils.mapSeries(new Array(100), function (n, next) {
         metadata.getTable('ks_tbl_meta', 'tbl1', next);
       }, function (err, results) {
         assert.ifError(err);
@@ -1469,7 +1468,7 @@ describe('Metadata', function () {
         };
         var metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { functions: {}};
-        async.times(10, function (n, next) {
+        utils.times(10, function (n, next) {
           metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
             assert.ifError(err);
             assert.ok(funcArray);
@@ -1497,7 +1496,7 @@ describe('Metadata', function () {
         };
         var metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { functions: {}};
-        async.timesSeries(10, function (n, next) {
+        utils.timesSeries(10, function (n, next) {
           metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
             assert.ifError(err);
             assert.ok(funcArray);
@@ -1530,7 +1529,7 @@ describe('Metadata', function () {
         };
         var metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { functions: {}};
-        async.timesSeries(10, function (n, next) {
+        utils.timesSeries(10, function (n, next) {
           metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
             assert.ifError(err);
             assert.ok(funcArray);
@@ -1569,7 +1568,7 @@ describe('Metadata', function () {
         };
         var metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { functions: {}};
-        async.timesSeries(10, function (n, next) {
+        utils.timesSeries(10, function (n, next) {
           metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
             if (n < 5) {
               assert.ok(err);
@@ -1725,7 +1724,7 @@ describe('Metadata', function () {
       };
       var metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces['ks_udf'] = { functions: {}};
-      async.times(10, function (n, next) {
+      utils.times(10, function (n, next) {
         metadata.getFunction('ks_udf', 'plus', ['bigint', 'bigint'], function (err, func) {
           assert.ifError(err);
           assert.ok(func);
@@ -1754,7 +1753,7 @@ describe('Metadata', function () {
       };
       var metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces['ks_udf'] = { functions: {}};
-      async.timesSeries(10, function (n, next) {
+      utils.timesSeries(10, function (n, next) {
         metadata.getFunction('ks_udf', 'plus', ['bigint', 'bigint'], function (err, func) {
           assert.ifError(err);
           assert.ok(func);
@@ -1848,7 +1847,7 @@ describe('Metadata', function () {
         };
         var metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { aggregates: {}};
-        async.times(10, function (n, next) {
+        utils.times(10, function (n, next) {
           metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
             assert.ifError(err);
             assert.ok(funcArray);
@@ -1876,7 +1875,7 @@ describe('Metadata', function () {
         };
         var metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { aggregates: {}};
-        async.timesSeries(10, function (n, next) {
+        utils.timesSeries(10, function (n, next) {
           metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
             assert.ifError(err);
             assert.ok(funcArray);
@@ -1909,7 +1908,7 @@ describe('Metadata', function () {
         };
         var metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { aggregates: {}};
-        async.timesSeries(10, function (n, next) {
+        utils.timesSeries(10, function (n, next) {
           metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
             assert.ifError(err);
             assert.ok(funcArray);
@@ -1949,7 +1948,7 @@ describe('Metadata', function () {
         };
         var metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { aggregates: {}};
-        async.timesSeries(10, function (n, next) {
+        utils.timesSeries(10, function (n, next) {
           metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
             if (n < 5) {
               assert.ok(err);

--- a/test/unit/parser-tests.js
+++ b/test/unit/parser-tests.js
@@ -1,12 +1,12 @@
 'use strict';
 var assert = require('assert');
 var util = require('util');
-var async = require('async');
 
 var Encoder = require('../../lib/encoder');
 var streams = require('../../lib/streams');
 var errors = require('../../lib/errors');
 var types = require('../../lib/types');
+var utils = require('../../lib/utils');
 var helper = require('../test-helper');
 
 /**
@@ -396,7 +396,7 @@ describe('Parser', function () {
       //Add the length 0x00300000 of the value
       cellValue = [0, 30, 0, 0].concat(cellValue);
       var rowLength = 1;
-      async.series([function (next) {
+      utils.series([function (next) {
         var parser = newInstance();
         var rowCounter = 0;
         parser.on('readable', function () {

--- a/test/unit/protocol-stream-tests.js
+++ b/test/unit/protocol-stream-tests.js
@@ -1,7 +1,6 @@
 'use strict';
 var assert = require('assert');
 var util = require('util');
-var async = require('async');
 
 var Protocol = require('../../lib/streams').Protocol;
 var types = require('../../lib/types');

--- a/test/unit/reconnection-test.js
+++ b/test/unit/reconnection-test.js
@@ -1,14 +1,14 @@
 var assert = require('assert');
-var async = require('async');
 var util = require('util');
 //project modules
-var reconnection = require('../../lib/policies/reconnection.js');
+var utils = require('../../lib/utils');
+var reconnection = require('../../lib/policies/reconnection');
 
 describe('ConstantReconnectionPolicy', function () {
   it('should yield the same wait time', function (done) {
     var delay = 2000;
     var policy = new reconnection.ConstantReconnectionPolicy(delay);
-    async.times(100, function (n, next) {
+    utils.times(100, function (n, next) {
       var schedule = policy.newSchedule();
       for (var i = 0; i < 5; i++) {
         assert.strictEqual(schedule.next().value, delay);
@@ -24,7 +24,7 @@ describe('ExponentialReconnectionPolicy', function () {
     var baseDelay = 1000;
     var maxDelay = 256000;
     var policy = new reconnection.ExponentialReconnectionPolicy(baseDelay, maxDelay, false);
-    async.times(1, function (n, next) {
+    utils.times(1, function (n, next) {
       var schedule = policy.newSchedule();
       for (var i = 0; i < 8; i++) {
         assert.strictEqual(schedule.next().value, Math.pow(2, i + 1) * baseDelay);

--- a/test/unit/request-handler-tests.js
+++ b/test/unit/request-handler-tests.js
@@ -1,5 +1,4 @@
 var assert = require('assert');
-var async = require('async');
 var util = require('util');
 var rewire = require('rewire');
 

--- a/test/unit/utils-tests.js
+++ b/test/unit/utils-tests.js
@@ -1,0 +1,16 @@
+"use strict";
+
+var utils = require('../../lib/utils');
+
+describe('utils', function () {
+  describe('timesLimit()', function () {
+    it('should handle sync and async functions', function (done) {
+      utils.timesLimit(5, 10, function (i, next) {
+        if (i == 0) {
+          return setImmediate(next);
+        }
+        next();
+      }, done);
+    });
+  });
+});


### PR DESCRIPTION
Created control flow methods and functional utilities in the utils module adapted to our needs:
- `series()` method invokes the final callback (if provided) with the last result.
- `times()`, `timesSeries()` and `timesLimit()` don't accumulate the result of each async execution.

Included micro benchmarks of each method against "async" and "neo-async" modules, where it beats both of them: https://github.com/riptano/nodejs-driver-sut/tree/master/test/micro