### PR TITLE
Fix read streaming frame flags

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   ci_type: ci_unit
   matrix:
     - nodejs_version: 6
-      TEST_CASSANDRA_VERSION: 3.7
+      TEST_CASSANDRA_VERSION: 3.0.9
       ci_type: ci
     - nodejs_version: 5
     - nodejs_version: 4

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -163,14 +163,19 @@ Parser.prototype._transform = function (item, encoding, callback) {
 Parser.prototype.parseBody = function (frameInfo, item) {
   frameInfo.isStreaming = frameInfo.byRow && item.header.opcode === types.opcodes.result;
   if (!this.handleFrameBuffers(frameInfo, item)) {
+    // Frame isn't complete and we are not streaming the frame
     return;
   }
   var reader = new FrameReader(item.header, item.chunk, item.offset);
-  var originalOffset = reader.offset;
-  try {
-    frameInfo.flagsInfo = reader.readFlagsInfo();
-  } catch (e) {
-    return this.handleParsingError(e, frameInfo, reader, originalOffset);
+  // Check that flags have not been parsed yet for this frame
+  if (frameInfo.flagsInfo === undefined) {
+    var originalOffset = reader.offset;
+    try {
+      frameInfo.flagsInfo = reader.readFlagsInfo();
+    }
+    catch (e) {
+      return this.handleParsingError(e, frameInfo, reader, originalOffset);
+    }
   }
 
   //All the body for most operations is already buffered at this stage
@@ -280,46 +285,52 @@ Parser.prototype.getFrameBuffer = function (frameInfo, item) {
  * @param {FrameReader} reader
  */
 Parser.prototype.parseResult = function (frameInfo, reader) {
+  var result;
+  // As we might be streaming and the frame buffer might not be complete,
+  // read the metadata and different types of result values in a try-catch.
+  // Store the reader position
   var originalOffset = reader.offset;
   try {
     if (!frameInfo.meta) {
       frameInfo.kind = reader.readInt();
-      if (frameInfo.kind === types.resultKind.prepared) {
-        frameInfo.preparedId = utils.copyBuffer(reader.readShortBytes());
-      }
-      else if (frameInfo.kind === types.resultKind.setKeyspace) {
-        frameInfo.keyspace = reader.readString();
-      }
-      if (frameInfo.kind === types.resultKind.rows ||
-          frameInfo.kind === types.resultKind.prepared) {
-        frameInfo.meta = reader.readMetadata(frameInfo.kind);
+      // Spec 4.2.5
+      switch (frameInfo.kind) {
+        case types.resultKind.voidResult:
+          result = { header: frameInfo.header, flags: frameInfo.flagsInfo };
+          break;
+        case types.resultKind.rows:
+          // Parse the rows metadata, the rest of the response is going to be parsed afterwards
+          frameInfo.meta = reader.readMetadata(frameInfo.kind);
+          break;
+        case types.resultKind.setKeyspace:
+          result = { header: frameInfo.header, keyspaceSet: reader.readString(), flags: frameInfo.flagsInfo };
+          break;
+        case types.resultKind.prepared:
+          var preparedId = utils.copyBuffer(reader.readShortBytes());
+          frameInfo.meta = reader.readMetadata(frameInfo.kind);
+          result = { header: frameInfo.header, id: preparedId, meta: frameInfo.meta, flags: frameInfo.flagsInfo };
+          break;
+        case types.resultKind.schemaChange:
+          result = { header: frameInfo.header, schemaChange: reader.parseSchemaChange(), flags: frameInfo.flagsInfo };
+          break;
+        default:
+          //noinspection ExceptionCaughtLocallyJS
+          throw errors.DriverInternalError('Unexpected result kind: ' + frameInfo.kind);
       }
     }
   }
   catch (e) {
     return this.handleParsingError(e, frameInfo, reader, originalOffset);
   }
-  switch (frameInfo.kind) {
-    case types.resultKind.setKeyspace:
-      return this.push({ header: frameInfo.header, keyspaceSet: frameInfo.keyspace});
-    case types.resultKind.voidResult:
-      return this.push({ header: frameInfo.header, id: frameInfo.preparedId, flags: frameInfo.flagsInfo});
-    case types.resultKind.schemaChange:
-      //it contains additional info that it is not parsed
-      if (frameInfo.emitted) {
-        return;
-      }
-      frameInfo.emitted = true;
-      return this.push({ header: frameInfo.header, schemaChange: reader.parseSchemaChange() });
-    case types.resultKind.prepared:
-      //it contains result metadata that it is not parsed
-      if (frameInfo.emitted) {
-        return;
-      }
-      frameInfo.emitted = true;
-      return this.push({ header: frameInfo.header, id: frameInfo.preparedId, meta: frameInfo.meta, flags: frameInfo.flagsInfo});
+  if (result) {
+    if (frameInfo.emitted) {
+      // It may contain additional metadata and info that it's not being parsed
+      return;
+    }
+    frameInfo.emitted = true;
+    return this.push(result);
   }
-  //it contains rows
+  // Its a `Rows` result
   if (reader.remainingLength() > 0) {
     this.parseRows(frameInfo, reader);
   }
@@ -334,7 +345,7 @@ Parser.prototype.parseRows = function (frameInfo, reader) {
     //No more processing on this frame
     return;
   }
-  if (typeof frameInfo.rowLength === 'undefined') {
+  if (frameInfo.rowLength === undefined) {
     try {
       frameInfo.rowLength = reader.readInt();
     }
@@ -429,6 +440,7 @@ Parser.prototype.handleParsingError = function (e, frameInfo, reader, originalOf
     return this.bufferResultCell(frameInfo, reader, originalOffset, rowIndex, e.expectedLength);
   }
   frameInfo.parsingError = true;
+  frameInfo.cellBuffer = null;
   this.push({ header: frameInfo.header, error: e });
 };
 

--- a/test/integration/short/client-each-row-tests.js
+++ b/test/integration/short/client-each-row-tests.js
@@ -533,10 +533,10 @@ describe('Client', function () {
         client.shutdown(done);
       });
     });
-    it('should retrieve large result sets in parallel', function (done) {
+    vit('2.0', 'should retrieve large result sets in parallel', function (done) {
       insertSelectTest(table, 50000, 20, 50000, { prepare: true }, done);
     });
-    it('should query multiple times in parallel with query tracing enabled', function (done) {
+    vit('2.0', 'should query multiple times in parallel with query tracing enabled', function (done) {
       insertSelectTest(table, 50000, 2000, 10, { prepare: true, traceQuery: true }, done);
     });
   });

--- a/test/integration/short/client-each-row-tests.js
+++ b/test/integration/short/client-each-row-tests.js
@@ -533,12 +533,14 @@ describe('Client', function () {
         client.shutdown(done);
       });
     });
-    vit('2.0', 'should retrieve large result sets in parallel', function (done) {
-      insertSelectTest(table, 50000, 20, 50000, { prepare: true }, done);
-    });
-    vit('2.0', 'should query multiple times in parallel with query tracing enabled', function (done) {
-      insertSelectTest(table, 50000, 2000, 10, { prepare: true, traceQuery: true }, done);
-    });
+    if (!helper.isWin()) {
+      vit('2.0', 'should retrieve large result sets in parallel', function (done) {
+        insertSelectTest(table, 50000, 20, 50000, { prepare: true }, done);
+      });
+      vit('2.0', 'should query multiple times in parallel with query tracing enabled', function (done) {
+        insertSelectTest(table, 50000, 2000, 10, { prepare: true, traceQuery: true }, done);
+      });
+    }
   });
 });
 

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -508,9 +508,11 @@ var helper = {
    * @returns {Function}
    */
   finish: function (client, callback) {
-    return (function (err) {
-      assert.ifError(err);
-      client.shutdown(callback);
+    return (function onFinish(err) {
+      client.shutdown(function () {
+        assert.ifError(err);
+        callback();
+      });
     });
   },
 


### PR DESCRIPTION
Avoid parsing frame flags multiple times for streaming frames.
Refactor result parsing to attempt to make it more readable according to the spec.
Use a single catch block to handle range errors from all result kinds.