### PR TITLE
Reset the ControlConnection state after failed init attempt

### DIFF
--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -120,8 +120,16 @@ ControlConnection.prototype.init = function (callback) {
     function tryInitOnConnection(next) {
       self.refreshOnConnection(true, next);
     }
-  ], function (err) {
+  ], function seriesFinished(err) {
     self.initialized = !err;
+    if (err) {
+      // Reset the internal state of the ControlConnection for future initialization attempts
+      var currentHosts = self.hosts;
+      currentHosts.forEach(function forEachHost(h) {
+        h.shutdown();
+      });
+      self.hosts = new HostMap();
+    }
     callback(err);
   });
 };

--- a/test/unit/client-tests.js
+++ b/test/unit/client-tests.js
@@ -659,6 +659,25 @@ describe('Client', function () {
         }
       ], done);
     });
+    it('should not attempt reconnection and log after shutdown', function (done) {
+      var rp = new policies.reconnection.ConstantReconnectionPolicy(50);
+      var Client = require('../../lib/client');
+      var client = new Client(utils.extend({}, helper.baseOptions, { policies: { reconnection: rp } }));
+      var logEvents = [];
+      client.on('log', logEvents.push.bind(logEvents));
+      client.connect(function (err) {
+        helper.assertInstanceOf(err, errors.NoHostAvailableError);
+        client.shutdown(function clientShutdownCallback(err) {
+          assert.ifError(err);
+          logEvents.length = 0;
+          setTimeout(function assertAfterSomeTime() {
+            assert.strictEqual(
+              logEvents.length, 0, 'Expected no log events after shutdown but was: ' + util.inspect(logEvents));
+            done();
+          }, 400);
+        });
+      })
+    });
   });
   describe('#_waitForSchemaAgreement()', function () {
     var Client = require('../../lib/client.js');


### PR DESCRIPTION
- Shutdown all connection pools on failed initialization attempt to avoid reconnection attempts.
- Created test for failed connection attempts, shutting down and logging events.