### PR TITLE
Connection: prevent socket 'error' listener to be executed before 'close' listener

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -177,7 +177,7 @@ Connection.prototype.startup = function (callback) {
         //The host closed the connection, close the socket
         setImmediate(function decreasingVersionClosing() {
           self.close(function decreasingVersionOpening() {
-          //Retry
+            // Attempt to open with the correct protocol version
             self.open(callback);
           });
         });
@@ -669,6 +669,11 @@ Connection.prototype.close = function (callback) {
     }
     setImmediate(callback);
   });
+  // Prevent 'error' listener to be executed before 'close' listener
+  this.netClient.removeAllListeners('error');
+  // Add a noop handler for 'error' event to prevent Socket to throw the error
+  this.netClient.on('error', utils.noop);
+  // Half-close the socket, it will result in 'close' event being fired
   this.netClient.end();
 };
 


### PR DESCRIPTION
In some platforms (OSX, Windows), the 'error' handler is called before 'close' when the server sent a `FIN` packet as a result of a higher protocol version than supported.