### PR TITLE
Call readFlagsInfo before parsing response body

### DIFF
--- a/lib/streams.js
+++ b/lib/streams.js
@@ -166,6 +166,13 @@ Parser.prototype.parseBody = function (frameInfo, item) {
     return;
   }
   var reader = new FrameReader(item.header, item.chunk, item.offset);
+  var originalOffset = reader.offset;
+  try {
+    frameInfo.flagsInfo = reader.readFlagsInfo();
+  } catch (e) {
+    return this.handleParsingError(e, frameInfo, reader, originalOffset);
+  }
+
   //All the body for most operations is already buffered at this stage
   //Except for RESULT
   switch (item.header.opcode) {
@@ -276,7 +283,6 @@ Parser.prototype.parseResult = function (frameInfo, reader) {
   var originalOffset = reader.offset;
   try {
     if (!frameInfo.meta) {
-      frameInfo.flagsInfo = reader.readFlagsInfo();
       frameInfo.kind = reader.readInt();
       if (frameInfo.kind === types.resultKind.prepared) {
         frameInfo.preparedId = utils.copyBuffer(reader.readShortBytes());


### PR DESCRIPTION
Warnings, Custom Payload or Trace Id may be present on any response so
flags should always be checked and these should be parsed before reading
the rest of the body.  Previously this was only done for RESULT
messages.

Fixes `should callback with readFailure error when tombstone overwhelmed on replica`.  ~~I'd like to add a more targeted test, so labeled wip~~ [done].