### PR TITLE
Introduce host pool states

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -59,6 +59,7 @@ function Connection(endpoint, protocolVersion, options) {
   this.encoder = new Encoder(protocolVersion, options);
   this.keyspace = null;
   this.emitDrain = false;
+  this.isClosed = false;
 }
 
 util.inherits(Connection, events.EventEmitter);
@@ -632,6 +633,9 @@ Connection.prototype.onTimeout = function (streamId, millis) {
  */
 Connection.prototype.close = function (callback) {
   this.log('verbose', 'disconnecting');
+  this.isClosed = true;
+  // Drain is never going to be emitted once it is set to closed
+  this.removeAllListeners('drain');
   this.clearAndInvokePending();
   if(!callback) {
     callback = function noop() {};

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -274,7 +274,14 @@ ControlConnection.prototype.refreshOnConnection = function (firstTime, callback)
   self.log('info', 'Connection acquired to ' + self.host.address + ', refreshing nodes list');
   utils.series([
     function getLocalAndPeersInfo(next) {
-      self.host.once('down', self.hostDownHandler.bind(self));
+      var host = self.host;
+      function downOrIgnoredHandler() {
+        host.removeListener('down', downOrIgnoredHandler);
+        host.removeListener('ignore', downOrIgnoredHandler);
+        self.hostDownHandler();
+      }
+      host.once('down', downOrIgnoredHandler);
+      host.once('ignore', downOrIgnoredHandler);
       self.refreshHosts(firstTime, next);
     },
     function subscribeConnectionEvents(next) {

--- a/lib/host-connection-pool.js
+++ b/lib/host-connection-pool.js
@@ -11,6 +11,28 @@ var connectionIndex = 0;
 var connectionIndexOverflow = Math.pow(2, 15);
 
 /**
+ * Represents the possible states of the pool.
+ * Possible state transitions:
+ *  - From initial to closing: The pool must be closed because the host is ignored.
+ *  - From initial to shuttingDown: The pool is being shutdown as a result of a client shutdown.
+ *  - From closing to initial state: The pool finished closing connections (is now ignored) and it resets to
+ *    initial state in case the host is marked as local/remote in the future.
+ *  - From closing to shuttingDown (rare): It was marked as ignored, now the client is being shutdown.
+ *  - From shuttingDown to shutdown: Finished shutting down, the pool should not be reused.
+ * @private
+ */
+var state = {
+  // Initial state: open / opening / ready to be opened
+  initial: 0,
+  // When the pool is being closed as part of a distance change
+  closing: 1,
+  // When the pool is being shutdown for good
+  shuttingDown: 2,
+  // When the pool has being shutdown
+  shutDown: 4
+};
+
+/**
  * Represents a pool of connections to a host
  * @param {Host} host
  * @param {Number} protocolVersion Initial protocol version
@@ -20,9 +42,10 @@ var connectionIndexOverflow = Math.pow(2, 15);
 function HostConnectionPool(host, protocolVersion) {
   events.EventEmitter.call(this);
   this._address = host.address;
-  this.options = host.options;
   this._newConnectionTimeout = null;
   this._creating = false;
+  this._state = state.initial;
+  this.options = host.options;
   this.protocolVersion = protocolVersion;
   this.coreConnectionsLength = 1;
   /**
@@ -30,7 +53,6 @@ function HostConnectionPool(host, protocolVersion) {
    * @type {Array.<Connection>}
    */
   this.connections = utils.emptyArray;
-  this.shuttingDown = false;
   this.setMaxListeners(0);
 }
 
@@ -41,15 +63,13 @@ util.inherits(HostConnectionPool, events.EventEmitter);
  */
 HostConnectionPool.prototype.borrowConnection = function (callback) {
   var self = this;
-  this.create(false, function (err) {
+  this.create(false, function afterCreating(err) {
     if (err) {
       return callback(err);
     }
     if (self.connections.length === 0) {
-      //something happen in the middle between the creation pool and now.
-      err = Error('No connection available');
-      err.isSocketError = true;
-      return callback(err);
+      // Normally an error should be thrown in this case, but better to handle this possibility
+      return callback(new Error('No connection available'));
     }
     var c = HostConnectionPool.minInFlight(self.connections);
     callback(null, c);
@@ -85,6 +105,9 @@ HostConnectionPool.minInFlight = function(connections) {
  * @param {Function} callback
  */
 HostConnectionPool.prototype.create = function (warmup, callback) {
+  if (this.isClosing()) {
+    return callback(new Error('Pool is being closed when calling create'));
+  }
   // The value of this.coreConnectionsLength can change over time
   // when an existing pool is being resized (by setting the distance).
   if (this.connections.length >= this.coreConnectionsLength) {
@@ -115,9 +138,16 @@ HostConnectionPool.prototype.create = function (warmup, callback) {
       self._attemptNewConnection(next);
     }, function whilstEnded(err) {
       self._creating = false;
-      if (err && self.connections.length === 0) {
-        // there was an error and no connections could be successfully opened
-        self.log('warning', util.format('Connection pool to host %s could not be created', self._address));
+      if (err) {
+        if (self.isClosing()) {
+          self.log('info', 'Connection pool created but it was being closed');
+          self._closeAllConnections();
+          err = new Error('Pool is being closed');
+        }
+        else {
+          // there was an error and no connections could be successfully opened
+          self.log('warning', util.format('Connection pool to host %s could not be created', self._address), err);
+        }
         return self.emit('creation', err);
       }
       self.log('info', util.format('Connection pool to host %s created with %d connection(s)',
@@ -169,6 +199,11 @@ HostConnectionPool.prototype._attemptNewConnection = function (callback) {
       c.close();
       return self.emit('open', err);
     }
+    if (self.isClosing()) {
+      self.log('info', util.format('Connection to %s opened successfully but pool was being closed', self._address));
+      c.close();
+      return self.emit('open', new Error('Connection closed'));
+    }
     // use a copy of the connections array
     var newConnections = self.connections.slice(0);
     newConnections.push(c);
@@ -176,6 +211,22 @@ HostConnectionPool.prototype._attemptNewConnection = function (callback) {
     self.log('info', util.format('Connection to %s opened successfully', self._address));
     self.emit('open', null, c);
   });
+};
+
+HostConnectionPool.prototype.attemptNewConnectionImmediate = function () {
+  var self = this;
+  function openConnection() {
+    self.clearNewConnectionAttempt();
+    self.scheduleNewConnectionAttempt(0);
+  }
+  if (this._state === state.initial) {
+    return openConnection();
+  }
+  if (this._state === state.closing) {
+    return this.once('close', openConnection);
+  }
+  // In the case the pool its being / has been shutdown for good
+  // Do not attempt to create a new connection.
 };
 
 /**
@@ -203,7 +254,7 @@ HostConnectionPool.prototype.remove = function (connection) {
  * @param {Number} delay
  */
 HostConnectionPool.prototype.scheduleNewConnectionAttempt = function (delay) {
-  if (this.shuttingDown) {
+  if (this.isClosing()) {
     return;
   }
   var self = this;
@@ -233,14 +284,25 @@ HostConnectionPool.prototype.increaseSize = function () {
 };
 
 /**
+ * Gets a boolean indicating if the pool is being closed / shutting down or has been shutdown.
+ */
+HostConnectionPool.prototype.isClosing = function () {
+  return this._state !== state.initial;
+};
+
+/**
  * Gracefully waits for all in-flight requests to finish and closes the pool.
  */
 HostConnectionPool.prototype.drainAndShutdown = function () {
-  this.shuttingDown = true;
+  if (this.isClosing()) {
+    // Its already closing / shutting down
+    return;
+  }
+  this._state = state.closing;
   this.clearNewConnectionAttempt();
   var self = this;
   if (this.connections.length === 0) {
-    return this.setAsShutdown();
+    return this._afterClosing();
   }
   var connections = this.connections;
   this.connections = utils.emptyArray;
@@ -255,49 +317,58 @@ HostConnectionPool.prototype.drainAndShutdown = function () {
     c.emitDrain = true;
     c.once('drain', getDelayedClose(c));
   }
-
-  var wasSetAsShutdown = false;
+  var wasClosed = false;
   var checkShutdownTimeout;
   function getDelayedClose(connection) {
     return (function delayedClose() {
       connection.close();
-      connection.setAsClosed = true;
       if (++closedConnections < connections.length) {
         return;
       }
-      if (wasSetAsShutdown) {
+      if (wasClosed) {
         return;
       }
-      wasSetAsShutdown = true;
+      wasClosed = true;
       if (checkShutdownTimeout) {
         clearTimeout(checkShutdownTimeout);
       }
-      self.setAsShutdown();
+      self._afterClosing();
     });
   }
-  // check that after sometime (readTimeout + 2 secs) the connections have been drained
-  var delay = (this.options.socketOptions.readTimeout || defaultOptions.socketOptions.readTimeout) + 2000;
-  setTimeout(function checkShutdown() {
-    if (wasSetAsShutdown) {
-      return;
-    }
-    wasSetAsShutdown = true;
-    self.setAsShutdown();
+  // Check that after sometime (readTimeout + 100ms) the connections have been drained
+  var delay = (this.options.socketOptions.readTimeout || defaultOptions.socketOptions.readTimeout) + 100;
+  checkShutdownTimeout = setTimeout(function checkShutdown() {
+    wasClosed = true;
+    connections.forEach(function (c) {
+      if (c.isClosed) {
+        return;
+      }
+      c.close();
+    });
+    self._afterClosing();
   }, delay);
 };
 
-HostConnectionPool.prototype.setAsShutdown = function () {
-  if (this._creating) {
-    var self = this;
-    return this.once('creation', function onCreateShutdown() {
-      // ensure all creation process finished
-      process.nextTick(function nextTickCreateShutdown() {
-        self.shuttingDown = false;
-        self.emit('shutdown');
-      });
-    });
+HostConnectionPool.prototype._afterClosing = function () {
+  var self = this;
+  function resetState() {
+    if (self._state === state.shuttingDown) {
+      self._state = state.shutDown;
+    }
+    else {
+      self._state = state.initial;
+    }
+    self.emit('close');
   }
-  this.shuttingDown = false;
+  if (this._creating) {
+    // The pool is being created, reset the state back to init once the creation finished (without any new connection)
+    return this.once('creation', resetState);
+  }
+  if (this._opening) {
+    // The pool is growing, reset the state back to init once the open finished (without any new connection)
+    return this.once('open', resetState);
+  }
+  resetState();
 };
 
 /**
@@ -306,26 +377,42 @@ HostConnectionPool.prototype.setAsShutdown = function () {
 HostConnectionPool.prototype.shutdown = function (callback) {
   this.clearNewConnectionAttempt();
   if (!this.connections.length) {
+    this._state = state.shutDown;
     return callback();
   }
-  if (this.shuttingDown) {
-    return this.once('shutdown', callback);
+  var previousState = this._state;
+  this._state = state.shuttingDown;
+  if (previousState === state.closing) {
+    return this.once('close', callback);
   }
-  this.shuttingDown = true;
+  this.once('shutdown', callback);
+  if (previousState === state.shuttingDown) {
+    // Its going to be emitted
+    return;
+  }
+  var self = this;
+  this._closeAllConnections(function closeAllCallback() {
+    self._state = state.shutDown;
+    self.emit('shutdown');
+  });
+};
+
+/** @param {Function} [callback] */
+HostConnectionPool.prototype._closeAllConnections = function (callback) {
+  callback = callback || utils.noop;
   var connections = this.connections;
   // point to an empty array
   this.connections = utils.emptyArray;
+  if (connections.length === 0) {
+    return callback();
+  }
   this.log('info', util.format('Closing %d connections to %s', connections.length, this._address));
-  var self = this;
   utils.each(connections, function closeEach(c, next) {
     c.close(function closedCallback() {
       //ignore errors
       next();
     });
-  }, function poolShutdownEnded() {
-    self.setAsShutdown();
-    callback();
-  });
+  }, callback);
 };
 
 HostConnectionPool.prototype.log = utils.log;

--- a/lib/host.js
+++ b/lib/host.js
@@ -68,8 +68,8 @@ Host.prototype.setDown = function() {
     // the host is already marked as Down
     return;
   }
-  if (this.pool.shuttingDown) {
-    // the pool is being shutdown, don't mind
+  if (this.pool.isClosing()) {
+    // the pool is being closed/shutdown, don't mind
     return;
   }
   this.setDownAt = Date.now();
@@ -114,18 +114,9 @@ Host.prototype.checkIsUp = function () {
   if (this.isUp()) {
     return;
   }
-  var self = this;
-  function openConnectionImmediate() {
-    // if it was unhealthy and now maybe its not, lets reset the reconnection schedule.
-    self.pool.clearNewConnectionAttempt();
-    self.reconnectionSchedule = self.options.policies.reconnection.newSchedule();
-    self.reconnectionDelay = 0;
-    self.pool.scheduleNewConnectionAttempt(self.reconnectionDelay);
-  }
-  if (this.pool.shuttingDown) {
-    return this.pool.once('shutdown', openConnectionImmediate);
-  }
-  openConnectionImmediate();
+  this.reconnectionSchedule = this.options.policies.reconnection.newSchedule();
+  this.reconnectionDelay = 0;
+  this.pool.attemptNewConnectionImmediate();
 };
 
 /**
@@ -182,6 +173,7 @@ Host.prototype.setDistance = function (distance) {
   }
   if (this._distance === types.distance.ignored) {
     // this host was local/remote and now must be ignored
+    this.emit('ignore');
     this.pool.drainAndShutdown();
   }
   else if (!this.isUp()) {
@@ -254,7 +246,7 @@ Host.prototype.checkHealth = function (connection) {
  */
 Host.prototype.removeFromPool = function (connection) {
   this.pool.remove(connection);
-  if (this.pool.shuttingDown) {
+  if (this.pool.isClosing()) {
     return;
   }
   this._checkPoolState();

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -36,6 +36,15 @@ var helper = {
     setImmediate(cb);
   },
   /**
+   * Returns a function that returns the provided value
+   * @param value
+   */
+  functionOf: function (value) {
+    return (function fnOfFixedValue() {
+      return value;
+    });
+  },
+  /**
    * @type {ClientOptions}
    */
   baseOptions: (function () {


### PR DESCRIPTION
Track states of the HostConnectionPool as a FSM.
Differentiate between pool closing, as a result of change in distance, and shutting down, as a result of client shutdown.
Check the state of the pool when creating it and when increasing its size.
When the control connection host is ignored, move to a different host.

Included some tests to check the transitions between local/remote and ignore.

Fixes NODEJS-283: Included an integration test trying to force a race condition between a pool increasing size and being shutdown.