### PR TITLE
Make control connection tests more resilient

### DIFF
--- a/test/integration/short/client-pool-tests.js
+++ b/test/integration/short/client-pool-tests.js
@@ -887,11 +887,8 @@ describe('Client', function () {
             });
           }, next);
         },
-        function startNode3(next) {
-          helper.waitOnHost(function () {
-            helper.ccmHelper.startNode(3);
-          }, client, 3, 'up', helper.wait(5000, next));
-        },
+        helper.toTask(helper.ccmHelper.startNode, null, 3),
+        helper.waitOnHostUp(client, 3),
         function assertReconnected(next) {
           assert.strictEqual('3', helper.lastOctetOf(client.controlConnection.host));
           client.hosts.forEach(function (host) {


### PR DESCRIPTION
Remove 5 second delays from tests in favor of waiting for a condition to be met within 20 seconds with an attempt every second.  This should allow the tests more time to meet the condition and also possibly complete faster if the condition is met sooner.