### PR TITLE
Disable waiting for trace events in parallel query test

### DIFF
--- a/test/integration/short/client-each-row-tests.js
+++ b/test/integration/short/client-each-row-tests.js
@@ -169,7 +169,9 @@ describe('Client', function () {
     before(function (done) {
       var client = newInstance();
       utils.series([
-        helper.ccmHelper.start(3),
+        helper.ccmHelper.start(3, {
+          jvmArgs: ['-Dcassandra.wait_for_tracing_events_timeout_secs=-1']
+        }),
         function (next) {
           client.eachRow(helper.createKeyspaceCql(keyspace, 3), [], noop, next);
         },


### PR DESCRIPTION
`should query multiple times in parallel with query tracing enabled` was timing out in CI because of a change introduced in C* 2.2.8/3.0.9 ([CASSANDRA-11465](https://issues.apache.org/jira/browse/CASSANDRA-11465)) that causes C* to wait for trace events to be written before returning a response.   For this particular test we are not interested in the trace responses, which often timeout because of the amount of burden put on the events table from 2000 queries that each page several times.