### PR TITLE
Test: use additional init delay for ControlConnection STATUS_CHANGE

### DIFF
--- a/test/integration/short/control-connection-tests.js
+++ b/test/integration/short/control-connection-tests.js
@@ -92,6 +92,7 @@ describe('ControlConnection', function () {
       var cc = newInstance({ policies: { loadBalancing: new TestLoadBalancing() } });
       utils.series([
         cc.init.bind(cc),
+        helper.delay(2000 + (helper.isWin() ? 13000 : 0)),
         // Don't stop the node until we know it's up.
         helper.waitOnHostUp(cc, 2),
         // Stop the node and ensure it gets marked down.

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -117,7 +117,7 @@ var helper = {
      */
     startNode: function (nodeIndex, callback) {
       var args = ['node' + nodeIndex, 'start', '--wait-other-notice', '--wait-for-binary-proto'];
-      if (process.platform.indexOf('win') === 0 && helper.isCassandraGreaterThan('2.2.4')) {
+      if (helper.isWin() && helper.isCassandraGreaterThan('2.2.4')) {
         args.push('--quiet-windows')
       }
       new Ccm().exec(args, callback);
@@ -591,6 +591,13 @@ var helper = {
     pooling.coreConnectionsPerHost[types.distance.remote] = remoteLength || 1;
     pooling.coreConnectionsPerHost[types.distance.ignored] = 0;
     return pooling;
+  },
+  /**
+   * Returns true if the tests are being run on Windows
+   * @returns {boolean}
+   */
+  isWin: function () {
+    return process.platform.indexOf('win') === 0;
   }
 };
 
@@ -660,13 +667,13 @@ Ccm.prototype.startAll = function (nodeLength, options, callback) {
     },
     function (next) {
       var start = ['start', '--wait-for-binary-proto'];
-      if (process.platform.indexOf('win') === 0 && helper.isCassandraGreaterThan('2.2.4')) {
+      if (helper.isWin() && helper.isCassandraGreaterThan('2.2.4')) {
         start.push('--quiet-windows')
       }
       if (util.isArray(options.jvmArgs)) {
         options.jvmArgs.forEach(function (arg) {
           // Windows requires jvm arguments to be quoted, while *nix requires unquoted.
-          var jvmArg = process.platform.indexOf('win') === 0 ? '"' + arg + '"' : arg;
+          var jvmArg = helper.isWin() ? '"' + arg + '"' : arg;
           start.push('--jvm_arg', jvmArg);
         }, this);
         helper.trace('With jvm args', options.jvmArgs);
@@ -690,7 +697,7 @@ Ccm.prototype.spawn = function (processName, params, callback) {
   params = params || [];
   var originalProcessName = processName;
   var spawn = require('child_process').spawn;
-  if (process.platform.indexOf('win') === 0) {
+  if (helper.isWin()) {
     params = ['-ExecutionPolicy', 'Unrestricted', processName].concat(params);
     processName = 'powershell.exe';
   }


### PR DESCRIPTION
Recently [we removed an initial delay in a control connection integration test](https://github.com/datastax/nodejs-driver/pull/178/files#diff-8b7c72a01eed76ae230bbb5e6cd1c32bL97) for internode gossip to settle on Windows before marking the first node as down.

This caused several build failures on appveyor. Here's a fix with a longer delay for Windows. I've tested it [here](https://ci.appveyor.com/project/DataStax/nodejs-driver/build/442.test-status-change-fix/job/6k7y0wpg27reu4cw) and [here](https://ci.appveyor.com/project/DataStax/nodejs-driver/build/441.test-status-change-fix/job/8t2jdyuf14edyrh2).