### PR TITLE
protect getPeersSchemaVersions from null schema version values

### DIFF
--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -150,7 +150,7 @@ Metadata.prototype.refreshKeyspace = function (name, callback) {
       delete self.keyspaces[name];
       return callback();
     }
-    // tokens are lazily init on the keyspace, once a replica from that keyspace is retrieved. 
+    // tokens are lazily init on the keyspace, once a replica from that keyspace is retrieved.
     self.keyspaces[ksInfo.name] = ksInfo;
     callback(null, ksInfo);
   });
@@ -625,7 +625,10 @@ Metadata.prototype.getPeersSchemaVersions = function (connection, callback) {
     var versions = [];
     if (!err && result && result.rows) {
       for (var i = 0; i < result.rows.length; i++) {
-        versions.push(result.rows[i]['schema_version']);
+        var schemaVersion = result.rows[i]['schema_version'];
+        if (schemaVersion) {
+          versions.push(schemaVersion);
+        }
       }
     }
     callback(err, versions);


### PR DESCRIPTION
`Client.prototype._waitForSchemaAgreement` fails if its internal call to `self.metadata.getPeersSchemaVersions` returns an array of schema entries with `null` values.  It fails on line 595 when `toString()` is called on the null value.

This patch filters out null values before it returns schema versions.