### PR TITLE
Use deepExtend for Client options in tests

### DIFF
--- a/test/integration/long/client-metadata-tests.js
+++ b/test/integration/long/client-metadata-tests.js
@@ -151,5 +151,5 @@ function validateMurmurReplicas(client) {
 
 /** @returns {Client}  */
 function newInstance(options) {
-  return new Client(utils.extend({}, helper.baseOptions, options));
+  return new Client(utils.deepExtend({}, helper.baseOptions, options));
 }

--- a/test/integration/long/error-tests.js
+++ b/test/integration/long/error-tests.js
@@ -97,5 +97,5 @@ describe('Client', function () {
 
 /** @returns {Client}  */
 function newInstance(options) {
-  return new Client(utils.extend({}, helper.baseOptions, options));
+  return new Client(utils.deepExtend({}, helper.baseOptions, options));
 }

--- a/test/integration/long/event-tests.js
+++ b/test/integration/long/event-tests.js
@@ -115,5 +115,5 @@ describe('Client', function () {
 
 /** @returns {Client}  */
 function newInstance(options) {
-  return new Client(utils.extend({}, helper.baseOptions, options));
+  return new Client(utils.deepExtend({}, helper.baseOptions, options));
 }

--- a/test/integration/long/reconnection-tests.js
+++ b/test/integration/long/reconnection-tests.js
@@ -303,6 +303,6 @@ function killConnections(client, destroy) {
  */
 function newInstance(options) {
   options = options || {};
-  options = utils.extend(options, helper.baseOptions);
+  options = utils.deepExtend(options, helper.baseOptions);
   return new Client(options);
 }

--- a/test/integration/long/stress-tests.js
+++ b/test/integration/long/stress-tests.js
@@ -173,5 +173,5 @@ describe('Client', function () {
  * @returns {Client}
  */
 function newInstance(options) {
-  return new Client(utils.extend({}, helper.baseOptions, options));
+  return new Client(utils.deepExtend({}, helper.baseOptions, options));
 }

--- a/test/integration/short/client-batch-tests.js
+++ b/test/integration/short/client-batch-tests.js
@@ -496,5 +496,5 @@ describe('Client', function () {
  * @returns {Client}
  */
 function newInstance(options) {
-  return new Client(utils.extend({}, helper.baseOptions, options));
+  return new Client(utils.deepExtend({}, helper.baseOptions, options));
 }

--- a/test/integration/short/client-each-row-tests.js
+++ b/test/integration/short/client-each-row-tests.js
@@ -574,7 +574,7 @@ describe('Client', function () {
  */
 function newInstance(options) {
   options = options || {};
-  options = utils.extend(options, helper.baseOptions);
+  options = utils.deepExtend(options, helper.baseOptions);
   return new Client(options);
 }
 

--- a/test/integration/short/client-execute-prepared-tests.js
+++ b/test/integration/short/client-execute-prepared-tests.js
@@ -1104,7 +1104,7 @@ describe('Client', function () {
  */
 function newInstance(options) {
   options = options || {};
-  options = utils.extend({
+  options = utils.deepExtend({
     queryOptions: {consistency: types.consistencies.quorum}
   }, options, helper.baseOptions);
   return new Client(options);

--- a/test/integration/short/client-execute-tests.js
+++ b/test/integration/short/client-execute-tests.js
@@ -954,5 +954,5 @@ function verifyRow(table, id, fields, values, callback) {
  * @returns {Client}
  */
 function newInstance(options) {
-  return new Client(utils.extend({}, helper.baseOptions, options));
+  return new Client(utils.deepExtend({}, helper.baseOptions, options));
 }

--- a/test/integration/short/client-pool-tests.js
+++ b/test/integration/short/client-pool-tests.js
@@ -966,7 +966,7 @@ describe('Client', function () {
 
 /** @returns {Client}  */
 function newInstance(options) {
-  return new Client(utils.extend({}, helper.baseOptions, options));
+  return new Client(utils.deepExtend({}, helper.baseOptions, options));
 }
 
 /**

--- a/test/integration/short/client-stream-tests.js
+++ b/test/integration/short/client-stream-tests.js
@@ -360,5 +360,5 @@ describe('Client', function () {
  * @returns {Client}
  */
 function newInstance(options) {
-  return new Client(utils.extend({}, helper.baseOptions, options));
+  return new Client(utils.deepExtend({}, helper.baseOptions, options));
 }

--- a/test/integration/short/connection-tests.js
+++ b/test/integration/short/connection-tests.js
@@ -215,7 +215,7 @@ function newInstance(address, protocolVersion, options){
     protocolVersion = getProtocolVersion();
   }
   //var logEmitter = function (name, type) { if (type === 'verbose') { return; } console.log.apply(console, arguments);};
-  options = utils.extend({logEmitter: helper.noop}, options || defaultOptions);
+  options = utils.deepExtend({logEmitter: helper.noop}, options || defaultOptions);
   return new Connection(address + ':' + options.protocolOptions.port, protocolVersion, options);
 }
 

--- a/test/integration/short/control-connection-tests.js
+++ b/test/integration/short/control-connection-tests.js
@@ -251,7 +251,7 @@ describe('ControlConnection', function () {
 
 /** @returns {ControlConnection} */
 function newInstance(options, localConnections, remoteConnections) {
-  options = clientOptions.extend(utils.extend({ pooling: { coreConnectionsPerHost: {}}}, helper.baseOptions, options));
+  options = clientOptions.extend(utils.deepExtend({ pooling: { coreConnectionsPerHost: {}}}, helper.baseOptions, options));
   //disable the heartbeat
   options.pooling.heartBeatInterval = 0;
   options.pooling.coreConnectionsPerHost[types.distance.local] = localConnections || 2;

--- a/test/integration/short/custom-payload-tests.js
+++ b/test/integration/short/custom-payload-tests.js
@@ -204,5 +204,5 @@ describe('custom payload', function () {
  * @returns {Client}
  */
 function newInstance(options) {
-  return new Client(utils.extend({ pooling: { heartBeatInterval: 0 }}, helper.baseOptions, options));
+  return new Client(utils.deepExtend({ pooling: { heartBeatInterval: 0 }}, helper.baseOptions, options));
 }

--- a/test/integration/short/execution-profile-tests.js
+++ b/test/integration/short/execution-profile-tests.js
@@ -48,7 +48,7 @@ describe('ProfileManager', function() {
 
   function newInstance(options, profiles) {
     options = options || {};
-    options = utils.extend({
+    options = utils.deepExtend({
       profiles: profiles || createProfiles()
     }, helper.baseOptions, options);
     return new Client(options);

--- a/test/integration/short/load-balancing-tests.js
+++ b/test/integration/short/load-balancing-tests.js
@@ -150,6 +150,6 @@ describe('WhiteListPolicy', function () {
 });
 
 function newInstance(policy) {
-  var options = utils.extend({}, helper.baseOptions, { policies: { loadBalancing: policy}});
+  var options = utils.deepExtend({}, helper.baseOptions, { policies: { loadBalancing: policy}});
   return new Client(options);
 }

--- a/test/integration/short/metadata-tests.js
+++ b/test/integration/short/metadata-tests.js
@@ -967,5 +967,5 @@ describe('Metadata', function () {
 
 /** @returns {Client}  */
 function newInstance(options) {
-  return new Client(utils.extend({}, helper.baseOptions, options));
+  return new Client(utils.deepExtend({}, helper.baseOptions, options));
 }

--- a/test/integration/short/timeout-tests.js
+++ b/test/integration/short/timeout-tests.js
@@ -301,7 +301,7 @@ describe('client read timeouts', function () {
 
 /** @returns {Client}  */
 function newInstance(options) {
-  return new Client(utils.extend({}, helper.baseOptions, options));
+  return new Client(utils.deepExtend({}, helper.baseOptions, options));
 }
 
 /**

--- a/test/integration/short/udf-tests.js
+++ b/test/integration/short/udf-tests.js
@@ -354,5 +354,5 @@ vdescribe('2.2', 'Metadata', function () {
 
 /** @returns {Client}  */
 function newInstance(options) {
-  return new Client(utils.extend({}, helper.baseOptions, options));
+  return new Client(utils.deepExtend({}, helper.baseOptions, options));
 }


### PR DESCRIPTION
This is probably overkill, but based on the [discussion here](https://github.com/datastax/nodejs-driver/pull/176#issuecomment-242717496) it seems like using deepExtend is a better choice for extending client options in the tests when calling `newInstance`.  In most cases this is not needed, but it is useful in the event when there are options passed in that could replace base options (like `helper.baseOptions`' use of policies.retry.RetryMultipleTimes being replaced by other policy specifications like LBP).