### PR TITLE
[Do not merge] Run short suite against 2.1 as well.

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -2,12 +2,14 @@ environment:
   ci_type: ci_unit
   matrix:
     - nodejs_version: 6
-      TEST_CASSANDRA_VERSION: 3.7
+      TEST_CASSANDRA_VERSION: 2.1.15
       ci_type: ci
     - nodejs_version: 5
     - nodejs_version: 4
     - nodejs_version: 0.12
     - nodejs_version: 0.10
+      TEST_CASSANDRA_VERSION: 3.7
+      ci_type: ci
 os: Previous Visual Studio 2015
 platform:
   - x64


### PR DESCRIPTION
Just a test against the 3.1.1 tag to see if 2.1 runs cleanly with ccm on appveyor.

Run short suite against C* 2.1 on latest node.  Run 3.7 instead of 3.0.7
and on oldest supported node version.