### PR TITLE
Set appveyor os to 'Previous Visual Studio 2015' temporarily.

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   ci_type: ci_unit
   matrix:
     - nodejs_version: 6
-      TEST_CASSANDRA_VERSION: 3.0.7
+      TEST_CASSANDRA_VERSION: 3.7
       ci_type: ci
     - nodejs_version: 5
     - nodejs_version: 4

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -8,6 +8,7 @@ environment:
     - nodejs_version: 4
     - nodejs_version: 0.12
     - nodejs_version: 0.10
+os: Previous Visual Studio 2015
 platform:
   - x64
 install:

--- a/ci/hardwareinfo.ps1
+++ b/ci/hardwareinfo.ps1
@@ -6,6 +6,7 @@ $computerSystem = Get-CimInstance CIM_ComputerSystem
 $computerOS = Get-CimInstance CIM_OperatingSystem
 $computerCPU = Get-CimInstance CIM_Processor
 $computerHDD = Get-CimInstance Win32_LogicalDisk -Filter "DeviceID = 'C:'"
+$javaVersion = (java.exe -version 2>&1)
 
 Write-Host "System Information for: " $computerSystem.Name -BackgroundColor DarkCyan
 "CPU: " + $computerCPU.Name
@@ -13,3 +14,5 @@ Write-Host "System Information for: " $computerSystem.Name -BackgroundColor Dark
 "HDD Space: " + "{0:P2}" -f ($computerHDD.FreeSpace/$computerHDD.Size) + " Free (" + "{0:N2}" -f ($computerHDD.FreeSpace/1GB) + "GB)"
 "RAM: " + "{0:N2}" -f ($computerSystem.TotalPhysicalMemory/1GB) + "GB"
 "Operating System: " + $computerOS.caption + ", Service Pack: " + $computerOS.ServicePackMajorVersion
+
+Write-Host "Java Version: " $javaVersion


### PR DESCRIPTION
[CASSANDRA-12278](https://issues.apache.org/jira/browse/CASSANDRA-12278) prevents C* from working with j8u100+.  Previous image
has an older version of the JDK.

Also include java version in hardwareinfo and update to cassandra 3.7.