### PR TITLE
fixes 3.1.0 breaking change - control connection no longer accepting local hostnames

### DIFF
--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -692,6 +692,15 @@ ControlConnection.prototype.shutdown = function () {
 function resolveAll(name, callback) {
   var addresses = [];
   utils.parallel([
+    function lookupHost(next) {
+      dns.lookup(name, function lookupHostCallback(err, ip) {
+        if (ip) {
+          addresses.push(ip);
+        }
+        // Ignore error
+        next();
+      });
+    },
     function resolve4(next) {
       dns.resolve4(name, function resolve4Callback(err, arr) {
         if (arr) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cassandra-driver",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "DataStax Node.js Driver for Apache Cassandra",
   "author": "DataStax",
   "keywords": [


### PR DESCRIPTION
When servers expose local or private hosts which cannot be resolved by dns lookup, the connection will fail. In 3.0.x, a `dns.lookup` was performed which would resolve these hostnames https://github.com/datastax/nodejs-driver/blob/3.0/lib/control-connection.js#L90. Currently, the `resolveAll` call assumes address as ipv4 or ipv6 https://github.com/datastax/nodejs-driver/blob/3.1/lib/control-connection.js#L692. This breaks our setup.