### PR TITLE
Remove connection from host pool when closed by server side

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -59,6 +59,15 @@ function Connection(endpoint, protocolVersion, options) {
   this.encoder = new Encoder(protocolVersion, options);
   this.keyspace = null;
   this.emitDrain = false;
+  /**
+   * Determines if the socket is open and startup succeeded, whether the connection can be used to send requests / 
+   * receive events
+   */
+  this.connected = false;
+  /**
+   * Determines if the socket can be considered as open
+   */
+  this.isSocketOpen = false;
 }
 
 util.inherits(Connection, events.EventEmitter);
@@ -78,8 +87,12 @@ Connection.prototype.bindSocketListeners = function() {
   this.netClient.on('close', function() {
     self.log('info', 'Connection to ' + self.endpoint + ' closed');
     self.isSocketOpen = false;
+    var wasConnected = self.connected;
     self.close();
-    self.emit('close');
+    if (wasConnected) {
+      // Emit only when it was closed unexpectedly
+      self.emit('socketClose');
+    }
   });
 
   this.protocol = new streams.Protocol({ objectMode: true });
@@ -628,6 +641,7 @@ Connection.prototype.onTimeout = function (streamId, millis) {
 
 /**
  * Closes the socket (if not already closed) and cancels all in-flight requests.
+ * Multiple calls to this method have no additional side-effects.
  * @param {Function} [callback]
  */
 Connection.prototype.close = function (callback) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -113,6 +113,7 @@ Connection.prototype.bindSocketListeners = function() {
 
 /**
  * Connects a socket and sends the startup protocol messages.
+ * Note that when open() callbacks in error, the caller should immediately call {@link Connection#close}.
  */
 Connection.prototype.open = function (callback) {
   var self = this;
@@ -134,7 +135,7 @@ Connection.prototype.open = function (callback) {
       self.startup(callback);
     });
   }
-  this.netClient.once('error', function (err) {
+  this.netClient.once('error', function socketError(err) {
     self.errorConnecting(err, false, callback);
   });
   this.netClient.once('timeout', function connectTimedOut() {
@@ -191,7 +192,7 @@ Connection.prototype.startup = function (callback) {
 
   function startupCallback(err) {
     if (err) {
-      return self.errorConnecting(err, true, callback);
+      return self.errorConnecting(err, false, callback);
     }
     //The socket is connected and the connection is authenticated
     return self.connectionReady(callback);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -59,7 +59,6 @@ function Connection(endpoint, protocolVersion, options) {
   this.encoder = new Encoder(protocolVersion, options);
   this.keyspace = null;
   this.emitDrain = false;
-  this.isClosed = false;
 }
 
 util.inherits(Connection, events.EventEmitter);
@@ -73,12 +72,14 @@ Connection.prototype.bindSocketListeners = function() {
   //Remove listeners that were used for connecting
   this.netClient.removeAllListeners('connect');
   this.netClient.removeAllListeners('timeout');
+  // The socket is expected to be open at this point
+  this.isSocketOpen = true;
   var self = this;
   this.netClient.on('close', function() {
-    self.log('info', 'Connection to ' + self.address + ':' + self.port + ' closed');
-    self.connected = false;
-    self.connecting = false;
-    self.clearAndInvokePending();
+    self.log('info', 'Connection to ' + self.endpoint + ' closed');
+    self.isSocketOpen = false;
+    self.close();
+    self.emit('close');
   });
 
   this.protocol = new streams.Protocol({ objectMode: true });
@@ -103,7 +104,6 @@ Connection.prototype.bindSocketListeners = function() {
 Connection.prototype.open = function (callback) {
   var self = this;
   this.log('info', 'Connecting to ' + this.address + ':' + this.port);
-  this.connecting = true;
   if (!this.options.sslOptions) {
     this.netClient = new net.Socket();
     this.netClient.connect(this.port, this.address, function connectCallback() {
@@ -186,7 +186,6 @@ Connection.prototype.startup = function (callback) {
 };
 
 Connection.prototype.errorConnecting = function (err, destroy, callback) {
-  this.connecting = false;
   this.log('warning', 'There was an error when trying to connect to the host ' + this.address, err);
   if (destroy) {
     //there is a TCP connection that should be killed.
@@ -201,7 +200,6 @@ Connection.prototype.errorConnecting = function (err, destroy, callback) {
 Connection.prototype.connectionReady = function (callback) {
   this.emit('connected');
   this.connected = true;
-  this.connecting = false;
   // Remove existing error handlers as the connection is now ready.
   this.netClient.removeAllListeners('error');
   this.netClient.on('error', this.handleSocketError.bind(this));
@@ -629,26 +627,24 @@ Connection.prototype.onTimeout = function (streamId, millis) {
 };
 
 /**
+ * Closes the socket (if not already closed) and cancels all in-flight requests.
  * @param {Function} [callback]
  */
 Connection.prototype.close = function (callback) {
-  this.log('verbose', 'disconnecting');
-  this.isClosed = true;
-  // Drain is never going to be emitted once it is set to closed
+  callback = callback || utils.noop;
+  if (!this.connected && !this.isSocketOpen) {
+    return callback();
+  }
+  this.connected = false;
+  // Drain is never going to be emitted, once it is set to closed
   this.removeAllListeners('drain');
   this.clearAndInvokePending();
-  if(!callback) {
-    callback = function noop() {};
+  if (!this.isSocketOpen) {
+    return callback();
   }
-  if (!this.netClient) {
-    callback();
-    return;
-  }
-  if (!this.connected) {
-    this.netClient.destroy();
-    setImmediate(callback);
-    return;
-  }
+  // Set the socket as closed now (before socket.end() is called) to avoid being invoked more than once
+  this.isSocketOpen = false;
+  this.log('verbose', 'Closing connection to ' + this.endpoint);
   var self = this;
   this.netClient.once('close', function (hadError) {
     if (hadError) {
@@ -657,7 +653,6 @@ Connection.prototype.close = function (callback) {
     setImmediate(callback);
   });
   this.netClient.end();
-  this.streamHandlers = {};
 };
 
 module.exports = Connection;

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -326,6 +326,7 @@ ControlConnection.prototype.refreshHosts = function (newNodesUp, callback) {
   }
   this.log('info', 'Refreshing local and peers info');
   var c = this.connection;
+  var host = this.host;
   utils.series([
     function getLocalInfo(next) {
       var request = new requests.QueryRequest(selectLocal, null, null);
@@ -342,7 +343,7 @@ ControlConnection.prototype.refreshHosts = function (newNodesUp, callback) {
     },
     function getKeyspaces(next) {
       // to acquire metadata we need to specify the cassandra version
-      self.metadata.setCassandraVersion(self.host.getCassandraVersion());
+      self.metadata.setCassandraVersion(host.getCassandraVersion());
       self.metadata.buildTokens(self.hosts);
       if (!self.options.isMetadataSyncEnabled) {
         return next();

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -135,10 +135,16 @@ ControlConnection.prototype.init = function (callback) {
 ControlConnection.prototype.getConnection = function (callback) {
   var self = this;
   function done(err, c, host) {
-    if (c) {
-      self.connection = c;
-      self.encoder = c.encoder;
-      self.host = host;
+    if (!err) {
+      if (c) {
+        self.connection = c;
+        self.encoder = c.encoder;
+        self.host = host;
+      }
+      else {
+        // Make sure that an error is being thrown
+        err = new errors.DriverInternalError('No connection could be acquired but no error was found');
+      }
     }
     callback(err);
     self.emit('newConnection', err, c, host);
@@ -234,7 +240,8 @@ ControlConnection.prototype.getConnectionToNewHost = function (callback) {
       function whilstEnded() {
         if (!connection) {
           self.listenHostsForUp();
-          return callback();
+          // Callback in error as no connection could be acquired
+          return callback(new errors.NoHostAvailableError(null));
         }
         callback(null, connection, host);
       });

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -360,7 +360,7 @@ ControlConnection.prototype.refreshHosts = function (newNodesUp, callback) {
       if (!self.options.isMetadataSyncEnabled) {
         return next();
       }
-      self.metadata.refreshKeyspaces(next);
+      self.metadata.refreshKeyspaces(false, next);
     }
   ], callback);
 };
@@ -675,17 +675,26 @@ ControlConnection.prototype.waitForReconnection = function (callback) {
 
 /**
  * Executes a query using the active connection
- * @param {string} cqlQuery
- * @param {function} callback
+ * @param {String} cqlQuery
+ * @param {Boolean} [waitReconnect] Determines if it should wait for reconnection in case the control connection is not
+ * connected at the moment. Default: true.
+ * @param {Function} callback
  */
-ControlConnection.prototype.query = function (cqlQuery, callback) {
+ControlConnection.prototype.query = function (cqlQuery, waitReconnect, callback) {
   var self = this;
+  if (typeof waitReconnect === 'function') {
+    callback = waitReconnect;
+    waitReconnect = true;
+  }
   function queryOnConnection() {
     var request = new requests.QueryRequest(cqlQuery, null, null);
     self.connection.sendStream(request, null, callback);
   }
   if (!this.connection) {
-    //It's reconnecting
+    if (!waitReconnect) {
+      return callback(new errors.NoHostAvailableError(null));
+    }
+    // Wait until its reconnected (or timer elapses)
     return this.waitForReconnection(function waitCallback(err) {
       if (err) {
         //it was not able to reconnect in time

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -643,14 +643,15 @@ ControlConnection.prototype.getAddressForPeerHost = function (row, defaultPort, 
  */
 ControlConnection.prototype.waitForReconnection = function (callback) {
   var timeout;
+  var self = this;
   function newConnectionListener(err) {
     clearTimeout(timeout);
     callback(err);
   }
   this.once('newConnection', newConnectionListener);
   timeout = setTimeout(function waitTimeout() {
-    this.removeListener('newConnection', newConnectionListener);
-    callback(errors.OperationTimedOutError('A connection could not be acquired before timeout.'));
+    self.removeListener('newConnection', newConnectionListener);
+    callback(new errors.OperationTimedOutError('A connection could not be acquired before timeout.'));
   }, metadataQueryAbortTimeout);
 };
 

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -59,6 +59,10 @@ function ControlConnection(options, profileManager) {
   this.encoder = null;
   this.debouncer = new EventDebouncer(options.refreshSchemaDelay, this.log.bind(this));
   this.profileManager = profileManager;
+  /** Timeout used for delayed handling of topology changes */
+  this.topologyChangeTimeout = null;
+  /** Timeout used for delayed handling of node status changes */
+  this.nodeStatusChangeTimeout = null;
 }
 
 util.inherits(ControlConnection, events.EventEmitter);
@@ -300,6 +304,7 @@ ControlConnection.prototype.refreshOnConnection = function (firstTime, callback)
     }],
     function initDone(err) {
       if (err) {
+        // An error occurred, the ControlConnection will still reconnect as it's listening to host 'down' event
         self.log('error', 'ControlConnection could not be initialized', err);
       }
       else {
@@ -407,7 +412,10 @@ ControlConnection.prototype.nodeTopologyChangeHandler = function (event) {
   this.log('info', 'Received topology change', event);
   // all hosts information needs to be refreshed as tokens might have changed
   var self = this;
-  setTimeout(function nodeTopologyDelayedHandler() {
+  clearTimeout(this.topologyChangeTimeout);
+  // Use an additional timer to make sure that the refresh hosts is executed only AFTER the delay
+  // In this case, the event debouncer doesn't help because it could not honor the sliding delay (ie: processNow)
+  this.topologyChangeTimeout = setTimeout(function nodeTopologyDelayedHandler() {
     self.scheduleRefreshHosts();
   }, newNodeDelay);
 };
@@ -430,10 +438,12 @@ ControlConnection.prototype.nodeStatusChangeHandler = function (event) {
       if (distance === types.distance.ignored) {
         return host.setUp(true);
       }
-      //wait a couple of seconds before marking it as UP
-      return setTimeout(function delayCheckIsUp() {
+      clearTimeout(self.nodeStatusChangeTimeout);
+      // Waits a couple of seconds before marking it as UP
+      self.nodeStatusChangeTimeout = setTimeout(function delayCheckIsUp() {
         host.checkIsUp();
       }, newNodeDelay);
+      return;
     }
     // marked as down
     if (distance === types.distance.ignored) {
@@ -698,6 +708,11 @@ ControlConnection.prototype.getEncoder = function () {
 ControlConnection.prototype.shutdown = function () {
   // no need for callback as it all sync
   this.debouncer.shutdown();
+  // Emit a "newConnection" event with Error, as it may clear timeouts that were waiting new connections
+  this.emit('newConnection', new errors.DriverError('ControlConnection is being shutdown'));
+  // Cancel other timers
+  clearTimeout(this.topologyChangeTimeout);
+  clearTimeout(this.nodeStatusChangeTimeout);
 };
 
 /**

--- a/lib/host-connection-pool.js
+++ b/lib/host-connection-pool.js
@@ -339,10 +339,7 @@ HostConnectionPool.prototype.drainAndShutdown = function () {
   var delay = (this.options.socketOptions.readTimeout || defaultOptions.socketOptions.readTimeout) + 100;
   checkShutdownTimeout = setTimeout(function checkShutdown() {
     wasClosed = true;
-    connections.forEach(function (c) {
-      if (c.isClosed) {
-        return;
-      }
+    connections.forEach(function connectionEach(c) {
       c.close();
     });
     self._afterClosing();

--- a/lib/host-connection-pool.js
+++ b/lib/host-connection-pool.js
@@ -161,11 +161,12 @@ HostConnectionPool.prototype.create = function (warmup, callback) {
 HostConnectionPool.prototype._createConnection = function () {
   var c = new Connection(this._address, this.protocolVersion, this.options);
   var self = this;
-  //Relay the event idleRequestError
-  c.on('idleRequestError', function idleErrorCallback(err, connection) {
-    //The pool will emit the event
-    self.emit('idleRequestError', err, connection);
-  });
+  function connectionErrorCallback() {
+    // The socket is not fully open / can not send heartbeat
+    self.remove(c);
+  }
+  c.on('idleRequestError', connectionErrorCallback);
+  c.on('socketClose', connectionErrorCallback);
   return c;
 };
 
@@ -248,6 +249,7 @@ HostConnectionPool.prototype.remove = function (connection) {
   setImmediate(function removeClose() {
     connection.close();
   });
+  this.emit('remove');
 };
 
 /**

--- a/lib/host.js
+++ b/lib/host.js
@@ -26,10 +26,10 @@ function Host(address, protocolVersion, options) {
    */
   Object.defineProperty(this, 'pool', { value: new HostConnectionPool(this, protocolVersion), enumerable: false});
   var self = this;
-  this.pool.on('idleRequestError', function pooledConnectionRequestError(err, connection) {
-    self.removeFromPool(connection);
-  });
   this.pool.on('open', this._onNewConnectionOpen.bind(this));
+  this.pool.on('remove', function onConnectionRemovedFromPool() {
+    self._checkPoolState();
+  });
   /**
    * Gets string containing the Cassandra version.
    * @type {String}
@@ -246,9 +246,6 @@ Host.prototype.checkHealth = function (connection) {
  */
 Host.prototype.removeFromPool = function (connection) {
   this.pool.remove(connection);
-  if (this.pool.isClosing()) {
-    return;
-  }
   this._checkPoolState();
 };
 
@@ -259,6 +256,9 @@ Host.prototype.removeFromPool = function (connection) {
  * @private
  */
 Host.prototype._checkPoolState = function () {
+  if (this.pool.isClosing()) {
+    return;
+  }
   if (this.pool.connections.length < this.pool.coreConnectionsLength) {
     // the pool still needs to grow
     if (!this.pool.hasScheduledNewConnection()) {

--- a/lib/host.js
+++ b/lib/host.js
@@ -127,10 +127,14 @@ Host.prototype.checkIsUp = function () {
  * @ignore
  */
 Host.prototype.shutdown = function (waitForPending, callback) {
+  callback = callback || utils.noop;
   if (waitForPending) {
-    return this.pool.drainAndShutdown();
+    this.pool.drainAndShutdown();
+    // Gracefully draining and shutting down the pool is being done in the background, it's not required
+    // for the shutting down to be over to callback
+    return callback();
   }
-  this.pool.shutdown(callback || utils.noop);
+  this.pool.shutdown(callback);
 };
 
 /**

--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -158,15 +158,19 @@ Metadata.prototype.refreshKeyspace = function (name, callback) {
 
 /**
  * Gets the metadata information of all the keyspaces and updates the internal state of the driver.
+ * @param {Boolean} [waitReconnect] Determines if it should wait for reconnection in case the control connection is not
+ * connected at the moment. Default: true.
  * @param {Function} [callback] Optional callback.
  */
-Metadata.prototype.refreshKeyspaces = function (callback) {
+Metadata.prototype.refreshKeyspaces = function (waitReconnect, callback) {
   this.log('info', 'Retrieving keyspaces metadata');
   var self = this;
-  if (!callback) {
-    callback = function () {};
+  if (typeof waitReconnect === 'function' || typeof waitReconnect === 'undefined') {
+    callback = waitReconnect;
+    waitReconnect = true;
   }
-  this._schemaParser.getKeyspaces(function (err, keyspaces) {
+  callback = callback || utils.noop;
+  this._schemaParser.getKeyspaces(waitReconnect, function getKeyspacesCallback(err, keyspaces) {
     if (err) {
       self.log('error', 'There was an error while trying to retrieve keyspaces information', err);
       return callback(err);

--- a/lib/metadata/schema-parser.js
+++ b/lib/metadata/schema-parser.js
@@ -82,9 +82,10 @@ SchemaParser.prototype.getKeyspace = function (name, callback) {
 
 /**
  * @abstract
+ * @param {Boolean} waitReconnect
  * @param {Function} callback
  */
-SchemaParser.prototype.getKeyspaces = function (callback) {
+SchemaParser.prototype.getKeyspaces = function (waitReconnect, callback) {
 };
 
 /**
@@ -337,10 +338,10 @@ function SchemaParserV1(cc) {
 util.inherits(SchemaParserV1, SchemaParser);
 
 /** @override */
-SchemaParserV1.prototype.getKeyspaces = function (callback) {
+SchemaParserV1.prototype.getKeyspaces = function (waitReconnect, callback) {
   var self = this;
   var keyspaces = {};
-  this.cc.query(_selectAllKeyspacesV1, function (err, result) {
+  this.cc.query(_selectAllKeyspacesV1, waitReconnect, function (err, result) {
     if (err) return callback(err);
     for (var i = 0; i < result.rows.length; i++) {
       var row = result.rows[i];
@@ -616,10 +617,10 @@ function SchemaParserV2(cc, udtResolver) {
 util.inherits(SchemaParserV2, SchemaParser);
 
 /** @override */
-SchemaParserV2.prototype.getKeyspaces = function (callback) {
+SchemaParserV2.prototype.getKeyspaces = function (waitReconnect, callback) {
   var self = this;
   var keyspaces = {};
-  this.cc.query(_selectAllKeyspacesV2, function (err, result) {
+  this.cc.query(_selectAllKeyspacesV2, waitReconnect, function (err, result) {
     if (err) return callback(err);
     for (var i = 0; i < result.rows.length; i++) {
       var ksInfo = self._parseKeyspace(result.rows[i]);

--- a/test/integration/short/client-pool-tests.js
+++ b/test/integration/short/client-pool-tests.js
@@ -637,7 +637,7 @@ describe('Client', function () {
               assert.deepEqual(getPoolInfo(client), expectedState);
               if (ignoredHost === '1') {
                 // The control connection should have changed
-                assert.ok(cc.isClosed);
+                assert.ok(!cc.connected);
                 assert.notStrictEqual(helper.lastOctetOf(client.controlConnection.host), '1');
               }
               else {

--- a/test/integration/short/connection-tests.js
+++ b/test/integration/short/connection-tests.js
@@ -19,7 +19,7 @@ describe('Connection', function () {
       var localCon = newInstance();
       localCon.open(function (err) {
         assert.ifError(err);
-        assert.ok(localCon.connected && !localCon.connecting, 'Must be status connected');
+        assert.ok(localCon.connected, 'Must be status connected');
         localCon.close(done);
       });
     });
@@ -54,7 +54,7 @@ describe('Connection', function () {
         var localCon = newInstance(null, protocolVersion);
         localCon.open(function (err) {
           assert.ifError(err);
-          assert.ok(localCon.connected && !localCon.connecting, 'Must be status connected');
+          assert.ok(localCon.connected, 'Must be status connected');
           localCon.close(next);
         });
       }, done);
@@ -63,7 +63,7 @@ describe('Connection', function () {
       var localCon = newInstance('1.1.1.1');
       localCon.open(function (err) {
         assert.ok(err, 'Must return a connection error');
-        assert.ok(!localCon.connected && !localCon.connecting);
+        assert.ok(!localCon.connected);
         localCon.close(done);
       });
     });
@@ -71,7 +71,7 @@ describe('Connection', function () {
       var localCon = newInstance('127.0.0.1:8090');
       localCon.open(function (err) {
         assert.ok(err, 'Must return a connection error');
-        assert.ok(!localCon.connected && !localCon.connecting);
+        assert.ok(!localCon.connected);
         localCon.close(done);
       });
     });
@@ -105,7 +105,7 @@ describe('Connection', function () {
       localCon.options.sslOptions = {};
       localCon.open(function (err) {
         assert.ifError(err);
-        assert.ok(localCon.connected && !localCon.connecting, 'Must be status connected');
+        assert.ok(localCon.connected, 'Must be status connected');
         localCon.sendStream(getRequest(helper.queries.basic), null, function (err, result) {
           assert.ifError(err);
           assert.ok(result);

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -550,6 +550,16 @@ var helper = {
     props.forEach(function comparePropItem(p) {
       assert.strictEqual(o1[p], o2[p]);
     });
+  },
+  getPoolingOptions: function (localLength, remoteLength, heartBeatInterval) {
+    var pooling = {
+      heartBeatInterval: heartBeatInterval || 0,
+      coreConnectionsPerHost: {}
+    };
+    pooling.coreConnectionsPerHost[types.distance.local] = localLength || 1;
+    pooling.coreConnectionsPerHost[types.distance.remote] = remoteLength || 1;
+    pooling.coreConnectionsPerHost[types.distance.ignored] = 0;
+    return pooling;
   }
 };
 

--- a/test/unit/connection-tests.js
+++ b/test/unit/connection-tests.js
@@ -239,7 +239,7 @@ describe('Connection', function () {
       SocketMock.prototype.connect = function (p, a, cb) {
         setImmediate(cb);
       };
-      SocketMock.prototype.destroy = function () {
+      SocketMock.prototype.end = function () {
         var self = this;
         setImmediate(function () {
           self.emit('close');

--- a/test/unit/control-connection-tests.js
+++ b/test/unit/control-connection-tests.js
@@ -422,7 +422,7 @@ describe('ControlConnection', function () {
         listenCalled++;
       };
       cc.getConnectionToNewHost(function (err, c, h) {
-        assert.ifError(err);
+        helper.assertInstanceOf(err, Error);
         assert.ok(!c);
         assert.ok(!h);
         assert.strictEqual(listenCalled, 1);
@@ -449,7 +449,7 @@ describe('ControlConnection', function () {
       var cc = newInstance(options);
       cc.listenHostsForUp = helper.noop;
       cc.getConnectionToNewHost(function (err, c, h) {
-        assert.ifError(err);
+        helper.assertInstanceOf(err, Error);
         assert.ok(!c);
         assert.ok(!h);
         assert.strictEqual(borrowCalled, 0);

--- a/test/unit/metadata-tests.js
+++ b/test/unit/metadata-tests.js
@@ -20,7 +20,7 @@ describe('Metadata', function () {
   describe('#refreshKeyspaces()', function () {
     it('should parse C*2 keyspace metadata for simple strategy', function (done) {
       var cc = {
-        query: function (q, cb) {
+        query: function (q, w, cb) {
           cb(null, { rows: [{
             'keyspace_name': 'ks1',
             'strategy_class': 'org.apache.cassandra.locator.SimpleStrategy',
@@ -49,7 +49,7 @@ describe('Metadata', function () {
     });
     it('should parse C*2 keyspace metadata for network strategy', function (done) {
       var cc = {
-        query: function (q, cb) {
+        query: function (q, w, cb) {
           cb(null, { rows: [{
             'keyspace_name': 'ks2',
             'strategy_class': 'org.apache.cassandra.locator.NetworkTopologyStrategy',
@@ -76,7 +76,7 @@ describe('Metadata', function () {
     });
     it('should parse C*3 keyspace metadata for simple strategy', function (done) {
       var cc = {
-        query: function (q, cb) {
+        query: function (q, w, cb) {
           cb(null, { rows: [{
             'keyspace_name': 'ks1',
             'replication': {'class': 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '3'},
@@ -104,7 +104,7 @@ describe('Metadata', function () {
     });
     it('should parse C*3 keyspace metadata for network strategy', function (done) {
       var cc = {
-        query: function (q, cb) {
+        query: function (q, w, cb) {
           cb(null, { rows: [{
             'keyspace_name': 'ks2',
             'replication': {'class': 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'datacenter1': '2'},
@@ -133,7 +133,7 @@ describe('Metadata', function () {
   describe('#getReplicas()', function () {
     it('should return depending on the rf and ring size with simple strategy', function () {
       var cc = {
-        query: function (q, cb) {
+        query: function (q, w, cb) {
           cb(null, { rows: [{
             'keyspace_name': 'dummy',
             'strategy_class': 'SimpleStrategy',
@@ -2207,7 +2207,10 @@ function getControlConnectionForTable(tableRow, columnRows, indexRows) {
 
 function getControlConnectionForRows(rows, protocolVersion) {
   return {
-    query: function (q, cb) {
+    query: function (q, w, cb) {
+      if (typeof w === 'function') {
+        cb = w;
+      }
       setImmediate(function () {
         cb(null, {rows: rows});
       });


### PR DESCRIPTION
`Connection` instances now emit `'socketClose'` events and `HostConnectionPool` emits `'remove'` events. This way, the `Host` can listen when a connection has been removed from the pool and decide if it's now considered as down or not.

Removed unclear `connecting` and `isClosed` internal flags in `Connection`.
Includes fixes and improvements for `ControlConnection` mechanism for reconnection. 