### PR TITLE
Retry policy decision: use current or next host

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -236,6 +236,7 @@ Connection.prototype.clearAndInvokePending = function (innerError) {
   }
   var err = new types.DriverError('Socket was closed');
   err.isSocketError = true;
+  err.wasRequestWritten = true;
   if (innerError) {
     err.innerError = innerError;
   }
@@ -407,11 +408,6 @@ Connection.prototype.getWriteCallback = function (request, options, callback) {
   var self = this;
   return (function writeCallback (err) {
     if (err) {
-      if (!(err instanceof TypeError)) {
-        //TypeError is raised when there is a serialization issue
-        //If it is not a serialization issue is a socket issue
-        err.isSocketError = true;
-      }
       return callback(err);
     }
     self.log('verbose', 'Sent stream #' + request.streamId + ' to ' + self.endpoint);

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -49,6 +49,10 @@ util.inherits(NoHostAvailableError, DriverError);
  */
 function ResponseError(code, message) {
   ResponseError.super_.call(this, message, this.constructor);
+  /**
+   * The error code as defined in [responseErrorCodes]{@link module:types~responseErrorCodes}.
+   * @type {Number}
+   */
   this.code = code;
   this.info = 'Represents an error message from the server';
 }

--- a/lib/policies/retry.js
+++ b/lib/policies/retry.js
@@ -8,43 +8,55 @@ function RetryPolicy() {
 
 }
 
+//noinspection JSUnusedLocalSymbols
 /**
  * Determines what to do when the drivers gets an UnavailableException from a Cassandra node
- * @param {{request: object, handler: RequestHandler, nbRetry: Number}} requestInfo
- * @param consistency
- * @param {Number} required
- * @param {Number} alive
+ * @param {{request: object, nbRetry: Number}} requestInfo
+ * @param {Number} consistency The [consistency]{@link module:types~consistencies} level of the query that triggered
+ * the exception.
+ * @param {Number} required The number of replicas whose response is required to achieve the
+ * required [consistency]{@link module:types~consistencies}.
+ * @param {Number} alive The number of replicas that were known to be alive when the request had been processed
+ * (since an unavailable exception has been triggered, there will be alive &lt; required)
  * @returns {DecisionInfo}
  */
 RetryPolicy.prototype.onUnavailable = function (requestInfo, consistency, required, alive) {
-  return this.rethrowResult();
+  if (requestInfo.nbRetry > 0) {
+    return this.rethrowResult();
+  }
+  return this.retryResult(undefined, false);
 };
 
 /**
  * Determines what to do when the drivers gets an ReadTimeoutException from a Cassandra node
- * @param {{request: object, handler: RequestHandler, nbRetry: Number}} requestInfo
- * @param consistency
- * @param {Number} received
- * @param blockFor
- * @param {Boolean} isDataPresent
+ * @param {{request: object, nbRetry: Number}} requestInfo
+ * @param {Number} consistency The [consistency]{@link module:types~consistencies} level of the query that triggered
+ * the exception.
+ * @param {Number} received The number of nodes having answered the request.
+ * @param {Number} blockFor The number of replicas whose response is required to achieve the
+ * required [consistency]{@link module:types~consistencies}.
+ * @param {Boolean} isDataPresent When <code>false</code>, it means the replica that was asked for data has not responded.
  * @returns {DecisionInfo}
  */
 RetryPolicy.prototype.onReadTimeout = function (requestInfo, consistency, received, blockFor, isDataPresent) {
   if (requestInfo.nbRetry > 0) {
     return this.rethrowResult();
   }
-  return ((received >= blockFor && !this.isDataPresent) ?
+  return ((received >= blockFor && !isDataPresent) ?
     this.retryResult() :
     this.rethrowResult());
 };
 
 /**
  * Determines what to do when the drivers gets an WriteTimeoutException from a Cassandra node
- * @param {{request: object, handler: RequestHandler, nbRetry: Number}} requestInfo
- * @param consistency
- * @param {Number} received
- * @param blockFor
- * @param {String} writeType
+ * @param {{request: object, nbRetry: Number}} requestInfo
+ * @param {Number} consistency The [consistency]{@link module:types~consistencies} level of the query that triggered
+ * the exception.
+ * @param {Number} received The number of nodes having acknowledged the request.
+ * @param {Number} blockFor The number of replicas whose acknowledgement is required to achieve the required
+ * [consistency]{@link module:types~consistencies}.
+ * @param {String} writeType A <code>string</code> that describes the type of the write that timed out ("SIMPLE"
+ * / "BATCH" / "BATCH_LOG" / "UNLOGGED_BATCH" / "COUNTER").
  * @returns {DecisionInfo}
  */
 RetryPolicy.prototype.onWriteTimeout = function (requestInfo, consistency, received, blockFor, writeType) {
@@ -56,22 +68,31 @@ RetryPolicy.prototype.onWriteTimeout = function (requestInfo, consistency, recei
 };
 
 /**
- * @returns {{decision: Number}}
+ * Returns a {@link DecisionInfo} to retry the request with the given [consistency]{@link module:types~consistencies}.
+ * @param {Number|undefined} [consistency] When specified, it retries the request with the given consistency.
+ * @param {Boolean} [useCurrentHost] When specified, determines if the retry should be made using the same coordinator.
+ * Default: true.
+ * @returns {DecisionInfo}
  */
-RetryPolicy.prototype.retryResult = function () {
-  return {decision: RetryPolicy.retryDecision.retry};
+RetryPolicy.prototype.retryResult = function (consistency, useCurrentHost) {
+  return {
+    decision: RetryPolicy.retryDecision.retry,
+    consistency: consistency,
+    useCurrentHost: useCurrentHost !== false
+  };
 };
 
 /**
- * @returns {{decision: Number}}
+ * Returns a {@link DecisionInfo} to callback in error when a err is obtained for a given request.
+ * @returns {DecisionInfo}
  */
 RetryPolicy.prototype.rethrowResult = function () {
-  return {decision: RetryPolicy.retryDecision.rethrow};
+  return { decision: RetryPolicy.retryDecision.rethrow };
 };
 
 /**
- * Retry decision of the retry policy.
- * @type {{rethrow: number, retry: number}}
+ * Determines the retry decision for the retry policies.
+ * @type {{rethrow: number, retry: number, ignore: number}}
  */
 RetryPolicy.retryDecision = {
   rethrow:  0,
@@ -83,7 +104,9 @@ RetryPolicy.retryDecision = {
 /**
  * Decision information
  * @typedef {Object} DecisionInfo
- * @property {Number} decision
- * @property {Number} consistency
+ * @property {Number} decision The decision as specified in
+ * [retryDecision]{@link module:policies/retry~RetryPolicy.retryDecision}.
+ * @property {Number} [consistency] The [consistency level]{@link module:types~consistencies}.
+ * @property {useCurrentHost} [useCurrentHost] Determines if it should use the same host to retry the request.
  */
 exports.RetryPolicy = RetryPolicy;

--- a/lib/policies/retry.js
+++ b/lib/policies/retry.js
@@ -1,3 +1,7 @@
+"use strict";
+
+var errors = require('../errors');
+
 /** @module policies/retry */
 /**
  * Base and default RetryPolicy.
@@ -65,6 +69,39 @@ RetryPolicy.prototype.onWriteTimeout = function (requestInfo, consistency, recei
   }
   // If the batch log write failed, retry the operation as this might just be we were unlucky at picking candidates
   return writeType == "BATCH_LOG" ? this.retryResult() : this.rethrowResult();
+};
+
+/**
+ * Defines whether to retry and at which consistency level on an unexpected error.
+ * <p>
+ * This method might be invoked in the following situations:
+ * </p>
+ * <ol>
+ * <li>On a client timeout, while waiting for the server response
+ * (see [socketOptions.readTimeout]{@link ClientOptions}), being the error an instance of
+ * [OperationTimedOutError]{@link module:errors~OperationTimedOutError}.</li>
+ * <li>On a connection error (socket closed, etc.).</li>
+ * <li>When the contacted host replies with an error, such as <code>overloaded</code>, <code>isBootstrapping</code>,
+ * </code>serverError, etc. In this case, the error is instance of [ResponseError]{@link module:errors~ResponseError}.
+ * </li>
+ * </ol>
+ * <p>
+ * Note that when this method is invoked, <em>the driver cannot guarantee that the mutation has been effectively
+ * applied server-side</em>; a retry should only be attempted if the request is known to be idempotent.
+ * </p>
+ * @param {{request: object, retryOnTimeout: boolean|undefined, nbRetry: Number}} requestInfo
+ * @param {Number|undefined} consistency The [consistency]{@link module:types~consistencies} level of the query that triggered
+ * the exception.
+ * @param {Error} err The error that caused this request to fail.
+ * @returns {DecisionInfo}
+ */
+RetryPolicy.prototype.onRequestError = function (requestInfo, consistency, err) {
+  if (err instanceof errors.OperationTimedOutError && !requestInfo.retryOnTimeout) {
+    return this.rethrowResult();
+  }
+  // The default implementation triggers a retry on the next host in the query plan with the same consistency level,
+  // regardless of the statement's idempotence, for historical reasons.
+  return this.retryResult(undefined, false);
 };
 
 /**

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -304,11 +304,11 @@ RequestHandler.prototype.handleError = function (err, callback) {
   //Add the error to the tried hosts
   this.triedHosts[this.host.address] = err;
   err['coordinator'] = this.host.address;
-  var decisionInfo = { decision: retry.RetryPolicy.retryDecision.rethrow };
+  var decisionInfo;
   //noinspection JSUnresolvedVariable
   if (err && err.isSocketError) {
     this.host.removeFromPool(this.connection);
-    return this.retry(callback);
+    return this.retry(null, false, callback);
   }
   if (err instanceof errors.OperationTimedOutError) {
     return this.onTimeout(err, callback);
@@ -327,24 +327,35 @@ RequestHandler.prototype.handleError = function (err, callback) {
       case types.responseErrorCodes.isBootstrapping:
       case types.responseErrorCodes.truncateError:
         //always retry
-        return this.retry(callback);
+        return this.retry(null, false, callback);
       case types.responseErrorCodes.unavailableException:
         //noinspection JSUnresolvedVariable
         decisionInfo = this.retryPolicy.onUnavailable(requestInfo, err.consistencies, err.required, err.alive);
         break;
       case types.responseErrorCodes.readTimeout:
         //noinspection JSUnresolvedVariable
-        decisionInfo = this.retryPolicy.onReadTimeout(requestInfo, err.consistencies, err.received, err.blockFor, err.isDataPresent);
+        decisionInfo = this.retryPolicy.onReadTimeout(
+          requestInfo, err.consistencies, err.received, err.blockFor, err.isDataPresent);
         break;
       case types.responseErrorCodes.writeTimeout:
         //noinspection JSUnresolvedVariable
-        decisionInfo = this.retryPolicy.onWriteTimeout(requestInfo, err.consistencies, err.received, err.blockFor, err.writeType);
+        decisionInfo = this.retryPolicy.onWriteTimeout(
+          requestInfo, err.consistencies, err.received, err.blockFor, err.writeType);
         break;
     }
   }
-  if (decisionInfo && decisionInfo.decision === retry.RetryPolicy.retryDecision.retry) {
-    return this.retry(callback);
+  if (decisionInfo) {
+    if (decisionInfo.decision === retry.RetryPolicy.retryDecision.retry) {
+      return this.retry(decisionInfo.consistency, decisionInfo.useCurrentHost, callback);
+    }
+    if (decisionInfo.decision === retry.RetryPolicy.retryDecision.ignore) {
+      //Return an empty response
+      return callback(
+        null,
+        new types.ResultSet(utils.emptyObject, this.host.address, this.triedHosts, this.request.consistency));
+    }
   }
+  //callback in error
   if (this.requestOptions && this.requestOptions.captureStackTrace) {
     //Fill error information and return it
     utils.fixStack(this.stackContainer.stack, err);
@@ -355,12 +366,26 @@ RequestHandler.prototype.handleError = function (err, callback) {
   callback(err);
 };
 
-RequestHandler.prototype.retry = function (callback) {
+/**
+ * @param {Number} consistency
+ * @param {Boolean} useCurrentHost
+ * @param {Function} callback
+ */
+RequestHandler.prototype.retry = function (consistency, useCurrentHost, callback) {
   this.retryCount++;
   this.log('info', 'Retrying request');
+  if (typeof consistency === 'number') {
+    this.request.consistency = consistency;
+  }
   if (this.retryHandler) {
+    // custom retry handler (not a QueryRequest / ExecuteRequest / BatchRequest)
     return this.retryHandler(callback);
   }
+  if (useCurrentHost !== false) {
+    // retry on the current host by default
+    return this.sendOnConnection(this.request, this.requestOptions, callback);
+  }
+  // use the next host in the query plan to send the request
   this.send(this.request, this.requestOptions, callback);
 };
 

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -8,6 +8,11 @@ var requests = require('./requests');
 var retry = require('./policies/retry');
 
 var maxSyncHostIterations = 20;
+var retryOnNextHostDecision = {
+  decision: retry.RetryPolicy.retryDecision.retry,
+  useCurrentHost: false,
+  consistency: undefined
+};
 
 /**
  * Handles a request to Cassandra, dealing with host fail-over and retries on error
@@ -296,74 +301,87 @@ RequestHandler.prototype.prepareOnConnection = function (queries, callbacksArray
 };
 
 /**
- * Checks if the exception is either a Cassandra response error or a socket exception to retry or failover if necessary.
- * @param {Error} err
+ * Checks if the error and determines if it should be ignored, retried or rethrown.
+ * @param {Object} err
  * @param {Function} callback
  */
 RequestHandler.prototype.handleError = function (err, callback) {
-  //Add the error to the tried hosts
+  // add the error to the tried hosts
   this.triedHosts[this.host.address] = err;
   err['coordinator'] = this.host.address;
-  var decisionInfo;
-  //noinspection JSUnresolvedVariable
-  if (err && err.isSocketError) {
+  if ((err instanceof errors.ResponseError) && err.code ===  types.responseErrorCodes.unprepared) {
+    //noinspection JSUnresolvedVariable
+    return this.prepareAndRetry(err.queryId, callback);
+  }
+  var decisionInfo = this.getDecision(err);
+  if (err.isSocketError) {
     this.host.removeFromPool(this.connection);
-    return this.retry(null, false, callback);
+  }
+  if (!decisionInfo || decisionInfo.decision === retry.RetryPolicy.retryDecision.rethrow) {
+    // callback in error
+    if (this.requestOptions && this.requestOptions.captureStackTrace) {
+      utils.fixStack(this.stackContainer.stack, err);
+    }
+    if (this.request instanceof requests.QueryRequest || this.request instanceof requests.ExecuteRequest) {
+      err['query'] = this.request.query;
+    }
+    return callback(err);
+  }
+  if (decisionInfo.decision === retry.RetryPolicy.retryDecision.ignore) {
+    //Return an empty response
+    return callback(
+      null,
+      new types.ResultSet(utils.emptyObject, this.host.address, this.triedHosts, this.request.consistency));
+  }
+  return this.retry(decisionInfo.consistency, decisionInfo.useCurrentHost, callback);
+};
+
+/**
+ * @returns {{decision, useCurrentHost, consistency}}
+ */
+RequestHandler.prototype.getDecision = function (err) {
+  var requestInfo = {
+    request: this.request,
+    handler: this,
+    nbRetry: this.retryCount
+  };
+  if (err.isSocketError) {
+    if (!err.wasRequestWritten) {
+      // the request was definitely not applied, it's safe to retry
+      return retryOnNextHostDecision;
+    }
+    return this.retryPolicy.onRequestError(requestInfo, this.request.consistency, err);
   }
   if (err instanceof errors.OperationTimedOutError) {
-    return this.onTimeout(err, callback);
+    this.log('warning', err.message);
+    this.host.checkHealth(this.connection);
+    if (this.request instanceof requests.PrepareRequest) {
+      // always retry on next host for PREPARE requests
+      return retryOnNextHostDecision;
+    }
+    requestInfo.retryOnTimeout = !this.requestOptions || this.requestOptions.retryOnTimeout !== false;
+    return this.retryPolicy.onRequestError(requestInfo, this.request.consistency, err);
   }
   if (err instanceof errors.ResponseError) {
-    var requestInfo = {
-      request: this.request,
-      handler: this,
-      nbRetry: this.retryCount
-    };
     switch (err.code) {
-      case types.responseErrorCodes.unprepared:
-        //noinspection JSUnresolvedVariable
-        return this.prepareAndRetry(err.queryId, callback);
       case types.responseErrorCodes.overloaded:
       case types.responseErrorCodes.isBootstrapping:
       case types.responseErrorCodes.truncateError:
-        //always retry
-        return this.retry(null, false, callback);
+        return this.retryPolicy.onRequestError(requestInfo, this.request.consistency, err);
       case types.responseErrorCodes.unavailableException:
         //noinspection JSUnresolvedVariable
-        decisionInfo = this.retryPolicy.onUnavailable(requestInfo, err.consistencies, err.required, err.alive);
-        break;
+        return this.retryPolicy.onUnavailable(requestInfo, err.consistencies, err.required, err.alive);
       case types.responseErrorCodes.readTimeout:
         //noinspection JSUnresolvedVariable
-        decisionInfo = this.retryPolicy.onReadTimeout(
+        return this.retryPolicy.onReadTimeout(
           requestInfo, err.consistencies, err.received, err.blockFor, err.isDataPresent);
-        break;
       case types.responseErrorCodes.writeTimeout:
         //noinspection JSUnresolvedVariable
-        decisionInfo = this.retryPolicy.onWriteTimeout(
+        return this.retryPolicy.onWriteTimeout(
           requestInfo, err.consistencies, err.received, err.blockFor, err.writeType);
-        break;
     }
   }
-  if (decisionInfo) {
-    if (decisionInfo.decision === retry.RetryPolicy.retryDecision.retry) {
-      return this.retry(decisionInfo.consistency, decisionInfo.useCurrentHost, callback);
-    }
-    if (decisionInfo.decision === retry.RetryPolicy.retryDecision.ignore) {
-      //Return an empty response
-      return callback(
-        null,
-        new types.ResultSet(utils.emptyObject, this.host.address, this.triedHosts, this.request.consistency));
-    }
-  }
-  //callback in error
-  if (this.requestOptions && this.requestOptions.captureStackTrace) {
-    //Fill error information and return it
-    utils.fixStack(this.stackContainer.stack, err);
-  }
-  if (this.request instanceof requests.QueryRequest || this.request instanceof requests.ExecuteRequest) {
-    err['query'] = this.request.query;
-  }
-  callback(err);
+  return { decision: retry.RetryPolicy.retryDecision.rethrow }
 };
 
 /**

--- a/lib/writers.js
+++ b/lib/writers.js
@@ -211,6 +211,12 @@ WriteQueue.prototype.process = function () {
         next();
       }
       self.netClient.write(Buffer.concat(buffers, totalLength), function (err) {
+        if (err) {
+          // it's not possible to determine if the request was actual received, but stating that it was written
+          // we state that the mutation could have been applied
+          err.isSocketError = true;
+          err.wasRequestWritten = true;
+        }
         for (var i = 0; i < callbacks.length; i++) {
           callbacks[i](err);
         }

--- a/test/unit/retry-policy-tests.js
+++ b/test/unit/retry-policy-tests.js
@@ -1,0 +1,75 @@
+"use strict";
+var assert = require('assert');
+var util = require('util');
+
+var types = require('../../lib/types');
+var RetryPolicy = require('../../lib/policies/retry').RetryPolicy;
+
+describe('RetryPolicy', function () {
+  describe('#onUnavailable()', function () {
+    it('should retry on the next host the first time', function () {
+      var policy = new RetryPolicy();
+      var result = policy.onUnavailable(getRequestInfo(0), types.consistencies.one, 3, 3);
+      assert.strictEqual(result.consistency, undefined);
+      assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
+      assert.strictEqual(result.useCurrentHost, false);
+    });
+    it('should rethrow the following times', function () {
+      var policy = new RetryPolicy();
+      var result = policy.onUnavailable(getRequestInfo(1), types.consistencies.one, 3, 3);
+      assert.strictEqual(result.consistency, undefined);
+      assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
+    });
+  });
+  describe('#onWriteTimeout()', function () {
+    it('should retry on the same host the first time when writeType is BATCH_LOG', function () {
+      var policy = new RetryPolicy();
+      var result = policy.onWriteTimeout(getRequestInfo(0), types.consistencies.one, 1, 1, 'BATCH_LOG');
+      assert.strictEqual(result.consistency, undefined);
+      assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
+      assert.strictEqual(result.useCurrentHost, true);
+    });
+    it('should rethrow the following times', function () {
+      var policy = new RetryPolicy();
+      var result = policy.onWriteTimeout(getRequestInfo(1), types.consistencies.one, 1, 1, 'BATCH_LOG');
+      assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
+    });
+    it('should rethrow when the writeType is not SIMPLE', function () {
+      var policy = new RetryPolicy();
+      var result = policy.onWriteTimeout(getRequestInfo(0), types.consistencies.one, 3, 2, 'SIMPLE');
+      assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
+    });
+    it('should rethrow when the writeType is not COUNTER', function () {
+      var policy = new RetryPolicy();
+      var result = policy.onWriteTimeout(getRequestInfo(0), types.consistencies.one, 3, 3, 'COUNTER');
+      assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
+    });
+  });
+  describe('#onReadTimeout()', function () {
+    it('should retry on the same host the first time when received is greater or equal than blockFor', function () {
+      var policy = new RetryPolicy();
+      var result = policy.onReadTimeout(getRequestInfo(0), types.consistencies.one, 2, 2, false);
+      assert.strictEqual(result.consistency, undefined);
+      assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
+      assert.strictEqual(result.useCurrentHost, true);
+    });
+    it('should rethrow the following times', function () {
+      var policy = new RetryPolicy();
+      var result = policy.onReadTimeout(getRequestInfo(1), types.consistencies.one, 2, 2, false);
+      assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
+    });
+    it('should rethrow when the received is less than blockFor', function () {
+      var policy = new RetryPolicy();
+      var result = policy.onReadTimeout(getRequestInfo(0), types.consistencies.one, 2, 3, false);
+      assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
+    });
+  });
+});
+
+function getRequestInfo(nbRetry) {
+  return {
+    handler: {},
+    nbRetry: nbRetry || 0,
+    request: {}
+  };
+}


### PR DESCRIPTION
Includes `RetryPolicy` jsdoc improvements (NODEJS-225) and new `#onRequestError()` method (NODEJS-251).