### PR TITLE
Resolve host name using dns.lookup() in case DNS queries fail

### DIFF
--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -85,7 +85,7 @@ ControlConnection.prototype.init = function (callback) {
   }
   utils.series([
     function resolveNames(next) {
-      utils.each(self.options.contactPoints, function (name, eachNext) {
+      utils.each(self.options.contactPoints, function eachResolve(name, eachNext) {
         if (name.indexOf('[') === 0 && name.indexOf(']:') > 1) {
           // IPv6 host notation [ip]:port (RFC 3986 section 3.2.2)
           var portSeparatorIndex = name.lastIndexOf(']:');
@@ -101,7 +101,7 @@ ControlConnection.prototype.init = function (callback) {
         }
         resolveAll(name, function (err, addresses) {
           if (err) {
-            self.log('error', 'Host with name ' + name + ' could not be resolved');
+            self.log('error', 'Host with name ' + name + ' could not be resolved', err);
             return eachNext();
           }
           addresses.forEach(function (address) {
@@ -691,13 +691,14 @@ ControlConnection.prototype.shutdown = function () {
  */
 function resolveAll(name, callback) {
   var addresses = [];
-  utils.series([
+  utils.parallel([
     function resolve4(next) {
       dns.resolve4(name, function resolve4Callback(err, arr) {
         if (arr) {
           addresses.push.apply(addresses, arr);
         }
-        next(err);
+        // Ignore error
+        next();
       });
     },
     function resolve6(next) {
@@ -705,12 +706,21 @@ function resolveAll(name, callback) {
         if (arr) {
           addresses.push.apply(addresses, arr);
         }
-        next(err);
+        // Ignore error
+        next();
       });
     }
-  ], function resolveAllCallback(err) {
-    if (err) {
-      return callback(err);
+  ], function resolveAllCallback() {
+    if (addresses.length === 0) {
+      // In case dns.resolve*() methods don't yield a valid address for the host name
+      // Use system call getaddrinfo() that might resolve according to host system definitions
+      return dns.lookup(name, function (err, addr) {
+        if (err) {
+          return callback(err);
+        }
+        addresses.push(addr);
+        callback(null, addresses);
+      });
     }
     callback(null, addresses);
   });


### PR DESCRIPTION
In case the methods `dns.resolve4()` and `dns.resolve6()` are not able to resolve an address for a given host name, use `dns.lookup()` that performs a `getaddrinfo()` system call and might resolve using host system definitions.
Ignore `resolve4()` and `resolve6()` call errors.