### PR TITLE
Don't mark host down while one connection is active

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -260,6 +260,8 @@ Client.prototype.connect = function (callback) {
       self.options.policies.loadBalancing.init(self, self.hosts, next);
     },
     function setKeyspace(next) {
+      // Set the distance of the control connection host relatively to this instance
+      self.controlConnection.host.getDistance(self.options.policies.loadBalancing);
       if (!self.keyspace) {
         return next();
       }
@@ -271,7 +273,7 @@ Client.prototype.connect = function (callback) {
       if (self.controlConnection.protocolVersion < 3) {
         coreConnectionsPerHost = clientOptions.coreConnectionsPerHostV2;
       }
-      self.options.pooling = utils.deepExtend({}, {coreConnectionsPerHost: coreConnectionsPerHost}, self.options.pooling);
+      self.options.pooling = utils.deepExtend({}, { coreConnectionsPerHost: coreConnectionsPerHost }, self.options.pooling);
       if (!self.options.pooling.warmup) {
         return next();
       }
@@ -401,7 +403,7 @@ Client.prototype.stream = function () {
   var args = Array.prototype.slice.call(arguments);
   if (typeof args[args.length-1] !== 'function') {
     //the callback is not required
-    args.push(function noop() {});
+    args.push(utils.noop);
   }
   args = utils.parseCommonArgs.apply(null, args);
   // NOTE: the nodejs stream maintains yet another internal buffer 
@@ -494,7 +496,7 @@ Client.prototype.shutdown = function (callback) {
   var self = this;
   var hosts = this.hosts.values();
   utils.each(hosts, function (h, next) {
-    h.shutdown(next);
+    h.shutdown(false, next);
   }, function(err) {
     self.connected = !!err;
     callback(err);
@@ -845,15 +847,14 @@ Client.prototype._warmup = function (callback) {
   loadBalancingPolicy.newQueryPlan(this.keyspace, utils.emptyObject, function (err, iterator) {
     if (err) return callback(err);
     var hosts = utils.iteratorToArray(iterator);
-    utils.timesLimit(hosts.length, 32, function (i, next) {
+    utils.timesLimit(hosts.length, 32, function warmupEachCallback(i, next) {
       var h = hosts[i];
-      var distance = loadBalancingPolicy.getDistance(h);
-      h.setDistance(distance);
+      var distance = h.getDistance(loadBalancingPolicy);
       if (distance !== types.distance.local) {
         //do not warmup pool for remote or ignored hosts
         return next();
       }
-      h.borrowConnection(function (err) {
+      h.warmupPool(function (err) {
         if (err) {
           //An error while trying to create a connection
           //To 1 host is not an issue, warn the user and move on

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -22,6 +22,7 @@ var maxProtocolVersion = 4;
  * @param {String} endpoint An string containing ip address and port of the host
  * @param {Number} protocolVersion
  * @param {ClientOptions} options
+ * @extends EventEmitter
  * @constructor
  */
 function Connection(endpoint, protocolVersion, options) {
@@ -57,6 +58,7 @@ function Connection(endpoint, protocolVersion, options) {
   this.streamIds = new StreamIdStack(this.protocolVersion);
   this.encoder = new Encoder(protocolVersion, options);
   this.keyspace = null;
+  this.emitDrain = false;
 }
 
 util.inherits(Connection, events.EventEmitter);
@@ -182,7 +184,6 @@ Connection.prototype.startup = function (callback) {
   }
 };
 
-
 Connection.prototype.errorConnecting = function (err, destroy, callback) {
   this.connecting = false;
   this.log('warning', 'There was an error when trying to connect to the host ' + this.address, err);
@@ -230,8 +231,11 @@ Connection.prototype.clearAndInvokePending = function (innerError) {
     this.idleTimeout = null;
   }
   this.streamIds.clear();
+  if (this.emitDrain) {
+    this.emit('drain');
+  }
   var err = new types.DriverError('Socket was closed');
-  err.isServerUnhealthy = true;
+  err.isSocketError = true;
   if (innerError) {
     err.innerError = innerError;
   }
@@ -373,7 +377,7 @@ Connection.prototype.prepareOnce = function (query, callback) {
 /**
  * Uses the frame writer to write into the wire
  * @param request
- * @param {QueryOptions} options
+ * @param {QueryOptions|null} options
  * @param {function} callback Function to be called once the response has been received
  */
 Connection.prototype.sendStream = function (request, options, callback) {
@@ -385,9 +389,6 @@ Connection.prototype.sendStream = function (request, options, callback) {
         this.pendingWrites.length +
         ', if this message is recurrent consider configuring more connections per host or lowering the pressure');
     return this.pendingWrites.push({request: request, options: options, callback: callback});
-  }
-  if (!callback) {
-    callback = function noop () {};
   }
   this.log('verbose', 'Sending stream #' + streamId);
   request.streamId = streamId;
@@ -409,7 +410,7 @@ Connection.prototype.getWriteCallback = function (request, options, callback) {
       if (!(err instanceof TypeError)) {
         //TypeError is raised when there is a serialization issue
         //If it is not a serialization issue is a socket issue
-        err.isServerUnhealthy = true;
+        err.isSocketError = true;
       }
       return callback(err);
     }
@@ -465,7 +466,7 @@ Connection.prototype.idleTimeoutHandler = function () {
       return;
     }
     self.log('warning', 'Received heartbeat request error', err);
-    self.emit('idleRequestError', err);
+    self.emit('idleRequestError', err, self);
   });
 };
 
@@ -484,6 +485,9 @@ Connection.prototype.freeStreamId = function(header) {
   }
   delete this.streamHandlers[streamId];
   this.streamIds.push(streamId);
+  if (this.emitDrain && this.streamIds.inUse === 0 && this.pendingWrites.length === 0) {
+    this.emit('drain');
+  }
   this.writeNext();
   this.log('verbose', 'Done receiving frame #' + streamId);
 };
@@ -635,7 +639,7 @@ Connection.prototype.close = function (callback) {
   this.log('verbose', 'disconnecting');
   this.clearAndInvokePending();
   if(!callback) {
-    callback = function () {};
+    callback = function noop() {};
   }
   if (!this.netClient) {
     callback();

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -37,6 +37,7 @@ function ControlConnection(options) {
    */
   this.metadata = new Metadata(this.options, this);
   this.addressTranslator = this.options.policies.addressResolution;
+  this.loadBalancingPolicy = this.options.policies.loadBalancing;
   this.initialized = false;
   /**
    * Host used by the control connection
@@ -188,8 +189,7 @@ ControlConnection.prototype.getConnectionToNewHost = function (callback) {
   var self = this;
   var host;
   var connection = null;
-  var loadBalancingPolicy = this.options.policies.loadBalancing;
-  loadBalancingPolicy.newQueryPlan(null, null, function (err, iterator) {
+  this.loadBalancingPolicy.newQueryPlan(null, null, function (err, iterator) {
     if (err) {
       var message = 'Control connection could not retrieve a query plan to determine which hosts to use, ' +
         'using current hosts map';
@@ -208,11 +208,10 @@ ControlConnection.prototype.getConnectionToNewHost = function (callback) {
         return (!item.done);
       },
       function whileIterator(next) {
+        var distance = host.getDistance(self.loadBalancingPolicy);
         if (!host.isUp()) {
           return next();
         }
-        var distance = loadBalancingPolicy.getDistance(host);
-        host.setDistance(distance);
         if (distance === types.distance.ignored) {
           return next();
         }
@@ -287,7 +286,7 @@ ControlConnection.prototype.refreshOnConnection = function (firstTime, callback)
       c.on('nodeStatusChange', self.nodeStatusChangeHandler.bind(self));
       c.on('nodeSchemaChange', self.nodeSchemaChangeHandler.bind(self));
       var request = new requests.RegisterRequest(['TOPOLOGY_CHANGE', 'STATUS_CHANGE', 'SCHEMA_CHANGE']);
-      c.sendStream(request, {}, next);
+      c.sendStream(request, null, next);
     }],
     function initDone(err) {
       if (err) {
@@ -329,14 +328,14 @@ ControlConnection.prototype.refreshHosts = function (newNodesUp, callback) {
   utils.series([
     function getLocalInfo(next) {
       var request = new requests.QueryRequest(selectLocal, null, null);
-      c.sendStream(request, {}, function (err, result) {
+      c.sendStream(request, null, function (err, result) {
         self.setLocalInfo(c.endpoint, result);
         next(err);
       });
     },
     function getPeersInfo(next) {
       var request = new requests.QueryRequest(selectPeers, null, null);
-      c.sendStream(request, {}, function (err, result) {
+      c.sendStream(request, null, function (err, result) {
         self.setPeersInfo(newNodesUp, result, next);
       });
     }], callback);
@@ -399,21 +398,29 @@ ControlConnection.prototype.nodeTopologyChangeHandler = function (event) {
  */
 ControlConnection.prototype.nodeStatusChangeHandler = function (event) {
   var self = this;
-  this.addressTranslator.translate(event.inet.address.toString(), this.options.protocolOptions.port, function (endPoint) {
+  var addressToTranslate = event.inet.address.toString();
+  var port = this.options.protocolOptions.port;
+  this.addressTranslator.translate(addressToTranslate, port, function translateCallback(endPoint) {
     var host = self.hosts.get(endPoint);
     if (!host) {
-      self.log('warning', 'Received status change event but host was not found: ' + event.inet.address);
+      self.log('warning', 'Received status change event but host was not found: ' + addressToTranslate);
       return;
     }
+    var distance = host.getDistance(self.loadBalancingPolicy);
     if (event.up) {
+      if (distance === types.distance.ignored) {
+        return host.setUp(true);
+      }
       //wait a couple of seconds before marking it as UP
-      setTimeout(function () {
-        host.setUp();
+      return setTimeout(function delayCheckIsUp() {
+        host.checkIsUp();
       }, newNodeDelay);
     }
-    else {
-      host.setDown();
+    // marked as down
+    if (distance === types.distance.ignored) {
+      return host.setDown();
     }
+    self.log('warning', 'Received status change to DOWN for host ' + host.address);
   });
 };
 
@@ -490,8 +497,8 @@ ControlConnection.prototype.setPeersInfo = function (newNodesUp, result, callbac
   //A map of peers, could useful for in case there are discrepancies
   var peers = {};
   var port = this.options.protocolOptions.port;
-  utils.eachSeries(result.rows, function (row, next) {
-    self.getAddressForPeerHost(row, port, function (endPoint) {
+  utils.eachSeries(result.rows, function eachPeer(row, next) {
+    self.getAddressForPeerHost(row, port, function getAddressForPeerCallback(endPoint) {
       if (!endPoint) {
         return next();
       }
@@ -525,7 +532,7 @@ ControlConnection.prototype.setPeersInfo = function (newNodesUp, result, callbac
         if (!peers[h.address] && h !== self.host) {
           self.log('info', 'Removing host ' + h.address);
           toRemove.push(h.address);
-          h.setDown();
+          h.shutdown(true);
         }
       });
       self.hosts.removeMultiple(toRemove);
@@ -582,7 +589,7 @@ ControlConnection.prototype.query = function (cqlQuery, callback) {
   var self = this;
   function queryOnConnection() {
     var request = new requests.QueryRequest(cqlQuery, null, null);
-    self.connection.sendStream(request, utils.emptyObject, callback);
+    self.connection.sendStream(request, null, callback);
   }
   if (!this.connection) {
     //It's reconnecting

--- a/lib/host-connection-pool.js
+++ b/lib/host-connection-pool.js
@@ -1,0 +1,333 @@
+"use strict";
+var util = require('util');
+var events = require('events');
+
+var Connection = require('./connection');
+var utils = require('./utils');
+var defaultOptions = require('./client-options').defaultOptions();
+
+// Used to get the index of the connection with less in-flight requests
+var connectionIndex = 0;
+var connectionIndexOverflow = Math.pow(2, 15);
+
+/**
+ * Represents a pool of connections to a host
+ * @param {Host} host
+ * @param {Number} protocolVersion Initial protocol version
+ * @extends EventEmitter
+ * @constructor
+ */
+function HostConnectionPool(host, protocolVersion) {
+  events.EventEmitter.call(this);
+  this._address = host.address;
+  this.options = host.options;
+  this._newConnectionTimeout = null;
+  this._creating = false;
+  this.protocolVersion = protocolVersion;
+  this.coreConnectionsLength = 1;
+  /**
+   * An immutable array of connections
+   * @type {Array.<Connection>}
+   */
+  this.connections = utils.emptyArray;
+  this.shuttingDown = false;
+  this.setMaxListeners(0);
+}
+
+util.inherits(HostConnectionPool, events.EventEmitter);
+
+/**
+ * @param {Function} callback
+ */
+HostConnectionPool.prototype.borrowConnection = function (callback) {
+  var self = this;
+  this.create(false, function (err) {
+    if (err) {
+      return callback(err);
+    }
+    if (self.connections.length === 0) {
+      //something happen in the middle between the creation pool and now.
+      err = Error('No connection available');
+      err.isSocketError = true;
+      return callback(err);
+    }
+    var c = HostConnectionPool.minInFlight(self.connections);
+    callback(null, c);
+  });
+};
+
+/**
+ * Gets the connection with the minimum number of in-flight requests.
+ * Only checks for index + 1 and index, to avoid a loop through all the connections.
+ * @param {Array.<Connection>} connections
+ * @returns {Connection}
+ */
+HostConnectionPool.minInFlight = function(connections) {
+  var length = connections.length;
+  if (length === 1) {
+    return connections[0];
+  }
+  var index = ++connectionIndex;
+  if (connectionIndex >= connectionIndexOverflow) {
+    connectionIndex = 0;
+  }
+  var current = connections[index % length];
+  var previous = connections[(index - 1) % length];
+  if (previous.getInFlight() < current.getInFlight()) {
+    return previous;
+  }
+  return current;
+};
+
+/**
+ * Create the min amount of connections, if the pool is empty.
+ * @param {Boolean} warmup Determines if all connections must be created before invoking the callback
+ * @param {Function} callback
+ */
+HostConnectionPool.prototype.create = function (warmup, callback) {
+  // The value of this.coreConnectionsLength can change over time
+  // when an existing pool is being resized (by setting the distance).
+  if (this.connections.length >= this.coreConnectionsLength) {
+    return callback();
+  }
+  if (!warmup && this.connections.length > 0) {
+    // we already have a valid connection
+    // let the connection grow continue in the background
+    this.increaseSize();
+    return callback();
+  }
+  this.once('creation', callback);
+  if (this._creating) {
+    // wait for the pool to be creating
+    return;
+  }
+  this._creating = true;
+  var connectionsToCreate = this.coreConnectionsLength;
+  if (!warmup) {
+    connectionsToCreate = 1;
+  }
+  var self = this;
+  utils.whilst(
+    function condition() {
+      return self.connections.length < connectionsToCreate;
+    },
+    function iterator(next) {
+      self._attemptNewConnection(next);
+    }, function whilstEnded(err) {
+      self._creating = false;
+      if (err && self.connections.length === 0) {
+        // there was an error and no connections could be successfully opened
+        self.log('warning', util.format('Connection pool to host %s could not be created', self._address));
+        return self.emit('creation', err);
+      }
+      self.log('info', util.format('Connection pool to host %s created with %d connection(s)',
+        self._address, self.connections.length));
+      self.emit('creation');
+      self.increaseSize();
+    });
+};
+
+/** @returns {Connection} */
+HostConnectionPool.prototype._createConnection = function () {
+  var c = new Connection(this._address, this.protocolVersion, this.options);
+  var self = this;
+  //Relay the event idleRequestError
+  c.on('idleRequestError', function idleErrorCallback(err, connection) {
+    //The pool will emit the event
+    self.emit('idleRequestError', err, connection);
+  });
+  return c;
+};
+
+/**
+ * Prevents reconnection timeout from triggering
+ */
+HostConnectionPool.prototype.clearNewConnectionAttempt = function () {
+  if (!this._newConnectionTimeout) {
+    return;
+  }
+  clearTimeout(this._newConnectionTimeout);
+  this._newConnectionTimeout = null;
+};
+
+/**
+ * @param {Function} callback
+ */
+HostConnectionPool.prototype._attemptNewConnection = function (callback) {
+  var c = this._createConnection();
+  var self = this;
+  this.once('open', callback);
+  if (this._opening) {
+    // wait for the event to fire
+    return;
+  }
+  this._opening = true;
+  c.open(function attemptOpenCallback(err) {
+    self._opening = false;
+    if (err) {
+      self.log('warning', util.format('Connection to %s could not be created: %s', self._address, err), err);
+      c.close();
+      return self.emit('open', err);
+    }
+    // use a copy of the connections array
+    var newConnections = self.connections.slice(0);
+    newConnections.push(c);
+    self.connections = newConnections;
+    self.log('info', util.format('Connection to %s opened successfully', self._address));
+    self.emit('open', null, c);
+  });
+};
+
+/**
+ * Closes the connection and removes a connection from the pool.
+ * @param {Connection} connection
+ */
+HostConnectionPool.prototype.remove = function (connection) {
+  // locating an object by position in the array is O(n), but normally there should be between 1 to 8 connections.
+  var index = this.connections.indexOf(connection);
+  if (index < 0) {
+    // it was already removed from the connections and it's closing
+    return;
+  }
+  // remove the connection from the pool, using an pool copy
+  var newConnections = this.connections.slice(0);
+  newConnections.splice(index, 1);
+  this.connections = newConnections;
+  // close the connection
+  setImmediate(function removeClose() {
+    connection.close();
+  });
+};
+
+/**
+ * @param {Number} delay
+ */
+HostConnectionPool.prototype.scheduleNewConnectionAttempt = function (delay) {
+  if (this.shuttingDown) {
+    return;
+  }
+  var self = this;
+  this._newConnectionTimeout = setTimeout(function newConnectionTimeoutExpired() {
+    self._newConnectionTimeout = null;
+    if (self.connections.length >= self.coreConnectionsLength) {
+      // new connection can be scheduled while a new connection is being opened
+      // the pool has the appropriate size
+      return;
+    }
+    self._attemptNewConnection(utils.noop);
+  }, delay);
+};
+
+HostConnectionPool.prototype.hasScheduledNewConnection = function () {
+  return !!this._newConnectionTimeout || this._opening;
+};
+
+/**
+ * Increases the size of the connection pool in the background, if needed.
+ */
+HostConnectionPool.prototype.increaseSize = function () {
+  if (this.connections.length < this.coreConnectionsLength && !this.hasScheduledNewConnection()) {
+    // schedule the next connection in the background
+    this.scheduleNewConnectionAttempt(0);
+  }
+};
+
+/**
+ * Gracefully waits for all in-flight requests to finish and closes the pool.
+ */
+HostConnectionPool.prototype.drainAndShutdown = function () {
+  this.shuttingDown = true;
+  this.clearNewConnectionAttempt();
+  var self = this;
+  if (this.connections.length === 0) {
+    return this.setAsShutdown();
+  }
+  var connections = this.connections;
+  this.connections = utils.emptyArray;
+  var closedConnections = 0;
+  this.log('info', util.format('Draining and closing %d connections to %s', connections.length, this._address));
+  for (var i = 0; i < connections.length; i++) {
+    var c = connections[i];
+    if (c.getInFlight() === 0) {
+      getDelayedClose(c)();
+      continue;
+    }
+    c.emitDrain = true;
+    c.once('drain', getDelayedClose(c));
+  }
+
+  var wasSetAsShutdown = false;
+  var checkShutdownTimeout;
+  function getDelayedClose(connection) {
+    return (function delayedClose() {
+      connection.close();
+      connection.setAsClosed = true;
+      if (++closedConnections < connections.length) {
+        return;
+      }
+      if (wasSetAsShutdown) {
+        return;
+      }
+      wasSetAsShutdown = true;
+      if (checkShutdownTimeout) {
+        clearTimeout(checkShutdownTimeout);
+      }
+      self.setAsShutdown();
+    });
+  }
+  // check that after sometime (readTimeout + 2 secs) the connections have been drained
+  var delay = (this.options.socketOptions.readTimeout || defaultOptions.socketOptions.readTimeout) + 2000;
+  setTimeout(function checkShutdown() {
+    if (wasSetAsShutdown) {
+      return;
+    }
+    wasSetAsShutdown = true;
+    self.setAsShutdown();
+  }, delay);
+};
+
+HostConnectionPool.prototype.setAsShutdown = function () {
+  if (this._creating) {
+    var self = this;
+    return this.once('creation', function onCreateShutdown() {
+      // ensure all creation process finished
+      process.nextTick(function nextTickCreateShutdown() {
+        self.shuttingDown = false;
+        self.emit('shutdown');
+      });
+    });
+  }
+  this.shuttingDown = false;
+};
+
+/**
+ * @param {Function} callback
+ */
+HostConnectionPool.prototype.shutdown = function (callback) {
+  this.clearNewConnectionAttempt();
+  if (!this.connections.length) {
+    return callback();
+  }
+  if (this.shuttingDown) {
+    return this.once('shutdown', callback);
+  }
+  this.shuttingDown = true;
+  var connections = this.connections;
+  // point to an empty array
+  this.connections = utils.emptyArray;
+  this.log('info', util.format('Closing %d connections to %s', connections.length, this._address));
+  var self = this;
+  utils.each(connections, function closeEach(c, next) {
+    c.close(function closedCallback() {
+      //ignore errors
+      next();
+    });
+  }, function poolShutdownEnded() {
+    self.setAsShutdown();
+    callback();
+  });
+};
+
+HostConnectionPool.prototype.log = utils.log;
+
+module.exports = HostConnectionPool;

--- a/lib/host.js
+++ b/lib/host.js
@@ -2,17 +2,12 @@
 var util = require('util');
 var events = require('events');
 
-var Connection = require('./connection');
 var utils = require('./utils');
 var types = require('./types');
+var HostConnectionPool = require('./host-connection-pool');
 /**
- * Used to get the index of the connection with less in-flight requests
- * @type {number}
- * @private
- */
-var connectionIndex = 0;
-var connectionIndexOverflow = Math.pow(2, 15);
-/**
+ * Creates a new Host instance.
+ * @classdesc
  * Represents a Cassandra node.
  * @extends EventEmitter
  * @constructor
@@ -24,13 +19,17 @@ function Host(address, protocolVersion, options) {
    * @type {String}
    */
   this.address = address;
-  this.unhealthyAt = 0;
+  this.setDownAt = 0;
   Object.defineProperty(this, 'options', { value: options, enumerable: false, writable: false});
   /**
    * @type {HostConnectionPool}
    */
   Object.defineProperty(this, 'pool', { value: new HostConnectionPool(this, protocolVersion), enumerable: false});
-  this.pool.on('idleRequestError', this.setDown.bind(this));
+  var self = this;
+  this.pool.on('idleRequestError', function pooledConnectionRequestError(err, connection) {
+    self.removeFromPool(connection);
+  });
+  this.pool.on('open', this._onNewConnectionOpen.bind(this));
   /**
    * Gets string containing the Cassandra version.
    * @type {String}
@@ -51,65 +50,96 @@ function Host(address, protocolVersion, options) {
    * @type {Array}
    */
   this.tokens = null;
+  // the distance as last set using the load balancing policy
+  this._distance = types.distance.ignored;
   this.reconnectionSchedule = this.options.policies.reconnection.newSchedule();
 }
 
 util.inherits(Host, events.EventEmitter);
 
 /**
- * Sets this host as unavailable
+ * Marks this host as not available for query coordination.
  * @internal
  * @ignore
  */
 Host.prototype.setDown = function() {
-  //the multiple connections and events signaling that a host is failing
-  //could call #setDown() multiple times
-  if (!this.canBeConsideredAsUp()) {
-    //The host is already marked as Down
+  // multiple events signaling that a host is failing could cause multiple calls to this method
+  if (this.setDownAt !== 0) {
+    // the host is already marked as Down
     return;
   }
-  if (this.closing) {
-    //This host is not down, the pool is being shutdown
+  if (this.pool.shuttingDown) {
+    // the pool is being shutdown, don't mind
     return;
   }
-  this.reconnectionDelay = this.reconnectionSchedule.next().value;
-  this.log('warning', util.format('Host %s considered as DOWN. Reconnection delay %dms.', this.address, this.reconnectionDelay));
-
-  var wasUp = this.isUp();
-  this.unhealthyAt = new Date().getTime();
-  // Only emit a down event if was previously up.
-  if(wasUp) {
-    this.emit('down');
+  this.setDownAt = Date.now();
+  if (this._distance !== types.distance.ignored) {
+    this.log('warning',
+      util.format('Host %s considered as DOWN. Reconnection delay %dms.', this.address, this.reconnectionDelay));
   }
-  this.pool.scheduleReconnection(this.reconnectionDelay);
+  else {
+    this.log('info', util.format('Host %s considered as DOWN.', this.address));
+  }
+  this.emit('down');
+  this._checkPoolState();
 };
 
 /**
- * Sets the host as available for querying
+ * Marks this host as available for querying.
+ * @param {Boolean} [clearReconnection]
  * @internal
  * @ignore
  */
-Host.prototype.setUp = function () {
-  if (!this.unhealthyAt) {
+Host.prototype.setUp = function (clearReconnection) {
+  if (!this.setDownAt) {
     //The host is already marked as UP
     return;
   }
-  this.log('info', 'Setting host ' + this.address + ' as UP');
-  this.unhealthyAt = 0;
+  this.log('info', util.format('Setting host %s as UP', this.address));
+  this.setDownAt = 0;
   //if it was unhealthy and now it is not, lets reset the reconnection schedule.
   this.reconnectionSchedule = this.options.policies.reconnection.newSchedule();
-  this.pool.clearReconnection();
+  if (clearReconnection) {
+    this.pool.clearNewConnectionAttempt();
+  }
   this.emit('up');
 };
 
 /**
- * @param {Function} callback
+ * Resets the reconnectionSchedule and tries to issue a reconnection immediately.
  * @internal
  * @ignore
  */
-Host.prototype.shutdown = function (callback) {
-  this.closing = true;
-  this.pool.shutdown(callback);
+Host.prototype.checkIsUp = function () {
+  if (this.isUp()) {
+    return;
+  }
+  var self = this;
+  function openConnectionImmediate() {
+    // if it was unhealthy and now maybe its not, lets reset the reconnection schedule.
+    self.pool.clearNewConnectionAttempt();
+    self.reconnectionSchedule = self.options.policies.reconnection.newSchedule();
+    self.reconnectionDelay = 0;
+    self.pool.scheduleNewConnectionAttempt(self.reconnectionDelay);
+  }
+  if (this.pool.shuttingDown) {
+    return this.pool.once('shutdown', openConnectionImmediate);
+  }
+  openConnectionImmediate();
+};
+
+/**
+ * @param {Boolean} waitForPending When true, it waits for in-flight operations to be finish before closing the
+ * connections.
+ * @param {Function} [callback]
+ * @internal
+ * @ignore
+ */
+Host.prototype.shutdown = function (waitForPending, callback) {
+  if (waitForPending) {
+    return this.pool.drainAndShutdown();
+  }
+  this.pool.shutdown(callback || utils.noop);
 };
 
 /**
@@ -117,7 +147,7 @@ Host.prototype.shutdown = function (callback) {
  * @returns {boolean}
  */
 Host.prototype.isUp = function () {
-  return !this.unhealthyAt;
+  return !this.setDownAt;
 };
 
 /**
@@ -127,26 +157,37 @@ Host.prototype.isUp = function () {
 Host.prototype.canBeConsideredAsUp = function () {
   var self = this;
   function hasTimePassed() {
-    return new Date().getTime() - self.unhealthyAt >= self.reconnectionDelay;
+    return new Date().getTime() - self.setDownAt >= self.reconnectionDelay;
   }
-  return !this.unhealthyAt || hasTimePassed();
+  return !this.setDownAt || hasTimePassed();
 };
 
 /**
- * Sets the distance of the host relative to the client.
- * It affects how the connection pool of the host nature (min/max size)
- * @param distance
+ * Sets the distance of the host relative to the client using the load balancing policy.
+ * @param {LoadBalancingPolicy} policy
  * @internal
  * @ignore
  */
-Host.prototype.setDistance = function (distance) {
-  distance = distance || types.distance.local;
-  this.pool.coreConnectionsLength = this.options.pooling.coreConnectionsPerHost[distance];
-  if (distance === types.distance.ignored && this.pool.connections.length > 0) {
-    //this host was local/remote and now must be ignored
-    //close all the connections to it
-    this.pool.shutdown(noop);
+Host.prototype.getDistance = function (policy) {
+  var previousDistance = this._distance;
+  this._distance = policy.getDistance(this) || types.distance.local;
+  if (this.options.pooling.coreConnectionsPerHost) {
+    this.pool.coreConnectionsLength = this.options.pooling.coreConnectionsPerHost[this._distance] || 0;
   }
+  else {
+    this.pool.coreConnectionsLength = 1;
+  }
+  if (this._distance === previousDistance) {
+    return this._distance;
+  }
+  if (this._distance === types.distance.ignored) {
+    // this host was local/remote and now must be ignored
+    this.pool.drainAndShutdown();
+  }
+  else if (!this.isUp()) {
+    this.checkIsUp();
+  }
+  return this._distance;
 };
 
 /**
@@ -162,12 +203,22 @@ Host.prototype.setProtocolVersion = function (value) {
 /**
  * It gets an open connection to the host.
  * If there isn't an available connections, it will open a new one according to the pooling options.
- * @param callback
+ * @param {Function} callback
  * @internal
  * @ignore
  */
 Host.prototype.borrowConnection = function (callback) {
   this.pool.borrowConnection(callback);
+};
+
+/**
+ * Creates all the connection in the pool.
+ * @param {Function} callback
+ * @internal
+ * @ignore
+ */
+Host.prototype.warmupPool = function (callback) {
+  this.pool.create(true, callback);
 };
 
 /**
@@ -190,7 +241,57 @@ Host.prototype.getActiveConnection = function () {
  * @ignore
  */
 Host.prototype.checkHealth = function (connection) {
-  this.pool.checkHealth(connection);
+  if (connection.timedOutHandlers <= this.options.socketOptions.defunctReadTimeoutThreshold) {
+    return;
+  }
+  this.removeFromPool(connection);
+};
+
+/**
+ * @param {Connection} connection
+ * @internal
+ * @ignore
+ */
+Host.prototype.removeFromPool = function (connection) {
+  this.pool.remove(connection);
+  if (this.pool.shuttingDown) {
+    return;
+  }
+  this._checkPoolState();
+};
+
+/**
+ * Validates that the internal state of the connection pool.
+ * If the pool size is smaller than expected, schedule a new connection attempt.
+ * If the amount of connections is 0 for not ignored hosts, the host must be down.
+ * @private
+ */
+Host.prototype._checkPoolState = function () {
+  if (this.pool.connections.length < this.pool.coreConnectionsLength) {
+    // the pool still needs to grow
+    if (!this.pool.hasScheduledNewConnection()) {
+      this.reconnectionDelay = this.reconnectionSchedule.next().value;
+      this.pool.scheduleNewConnectionAttempt(this.reconnectionDelay);
+    }
+  }
+  if (this._distance !== types.distance.ignored &&
+      this.pool.connections.length === 0 &&
+      this.pool.coreConnectionsLength > 0) {
+    this.setDown();
+  }
+};
+
+/**
+ * Executed after an scheduled new connection attempt finished
+ * @private
+ */
+Host.prototype._onNewConnectionOpen = function (err) {
+  if (err) {
+    this._checkPoolState();
+    return;
+  }
+  this.setUp();
+  this.pool.increaseSize();
 };
 
 /**
@@ -206,240 +307,6 @@ Host.prototype.getCassandraVersion = function () {
 };
 
 Host.prototype.log = utils.log;
-
-/**
- * Represents a pool of connections to a host
- * @param {Host} host
- * @param {Number} protocolVersion Initial protocol version
- * @constructor
- * @ignore
- */
-function HostConnectionPool(host, protocolVersion) {
-  events.EventEmitter.call(this);
-  this.address = host.address;
-  this.options = host.options;
-  this.host = host;
-  this.protocolVersion = protocolVersion;
-  this.coreConnectionsLength = 1;
-  //Use like an immutable array
-  this.connections = utils.emptyArray;
-  /**
-   * Timeout instance for next reconnection attempt, if any.
-   * @type {Object|null}
-   */
-  this.reconnectionTimeout = null;
-  this.setMaxListeners(0);
-}
-
-util.inherits(HostConnectionPool, events.EventEmitter);
-
-HostConnectionPool.prototype.borrowConnection = function (callback) {
-  var c;
-  var self = this;
-  utils.series([
-    function createPoolIfNeeded(next) {
-      self._maybeCreatePool(next)
-    },
-    function getLeastBusy(next) {
-      if (self.connections.length === 0) {
-        //something happen in the middle between the creation pool and now.
-        var err = Error('No connection available');
-        err.isServerUnhealthy = true;
-        return next(err);
-      }
-      c = HostConnectionPool.minInFlight(self.connections);
-      next();
-    }
-  ], function seriesEnd(err) {
-    callback(err, c);
-  });
-};
-
-/**
- * Gets the connection with the minimum number of in-flight requests.
- * Only checks for index + 1 and index, to avoid a loop through all the connections.
- * @param {Array.<Connection>} connections
- * @returns {Connection}
- */
-HostConnectionPool.minInFlight = function(connections) {
-  var length = connections.length;
-  if (length === 1) {
-    return connections[0];
-  }
-  var index = ++connectionIndex;
-  if (connectionIndex >= connectionIndexOverflow) {
-    connectionIndex = 0;
-  }
-  var current = connections[index % length];
-  var previous = connections[(index - 1) % length];
-  if (previous.getInFlight() < current.getInFlight()) {
-    return previous;
-  }
-  return current;
-};
-
-/**
- * Create the min amount of connections, if the pool is empty
- */
-HostConnectionPool.prototype._maybeCreatePool = function (callback) {
-  //The value of this.coreConnectionsLength can change over time
-  //when an existing pool is being resized (by setting the distance).
-  if (this.connections.length >= this.coreConnectionsLength) {
-    return callback();
-  }
-  if (this.creating) {
-    if (this.connections.length > 0) {
-      //we already have a valid connection
-      //let the connection grow continue in the background
-      return callback();
-    }
-    //subscribe and move on
-    return this.once('creation', callback);
-  }
-  this.once('creation', callback);
-  this.creating = true;
-  //Use a copy
-  var connections = this.connections.slice(0);
-  var self = this;
-  utils.whilst(
-    function condition() {
-      return connections.length < self.coreConnectionsLength;
-    },
-    function iterator(next) {
-      var c = self._createConnection();
-      connections.push(c);
-      c.open(function createOpenCallback(err) {
-        if (err) {
-          setImmediate(function createOpenError() {
-            c.close();
-          });
-        }
-        next(err);
-      });
-    }, function whilstEnded(err) {
-      if (!err) {
-        //set the new reference
-        self.connections = connections;
-      }
-      self.creating = false;
-      self.emit('creation', err);
-  });
-};
-
-/** @returns {Connection} */
-HostConnectionPool.prototype._createConnection = function () {
-  var c = new Connection(this.address, this.protocolVersion, this.options);
-  var self = this;
-  //Relay the event idleRequestError
-  c.on('idleRequestError', function idleErrorCallback(err) {
-    //The pool will emit the event
-    self.emit('idleRequestError', err);
-  });
-  return c;
-};
-
-HostConnectionPool.prototype.checkHealth = function (connection) {
-  if (connection.timedOutHandlers > this.options.socketOptions.defunctReadTimeoutThreshold) {
-    //defunct connection: locate in the connection pool
-    //Locating an object by position in the array is a O(n), but normally there should be between 1 to 8 connections.
-    var index = this.connections.indexOf(connection);
-    if (index < 0) {
-      //it was already removed from the connections and it's closing
-      return;
-    }
-    //Remove the connection from the pool, using an pool copy
-    var newConnections = this.connections.slice(0);
-    newConnections.splice(index, 1);
-    this.connections = newConnections;
-    //close the connection
-    setImmediate(function checkHealthClose() {
-      connection.close(noop);
-    });
-  }
-};
-
-HostConnectionPool.prototype._forceShutdown = function () {
-  //kills all the connections
-  if (!this.connections.length) {
-    return;
-  }
-  this.log('info', 'Closing force ' + this.connections.length + ' connections to ' + this.address);
-  var activeConnections = this.connections;
-  this.connections = utils.emptyArray;
-  utils.each(activeConnections, function forceShutdownEachCallback(c, next) {
-    c.close(function forceShutdownCloseCallback() {
-      //don't mind if there was an error
-      next();
-    });
-  });
-};
-
-/**
- * Closes all open connections and schedules reconnection
- * @param {Number} delay
- */
-HostConnectionPool.prototype.scheduleReconnection = function (delay) {
-  this._forceShutdown();
-  this.reconnectionTimeout = setTimeout(this._attemptReconnection.bind(this), delay);
-};
-
-/**
- * Prevents reconnection timeout from triggering
- */
-HostConnectionPool.prototype.clearReconnection = function () {
-  if (!this.reconnectionTimeout) {
-    return;
-  }
-  clearTimeout(this.reconnectionTimeout);
-  this.reconnectionTimeout = null;
-};
-
-HostConnectionPool.prototype._attemptReconnection = function () {
-  this.reconnectionTimeout = null;
-  var c = this._createConnection();
-  var self = this;
-  c.open(function attempOpenCallback(err) {
-    if (err) {
-      self.log('info', util.format('Reconnection attempt to host %s failed', self.address), err);
-      self.host.setDown();
-      return c.close();
-    }
-    self.host.setUp();
-    self.connections = [ c ];
-    setImmediate(function afterReconnectionSuccess() {
-      self._maybeCreatePool(noop);
-    });
-  });
-};
-
-/**
- * @param {Function} callback
- * @returns {*}
- */
-HostConnectionPool.prototype.shutdown = function (callback) {
-  this.clearReconnection();
-  if (!this.connections.length) {
-    return callback();
-  }
-  if (this.shuttingDown) {
-    return this.once('shutdown', callback);
-  }
-  this.log('info', 'Closing ' + this.connections.length + ' connections to ' + this.address);
-  this.shuttingDown = true;
-  var self = this;
-  var connections = this.connections;
-  //Create a new reference
-  this.connections = utils.emptyArray;
-  utils.each(connections, function closeEach(c, next) {
-    c.close(next);
-  }, function shutdownEachEnded(err) {
-    self.shuttingDown = false;
-    callback(err);
-    self.emit('shutdown', err);
-  });
-};
-
-HostConnectionPool.prototype.log = utils.log;
 
 /**
  * Represents an associative-array of {@link Host hosts} that can be iterated.
@@ -615,8 +482,5 @@ HostMap.prototype.toJSON = function() {
   return this._items;
 };
 
-function noop () {}
-
-exports.HostConnectionPool = HostConnectionPool;
 exports.Host = Host;
 exports.HostMap = HostMap;

--- a/lib/policies/reconnection.js
+++ b/lib/policies/reconnection.js
@@ -14,7 +14,7 @@ function ReconnectionPolicy() {
 
 /**
  * A new reconnection schedule.
- * @returns {{next: next}} An infinite iterator
+ * @returns {{next: function}} An infinite iterator
  */
 ReconnectionPolicy.prototype.newSchedule = function () {
   throw new Error('You must implement a new schedule for the Reconnection class');

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -64,6 +64,7 @@ RequestHandler.prototype.getNextConnection = function (queryOptions, callback) {
  * @param {Function} callback callback(err, connection, host) to use
  */
 RequestHandler.prototype.iterateThroughHosts = function (iterator, callback) {
+  /** @type {Host} */
   var host;
   // get a host that is UP in a sync loop
   while (true) {
@@ -73,8 +74,7 @@ RequestHandler.prototype.iterateThroughHosts = function (iterator, callback) {
     }
     host = item.value;
     // set the distance relative to the client first, using the load balancing policy
-    var distance = this.loadBalancingPolicy.getDistance(host);
-    host.setDistance(distance);
+    var distance = host.getDistance(this.loadBalancingPolicy);
     if (distance === types.distance.ignored) {
       //If its marked as ignore by the load balancing policy, move on.
       continue;
@@ -93,7 +93,6 @@ RequestHandler.prototype.iterateThroughHosts = function (iterator, callback) {
     }
     if (err) {
       self.triedHosts[host.address] = err;
-      host.setDown();
     }
     if (++self.hostIterations > maxSyncHostIterations) {
       //avoid a large number sync recursive calls
@@ -125,7 +124,11 @@ RequestHandler.prototype.getPooledConnection = function (host, callback) {
     }
     // switch keyspace
     connection.changeKeyspace(self.client.keyspace, function (err) {
-      callback(err, err ? null : connection);
+      if (err) {
+        host.removeFromPool(connection);
+        return callback(err);
+      }
+      callback(null, connection);
     });
   });
 };
@@ -175,8 +178,6 @@ RequestHandler.prototype.sendOnConnection = function (request, options, callback
       //Something bad happened, maybe retry or do something about it
       return self.handleError(err, callback);
     }
-    //it looks good, lets ensure this host is marked as UP
-    self.host.setUp();
     response = response || utils.emptyObject;
     var result = new types.ResultSet(response, self.host.address, self.triedHosts, self.request.consistency);
     if (result.info.warnings) {
@@ -305,8 +306,8 @@ RequestHandler.prototype.handleError = function (err, callback) {
   err['coordinator'] = this.host.address;
   var decisionInfo = { decision: retry.RetryPolicy.retryDecision.rethrow };
   //noinspection JSUnresolvedVariable
-  if (err && err.isServerUnhealthy) {
-    this.host.setDown();
+  if (err && err.isSocketError) {
+    this.host.removeFromPool(this.connection);
     return this.retry(callback);
   }
   if (err instanceof errors.OperationTimedOutError) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -822,6 +822,7 @@ exports.log = log;
 exports.map = map;
 exports.mapSeries = mapSeries;
 exports.maxInt = maxInt;
+exports.noop = noop;
 exports.objectValues = objectValues;
 exports.parallel = parallel;
 exports.parseCommonArgs = parseCommonArgs;

--- a/test/integration/short/connection-tests.js
+++ b/test/integration/short/connection-tests.js
@@ -194,7 +194,7 @@ describe('Connection', function () {
             var request = getRequest('SELECT key FROM system.local');
             connection.sendStream(request, null, function (err) {
               if (killed && err) {
-                assert.ok(err.isServerUnhealthy);
+                assert.ok(err.isSocketError);
                 err = null;
               }
               next(err);

--- a/test/integration/short/load-balancing-tests.js
+++ b/test/integration/short/load-balancing-tests.js
@@ -59,7 +59,7 @@ describe('TokenAwarePolicy', function () {
             assert.strictEqual(helper.lastOctetOf(address), expectedPartition[id.toString()]);
             timesNext();
           });
-        }, next);
+        }, helper.finish(client, next));
       },
       helper.ccmHelper.remove
     ], done);

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -1,3 +1,4 @@
+"use strict";
 var assert = require('assert');
 var util = require('util');
 var path = require('path');
@@ -100,7 +101,7 @@ var helper = {
      * @param {Function} callback
      */
     startNode: function (nodeIndex, callback) {
-      args = ['node' + nodeIndex, 'start', '--wait-other-notice', '--wait-for-binary-proto'];
+      var args = ['node' + nodeIndex, 'start', '--wait-other-notice', '--wait-for-binary-proto'];
       if (process.platform.indexOf('win') === 0 && helper.isCassandraGreaterThan('2.2.4')) {
         args.push('--quiet-windows')
       }
@@ -258,7 +259,7 @@ var helper = {
     //noinspection JSUnresolvedVariable
     var version = process.env.TEST_CASSANDRA_VERSION;
     if (!version) {
-      version = '2.1.4';
+      version = '3.0.5';
     }
     return version;
   },
@@ -465,6 +466,29 @@ var helper = {
       assert.ifError(err);
       client.shutdown(callback);
     });
+  },
+
+  /**
+   * Executes a function at regular intervals while the condition is false or the amount of attempts >= maxAttempts.
+   * @param {Function} condition
+   * @param {Number} delay
+   * @param {Number} maxAttempts
+   * @param {Function} done
+   */
+  setIntervalUntil: function (condition, delay, maxAttempts, done) {
+    var attempts = 0;
+    utils.whilst(
+      function whilstCondition() {
+        return !condition();
+      },
+      function whilstItem(next) {
+        if (attempts++ >= maxAttempts) {
+          return next(new Error(util.format('Condition still false after %d attempts: %s', maxAttempts, condition)));
+        }
+
+        setTimeout(next, delay);
+      },
+      done);
   },
   queries: {
     basic: "SELECT key FROM system.local",

--- a/test/unit/request-handler-tests.js
+++ b/test/unit/request-handler-tests.js
@@ -493,7 +493,7 @@ describe('RequestHandler', function () {
     var getHost = function (address, isUp) {
       return {
         isUp: function () { return isUp !== false; },
-        setDistance: helper.noop,
+        getDistance: helper.noop,
         address: address,
         setDown: function () {
           //noinspection JSPotentiallyInvalidUsageOfThis
@@ -512,28 +512,6 @@ describe('RequestHandler', function () {
         assert.ifError(err);
         assert.ok(c);
         assert.ok(sync);
-        done();
-      });
-      sync = false;
-    });
-    it('should set the host down when calling getPooledConnection() returns an error', function (done) {
-      var handler = newInstance();
-      var hosts = [ getHost(), getHost() ];
-      var counter = 0;
-      handler.getPooledConnection = function (h, cb) {
-        //For the second host, it returns a valid connection
-        if (++counter === 2) {
-          return cb(null, {});
-        }
-        cb(new Error('Test error'));
-      };
-      var sync = true;
-      handler.iterateThroughHosts(utils.arrayIterator(hosts), function (err, c) {
-        assert.ifError(err);
-        assert.ok(c);
-        assert.ok(sync);
-        assert.ok(hosts[0].isDown);
-        assert.ok(!hosts[1].isDown);
         done();
       });
       sync = false;


### PR DESCRIPTION
Don't mark host down while at least one connection to it is active. Allow partially connected connection pools and keep reconnecting in the background.
When a DOWN event is received and there are no connections to the host, mark the node as down, ignore it otherwise.