### PR TITLE
Update build.yaml, remove nodejs 5 for 6.  Add C* 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "6"
   - "5"
   - "4"
   - "0.12"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   ci_type: ci_unit
   matrix:
     - nodejs_version: 6
-      TEST_CASSANDRA_VERSION: 3.0.6
+      TEST_CASSANDRA_VERSION: 3.0.7
       ci_type: ci
     - nodejs_version: 5
     - nodejs_version: 4
@@ -15,7 +15,6 @@ install:
   - npm install
 build: off
 test_script:
-  - "ccm create -v 3.0.6 -n 1 predownload"
   - "npm run %ci_type%"
 cache:
   - node_modules -> package.json

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,8 @@
 nodejs:
   - "0.10"
   - "0.12"
-  - "4.3"
-  - "5.6"
+  - "4"
+  - "6"
 os:
   - ubuntu/trusty64
 cassandra:
@@ -11,6 +11,7 @@ cassandra:
   - 2.1
   - 2.2
   - 3.0
+  - 3.7
 build:
   - type: envinject
     properties: |

--- a/test/integration/short/client-each-row-tests.js
+++ b/test/integration/short/client-each-row-tests.js
@@ -514,8 +514,13 @@ describe('Client', function () {
           loggedMessage = true;
         }
       });
-      var query = util.format("BEGIN UNLOGGED BATCH INSERT INTO %s (id, text_sample) VALUES (?, ?) APPLY BATCH", table);
-      var params = [types.Uuid.random(), utils.stringRepeat('c', 5 * 1025)];
+      var query = util.format(
+        "BEGIN UNLOGGED BATCH INSERT INTO %s (id, text_sample) VALUES (:id1, :sample)\n" +
+        "INSERT INTO %s (id, text_sample) VALUES (:id2, :sample) APPLY BATCH",
+        table,
+        table
+      );
+      var params = { id1: types.Uuid.random(), id2: types.Uuid.random(), sample: utils.stringRepeat('c', 2562) };
       client.eachRow(query, params, {prepare: true}, function () {
         
       }, function (err, result) {

--- a/test/integration/short/client-execute-prepared-tests.js
+++ b/test/integration/short/client-execute-prepared-tests.js
@@ -500,8 +500,13 @@ describe('Client', function () {
           loggedMessage = true;
         }
       });
-      var query = util.format("BEGIN UNLOGGED BATCH INSERT INTO %s (id1, id2, text_sample) VALUES (?, ?, ?) APPLY BATCH", commonTable);
-      var params = [Uuid.random(), types.TimeUuid.now(), utils.stringRepeat('b', 5 * 1025)];
+      var query = util.format(
+        "BEGIN UNLOGGED BATCH INSERT INTO %s (id1, id2, text_sample) VALUES (:id0, :id2, :sample)\n" +
+        "INSERT INTO %s (id1, id2, text_sample) VALUES (:id1, :id2, :sample) APPLY BATCH",
+        commonTable,
+        commonTable
+      );
+      var params = { id0: types.Uuid.random(), id1: types.Uuid.random(), id2: types.TimeUuid.now(), sample: utils.stringRepeat('c', 2562) };
       client.execute(query, params, {prepare: true}, function (err, result) {
         assert.ifError(err);
         assert.ok(result.info.warnings);

--- a/test/integration/short/client-execute-tests.js
+++ b/test/integration/short/client-execute-tests.js
@@ -493,10 +493,14 @@ describe('Client', function () {
         }
       });
       var query = util.format(
-        "BEGIN UNLOGGED BATCH INSERT INTO %s (id, text_sample) VALUES (%s, '%s') APPLY BATCH",
+        "BEGIN UNLOGGED BATCH INSERT INTO %s (id, text_sample) VALUES (%s, '%s')\n" +
+        "INSERT INTO %s (id, text_sample) VALUES (%s, '%s') APPLY BATCH",
         table,
         types.Uuid.random(),
-        utils.stringRepeat('a', 5 * 1025)
+        utils.stringRepeat('a', 2 * 1025),
+        table,
+        types.Uuid.random(),
+        utils.stringRepeat('a', 3 * 1025)
       );
       client.execute(query, function (err, result) {
         assert.ifError(err);

--- a/test/integration/short/metadata-tests.js
+++ b/test/integration/short/metadata-tests.js
@@ -216,7 +216,9 @@ describe('Metadata', function () {
   });
   describe('#getTrace()', function () {
     it('should retrieve the trace immediately after', function (done) {
-      var client = newInstance();
+      // use a single node
+      var lbp = new helper.WhiteListPolicy(['1']);
+      var client = newInstance({ policies: { loadBalancing: lbp }});
       var traceId;
       utils.series([
         client.connect.bind(client),
@@ -244,12 +246,14 @@ describe('Metadata', function () {
       ], done);
     });
     it('should retrieve the trace a few seconds after', function (done) {
-      var client = newInstance();
+      // use a single node
+      var lbp = new helper.WhiteListPolicy(['2']);
+      var client = newInstance({ policies: { loadBalancing: lbp }});
       var traceId;
       utils.series([
         client.connect.bind(client),
         function executeQuery(next) {
-          client.execute('SELECT * FROM system.local', [], { traceQuery: true}, function (err, result) {
+          client.execute(helper.queries.basic, [], { traceQuery: true}, function (err, result) {
             traceId = result.info.traceId;
             if (err) {
               return next(err);


### PR DESCRIPTION
Also add nodejs 6 to .travis.yml.  Use 3.0.7 in appveyor.yml.

Rationale:

* nodejs 5 is not an LTS release, so to reduce integration build axis its not included.
* C* 3.7 is the latest 'tock' release.  Would be good to include that on the matrix.