### PR TITLE
Allow custom query options

### DIFF
--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -154,7 +154,7 @@ function createQueryOptions(client, userOptions, rowCallback, logged) {
   userOptions = (!userOptions || typeof userOptions === 'function') ? utils.emptyObject : userOptions;
   var defaultQueryOptions = client.options.queryOptions;
   // Using fixed property names is 2 order of magnitude faster than dynamically shallow clone objects
-  return {
+  var result = {
     autoPage: ifUndefined(userOptions.autoPage, defaultQueryOptions.autoPage),
     captureStackTrace: ifUndefined(userOptions.captureStackTrace, defaultQueryOptions.captureStackTrace),
     consistency: ifUndefined3(userOptions.consistency, profile.consistency, defaultQueryOptions.consistency),
@@ -179,6 +179,26 @@ function createQueryOptions(client, userOptions, rowCallback, logged) {
     // not part of query options
     rowCallback: rowCallback
   };
+  if (userOptions === utils.emptyObject) {
+    return result;
+  }
+  var userOptionsKeys = Object.keys(userOptions);
+  var key, value;
+  // Use the fastest iteration of array
+  var i = userOptionsKeys.length;
+  while (i--) {
+    key = userOptionsKeys[i];
+    if (key === 'executionProfile') {
+      // Execution profile was the only value that could has been "replaced"
+      continue;
+    }
+    value = userOptions[key];
+    if (value === undefined) {
+      continue;
+    }
+    result[key] = value;
+  }
+  return result;
 }
 
 function ifUndefined(v1, v2) {


### PR DESCRIPTION
Fixes breaking change introduced in #156 for NODEJS-201 that didn't allowed custom query options.

I think a found a good compromise between shallow cloning user query options + profile options + default options and having a fixed set of options. It eats up some of the throughput rate improvements from #156.

In my local machine compared to baseline (3b7424618f0343c68062e3dbfc4f9f8ac19c0212):
  - Fixed set of options: ~12% more throughput.
  - Allowing custom options: ~7%