### PR TITLE
Support promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ const client = new cassandra.Client({ contactPoints: ['h1', 'h2'], keyspace: 'ks
 
 const query = 'SELECT name, email FROM users WHERE key = ?';
 client.execute(query, [ 'someone' ])
-  .then(err => console.log('User with email %s', result.rows[0].email));
+  .then(result => console.log('User with email %s', result.rows[0].email));
 ```
 
 Alternatively, you can use the callback-based execution for all asynchronous methods of the API.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ $ npm install cassandra-driver
 - Automatic reconnection
 - Configurable [load balancing][load-balancing] and [retry policies][retry]
 - Works with any cluster size
+- Both promise and callback-based API
 - [Row streaming and pipes](#row-streaming-and-pipes)
 
 ## Documentation
@@ -40,10 +41,17 @@ You can use the [project mailing list][mailinglist] or create a ticket on the [J
 const cassandra = require('cassandra-driver');
 const client = new cassandra.Client({ contactPoints: ['h1', 'h2'], keyspace: 'ks1' });
 
-const query = 'SELECT name, age, email FROM users WHERE key = ?';
-client.execute(query, [ 'guy' ], function(err, result) {
+const query = 'SELECT name, email FROM users WHERE key = ?';
+client.execute(query, [ 'someone' ])
+  .then(err => console.log('User with email %s', result.rows[0].email));
+```
+
+Alternatively, you can use the callback-based execution for all asynchronous methods of the API.
+
+```javascript
+client.execute(query, [ 'someone' ], function(err, result) {
   assert.ifError(err);
-  console.log('got user profile with email ' + result.rows[0].email);
+  console.log('User with email %s', result.rows[0].email);
 });
 ```
 
@@ -61,10 +69,8 @@ The driver will prepare the query once on each host and execute the statement wi
 const query = 'UPDATE users SET birth = ? WHERE key=?'; 
 const params = [ new Date(1942, 10, 1), 'jimi-hendrix' ];
 // Set the prepare flag in the query options
-client.execute(query, params, { prepare: true }, function(err) {
-  assert.ifError(err);
-  console.log('Row updated on the cluster');
-});
+client.execute(query, params, { prepare: true })
+  .then(result => console.log('Row updated on the cluster'));
 ```
 
 ### Row streaming and pipes
@@ -90,7 +96,7 @@ The `#stream()` method works in the same way but instead of callback it returns 
 It can be **piped** downstream and provides automatic pause/resume logic (it buffers when not read).
 
 ```javascript
-client.stream('SELECT time, val FROM temperature WHERE station_id=', ['abc'])
+client.stream('SELECT time, val FROM temperature WHERE station_id=', [ 'abc' ])
   .on('readable', function () {
     // 'readable' is emitted as soon a row is received and parsed
     var row;
@@ -131,12 +137,13 @@ CREATE TABLE users (
 You can retrieve the user address details as a regular Javascript object.
 
 ```javascript
-const query = 'SELECT name, email, address FROM users WHERE name = ?';
-client.execute(query, [ name ], { prepare: true }, function (err, result) {
-  const row = result.first();
-  const address = row.address;
-  console.log('User lives in %s, %s - %s', address.street, address.city, address.state); 
-});
+const query = 'SELECT name, address FROM users WHERE key = ?';
+client.execute(query, [ key ], { prepare: true })
+  .then(result => {
+    const row = result.first();
+    const address = row.address;
+    console.log('User lives in %s, %s - %s', address.street, address.city, address.state); 
+  });
 ```
 
 Read more information  about using [UDTs with the Node.js Driver][doc-udt].
@@ -170,10 +177,8 @@ const queries = [
     params: [ 'hendrix', 'Changed email', new Date() ]
   }
 ];
-client.batch(queries, { prepare: true }, function(err) {
-  assert.ifError(err);
-  console.log('Data updated on cluster');
-});
+client.batch(queries, { prepare: true })
+  .then(result => console.log('Data updated on cluster'));
 ```
 
 ----
@@ -183,8 +188,8 @@ client.batch(queries, { prepare: true }, function(err) {
 There are few data types defined in the ECMAScript specification, this usually represents a problem when you are trying
  to deal with data types that come from other systems in Javascript.
 
-The driver supports all the CQL data types in Apache Cassandra (2.2 and below) even for types that no built-in
-Javascript representation exists, like decimal, varint and bigint. Check the documentation on working with
+The driver supports all the CQL data types in Apache Cassandra (3.0 and below) even for types with no built-in
+JavaScript representation, like decimal, varint and bigint. Check the documentation on working with
  [numerical values][doc-numerical], [uuids][doc-uuid] and [collections][doc-collections].
 
 ## Logging

--- a/doc/TOC.md
+++ b/doc/TOC.md
@@ -12,11 +12,11 @@ which node to use as coordinator for each query, how to handle retry and failove
 ```javascript
 const cassandra = require('cassandra-driver');
 const client = new cassandra.Client({ contactPoints: ['host1'] });
-client.execute('SELECT key FROM system.local', function (err, result) {
-  assert.ifError(err);
-  const row = result.first();
-  console.log(row['key']);
-});
+client.execute('SELECT key FROM system.local')
+  .then(function (result) {
+      const row = result.first();
+      console.log(row['key']);
+  });
 ```
 
 See [`Client class documentation`](Client.html).

--- a/doc/faq/README.md
+++ b/doc/faq/README.md
@@ -14,17 +14,18 @@ Use the [Uuid and TimeUuid classes](/features/datatypes/uuids) inside the types 
 
 ### Should I create one client instance per module in my application?
 
-Normally you should use one client instance per application. You should share that instance between modules within your
-application.
+Normally you should use one `Client` instance per application. You should share that instance between modules within
+your application.
 
 ### Should I shut down the pool after executing a query?
 
-No, only call client.shutdown() once in your application's lifetime.
+No, only call `client.shutdown()` once in your application's lifetime.
 
 ### How can I use a list of values with the IN operator in a WHERE clause?
 
-To provide a dynamic list of values in a single parameter, use the IN operator followed by the question mark placeholder
-without parenthesis in the query. The parameter containing the list of values should be of an instance of Array.
+To provide a dynamic list of values in a single parameter, use the `IN` operator followed by the question mark
+placeholder without parenthesis in the query. The parameter containing the list of values should be of an instance of
+Array.
 
 For example:
 
@@ -32,5 +33,5 @@ For example:
 const query = 'SELECT * FROM table1 WHERE key1 = ? AND key2 IN ?';
 const key1 = 'param1';
 const allKeys2 = [ 'val1', 'val2', 'val3' ];
-client.execute(query, [ key1, allKeys2 ], { prepare: true }, callback);
+client.execute(query, [ key1, allKeys2 ], { prepare: true });
 ```

--- a/doc/features/batch/README.md
+++ b/doc/features/batch/README.md
@@ -13,6 +13,19 @@ const queries = [
    { query: query1, params: [emailAddress, 'hendrix'] },
    { query: query2, params: ['hendrix', 'Changed email', new Date()] } 
 ];
+// Promise-based call
+client.batch(queries, { prepare: true })
+  .then(function() {
+    // All queries have been executed successfully
+  })
+  .catch(function(err) {
+    // None of the changes have been applied
+  });
+```
+
+Or using the callback-based invocation
+
+```javascript
 client.batch(queries, { prepare: true }, function (err) {
    // All queries have been executed successfully
    // Or none of the changes have been applied, check err
@@ -22,3 +35,7 @@ client.batch(queries, { prepare: true }, function (err) {
 By preparing your queries, you will get the best performance and your JavaScript parameters correctly mapped to 
 Cassandra types. The driver will prepare each query once on each host and execute the batch every time with the
 different parameters provided.
+
+Note that Cassandra batches are not suitable for bulk loading, there are dedicated tools for that. Batches allow you
+to group related updates in a single request, so keep the batch size small (in the order of tens).
+Starting from Cassandra version 2.0.8, the server issues a warning if the batch size is greater than 5K.

--- a/doc/features/datatypes/README.md
+++ b/doc/features/datatypes/README.md
@@ -37,8 +37,8 @@ type. Values of type `Number` will be encoded as `double` (because `Number` is I
 Consider the following example:
 
 ```javascript
-var key = 1000;
-client.execute('SELECT * FROM table1 where key = ?', [key], callback);
+const key = 1000;
+client.execute('SELECT * FROM table1 where key = ?', [ key ]);
 ```
 
 If the key column is of type `int`, the execution fails. There are two possible ways to avoid this type of problem, as
@@ -53,8 +53,8 @@ and are ready for future execution. Also, the driver retrieves information about
 Using the previous example, setting the `prepare` flag in the queryOptions will fix it:
 
 ```javascript
-// prepare the query before execution 
-client.execute('SELECT * FROM table1 where key = ?', [key], { prepare : true }, callback);
+// Prepare the query before execution 
+client.execute('SELECT * FROM table1 where key = ?', [ key ], { prepare : true });
 ```
 
 When using prepared statements, the driver prepares the statement once on each host to execute multiple times.
@@ -65,7 +65,7 @@ Providing parameter hints in the query options is another way around it.
 
 ```javascript
 // Hint that the first parameter is an integer 
-client.execute('SELECT * FROM table1 where key = ?', [key], { hints : ['int'] }, callback);
+client.execute('SELECT * FROM table1 where key = ?', [ key ], { hints : ['int'] });
 ```
 
 [inetaddress-api]: http://docs.datastax.com/en/latest-nodejs-driver-api/module-types-InetAddress.html

--- a/doc/features/datatypes/collections/README.md
+++ b/doc/features/datatypes/collections/README.md
@@ -6,11 +6,11 @@ When reading columns with CQL list or set data types, the driver exposes them as
 list or set column, you can pass in a Array.
 
 ```javascript
-client.execute('SELECT list_val, set_val, double_val FROM tbl', function (err, result) {
-    assert.ifError(err);
+client.execute('SELECT list_val, set_val, double_val FROM tbl')
+  .then(function (result) {
     console.log(Array.isArray(result.rows[0]['list_val'])); // true
     console.log(Array.isArray(result.rows[0]['set_val']));  // true
-});
+  });
 ```
 
 ## Map 
@@ -19,10 +19,10 @@ JavaScript objects are used to represent the CQL map data type in the driver, be
 arrays.
 
 ```javascript
-client.execute('SELECT map_val FROM tbl', function (err, result) {
-    assert.ifError(err);
-    console.log(JSON.stringify(result.rows[0]['map_val'])); //{"key1":1,"key2":2}
-});
+client.execute('SELECT map_val FROM tbl')
+  .then(function (result) {
+    console.log(JSON.stringify(result.rows[0]['map_val'])); // {"key1":1,"key2":2}
+  });
 ```
 
 When using CQL maps, the driver needs a way to determine that the object instance passed as a parameter must be encoded
@@ -31,16 +31,18 @@ When using CQL maps, the driver needs a way to determine that the object instanc
 ```javascript
 const query = 'INSERT INTO tbl (id, map_val) VALUES (?, ?)';
 const params = [id, {key1: 1, key2: 2}];
-client.execute(query, params, function (err) {
+client.execute(query, params)
+  .catch(function (err) {
     console.log(err) // TypeError: The target data type could not be guessed
-});
-```javascript
+  });
+```
 
 To overcome this limitation, you should prepare your queries. Preparing and executing statements in the driver does not
-require chaining two asynchronous calls, you can set the prepare flag in the query options and the driver will handle the rest. The previous query, using the prepare flag, will succeed:
+require chaining two asynchronous calls, you can set the prepare flag in the query options and the driver will handle
+the rest. The previous query, using the prepare flag, will succeed:
 
 ```javascript
-client.execute(query, params, { prepare: true}, callback);
+client.execute(query, params, { prepare: true });
 ```
 
 ### ECMAScript Map and Set support 
@@ -61,8 +63,8 @@ const client = new cassandra.Client(options);
 This way, when encoding or decoding map or set values, the driver uses those constructors:
 
 ```javascript
-client.execute('SELECT map_val FROM tbl', function (err, result) {
-    assert.ifError(err);
+client.execute('SELECT map_val FROM tbl')
+  .then(function (result) {
     console.log(result.rows[0]['map_val'] instanceof Map); // true
-});
+  });
 ```

--- a/doc/features/datatypes/nulls/README.md
+++ b/doc/features/datatypes/nulls/README.md
@@ -10,14 +10,14 @@ Cassandra 2.2 introduced the concept of unset for a parameter value. At the serv
 
 ```javascript
 const query = 'INSERT INTO tbl1 (id, val1) VALUES (?, ?)';
-client.execute(query, [id, cassandra.types.unset]);
+client.execute(query, [ id, cassandra.types.unset ]);
 ```
 
 You can even use the undefined primitive type to represent unset values on an INSERT or UPDATE operation.
 
 ```javascript
 const query = 'INSERT INTO tbl1 (id, val1) VALUES (?, ?)';
-client.execute(query, [id, undefined]);
+client.execute(query, [ id, undefined ]);
 ```
 
 The driver allows you to control the usage of undefined as unset with the flag useUndefinedAsUnset, which is set to true
@@ -25,7 +25,7 @@ in driver versions 3.0 and above:
 
 ```javascript
 const client = new cassandra.Client({
-  contactPoints: ['node1', 'node2'],
+  contactPoints: [ 'node1', 'node2' ],
   encoding: { useUndefinedAsUnset: false } 
 });
 ```

--- a/doc/features/datatypes/numerical/README.md
+++ b/doc/features/datatypes/numerical/README.md
@@ -12,13 +12,13 @@ JavaScript provides methods to operate with Numbers (that is, IEEE 754 double-pr
 When decoding any of these datatype values, it is returned as a `Number`.
 
 ```javascript
-client.execute('SELECT int_val, float_val, double_val FROM tbl', function (err, result) {
-    assert.ifError(err);
+client.execute('SELECT int_val, float_val, double_val FROM tbl')
+  .then(function (result) {
     console.log(typeof result.rows[0]['int_val']);    // Number
     console.log(typeof result.rows[0]['float_val']);  // Number
     console.log(typeof result.rows[0]['double_val']); // Number
-});
-```javascript
+  });
+```
 
 When encoding the data, the driver tries to encode a `Number` as double because it can not automatically determine if is
 dealing with an int, a float, or a double.
@@ -27,16 +27,17 @@ Inserting a Number value as a double succeeds:
 
 ```javascript
 const query = 'INSERT INTO tbl (id, double_val) VALUES (?, ?)';
-client.execute(query, [id, 1.2], callback);
+client.execute(query, [ id, 1.2 ]);
 ```
 
 But doing the same with a float fails:
 
 ```javascript
 const query = 'INSERT INTO tbl (id, float_val) VALUES (?, ?)';
-client.execute(query, [id, 1.2], function (err) {
+client.execute(query, [ id, 1.2 ])
+  .catch(function (err) {
     console.log(err) // ResponseError: Expected 4 or 0 byte value for a float (8)
-});
+  });
 ```
 
 Trying to do the same with an int, also fails because Cassandra expects a float or an int, and the driver sent a 64-bit
@@ -44,9 +45,10 @@ double.
 
 ```javascript
 const query = 'INSERT INTO tbl (id, int_val) VALUES (?, ?)';
-client.execute(query, [id, 1], function (err) {
+client.execute(query, [ id, 1 ])
+  .catch(function (err) {
     console.log(err) // ResponseError: Expected 4 or 0 byte int (8)
-});
+  });
 ```
 
 To overcome this limitation, you should prepare your queries. Because preparing and executing statements in the driver
@@ -57,8 +59,8 @@ The previous query, using the prepare flag, succeeds no matter if it is an int, 
 
 ```javascript
 const query = 'INSERT INTO tbl (id, int_val) VALUES (?, ?)';
-client.execute(query, [id, 1], { prepare: true }, callback);
-```javascript
+client.execute(query, [ id, 1 ], { prepare: true });
+```
 
 
 ## decimal 
@@ -78,11 +80,11 @@ console.log(value1.equals(value2)); // true
 The driver decodes CQL decimal datatype values as instances of `BigDecimal`.
 
 ```javascript
-client.execute('SELECT decimal_val FROM users', function (err, result) {
-    assert.ifError(err);
+client.execute('SELECT decimal_val FROM users')
+  .then(function (result) {
     console.log(result.rows[0]['decimal_val'] instanceof BigDecimal); // true
-});
-```javascript
+  });
+```
 
 ## bigint 
 
@@ -102,10 +104,10 @@ console.log(value1.add(value2).toString()); // 202
 The driver decodes CQL bigint datatype values as instances of `Long`.
 
 ```javascript
-client.execute('SELECT bigint_val FROM users', function (err, result) {
-    assert.ifError(err);
+client.execute('SELECT bigint_val FROM users')
+  .then(function (result) {
     console.log(result.rows[0]['bigint_val'] instanceof Long); // true
-});
+  });
 ```
 
 ## varint 
@@ -126,18 +128,19 @@ console.log(value1.add(value2).toString()); // 808
 The driver decodes CQL varint datatype values as instances of `Integer`.
 
 ```javascript
-client.execute('SELECT varint_val FROM users', function (err, result) {
-    assert.ifError(err);
+client.execute('SELECT varint_val FROM users')
+  .then(function (result) {
     console.log(result.rows[0]['varint_val'] instanceof Integer); // true
-});
+  });
 ```
 
 ## smallint and tinyint 
 
-Cassandra 2.2 introduced smallint for 2-byte numerical representation and tinyint for 1-byte numerical representation.
+Cassandra 2.2 introduced `smallint` for 2-byte numerical representation and `tinyint` for 1-byte numerical
+representation.
 
 The driver represents these types as `Number` to take advantage of the ECMAScript built-in operations for `Number` (sum,
 subtraction, division, bitwise, etc).
 
-For tinyint only Numbers between -128 and 127 are valid, and for smallint only Numbers between -32768 and 32767.
-Numbers outside valid ranges will callback with TypeError when executing.
+For `tinyint`, only Numbers between -128 and 127 are valid, and for `smallint` only Numbers between -32768 and 32767.
+Numbers outside valid ranges will callback with `TypeError` when executing.

--- a/doc/features/datatypes/tuples/README.md
+++ b/doc/features/datatypes/tuples/README.md
@@ -7,7 +7,7 @@ A tuple is a fixed-length set of typed positional fields. With the driver, you r
 
 For example, given the following table to represent the value of the exchange between two currencies.
 
-```javascript
+```
 CREATE TABLE forex (
    name text,
    time timeuuid,
@@ -19,13 +19,14 @@ CREATE TABLE forex (
 
 To retrieve the Tuple value:
 
-```javascript
+```
 const query = 'SELECT name, time, currencies, value FROM forex where name = ?';
-client.execute(query, [name], { prepare: true }, function (err, result) {
-   result.rows.forEach(function (row) {
+client.execute(query, [name], { prepare: true })
+  .then(function (result) {
+    result.rows.forEach(function (row) {
       console.log('%s to %s: %s', row.currencies.get(0), row.currencies.get(1), row.value);
-   });
-});
+    });
+  });
 ```
 
 You use the `get(index)` method to obtain the value at any position or the `values()` method to obtain an `Array`
@@ -39,5 +40,5 @@ const Tuple = require('cassandra-driver').types.Tuple;
 const currencies = new types.Tuple('USD', 'EUR');
 const query = 'INSERT INTO forex (name, time, currencies, value)  VALUES (?, ?, ?, ?)';
 const params = ['market1', TimeUuid.now(), currencies, new BigDecimal(1, 0)];
-client.execute(query, params, { prepare: true }, callback);
+client.execute(query, params, { prepare: true });
 ```

--- a/doc/features/datatypes/udts/README.md
+++ b/doc/features/datatypes/udts/README.md
@@ -12,7 +12,7 @@ With the Node.js driver, you can retrieve and store UDTs using JavaScript object
 
 For example, given the following UDT and table:
 
-``
+```
 CREATE TYPE address (
    street text,
    city text,
@@ -32,11 +32,12 @@ You retrieve the user address details as a regular JavaScript object.
 
 ```javascript
 const query = 'SELECT name, email, address FROM users WHERE id = ?';
-client.execute(query, [name], { prepare: true }, function (err, result) {
-   var row = result.first();
-   var address = row.address;
-   console.log('User lives in %s - %s', address.city, address.state); 
-});
+client.execute(query, [name], { prepare: true })
+  .then(function (result) {
+    const row = result.first();
+    const address = row.address;
+    console.log('User lives in %s - %s', address.city, address.state); 
+  });
 ```
 
 You modify the address using JavaScript objects as well:
@@ -49,15 +50,15 @@ const address = {
    zip: 95054,
    phones: ['650-389-6000']
 };
-var query = 'UPDATE users SET address = ? WHERE id = ?';
-client.execute(query, [address, name], { prepare: true}, callback);
+const query = 'UPDATE users SET address = ? WHERE id = ?';
+client.execute(query, [address, name], { prepare: true });
 ```
 
 **Setting the prepare flag is recommended** because it helps the driver to accurately map the UDT fields from and to
 object properties.
 
 You can provide JavaScript objects as parameters without setting the prepare flag, but you must provide the parameter
-hint (`udt<address>`) and initially the driver makes an extra roundtrip to the cluster to retrieve the UDT metadata.
+hint (`udt<address>`) and initially the driver makes an extra round-strip to the cluster to retrieve the UDT metadata.
 
 ## Nesting user-defined types in CQL 
 
@@ -91,12 +92,12 @@ You access the UDT fields in the same way, but as nested JavaScript objects.
 
 ```javascript
 const query = 'SELECT name, email, address FROM users WHERE id = ?';
-client.execute(query, [name], { prepare: true }, function (err, result) {
-   const row = result.first();
-   const address = row.address;
-   // phones is an Array of Objects
-   address.phones.forEach(function (phone) {
-      console.log(Phone %s: %s', phone.alias, phone.phone_number);
-   });
-});
+client.execute(query, [name], { prepare: true })
+  .then(function (result) {
+    const row = result.first();
+    const address = row.address;
+    // phones is an Array of Objects
+    address.phones.forEach(phone => 
+      console.log('Phone %s: %s', phone.alias, phone.phone_number));
+  });
 ```

--- a/doc/features/datatypes/uuids/README.md
+++ b/doc/features/datatypes/uuids/README.md
@@ -15,11 +15,11 @@ const id = Uuid.random();
 The driver decodes Cassandra uuid data type values as an instances of Uuid.
 
 ```javascript
-client.execute('SELECT id FROM users', function (err, result) {
-   assert.ifError(err);
-   console.log(result.rows[0].id instanceof Uuid); // true
-   console.log(result.rows[0].id.toString());      // xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-});
+client.execute('SELECT id FROM users')
+  .then(function (result) {
+    console.log(result.rows[0].id instanceof Uuid); // true
+    console.log(result.rows[0].id.toString());      // xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  });
 ```
 
 You can also parse a string representation of a uuid into a Uuid instance:
@@ -44,13 +44,13 @@ const id2 = TimeUuid.fromDate(new Date());
 The driver decodes CQL timeuuid data type values as instances of `TimeUuid`.
 
 ```javascript
-client.execute('SELECT id, timeid FROM sensor', function (err, result) {
-    assert.ifError(err);
+client.execute('SELECT id, timeid FROM sensor')
+  .then(function (result) {
     console.log(result.rows[0].timeid instanceof TimeUuid); // true
     console.log(result.rows[0].timeid instanceof Uuid); // true, it inherits from Uuid
     console.log(result.rows[0].timeid.toString());      // <- xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     console.log(result.rows[0].timeid.getDate());       // <- Date stored in the identifier
-});
+  });
 ```
 
 You can specify the other parts of the identifier, such as the node and the clock sequence, or the 100-nanosecond

--- a/doc/features/execution-profiles/README.md
+++ b/doc/features/execution-profiles/README.md
@@ -25,7 +25,7 @@ that apply to the profile.
 ```javascript
 const aggregationProfile = new ExecutionProfile('aggregation', {
   consistency: consistency.localQuorum,
-  loadBalancing: new DCAwareRoundRobinPolicy('us-west')
+  loadBalancing: new DCAwareRoundRobinPolicy('us-west'),
   retry: myRetryPolicy,
   readTimeout: 30000,
   serialConsistency: consistency.localSerial
@@ -68,14 +68,14 @@ For the settings that are not specified in the default profile, the driver will 
 Use the name to specify which profile you want to use for the execution.
 
 ```javascript
-client.execute(query, params, { executionProfile: 'aggregation' }, callback);
+client.execute(query, params, { executionProfile: 'aggregation' });
 ```
 ### Using an execution profile by instance
 
 You can also use the `ExecutionProfile` instance.
 
 ```javascript
-client.execute(query, params, { executionProfile: aggregationProfile }, callback);
+client.execute(query, params, { executionProfile: aggregationProfile });
 ```
 
 ### Using default execution profile
@@ -83,5 +83,5 @@ client.execute(query, params, { executionProfile: aggregationProfile }, callback
 When the execution profile is not provided in the options, the default execution profile is used.
 
 ```javascript
-client.execute(query, params, callback);
+client.execute(query, params);
 ```

--- a/doc/features/metadata/README.md
+++ b/doc/features/metadata/README.md
@@ -22,14 +22,13 @@ console.log(Object.keys(client.metadata.keyspaces));
 To retrieve the definition of a table, use the `Metadata#getTable()` method:
 
 ```javascript
-client.metadata.getTable('ks1', 'table1', function (err, tableInfo) {
-   if (!err) {
-      console.log('Table %s', table.name);
-      table.columns.forEach(function (column) {
-         console.log('Column %s with type %j', column.name, column.type);
-      });
-   }
-});
+client.metadata.getTable('ks1', 'table1')
+  .then(function (tableInfo) {
+    console.log('Table %s', table.name);
+    table.columns.forEach(function (column) {
+       console.log('Column %s with type %j', column.name, column.type);
+    });
+  });
 ```
 
 When retrieving the same table definition concurrently, the driver queries once and invokes all callbacks with the

--- a/doc/features/parameterized-queries/README.md
+++ b/doc/features/parameterized-queries/README.md
@@ -10,7 +10,7 @@ When using positional parameters, the query parameters must be provided as an Ar
 const query = 'INSERT INTO artists (id, name) VALUES (?, ?)';
 // Parameters by marker position
 const params = ['krichards', 'Keith Richards'];
-client.execute(query, params, { prepare: true }, callback);
+client.execute(query, params, { prepare: true });
 ```
 
 ##  Named parameterized query 
@@ -22,7 +22,7 @@ the `Object` property names matching the parameters names.
 const query = 'INSERT INTO artists (id, name) VALUES (:id, :name)';
 // Parameters by marker name
 const params = { id: 'krichards', name: 'Keith Richards' };
-client.execute(query, params, { prepare: true }, callback);
+client.execute(query, params, { prepare: true });
 ```
 
 Defining named markers in your queries is supported in Cassandra 2.0 or greater for prepared statements and

--- a/doc/features/promise-callback/README.md
+++ b/doc/features/promise-callback/README.md
@@ -1,0 +1,40 @@
+# Promise and callback-based API
+
+The driver supports both [promises][promise] and callbacks for the asynchronous methods exposed in the `Client` and
+`Metadata` prototypes, you can choose the approach that suits your needs.
+
+## Promise-based API
+
+```javascript
+client.execute('SELECT name, email FROM users')
+  .then(result => console.log('User with email %s', result.rows[0].email));
+```
+
+When a `callback` is not provided as the last argument, the driver will return a `Promise`, without the need to 
+_promisify_ the driver module. Returned promises are instances of [`Promise` global object][promise] and are created
+using the default constructor: `new Promise(executor)`.
+
+In case you want the driver use a third party `Promise` module (ie: [bluebird][bluebird]) to create the promise
+instances, you can optionally provide your own factory method when creating the `Client` instance, for example:
+
+```javascript
+const BbPromise = require('bluebird');
+const client = new Client({
+  contactPoints: contactPoints,
+  promiseFactory: BbPromise.fromCallback
+});
+```
+
+## Callback-based API
+
+All asynchronous methods of the driver supports an optional `callback` as the last argument.
+
+```javascript
+client.execute('SELECT name, email FROM users', function(err, result) {
+  assert.ifError(err);
+  console.log('User with email %s', result.rows[0].email);
+});
+```
+
+[promise]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[bluebird]: http://bluebirdjs.com/

--- a/doc/features/udfs/README.md
+++ b/doc/features/udfs/README.md
@@ -5,21 +5,21 @@ aggregates support. You access UDF and aggregate values in your queries like reg
 
 ```javascript
 const query = 'SELECT avg(salary) as salary FROM employees';
-client.execute(query, function (err, result) {
-    assert.ifError(err);
+client.execute(query)
+  .then(function (result) {
     const row = result.first();
     console.log('Average salary %d', row.salary); 
-});
+  });
 ```
 
 The driver also exposes [UDFs and aggregates metadata information][metadata-api], for example let's see how to retrieve the metadata
 information of a UDF named iif, that takes a boolean and int parameter.
 
 ```javascript
-client.metadata.getFunction('ks1', 'iif', ['boolean', 'int'], function (err, udf) {
-    if (err) return console.error(err);
+client.metadata.getFunction('ks1', 'iif', ['boolean', 'int'])
+  .then(function (err, udf) {
     console.log('Function metadata %j', udf);
-});
+  });
 ```
 
 [metadata-api]: http://docs.datastax.com/en/latest-nodejs-driver-api/module-metadata-Metadata.html

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,8 +7,8 @@ You should also visit the [Documentation][doc-index] and [FAQ][faq].
 ## Code samples
 - Basic
   - [Connect](basic/basic-connect.js)
-  - [Execute with nested callbacks](basic/basic-execute.js)
-  - [Execute using async series](basic/basic-execute-flow.js)
+  - [Execute with promise-based API](basic/basic-execute.js)
+  - [Execute using callbacks](basic/basic-execute-flow.js)
 - Metadata
   - [Get hosts information](metadata/metadata-hosts.js)
   - [Get keyspaces information](metadata/metadata-keyspaces.js)

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,6 @@ only call client.shutdown() once in your application's lifetime.
 If you have any doubt regarding these examples, feel free to post your question in the [mailing list][mailing-list].
 
 [cassandra]: http://cassandra.apache.org/
-[doc-index]: http://docs.datastax.com/en/developer/nodejs-driver/2.1/
+[doc-index]: http://docs.datastax.com/en/developer/nodejs-driver/latest/
 [mailing-list]: https://groups.google.com/a/lists.datastax.com/forum/#!forum/nodejs-driver-user
-[faq]: http://docs.datastax.com/en/developer/nodejs-driver/2.1/nodejs-driver/faq/njdFaq.html
+[faq]: http://docs.datastax.com/en/developer/nodejs-driver/latest/faq/

--- a/examples/basic/basic-connect.js
+++ b/examples/basic/basic-connect.js
@@ -1,15 +1,15 @@
 "use strict";
-var cassandra = require('cassandra-driver');
+const cassandra = require('cassandra-driver');
 
-var client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
-
-client.connect(function (err) {
-  if (err) {
-    client.shutdown();
-    return console.error('There was an error when connecting', err);
-  }
-  console.log('Connected to cluster with %d host(s): %j', client.hosts.length, client.hosts.keys());
-  console.log('Keyspaces: %j', Object.keys(client.metadata.keyspaces));
-  console.log('Shutting down');
-  client.shutdown();
-});
+const client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
+client.connect()
+  .then(function () {
+    console.log('Connected to cluster with %d host(s): %j', client.hosts.length, client.hosts.keys());
+    console.log('Keyspaces: %j', Object.keys(client.metadata.keyspaces));
+    console.log('Shutting down');
+    return client.shutdown();
+  })
+  .catch(function (err) {
+    console.error('There was an error when connecting', err);
+    return client.shutdown();
+  });

--- a/examples/basic/basic-execute-flow.js
+++ b/examples/basic/basic-execute-flow.js
@@ -1,17 +1,18 @@
 "use strict";
-var cassandra = require('cassandra-driver');
-var async = require('async');
-var assert = require('assert');
+const cassandra = require('cassandra-driver');
+const async = require('async');
+const assert = require('assert');
 
-var client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
+const client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
 
 /**
  * Example using async library for avoiding nested callbacks
  * See https://github.com/caolan/async
+ * Alternately you can use the Promise-based API.
  *
  * Inserts a row and retrieves a row
  */
-var id = cassandra.types.Uuid.random();
+const id = cassandra.types.Uuid.random();
 
 async.series([
   function connect(next) {
@@ -27,11 +28,11 @@ async.series([
   },
   function insert(next) {
     var query = 'INSERT INTO examples.basic (id, txt, val) VALUES (?, ?, ?)';
-    client.execute(query, [id, 'Hello!', 100], { prepare: true}, next);
+    client.execute(query, [ id, 'Hello!', 100 ], { prepare: true}, next);
   },
   function select(next) {
     var query = 'SELECT id, txt, val FROM examples.basic WHERE id = ?';
-    client.execute(query, [id], { prepare: true}, function (err, result) {
+    client.execute(query, [ id ], { prepare: true}, function (err, result) {
       if (err) return next(err);
       var row = result.first();
       console.log('Obtained row: ', row);

--- a/examples/basic/basic-execute.js
+++ b/examples/basic/basic-execute.js
@@ -1,25 +1,23 @@
 "use strict";
-var cassandra = require('cassandra-driver');
+const cassandra = require('cassandra-driver');
 
-var client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
+const client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
 
 /**
- * Example using nested callbacks.
- * See basic-execute-flow.js for a more elegant example.
+ * Example using Promise.
+ * See basic-execute-flow.js for an example using callback-based execution.
  */
-client.connect(function (err) {
-  if (err) {
-    client.shutdown();
-    return console.error('There was an error when connecting', err);
-  }
-  client.execute('SELECT * FROM system.local', function (err, result) {
-    if (err) {
-      client.shutdown();
-      return console.error('There was while trying to retrieve data from system.local', err);
-    }
-    var row = result.rows[0];
+client.connect()
+  .then(function () {
+    return client.execute('SELECT * FROM system.local');
+  })
+  .then(function (result) {
+    const row = result.rows[0];
     console.log('Obtained row: ', row);
     console.log('Shutting down');
-    client.shutdown();
+    return client.shutdown();
+  })
+  .catch(function (err) {
+    console.error('There was an error when connecting', err);
+    return client.shutdown();
   });
-});

--- a/examples/metadata/metadata-hosts.js
+++ b/examples/metadata/metadata-hosts.js
@@ -1,17 +1,17 @@
 "use strict";
-var cassandra = require('cassandra-driver');
+const cassandra = require('cassandra-driver');
 
-var client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
-
-client.connect(function (err) {
-  if (err) {
-    client.shutdown();
-    return console.error('There was an error when connecting', err);
-  }
-  console.log('Connected to cluster with %d host(s): %j', client.hosts.length);
-  client.hosts.forEach(function (host) {
-    console.log('Host %s v%s on rack %s, dc %s', host.address, host.cassandraVersion, host.rack, host.datacenter);
+const client = new cassandra.Client({ contactPoints: ['127.0.0.1'] });
+client.connect()
+  .then(function () {
+    console.log('Connected to cluster with %d host(s): %j', client.hosts.length);
+    client.hosts.forEach(function (host) {
+      console.log('Host %s v%s on rack %s, dc %s', host.address, host.cassandraVersion, host.rack, host.datacenter);
+    });
+    console.log('Shutting down');
+    return client.shutdown();
+  })
+  .catch(function (err) {
+    console.error('There was an error when connecting', err);
+    return client.shutdown();
   });
-  console.log('Shutting down');
-  client.shutdown();
-});

--- a/examples/metadata/metadata-keyspaces.js
+++ b/examples/metadata/metadata-keyspaces.js
@@ -1,19 +1,19 @@
 "use strict";
 var cassandra = require('cassandra-driver');
 
-var client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
-
-client.connect(function (err) {
-  if (err) {
-    client.shutdown();
-    return console.error('There was an error when connecting', err);
-  }
-  console.log('Connected, listing keyspaces:');
-  for (var name in client.metadata.keyspaces) {
-    if (!client.metadata.keyspaces.hasOwnProperty(name)) continue;
-    var keyspace = client.metadata.keyspaces[name];
-    console.log('- %s:\n\tstrategy %s\n\tstrategy options %j', keyspace.name, keyspace.strategy,  keyspace.strategyOptions);
-  }
-  console.log('Shutting down');
-  client.shutdown();
-});
+const client = new cassandra.Client({ contactPoints: ['127.0.0.1'] });
+client.connect()
+  .then(function () {
+    console.log('Connected, listing keyspaces:');
+    for (var name in client.metadata.keyspaces) {
+      if (!client.metadata.keyspaces.hasOwnProperty(name)) continue;
+      var keyspace = client.metadata.keyspaces[name];
+      console.log('- %s:\n\tstrategy %s\n\tstrategy options %j',
+        keyspace.name, keyspace.strategy,  keyspace.strategyOptions);
+    }
+    return client.shutdown();
+  })
+  .catch(function (err) {
+    console.error('There was an error when connecting', err);
+    return client.shutdown();
+  });

--- a/examples/metadata/metadata-table.js
+++ b/examples/metadata/metadata-table.js
@@ -1,42 +1,36 @@
 "use strict";
-var cassandra = require('cassandra-driver');
-var async = require('async');
-var assert = require('assert');
+const cassandra = require('cassandra-driver');
+const async = require('async');
 
-var client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
+const client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
 
 /**
  * Creates a table and retrieves its information
- * Example using async library for avoiding nested callbacks
- * See https://github.com/caolan/async
  */
-async.series([
-  function connect(next) {
-    client.connect(next);
-  },
-  function createKeyspace(next) {
-    var query = "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3' }";
-    client.execute(query, next);
-  },
-  function createTable(next) {
-    var query = "CREATE TABLE IF NOT EXISTS examples.meta_tbl1 (id1 uuid, id2 timeuuid, txt text, val int, PRIMARY KEY(id1, id2))";
-    client.execute(query, next);
-  },
-  function retrieveMetadata(next) {
-    client.metadata.getTable('examples', 'meta_tbl1', function (err, table) {
-      if (err) return next(err);
-      console.log('Table information');
-      console.log('- Name: %s', table.name);
-      console.log('- Columns:', table.columns);
-      console.log('- Partition keys:', table.partitionKeys);
-      console.log('- Clustering keys:', table.clusteringKeys);
-      next();
-    });
-  }
-], function (err) {
-  if (err) {
-    console.error('There was an error', err.message, err.stack);
-  }
-  console.log('Shutting down');
-  client.shutdown();
-});
+client.connect()
+  .then(function () {
+    const query = "CREATE KEYSPACE IF NOT EXISTS examples WITH replication =" +
+      "{'class': 'SimpleStrategy', 'replication_factor': '1' }";
+    return client.execute(query);
+  })
+  .then(function () {
+    const query = "CREATE TABLE IF NOT EXISTS examples.meta_tbl1" +
+      " (id1 uuid, id2 timeuuid, txt text, val int, PRIMARY KEY(id1, id2))";
+    return client.execute(query);
+  })
+  .then(function () {
+    return client.metadata.getTable('examples', 'meta_tbl1');
+  })
+  .then(function (table) {
+    console.log('Table information');
+    console.log('- Name: %s', table.name);
+    console.log('- Columns:', table.columns);
+    console.log('- Partition keys:', table.partitionKeys);
+    console.log('- Clustering keys:', table.clusteringKeys);
+    console.log('Shutting down');
+    client.shutdown();
+  })
+  .catch(function (err) {
+    console.error('There was an error', err);
+    return client.shutdown();
+  });

--- a/examples/runner.js
+++ b/examples/runner.js
@@ -27,8 +27,8 @@ function getJsFiles(dir, fileArray) {
   return fileArray;
 }
 
-if (typeof Promise === 'undefined') {
-  console.log('Examples where not executed as promises are not supported');
+if (typeof Promise === 'undefined' || process.version.indexOf('v0.') === 0) {
+  console.log('Examples where not executed as a modern runtime is required');
   return;
 }
 

--- a/examples/runner.js
+++ b/examples/runner.js
@@ -7,7 +7,7 @@ var path = require('path');
 
 /**
  * This script is used to check that the samples run correctly.
- * It is not a valid examples, see README.md and subdirectories for more information.
+ * It is not a valid example, see README.md and subdirectories for more information.
  */
 
 /** List all js files in the directory */
@@ -25,6 +25,11 @@ function getJsFiles(dir, fileArray) {
     fileArray.push(dir+file);
   });
   return fileArray;
+}
+
+if (typeof Promise === 'undefined') {
+  console.log('Examples where not executed as promises are not supported');
+  return;
 }
 
 var runnerFileName = path.basename(module.filename);

--- a/examples/tracing/retrieve-query-trace.js
+++ b/examples/tracing/retrieve-query-trace.js
@@ -1,43 +1,36 @@
 "use strict";
-var cassandra = require('cassandra-driver');
-var async = require('async');
-var assert = require('assert');
+const cassandra = require('cassandra-driver');
 
-var client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
+const client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
 
 /**
  * Creates a table and retrieves its information
- * Example using async library for avoiding nested callbacks
- * See https://github.com/caolan/async
  */
-async.series([
-  function connect(next) {
-    client.connect(next);
-  },
-  function createKeyspace(next) {
-    var query = "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3' }";
-    client.execute(query, next);
-  },
-  function createTable(next) {
-    var query = "CREATE TABLE IF NOT EXISTS examples.trace_tbl1 (id uuid, txt text, PRIMARY KEY(id))";
-    client.execute(query, next);
-  },
-  function retrieveTrace(next) {
-    var query = 'INSERT INTO examples.trace_tbl1 (id, txt) VALUES (?, ?)';
-    client.execute(query, [cassandra.types.Uuid.random(), 'hello trace'], { traceQuery: true}, function (err, result) {
-      if (err) return next(err);
-      var traceId = result.info.traceId;
-      client.metadata.getTrace(traceId, function (err, trace) {
-        console.log('Trace for the execution of the query: "%s":', query);
-        console.log(trace);
-        next();
-      });
-    });
-  }
-], function (err) {
-  if (err) {
-    console.error('There was an error', err.message, err.stack);
-  }
-  console.log('Shutting down');
-  client.shutdown();
-});
+client.connect()
+  .then(function () {
+    const query = "CREATE KEYSPACE IF NOT EXISTS examples WITH replication =" +
+      "{'class': 'SimpleStrategy', 'replication_factor': '1' }";
+    return client.execute(query);
+  })
+  .then(function () {
+    const query = "CREATE TABLE IF NOT EXISTS examples.trace_tbl1 (id uuid, txt text, PRIMARY KEY(id))";
+    return client.execute(query);
+  })
+  .then(function () {
+    const query = "INSERT INTO examples.trace_tbl1 (id, txt) VALUES (?, ?)";
+    return client.execute(query, [cassandra.types.Uuid.random(), 'hello trace'], { traceQuery: true});
+  })
+  .then(function (result) {
+    const traceId = result.info.traceId;
+    return client.metadata.getTrace(traceId);
+  })
+  .then(function (trace) {
+    console.log('Trace for the execution of the query:');
+    console.log(trace);
+    console.log('The trace was retrieved successfully');
+    client.shutdown();
+  })
+  .catch(function (err) {
+    console.error('There was an error', err);
+    return client.shutdown();
+  });

--- a/examples/tuple/tuple-insert-select.js
+++ b/examples/tuple/tuple-insert-select.js
@@ -7,42 +7,36 @@ var client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
 
 /**
  * Creates a table with a Tuple type, inserts a row and selects a row.
- * Example using async library for avoiding nested callbacks
- * See https://github.com/caolan/async
  */
-async.series([
-  function connect(next) {
-    client.connect(next);
-  },
-  function createKeyspace(next) {
-    var query = "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3' }";
-    client.execute(query, next);
-  },
-  function createTable(next) {
-    var query = "CREATE TABLE IF NOT EXISTS examples.tuple_forex (name text, time timeuuid, currencies frozen<tuple<text, text>>, value decimal, PRIMARY KEY (name, time))";
-    client.execute(query, next);
-  },
-  function insertData(next) {
+client.connect()
+  .then(function () {
+    const query = "CREATE KEYSPACE IF NOT EXISTS examples WITH replication =" +
+      "{'class': 'SimpleStrategy', 'replication_factor': '1' }";
+    return client.execute(query);
+  })
+  .then(function () {
+    const query = "CREATE TABLE IF NOT EXISTS examples.tuple_forex " +
+      "(name text, time timeuuid, currencies frozen<tuple<text, text>>, value decimal, PRIMARY KEY (name, time))";
+    return client.execute(query);
+  })
+  .then(function () {
     console.log('Inserting');
-    //create a new instance of a Tuple
-    var currencies = new cassandra.types.Tuple('USD', 'EUR');
-    var query = 'INSERT INTO examples.tuple_forex (name, time, currencies, value)  VALUES (?, ?, ?, ?)';
-    var params = ['market1', cassandra.types.TimeUuid.now(), currencies, new cassandra.types.BigDecimal(11, 1)];
-    client.execute(query, params, { prepare: true}, next);
-  },
-  function selectingData(next) {
-    var query = 'SELECT name, time, currencies, value FROM examples.tuple_forex where name = ?';
-    client.execute(query, ['market1'], { prepare: true}, function (err, result) {
-      if (err) return next(err);
-      var row = result.first();
-      console.log('%s to %s: %s', row.currencies.get(0), row.currencies.get(1), row.value);
-      next();
-    });
-  }
-], function (err) {
-  if (err) {
-    console.error('There was an error', err.message, err.stack);
-  }
-  console.log('Shutting down');
-  client.shutdown();
-});
+    // Create a new instance of a Tuple
+    const currencies = new cassandra.types.Tuple('USD', 'EUR');
+    const query = 'INSERT INTO examples.tuple_forex (name, time, currencies, value)  VALUES (?, ?, ?, ?)';
+    const params = [ 'market1', cassandra.types.TimeUuid.now(), currencies, new cassandra.types.BigDecimal(11, 1) ];
+    return client.execute(query, params, { prepare: true});
+  })
+  .then(function () {
+    const query = 'SELECT name, time, currencies, value FROM examples.tuple_forex where name = ?';
+    return client.execute(query, ['market1'], { prepare: true });
+  })
+  .then(function (result) {
+    const row = result.first();
+    console.log('%s to %s: %s', row['currencies'].get(0), row['currencies'].get(1), row['value']);
+    return client.shutdown();
+  })
+  .catch(function (err) {
+    console.error('There was an error', err);
+    return client.shutdown();
+  });

--- a/examples/udt/udt-insert-select.js
+++ b/examples/udt/udt-insert-select.js
@@ -1,32 +1,29 @@
 "use strict";
-var cassandra = require('cassandra-driver');
-var async = require('async');
-var assert = require('assert');
+const cassandra = require('cassandra-driver');
+const async = require('async');
 
-var client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
+const client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
 
 /**
  * Creates a table with a user-defined type, inserts a row and selects a row.
- * Example using async library for avoiding nested callbacks
- * See https://github.com/caolan/async
  */
-async.series([
-  function connect(next) {
-    client.connect(next);
-  },
-  function createKeyspace(next) {
-    var query = "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3' }";
-    client.execute(query, next);
-  },
-  function createType(next) {
-    var query = "CREATE TYPE IF NOT EXISTS examples.address (street text, city text, state text, zip int, phones set<text>)";
-    client.execute(query, next);
-  },
-  function createTable(next) {
-    var query = "CREATE TABLE IF NOT EXISTS examples.udt_tbl1 (name text PRIMARY KEY, email text, address frozen<address>)";
-    client.execute(query, next);
-  },
-  function insertData(next) {
+client.connect()
+  .then(function () {
+    const query = "CREATE KEYSPACE IF NOT EXISTS examples WITH replication =" +
+      "{'class': 'SimpleStrategy', 'replication_factor': '1' }";
+    return client.execute(query);
+  })
+  .then(function () {
+    const query = "CREATE TYPE IF NOT EXISTS examples.address " +
+      "(street text, city text, state text, zip int, phones set<text>)";
+    return client.execute(query);
+  })
+  .then(function () {
+    const query = "CREATE TABLE IF NOT EXISTS examples.udt_tbl1 " +
+      "(name text PRIMARY KEY, email text, address frozen<address>)";
+    return client.execute(query);
+  })
+  .then(function () {
     console.log('Inserting');
     var address = {
       city: 'Santa Clara',
@@ -35,22 +32,19 @@ async.series([
       zip: 95054,
       phones: ['650-389-6000']
     };
-    var query = 'INSERT INTO examples.udt_tbl1 (name, address) VALUES (?, ?)';
-    client.execute(query, ['The Rolling Stones', address], { prepare: true}, next);
-  },
-  function selectingData(next) {
+    const query = 'INSERT INTO examples.udt_tbl1 (name, address) VALUES (?, ?)';
+    return client.execute(query, ['The Rolling Stones', address], { prepare: true});
+  })
+  .then(function () {
     var query = 'SELECT name, address FROM examples.udt_tbl1 WHERE name = ?';
-    client.execute(query, ['The Rolling Stones'], { prepare: true}, function (err, result) {
-      if (err) return next(err);
-      var row = result.first();
-      console.log('Retrieved row: %j', row);
-      next();
-    });
-  }
-], function (err) {
-  if (err) {
-    console.error('There was an error', err.message, err.stack);
-  }
-  console.log('Shutting down');
-  client.shutdown();
-});
+    return client.execute(query, ['The Rolling Stones'], { prepare: true });
+  })
+  .then(function (result) {
+    const row = result.first();
+    console.log('Retrieved row: %j', row);
+    return client.shutdown();
+  })
+  .catch(function (err) {
+    console.error('There was an error', err);
+    return client.shutdown();
+  });

--- a/lib/client.js
+++ b/lib/client.js
@@ -225,6 +225,10 @@ var warmupLimit = 32;
  *   const row = result.first();
  *   console.log(row['key']);
  * });
+ * @example <caption>Executing a query with promise-based API</caption>
+ * const result = await client.execute('SELECT key FROM system.local');
+ * const row = result.first();
+ * console.log(row['key']);
  * @constructor
  */
 function Client(options) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -123,6 +123,16 @@ var warmupLimit = 32;
  *   Default: true.
  * </p>
  * @property {Array.<ExecutionProfile>} profiles The array of [execution profiles]{@link ExecutionProfile}.
+ * @property {Function} promiseFactory Function to be used to create a <code>Promise</code> from a
+ * callback-style function.
+ * <p>
+ *   Promise libraries often provide different methods to create a promise. For example, you can use Bluebird's
+ *   <code>Promise.fromCallback()</code> method.
+ * </p>
+ * <p>
+ *   By default, the driver will use the
+ *   [Promise constructor]{@link https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise}.
+ * </p>
  */
 
 /**
@@ -277,14 +287,36 @@ util.inherits(Client, events.EventEmitter);
  */
 
 /**
- * Tries to connect to one of the [contactPoints]{@link ClientOptions} and discover the nodes of the cluster.
+ * Tries to connect to one of the [contactPoints]{@link ClientOptions} and discovers the rest the nodes of the cluster.
  * <p>
- *   If the {@link Client} is already connected, it immediately invokes callback.
+ *   If a <code>callback</code> is provided, it will invoke the callback when the client is connected. Otherwise,
+ *   it will return a <code>Promise</code>.
  * </p>
- * @param {function} callback The callback is invoked when the pool is connected
- *  (or at least 1 connected and the rest failed to connect) or it is not possible to connect
+ * <p>
+ *   If the {@link Client} is already connected, it invokes callback immediately (when provided) or the promise is
+ *   fulfilled .
+ * </p>
+ * @example <caption>Callback-based execution</caption>
+ * client.connect(function (err) {
+ *   if (err) return console.error(err);
+ *   console.log('Connected to cluster with %d host(s): %j', client.hosts.length, client.hosts.keys());
+ * });
+ * @example <caption>Promise-based execution</caption>
+ * await client.connect();
+ * @param {function} [callback] The callback is invoked when the pool is connected it failed to connect.
  */
 Client.prototype.connect = function (callback) {
+  var self = this;
+  return utils.promiseWrapper(this.options, callback, function handler(cb) {
+    self._connectCb(cb);
+  });
+};
+
+/**
+ * @param {Function} callback
+ * @private
+ */
+Client.prototype._connectCb = function (callback) {
   if (this.connected) return callback();
   if (this.isShuttingDown) {
     //it is being shutdown, don't allow further calls to connect()
@@ -338,26 +370,51 @@ Client.prototype.connect = function (callback) {
 /**
  * Executes a query on an available connection.
  * <p>
- *   The query can be prepared (recommended) or not depending on {@link QueryOptions}.prepare flag. Retries on multiple
- *   hosts if needed.
+ *   If a <code>callback</code> is provided, it will invoke the callback when the execution completes. Otherwise,
+ *   it will return a <code>Promise</code>.
  * </p>
- * @param {String} query The query to execute
+ * <p>The query can be prepared (recommended) or not depending on {@link QueryOptions}.prepare flag.</p>
+ * <p>
+ *   Some executions failures can be handled transparently by the driver, according to the
+ *   [RetryPolicy]{@link module:policies/retry~RetryPolicy} defined at {@link ClientOptions} or {@link QueryOptions}
+ *   level.
+ * </p>
+ * @param {String} query The query to execute.
  * @param {Array|Object} [params] Array of parameter values or an associative array (object) containing parameter names
- * as keys and its value
- * @param {QueryOptions} [options]
- * @param {ResultCallback} callback Executes callback(err, result) when finished
+ * as keys and its value.
+ * @param {QueryOptions} [options] The query options for the execution.
+ * @param {ResultCallback} [callback] Executes callback(err, result) when execution completed. When not defined, the
+ * method will return a promise.
+ * @example <caption>Callback-based API</caption>
+ * const query = 'SELECT name, email FROM users WHERE id = ?';
+ * client.execute(query, [ id ], { prepare: true }, function (err, result) {
+ *   assert.ifError(err);
+ *   const row = result.first();
+ *   console.log('%s: %s', row.name, row.email);
+ * });
+ * @example <caption>Promise-based API, using async/await</caption>
+ * const query = 'SELECT name, email FROM users WHERE id = ?';
+ * const result = await client.execute(query, [ id ], { prepare: true });
+ * const row = result.first();
+ * console.log('%s: %s', row.name, row.email);
+ * @see {@link ExecutionProfile} to reuse a set of options across different query executions.
  */
 Client.prototype.execute = function (query, params, options, callback) {
   // set default argument values for optional parameters
-  callback = utils.bindDomain(callback || (options ? options : params));
-  params = typeof params !== 'function' ? params : null;
-  options = clientOptions.createQueryOptions(this, options);
-  this._innerExecute(query, params, options, callback);
+  callback = callback || (options ? options : params);
+  if (typeof callback === 'function') {
+    params = typeof params !== 'function' ? params : null;
+  }
+  var self = this;
+  return utils.promiseWrapper(this.options, callback, function handler(cb) {
+    options = clientOptions.createQueryOptions(self, options);
+    self._innerExecute(query, params, options, cb);
+  });
 };
 
 /**
- * Executes the query and calls rowCallback for each row as soon as they are received.
- *  Calls final callback after all rows have been sent, or when there is an error.
+ * Executes the query and calls rowCallback for each row as soon as they are received. Calls final callback after all
+ * rows have been sent, or when there is an error.
  * <p>
  *   The query can be prepared (recommended) or not depending on {@link QueryOptions}.prepare flag. Retries on multiple
  *   hosts if needed.
@@ -488,19 +545,36 @@ Client.prototype.stream = function (query, params, options, callback) {
 
 /**
  * Executes batch of queries on an available connection to a host.
+ * <p>
+ *   If a <code>callback</code> is provided, it will invoke the callback when the execution completes. Otherwise,
+ *   it will return a <code>Promise</code>.
+ * </p>
  * @param {Array.<string>|Array.<{query, params}>} queries The queries to execute as an Array of strings or as an array
  * of object containing the query and params
  * @param {QueryOptions} [options]
- * @param {ResultCallback} callback Executes callback(err, result) when the batch was executed
+ * @param {ResultCallback} [callback] Executes callback(err, result) when the batch was executed
  */
 Client.prototype.batch = function (queries, options, callback) {
-  callback = utils.bindDomain(callback || options);
+  callback = callback || options;
+  var self = this;
+  return utils.promiseWrapper(this.options, callback, function handler(cb) {
+    self._batchCb(queries, options, cb);
+  });
+};
+
+/**
+ * @param {Array.<string>|Array.<{query, params}>}queries
+ * @param {QueryOptions} options
+ * @param {ResultCallback} callback
+ * @private
+ */
+Client.prototype._batchCb = function (queries, options, callback) {
+  var self = this;
   queries = validateBatchQueries(queries);
   options = clientOptions.createQueryOptions(this, options, null, true);
   if (options.message && options instanceof Error) {
     return callback(options);
   }
-  var self = this;
   this.connect(function afterConnect(err) {
     if (err) {
       return callback(err);
@@ -527,10 +601,29 @@ Client.prototype.getReplicas = function (keyspace, token) {
 Client.prototype.log = utils.log;
 
 /**
- * Closes all connections to all hosts
- * @param {Function} [callback]
+ * Closes all connections to all hosts.
+ * <p>
+ *   If a <code>callback</code> is provided, it will invoke the callback when the client is disconnected. Otherwise,
+ *   it will return a <code>Promise</code>.
+ * </p>
+ * @param {Function} [callback] Optional callback to be invoked when finished closing all connections.
  */
 Client.prototype.shutdown = function (callback) {
+  if (!callback && typeof Promise === 'undefined') {
+    // Optional callback is supported, even for js engines without Promise support.
+    callback = utils.noop;
+  }
+  var self = this;
+  return utils.promiseWrapper(this.options, callback, function handler(cb) {
+    self._shutdownCb(cb);
+  });
+};
+
+/**
+ * @param {Function} callback
+ * @private
+ */
+Client.prototype._shutdownCb = function (callback) {
   var self = this;
   function doShutdown() {
     self.connected = false;

--- a/lib/client.js
+++ b/lib/client.js
@@ -306,10 +306,7 @@ util.inherits(Client, events.EventEmitter);
  * @param {function} [callback] The callback is invoked when the pool is connected it failed to connect.
  */
 Client.prototype.connect = function (callback) {
-  var self = this;
-  return utils.promiseWrapper(this.options, callback, function handler(cb) {
-    self._connectCb(cb);
-  });
+  return utils.promiseWrapper.call(this, this.options, callback, false, this._connectCb);
 };
 
 /**
@@ -405,10 +402,9 @@ Client.prototype.execute = function (query, params, options, callback) {
   if (typeof callback === 'function') {
     params = typeof params !== 'function' ? params : null;
   }
-  var self = this;
-  return utils.promiseWrapper(this.options, callback, function handler(cb) {
-    options = clientOptions.createQueryOptions(self, options);
-    self._innerExecute(query, params, options, cb);
+  return utils.promiseWrapper.call(this, this.options, callback, false, function handler(cb) {
+    options = clientOptions.createQueryOptions(this, options);
+    this._innerExecute(query, params, options, cb);
   });
 };
 
@@ -556,9 +552,8 @@ Client.prototype.stream = function (query, params, options, callback) {
  */
 Client.prototype.batch = function (queries, options, callback) {
   callback = callback || options;
-  var self = this;
-  return utils.promiseWrapper(this.options, callback, function handler(cb) {
-    self._batchCb(queries, options, cb);
+  return utils.promiseWrapper.call(this, this.options, callback, false, function handler(cb) {
+    this._batchCb(queries, options, cb);
   });
 };
 
@@ -609,14 +604,7 @@ Client.prototype.log = utils.log;
  * @param {Function} [callback] Optional callback to be invoked when finished closing all connections.
  */
 Client.prototype.shutdown = function (callback) {
-  if (!callback && typeof Promise === 'undefined') {
-    // Optional callback is supported, even for js engines without Promise support.
-    callback = utils.noop;
-  }
-  var self = this;
-  return utils.promiseWrapper(this.options, callback, function handler(cb) {
-    self._shutdownCb(cb);
-  });
+  return utils.promiseWrapper.call(this, this.options, callback, true, this._shutdownCb);
 };
 
 /**

--- a/lib/execution-profile.js
+++ b/lib/execution-profile.js
@@ -8,7 +8,7 @@ var types = require('./types');
  * @classdesc
  * Represents a set configurations to be used in a statement execution to be used for a single {@link Client} instance.
  * <p>
- *   A {@link ExecutionProfile} instance should not be shared across different {@link Client} instances.
+ *   An {@link ExecutionProfile} instance should not be shared across different {@link Client} instances.
  * </p>
  * @param {String} name Name of the execution profile.
  * <p>

--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -131,6 +131,10 @@ Metadata.prototype.buildTokens = function (hosts) {
 
 /**
  * Gets the keyspace metadata information and updates the internal state of the driver.
+ * <p>
+ *   If a <code>callback</code> is provided, the callback is invoked when the keyspaces metadata refresh completes.
+ *   Otherwise, it returns a <code>Promise</code>.
+ * </p>
  * @param {String} name Name of the keyspace.
  * @param {Function} [callback] Optional callback.
  */
@@ -166,6 +170,10 @@ Metadata.prototype._refreshKeyspaceCb = function (name, callback) {
 
 /**
  * Gets the metadata information of all the keyspaces and updates the internal state of the driver.
+ * <p>
+ *   If a <code>callback</code> is provided, the callback is invoked when the keyspace metadata refresh completes.
+ *   Otherwise, it returns a <code>Promise</code>.
+ * </p>
  * @param {Boolean} [waitReconnect] Determines if it should wait for reconnection in case the control connection is not
  * connected at the moment. Default: true.
  * @param {Function} [callback] Optional callback.
@@ -289,14 +297,18 @@ Metadata.prototype.clearPrepared = function () {
 };
 
 /**
- * Gets the definition of an user defined type.
+ * Gets the definition of an user-defined type.
  * <p>
- * When trying to retrieve the same udt definition concurrently,
- * it will query once and invoke all callbacks with the retrieved information.
+ *   If a <code>callback</code> is provided, the callback is invoked when the metadata retrieval completes.
+ *   Otherwise, it returns a <code>Promise</code>.
  * </p>
- * @param {String} keyspaceName Name of the keyspace
- * @param {String} name Name of the UDT
- * @param {Function} callback
+ * <p>
+ * When trying to retrieve the same UDT definition concurrently, it will query once and invoke all callbacks
+ * with the retrieved information.
+ * </p>
+ * @param {String} keyspaceName Name of the keyspace.
+ * @param {String} name Name of the UDT.
+ * @param {Function} [callback] The callback to invoke when retrieval completes.
  */
 Metadata.prototype.getUdt = function (keyspaceName, name, callback) {
   return utils.promiseWrapper.call(this, this.options, callback, false, function handler(cb) {
@@ -325,12 +337,16 @@ Metadata.prototype._getUdtCb = function (keyspaceName, name, callback) {
 /**
  * Gets the definition of a table.
  * <p>
- * When trying to retrieve the same table definition concurrently,
- * it will query once and invoke all callbacks with the retrieved information.
+ *   If a <code>callback</code> is provided, the callback is invoked when the metadata retrieval completes.
+ *   Otherwise, it returns a <code>Promise</code>.
  * </p>
- * @param {String} keyspaceName Name of the keyspace
- * @param {String} name Name of the Table
- * @param {Function} callback The callback with the err as a first parameter and the {@link TableMetadata} as
+ * <p>
+ * When trying to retrieve the same table definition concurrently, it will query once and invoke all callbacks
+ * with the retrieved information.
+ * </p>
+ * @param {String} keyspaceName Name of the keyspace.
+ * @param {String} name Name of the Table.
+ * @param {Function} [callback] The callback with the err as a first parameter and the {@link TableMetadata} as
  * second parameter.
  */
 Metadata.prototype.getTable = function (keyspaceName, name, callback) {
@@ -360,13 +376,17 @@ Metadata.prototype._getTableCb = function (keyspaceName, name, callback) {
 /**
  * Gets the definition of CQL functions for a given name.
  * <p>
- * When trying to retrieve the same function definition concurrently,
- * it will query once and invoke all callbacks with the retrieved information.
+ *   If a <code>callback</code> is provided, the callback is invoked when the metadata retrieval completes.
+ *   Otherwise, it returns a <code>Promise</code>.
  * </p>
- * @param {String} keyspaceName Name of the keyspace
- * @param {String} name Name of the Function
- * @param {Function} callback The callback with the err as a first parameter and the array of {@link SchemaFunction} as
- * second parameter.
+ * <p>
+ * When trying to retrieve the same function definition concurrently, it will query once and invoke all callbacks
+ * with the retrieved information.
+ * </p>
+ * @param {String} keyspaceName Name of the keyspace.
+ * @param {String} name Name of the Function.
+ * @param {Function} [callback] The callback with the err as a first parameter and the array of {@link SchemaFunction}
+ * as second parameter.
  */
 Metadata.prototype.getFunctions = function (keyspaceName, name, callback) {
   return utils.promiseWrapper.call(this, this.options, callback, false, function handler(cb) {
@@ -399,13 +419,17 @@ Metadata.prototype._getFunctionsCb = function (keyspaceName, name, callback) {
 /**
  * Gets a definition of CQL function for a given name and signature.
  * <p>
- * When trying to retrieve the same function definition concurrently,
- * it will query once and invoke all callbacks with the retrieved information.
+ *   If a <code>callback</code> is provided, the callback is invoked when the metadata retrieval completes.
+ *   Otherwise, it returns a <code>Promise</code>.
+ * </p>
+ * <p>
+ * When trying to retrieve the same function definition concurrently, it will query once and invoke all callbacks
+ * with the retrieved information.
  * </p>
  * @param {String} keyspaceName Name of the keyspace
  * @param {String} name Name of the Function
  * @param {Array.<String>|Array.<{code, info}>} signature Array of types of the parameters.
- * @param {Function} callback The callback with the err as a first parameter and the {@link SchemaFunction} as second
+ * @param {Function} [callback] The callback with the err as a first parameter and the {@link SchemaFunction} as second
  * parameter.
  */
 Metadata.prototype.getFunction = function (keyspaceName, name, signature, callback) {
@@ -417,8 +441,12 @@ Metadata.prototype.getFunction = function (keyspaceName, name, signature, callba
 /**
  * Gets the definition of CQL aggregate for a given name.
  * <p>
- * When trying to retrieve the same aggregates definition concurrently,
- * it will query once and invoke all callbacks with the retrieved information.
+ *   If a <code>callback</code> is provided, the callback is invoked when the metadata retrieval completes.
+ *   Otherwise, it returns a <code>Promise</code>.
+ * </p>
+ * <p>
+ * When trying to retrieve the same aggregates definition concurrently, it will query once and invoke all callbacks
+ * with the retrieved information.
  * </p>
  * @param {String} keyspaceName Name of the keyspace
  * @param {String} name Name of the Function
@@ -455,13 +483,17 @@ Metadata.prototype._getAggregatesCb = function (keyspaceName, name, callback) {
 /**
  * Gets a definition of CQL aggregate for a given name and signature.
  * <p>
- * When trying to retrieve the same aggregate definition concurrently,
- * it will query once and invoke all callbacks with the retrieved information.
+ *   If a <code>callback</code> is provided, the callback is invoked when the metadata retrieval completes.
+ *   Otherwise, it returns a <code>Promise</code>.
+ * </p>
+ * <p>
+ * When trying to retrieve the same aggregate definition concurrently, it will query once and invoke all callbacks
+ * with the retrieved information.
  * </p>
  * @param {String} keyspaceName Name of the keyspace
  * @param {String} name Name of the aggregate
  * @param {Array.<String>|Array.<{code, info}>} signature Array of types of the parameters.
- * @param {Function} callback The callback with the err as a first parameter and the {@link Aggregate} as second parameter.
+ * @param {Function} [callback] The callback with the err as a first parameter and the {@link Aggregate} as second parameter.
  */
 Metadata.prototype.getAggregate = function (keyspaceName, name, signature, callback) {
   return utils.promiseWrapper.call(this, this.options, callback, false, function handler(cb) {
@@ -472,13 +504,18 @@ Metadata.prototype.getAggregate = function (keyspaceName, name, signature, callb
 /**
  * Gets the definition of a CQL materialized view for a given name.
  * <p>
+ *   If a <code>callback</code> is provided, the callback is invoked when the metadata retrieval completes.
+ *   Otherwise, it returns a <code>Promise</code>.
+ * </p>
+ * <p>
  *   Note that, unlike the rest of the {@link Metadata} methods, this method does not cache the result for following
  *   calls, as the current version of the Cassandra native protocol does not support schema change events for
  *   materialized views. Each call to this method will produce one or more queries to the cluster.
  * </p>
  * @param {String} keyspaceName Name of the keyspace
  * @param {String} name Name of the materialized view
- * @param {Function} callback The callback with the err as a first parameter and the {@link MaterializedView} as second parameter.
+ * @param {Function} [callback] The callback with the err as a first parameter and the {@link MaterializedView} as
+ * second parameter.
  */
 Metadata.prototype.getMaterializedView = function (keyspaceName, name, callback) {
   return utils.promiseWrapper.call(this, this.options, callback, false, function handler(cb) {
@@ -572,8 +609,12 @@ Metadata.prototype._getSingleFunctionCb = function (keyspaceName, name, signatur
  * query. The trace itself is stored in Cassandra in the <code>sessions</code> and
  * <code>events</code> table in the <code>system_traces</code> keyspace and can be
  * retrieve manually using the trace identifier.
+ * <p>
+ *   If a <code>callback</code> is provided, the callback is invoked when the metadata retrieval completes.
+ *   Otherwise, it returns a <code>Promise</code>.
+ * </p>
  * @param {Uuid} traceId Identifier of the trace session.
- * @param {Function} callback The callback with the err as first parameter and the query trace as second parameter.
+ * @param {Function} [callback] The callback with the err as first parameter and the query trace as second parameter.
  */
 Metadata.prototype.getTrace = function (traceId, callback) {
   return utils.promiseWrapper.call(this, this.options, callback, false, function handler(cb) {

--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -174,29 +174,29 @@ Metadata.prototype._refreshKeyspaceCb = function (name, callback) {
  *   If a <code>callback</code> is provided, the callback is invoked when the keyspace metadata refresh completes.
  *   Otherwise, it returns a <code>Promise</code>.
  * </p>
- * @param {Boolean} [waitReconnect] Determines if it should wait for reconnection in case the control connection is not
+ * @param {Boolean|Function} [waitReconnect] Determines if it should wait for reconnection in case the control connection is not
  * connected at the moment. Default: true.
  * @param {Function} [callback] Optional callback.
  */
 Metadata.prototype.refreshKeyspaces = function (waitReconnect, callback) {
+  if (typeof waitReconnect === 'function' || typeof waitReconnect === 'undefined') {
+    callback = waitReconnect;
+    waitReconnect = true;
+  }
+
   return utils.promiseWrapper.call(this, this.options, callback, true, function handler(cb) {
     this._refreshKeyspacesCb(waitReconnect, cb);
   });
 };
 
 /**
- * @param {Boolean|Function} waitReconnect
+ * @param {Boolean} waitReconnect
  * @param {Function} callback
  * @private
  */
 Metadata.prototype._refreshKeyspacesCb = function (waitReconnect, callback) {
   this.log('info', 'Retrieving keyspaces metadata');
   var self = this;
-  if (typeof waitReconnect === 'function' || typeof waitReconnect === 'undefined') {
-    callback = waitReconnect;
-    waitReconnect = true;
-  }
-  callback = callback || utils.noop;
   this._schemaParser.getKeyspaces(waitReconnect, function getKeyspacesCallback(err, keyspaces) {
     if (err) {
       self.log('error', 'There was an error while trying to retrieve keyspaces information', err);
@@ -450,7 +450,7 @@ Metadata.prototype.getFunction = function (keyspaceName, name, signature, callba
  * </p>
  * @param {String} keyspaceName Name of the keyspace
  * @param {String} name Name of the Function
- * @param {Function} callback The callback with the err as a first parameter and the array of {@link Aggregate} as
+ * @param {Function} [callback] The callback with the err as a first parameter and the array of {@link Aggregate} as
  * second parameter.
  */
 Metadata.prototype.getAggregates = function (keyspaceName, name, callback) {

--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -135,10 +135,18 @@ Metadata.prototype.buildTokens = function (hosts) {
  * @param {Function} [callback] Optional callback.
  */
 Metadata.prototype.refreshKeyspace = function (name, callback) {
+  return utils.promiseWrapper.call(this, this.options, callback, true, function handler(cb) {
+    this._refreshKeyspaceCb(name, cb);
+  });
+};
+
+/**
+ * @param {String} name
+ * @param {Function} callback
+ * @private
+ */
+Metadata.prototype._refreshKeyspaceCb = function (name, callback) {
   this.log('info', util.format('Retrieving keyspace %s metadata', name));
-  if (!callback) {
-    callback = function () {};
-  }
   var self = this;
   this._schemaParser.getKeyspace(name, function (err, ksInfo) {
     if (err) {
@@ -163,6 +171,17 @@ Metadata.prototype.refreshKeyspace = function (name, callback) {
  * @param {Function} [callback] Optional callback.
  */
 Metadata.prototype.refreshKeyspaces = function (waitReconnect, callback) {
+  return utils.promiseWrapper.call(this, this.options, callback, true, function handler(cb) {
+    this._refreshKeyspacesCb(waitReconnect, cb);
+  });
+};
+
+/**
+ * @param {Boolean|Function} waitReconnect
+ * @param {Function} callback
+ * @private
+ */
+Metadata.prototype._refreshKeyspacesCb = function (waitReconnect, callback) {
   this.log('info', 'Retrieving keyspaces metadata');
   var self = this;
   if (typeof waitReconnect === 'function' || typeof waitReconnect === 'undefined') {
@@ -179,6 +198,7 @@ Metadata.prototype.refreshKeyspaces = function (waitReconnect, callback) {
     callback(null, keyspaces);
   });
 };
+
 /**
  * Gets the host list representing the replicas that contain such partition.
  * <p>
@@ -279,6 +299,18 @@ Metadata.prototype.clearPrepared = function () {
  * @param {Function} callback
  */
 Metadata.prototype.getUdt = function (keyspaceName, name, callback) {
+  return utils.promiseWrapper.call(this, this.options, callback, false, function handler(cb) {
+    this._getUdtCb(keyspaceName, name, cb);
+  });
+};
+
+/**
+ * @param {String} keyspaceName
+ * @param {String} name
+ * @param {Function} callback
+ * @private
+ */
+Metadata.prototype._getUdtCb = function (keyspaceName, name, callback) {
   var cache;
   if (this.options.isMetadataSyncEnabled) {
     var keyspace = this.keyspaces[keyspaceName];
@@ -298,9 +330,22 @@ Metadata.prototype.getUdt = function (keyspaceName, name, callback) {
  * </p>
  * @param {String} keyspaceName Name of the keyspace
  * @param {String} name Name of the Table
- * @param {Function} callback The callback with the err as a first parameter and the {@link TableMetadata} as second parameter.
+ * @param {Function} callback The callback with the err as a first parameter and the {@link TableMetadata} as
+ * second parameter.
  */
 Metadata.prototype.getTable = function (keyspaceName, name, callback) {
+  return utils.promiseWrapper.call(this, this.options, callback, false, function handler(cb) {
+    this._getTableCb(keyspaceName, name, cb);
+  });
+};
+
+/**
+ * @param {String} keyspaceName
+ * @param {String} name
+ * @param {Function} callback
+ * @private
+ */
+Metadata.prototype._getTableCb = function (keyspaceName, name, callback) {
   var cache;
   if (this.options.isMetadataSyncEnabled) {
     var keyspace = this.keyspaces[keyspaceName];
@@ -320,14 +365,28 @@ Metadata.prototype.getTable = function (keyspaceName, name, callback) {
  * </p>
  * @param {String} keyspaceName Name of the keyspace
  * @param {String} name Name of the Function
- * @param {Function} callback The callback with the err as a first parameter and the array of {@link SchemaFunction} as second parameter.
+ * @param {Function} callback The callback with the err as a first parameter and the array of {@link SchemaFunction} as
+ * second parameter.
  */
 Metadata.prototype.getFunctions = function (keyspaceName, name, callback) {
+  return utils.promiseWrapper.call(this, this.options, callback, false, function handler(cb) {
+    this._getFunctionsCb(keyspaceName, name, cb);
+  });
+};
+
+/**
+ * @param {String} keyspaceName
+ * @param {String} name
+ * @param {Function} callback
+ * @private
+ */
+Metadata.prototype._getFunctionsCb = function (keyspaceName, name, callback) {
   if (typeof callback !== 'function') {
     throw new errors.ArgumentError('Callback is not a function');
   }
   if (!keyspaceName || !name) {
-    return callback(new errors.ArgumentError('You must provide the keyspace name and cql function name to retrieve the metadata'));
+    return callback(
+      new errors.ArgumentError('You must provide the keyspace name and cql function name to retrieve the metadata'));
   }
   this._getFunctions(keyspaceName, name, false, function (err, functionsMap) {
     if (err) {
@@ -346,10 +405,13 @@ Metadata.prototype.getFunctions = function (keyspaceName, name, callback) {
  * @param {String} keyspaceName Name of the keyspace
  * @param {String} name Name of the Function
  * @param {Array.<String>|Array.<{code, info}>} signature Array of types of the parameters.
- * @param {Function} callback The callback with the err as a first parameter and the {@link SchemaFunction} as second parameter.
+ * @param {Function} callback The callback with the err as a first parameter and the {@link SchemaFunction} as second
+ * parameter.
  */
 Metadata.prototype.getFunction = function (keyspaceName, name, signature, callback) {
-  this._getSingleFunction(keyspaceName, name, signature, false, callback);
+  return utils.promiseWrapper.call(this, this.options, callback, false, function handler(cb) {
+    this._getSingleFunctionCb(keyspaceName, name, signature, false, cb);
+  });
 };
 
 /**
@@ -360,9 +422,22 @@ Metadata.prototype.getFunction = function (keyspaceName, name, signature, callba
  * </p>
  * @param {String} keyspaceName Name of the keyspace
  * @param {String} name Name of the Function
- * @param {Function} callback The callback with the err as a first parameter and the array of {@link Aggregate} as second parameter.
+ * @param {Function} callback The callback with the err as a first parameter and the array of {@link Aggregate} as
+ * second parameter.
  */
 Metadata.prototype.getAggregates = function (keyspaceName, name, callback) {
+  return utils.promiseWrapper.call(this, this.options, callback, false, function handler(cb) {
+    this._getAggregatesCb(keyspaceName, name, cb);
+  });
+};
+
+/**
+ * @param {String} keyspaceName
+ * @param {String} name
+ * @param {Function} callback
+ * @private
+ */
+Metadata.prototype._getAggregatesCb = function (keyspaceName, name, callback) {
   if (typeof callback !== 'function') {
     throw new errors.ArgumentError('Callback is not a function');
   }
@@ -389,7 +464,9 @@ Metadata.prototype.getAggregates = function (keyspaceName, name, callback) {
  * @param {Function} callback The callback with the err as a first parameter and the {@link Aggregate} as second parameter.
  */
 Metadata.prototype.getAggregate = function (keyspaceName, name, signature, callback) {
-  this._getSingleFunction(keyspaceName, name, signature, true, callback);
+  return utils.promiseWrapper.call(this, this.options, callback, false, function handler(cb) {
+    this._getSingleFunctionCb(keyspaceName, name, signature, true, cb);
+  });
 };
 
 /**
@@ -404,6 +481,18 @@ Metadata.prototype.getAggregate = function (keyspaceName, name, signature, callb
  * @param {Function} callback The callback with the err as a first parameter and the {@link MaterializedView} as second parameter.
  */
 Metadata.prototype.getMaterializedView = function (keyspaceName, name, callback) {
+  return utils.promiseWrapper.call(this, this.options, callback, false, function handler(cb) {
+    this._getMaterializedViewCb(keyspaceName, name, cb);
+  });
+};
+
+/**
+ * @param {String} keyspaceName
+ * @param {String} name
+ * @param {Function} callback
+ * @private
+ */
+Metadata.prototype._getMaterializedViewCb = function (keyspaceName, name, callback) {
   var cache;
   if (this.options.isMetadataSyncEnabled) {
     var keyspace = this.keyspaces[keyspaceName];
@@ -444,12 +533,13 @@ Metadata.prototype._getFunctions = function (keyspaceName, name, aggregate, call
  * @param {Function} callback
  * @private
  */
-Metadata.prototype._getSingleFunction = function (keyspaceName, name, signature, aggregate, callback) {
+Metadata.prototype._getSingleFunctionCb = function (keyspaceName, name, signature, aggregate, callback) {
   if (typeof callback !== 'function') {
     throw new errors.ArgumentError('Callback is not a function');
   }
   if (!keyspaceName || !name) {
-    return callback(new errors.ArgumentError('You must provide the keyspace name and cql function name to retrieve the metadata'));
+    return callback(
+      new errors.ArgumentError('You must provide the keyspace name and cql function name to retrieve the metadata'));
   }
   if (!util.isArray(signature)) {
     return callback(new errors.ArgumentError('Signature must be an array of types'));
@@ -483,9 +573,20 @@ Metadata.prototype._getSingleFunction = function (keyspaceName, name, signature,
  * <code>events</code> table in the <code>system_traces</code> keyspace and can be
  * retrieve manually using the trace identifier.
  * @param {Uuid} traceId Identifier of the trace session.
- * @param {Function} callback The callback with the err as first parameter and the query trace as second parameter
+ * @param {Function} callback The callback with the err as first parameter and the query trace as second parameter.
  */
 Metadata.prototype.getTrace = function (traceId, callback) {
+  return utils.promiseWrapper.call(this, this.options, callback, false, function handler(cb) {
+    this._getTraceCb(traceId, cb);
+  });
+};
+
+/**
+ * @param {Uuid} traceId
+ * @param {Function} callback
+ * @private
+ */
+Metadata.prototype._getTraceCb = function (traceId, callback) {
   var trace;
   var attempts = 0;
   var selectSession = util.format(_selectTraceSession, traceId);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -344,6 +344,45 @@ function objectValues(obj) {
   return values;
 }
 
+/**
+ * Wraps the callback-based method. When no originalCallback is not defined, it returns a Promise.
+ * @param {ClientOptions} options
+ * @param {Function} originalCallback
+ * @param {Function} handler
+ * @returns {Promise|undefined}
+ */
+function promiseWrapper(options, originalCallback, handler) {
+  if (typeof originalCallback === 'function') {
+    handler(bindDomain(originalCallback));
+    return undefined;
+  }
+  var factory = options.promiseFactory;
+  if (!factory) {
+    if (typeof Promise === 'undefined') {
+      throw new errors.ArgumentError(
+        'Callback was not provided and Promise is undefined. See ' +
+        'ClientOptions.promiseFactory documentation.');
+    }
+    factory = defaultPromiseFactory;
+  }
+  return factory(function executor(resolve, reject) {
+    handler(function handlerCallback(err, result) {
+      if (err) {
+        return reject(err);
+      }
+      resolve(result);
+    });
+  });
+}
+
+/**
+ * @param {Function} executor
+ * @returns {Promise}
+ */
+function defaultPromiseFactory (executor) {
+  return new Promise(executor);
+}
+
 // Classes
 
 /**
@@ -806,6 +845,7 @@ exports.maxInt = maxInt;
 exports.noop = noop;
 exports.objectValues = objectValues;
 exports.parallel = parallel;
+exports.promiseWrapper = promiseWrapper;
 exports.propCompare = propCompare;
 exports.series = series;
 exports.stringRepeat = stringRepeat;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -372,22 +372,24 @@ function promiseWrapper(options, originalCallback, allowNoPromiseSupport, handle
     factory = defaultPromiseFactory;
   }
   var self = this;
-  return factory(function executor(resolve, reject) {
-    handler.call(self, function handlerCallback(err, result) {
+  return factory(function handlerWrapper(callback) {
+    handler.call(self, callback);
+  });
+}
+
+/**
+ * @param {Function} handler
+ * @returns {Promise}
+ */
+function defaultPromiseFactory(handler) {
+  return new Promise(function executor(resolve, reject) {
+    handler(function handlerCallback(err, result) {
       if (err) {
         return reject(err);
       }
       resolve(result);
     });
   });
-}
-
-/**
- * @param {Function} executor
- * @returns {Promise}
- */
-function defaultPromiseFactory (executor) {
-  return new Promise(executor);
 }
 
 // Classes

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -348,12 +348,18 @@ function objectValues(obj) {
  * Wraps the callback-based method. When no originalCallback is not defined, it returns a Promise.
  * @param {ClientOptions} options
  * @param {Function} originalCallback
+ * @param {Boolean} allowNoPromiseSupport
  * @param {Function} handler
  * @returns {Promise|undefined}
  */
-function promiseWrapper(options, originalCallback, handler) {
+function promiseWrapper(options, originalCallback, allowNoPromiseSupport, handler) {
+  if (allowNoPromiseSupport && !originalCallback && !options.promiseFactory && typeof Promise === 'undefined') {
+    // Optional callback on some methods is supported, even for js engines without Promise support
+    originalCallback = noop;
+  }
   if (typeof originalCallback === 'function') {
-    handler(bindDomain(originalCallback));
+    // Callback-based invocation
+    handler.call(this, bindDomain(originalCallback));
     return undefined;
   }
   var factory = options.promiseFactory;
@@ -365,8 +371,9 @@ function promiseWrapper(options, originalCallback, handler) {
     }
     factory = defaultPromiseFactory;
   }
+  var self = this;
   return factory(function executor(resolve, reject) {
-    handler(function handlerCallback(err, result) {
+    handler.call(self, function handlerCallback(err, result) {
       if (err) {
         return reject(err);
       }

--- a/test/integration/short/client-batch-tests.js
+++ b/test/integration/short/client-batch-tests.js
@@ -296,6 +296,39 @@ describe('Client', function () {
         client.shutdown.bind(client),
       ], done);
     });
+    describe('with no callback specified', function () {
+      if (!helper.promiseSupport) {
+        return;
+      }
+      vit('2.0', 'should return a promise when batch completes', function () {
+        var insertQuery = 'INSERT INTO %s (id, text_sample) VALUES (%s, \'%s\')';
+        var selectQuery = 'SELECT * FROM %s WHERE id = %s';
+        var id1 = types.Uuid.random();
+        var id2 = types.Uuid.random();
+        var client = newInstance();
+        var queries = [
+          util.format(insertQuery, table1, id1, 'one'),
+          util.format(insertQuery, table2, id2, 'two')
+        ];
+
+        return client.batch(queries)
+          .then(function (result) {
+            assert.ok(result);
+            return client.execute(util.format(selectQuery, table1, id1));
+          })
+          .then(function (result) {
+            assert.ok(result);
+            assert.ok(result.rows);
+            assert.strictEqual(result.rows[0].text_sample, 'one');
+            return client.execute(util.format(selectQuery, table2, id2));
+          })
+          .then(function (result) {
+            assert.ok(result);
+            assert.ok(result.rows);
+            assert.strictEqual(result.rows[0].text_sample, 'two');
+          });
+      });
+    });
   });
   describe('#batch(queries, {prepare: 1}, callback)', function () {
     var keyspace = helper.getRandomName('ks');

--- a/test/integration/short/metadata-tests.js
+++ b/test/integration/short/metadata-tests.js
@@ -342,70 +342,42 @@ describe('Metadata', function () {
   });
   describe('#refreshKeyspace()', function() {
     describe('with no callback specified', function () {
-      if(!helper.promiseSupport) {
-        it('should throw an ArgumentError', function (done) {
-          var client = newInstance({ isMetadataSyncEnabled: false });
-          utils.series([
-            client.connect.bind(client),
-            function (next) {
-              assert.throws(function () {
-                client.metadata.refreshKeyspace('system');
-              }, errors.ArgumentError);
-              next();
-            },
-            client.shutdown.bind(client)
-          ], done);
+      if(helper.promiseSupport) {
+        it('should return keyspace in a promise', function () {
+          var client = newInstance({isMetadataSyncEnabled: false});
+          return client.connect()
+            .then(function () {
+              var ks = client.metadata.keyspaces;
+              assert.ok(ks['system'] === undefined);
+              return client.metadata.refreshKeyspace('system');
+            })
+            .then(function (keyspace) {
+              assert.ok(keyspace);
+              assert.strictEqual(keyspace.name, 'system');
+              return client.shutdown();
+            });
         });
-        return;
       }
-      it('should return keyspace in a promise', function () {
-        var client = newInstance({ isMetadataSyncEnabled: false });
-        return client.connect()
-          .then(function () {
-            var ks = client.metadata.keyspaces;
-            assert.ok(ks['system'] === undefined);
-            return client.metadata.refreshKeyspace('system');
-          })
-          .then(function (keyspace) {
-            assert.ok(keyspace);
-            assert.strictEqual(keyspace.name, 'system');
-            return client.shutdown();
-          });
-      });
     });
   });
   describe('#refreshKeyspaces()', function() {
     describe('with no callback specified', function () {
-      if(!helper.promiseSupport) {
-        it('should throw an ArgumentError', function (done) {
+      if(helper.promiseSupport) {
+        it('should return keyspaces in a promise', function () {
           var client = newInstance({ isMetadataSyncEnabled: false });
-          utils.series([
-            client.connect.bind(client),
-            function (next) {
-              assert.throws(function () {
-                client.metadata.refreshKeyspaces();
-              }, errors.ArgumentError);
-              next();
-            },
-            client.shutdown.bind(client)
-          ], done);
+          return client.connect()
+            .then(function () {
+              var ks = client.metadata.keyspaces;
+              assert.ok(ks['system'] === undefined);
+              return client.metadata.refreshKeyspaces();
+            })
+            .then(function (data) {
+              assert.ok(data);
+              assert.ok(data['system']);
+              return client.shutdown();
+            });
         });
-        return;
       }
-      it('should return keyspaces in a promise', function () {
-        var client = newInstance({ isMetadataSyncEnabled: false });
-        return client.connect()
-          .then(function () {
-            var ks = client.metadata.keyspaces;
-            assert.ok(ks['system'] === undefined);
-            return client.metadata.refreshKeyspaces();
-          })
-          .then(function (data) {
-            assert.ok(data);
-            assert.ok(data['system']);
-            return client.shutdown();
-          });
-      });
     });
   });
   describe('#getTable()', function () {

--- a/test/integration/short/metadata-tests.js
+++ b/test/integration/short/metadata-tests.js
@@ -324,7 +324,7 @@ describe('Metadata', function () {
       }
       it('should return the trace in a promise', function () {
         var client = newInstance();
-        client.connect()
+        return client.connect()
           .then(function () {
             return client.execute(helper.queries.basic, [], { traceQuery: true });
           })
@@ -335,6 +335,74 @@ describe('Metadata', function () {
             assert.ok(trace);
             assert.strictEqual(typeof trace.duration, 'number');
             assert.ok(trace.events.length);
+            return client.shutdown();
+          });
+      });
+    });
+  });
+  describe('#refreshKeyspace()', function() {
+    describe('with no callback specified', function () {
+      if(!helper.promiseSupport) {
+        it('should throw an ArgumentError', function (done) {
+          var client = newInstance({ isMetadataSyncEnabled: false });
+          util.series([
+            client.connect.bind(client),
+            function (next) {
+              assert.throws(function () {
+                client.metadata.refreshKeyspace('system');
+              }, errors.ArgumentError);
+              next();
+            },
+            client.shutdown.bind(client)
+          ], done);
+        });
+        return;
+      }
+      it('should return keyspace in a promise', function () {
+        var client = newInstance({ isMetadataSyncEnabled: false });
+        return client.connect()
+          .then(function () {
+            var ks = client.metadata.keyspaces;
+            assert.ok(ks['system'] === undefined);
+            return client.metadata.refreshKeyspace('system');
+          })
+          .then(function (keyspace) {
+            assert.ok(keyspace);
+            assert.strictEqual(keyspace.name, 'system');
+            return client.shutdown();
+          });
+      });
+    });
+  });
+  describe('#refreshKeyspaces()', function() {
+    describe('with no callback specified', function () {
+      if(!helper.promiseSupport) {
+        it('should throw an ArgumentError', function (done) {
+          var client = newInstance({ isMetadataSyncEnabled: false });
+          util.series([
+            client.connect.bind(client),
+            function (next) {
+              assert.throws(function () {
+                client.metadata.refreshKeyspaces();
+              }, errors.ArgumentError);
+              next();
+            },
+            client.shutdown.bind(client)
+          ], done);
+        });
+        return;
+      }
+      it('should return keyspaces in a promise', function () {
+        var client = newInstance({ isMetadataSyncEnabled: false });
+        return client.connect()
+          .then(function () {
+            var ks = client.metadata.keyspaces;
+            assert.ok(ks['system'] === undefined);
+            return client.metadata.refreshKeyspaces();
+          })
+          .then(function (data) {
+            assert.ok(data);
+            assert.ok(data['system']);
             return client.shutdown();
           });
       });
@@ -889,7 +957,7 @@ describe('Metadata', function () {
       }
       it('should return the metadata in a promise', function () {
         var client = newInstance();
-        client.connect()
+        return client.connect()
           .then(function () {
             return client.metadata.getTable(keyspace, 'tbl1');
           })
@@ -1079,13 +1147,13 @@ describe('Metadata', function () {
       }
       it('should return the metadata in a promise', function () {
         var client = newInstance();
-        client.connect()
+        return client.connect()
           .then(function () {
             return client.metadata.getMaterializedView(keyspace, 'dailyhigh');
           })
           .then(function (view) {
             assert.ok(view);
-            assert.strictEqual(view.name, 'tbl1');
+            assert.strictEqual(view.name, 'dailyhigh');
             assert.ok(view.clusteringKeys.length);
             return client.shutdown();
           });

--- a/test/integration/short/metadata-tests.js
+++ b/test/integration/short/metadata-tests.js
@@ -345,7 +345,7 @@ describe('Metadata', function () {
       if(!helper.promiseSupport) {
         it('should throw an ArgumentError', function (done) {
           var client = newInstance({ isMetadataSyncEnabled: false });
-          util.series([
+          utils.series([
             client.connect.bind(client),
             function (next) {
               assert.throws(function () {
@@ -379,7 +379,7 @@ describe('Metadata', function () {
       if(!helper.promiseSupport) {
         it('should throw an ArgumentError', function (done) {
           var client = newInstance({ isMetadataSyncEnabled: false });
-          util.series([
+          utils.series([
             client.connect.bind(client),
             function (next) {
               assert.throws(function () {

--- a/test/integration/short/metadata-tests.js
+++ b/test/integration/short/metadata-tests.js
@@ -5,6 +5,7 @@ var helper = require('../../test-helper');
 var Client = require('../../../lib/client');
 var utils = require('../../../lib/utils');
 var types = require('../../../lib/types');
+var errors = require('../../../lib/errors');
 var vit = helper.vit;
 var vdescribe = helper.vdescribe;
 
@@ -107,22 +108,39 @@ describe('Metadata', function () {
       });
     });
   });
-  describe('#getUdt()', function () {
-    vit('2.1', 'should return null if it does not exists', function (done) {
+  vdescribe('2.1', '#getUdt()', function () {
+    it('should return null if it does not exists', function (done) {
       var client = newInstance();
-      client.connect(function (err) {
-        assert.ifError(err);
-        var m = client.metadata;
-        utils.timesSeries(10, function (n, next) {
-          m.getUdt('ks1', 'udt_does_not_exists', function (err, udtInfo) {
-            assert.ifError(err);
-            assert.strictEqual(udtInfo, null);
-            next();
-          });
-        }, helper.finish(client, done));
-      });
+      utils.series([
+        client.connect.bind(client),
+        function testWithCallbacks(next) {
+          var m = client.metadata;
+          utils.timesSeries(10, function (n, timesNext) {
+            m.getUdt('ks1', 'udt_does_not_exists', function (err, udtInfo) {
+              assert.ifError(err);
+              assert.strictEqual(udtInfo, null);
+              timesNext();
+            });
+          }, next);
+        },
+        function testWithPromises(next) {
+          if (!helper.promiseSupport) {
+            return next();
+          }
+          var m = client.metadata;
+          utils.timesSeries(10, function (n, timesNext) {
+            m.getUdt('ks1', 'udt_does_not_exists')
+              .then(function (udtInfo) {
+                assert.strictEqual(udtInfo, null);
+              })
+              .then(timesNext)
+              .catch(timesNext)
+          }, next);
+        },
+        client.shutdown.bind(client),
+      ], done);
     });
-    vit('2.1', 'should return the udt information', function (done) {
+    it('should return the udt information', function (done) {
       var client = newInstance();
       var createUdtQuery1 = "CREATE TYPE phone (alias text, number text, country_code int, second_number 'DynamicCompositeType(s => UTF8Type, i => Int32Type)')";
       var createUdtQuery2 = 'CREATE TYPE address (street text, "ZIP" int, phones set<frozen<phone>>)';
@@ -173,10 +191,25 @@ describe('Metadata', function () {
             assert.strictEqual(udtInfo.fields[2].type.info.info.fields[0].name, 'alias');
             next();
           });
-        }
+        },
+        function checkAddressUdtWithPromises(next) {
+          if (!helper.promiseSupport) {
+            return next();
+          }
+          var m = client.metadata;
+          m.getUdt('ks_udt1', 'address')
+            .then(function (udtInfo) {
+              assert.ok(udtInfo);
+              assert.strictEqual(udtInfo.name, 'address');
+              assert.strictEqual(udtInfo.fields.length, 3);
+            })
+            .then(next)
+            .catch(next);
+        },
+        client.shutdown.bind(client)
       ], done);
     });
-    vit('2.1', 'should retrieve the updated metadata after a schema change', function (done) {
+    it('should retrieve the updated metadata after a schema change', function (done) {
       var client = newInstance({ refreshSchemaDelay: 50 });
       var nonSyncClient = newInstance({ isMetadataSyncEnabled: false });
       var clients = [client, nonSyncClient];
@@ -271,6 +304,40 @@ describe('Metadata', function () {
           });
         }
       ], done);
+    });
+    describe('with no callback specified', function () {
+      if (!helper.promiseSupport) {
+        it('should throw an ArgumentError', function (done) {
+          var client = newInstance();
+          utils.series([
+            client.connect.bind(client),
+            function (next) {
+              assert.throws(function () {
+                client.metadata.getTrace(types.Uuid.random());
+              }, errors.ArgumentError);
+              next();
+            },
+            client.shutdown.bind(client)
+          ], done);
+        });
+        return;
+      }
+      it('should return the trace in a promise', function () {
+        var client = newInstance();
+        client.connect()
+          .then(function () {
+            return client.execute(helper.queries.basic, [], { traceQuery: true });
+          })
+          .then(function (result) {
+            return client.metadata.getTrace(result.info.traceId);
+          })
+          .then(function (trace) {
+            assert.ok(trace);
+            assert.strictEqual(typeof trace.duration, 'number');
+            assert.ok(trace.events.length);
+            return client.shutdown();
+          });
+      });
     });
   });
   describe('#getTable()', function () {
@@ -803,6 +870,37 @@ describe('Metadata', function () {
         nonSyncClient.shutdown.bind(nonSyncClient)
       ], done);
     });
+    describe('with no callback specified', function () {
+      if (!helper.promiseSupport) {
+        it('should throw an ArgumentError', function (done) {
+          var client = newInstance();
+          utils.series([
+            client.connect.bind(client),
+            function (next) {
+              assert.throws(function () {
+                client.metadata.getTable(keyspace, 'tbl1');
+              }, errors.ArgumentError);
+              next();
+            },
+            client.shutdown.bind(client)
+          ], done);
+        });
+        return;
+      }
+      it('should return the metadata in a promise', function () {
+        var client = newInstance();
+        client.connect()
+          .then(function () {
+            return client.metadata.getTable(keyspace, 'tbl1');
+          })
+          .then(function (table) {
+            assert.ok(table);
+            assert.strictEqual(table.name, 'tbl1');
+            assert.ok(table.columns.length);
+            return client.shutdown();
+          });
+      });
+    });
   });
   vdescribe('3.0', '#getMaterializedView()', function () {
     var keyspace = 'ks_view_meta';
@@ -961,7 +1059,38 @@ describe('Metadata', function () {
         },
         client.shutdown.bind(client)
       ], done);
-    })
+    });
+    describe('with no callback specified', function () {
+      if (!helper.promiseSupport) {
+        it('should throw an ArgumentError', function (done) {
+          var client = newInstance();
+          utils.series([
+            client.connect.bind(client),
+            function (next) {
+              assert.throws(function () {
+                client.metadata.getMaterializedView(keyspace, 'dailyhigh');
+              }, errors.ArgumentError);
+              next();
+            },
+            client.shutdown.bind(client)
+          ], done);
+        });
+        return;
+      }
+      it('should return the metadata in a promise', function () {
+        var client = newInstance();
+        client.connect()
+          .then(function () {
+            return client.metadata.getMaterializedView(keyspace, 'dailyhigh');
+          })
+          .then(function (view) {
+            assert.ok(view);
+            assert.strictEqual(view.name, 'tbl1');
+            assert.ok(view.clusteringKeys.length);
+            return client.shutdown();
+          });
+      });
+    });
   });
 });
 

--- a/test/integration/short/udf-tests.js
+++ b/test/integration/short/udf-tests.js
@@ -5,6 +5,7 @@ var helper = require('../../test-helper');
 var Client = require('../../../lib/client');
 var utils = require('../../../lib/utils');
 var types = require('../../../lib/types');
+var errors = require('../../../lib/errors');
 var vdescribe = helper.vdescribe;
 
 vdescribe('2.2', 'Metadata', function () {

--- a/test/integration/short/udf-tests.js
+++ b/test/integration/short/udf-tests.js
@@ -83,6 +83,35 @@ vdescribe('2.2', 'Metadata', function () {
         client.shutdown.bind(client)
       ], done);
     });
+    describe('with no callback specified', function () {
+      if(!helper.promiseSupport) {
+        it('should throw an ArgumentError', function (done) {
+          var client = newInstance();
+          util.series([
+            client.connect.bind(client),
+            function (next) {
+              assert.throws(function () {
+                client.metadata.getFunctions(keyspace, 'plus');
+              }, errors.ArgumentError);
+              next();
+            },
+            client.shutdown.bind(client)
+          ], done);
+        });
+        return;
+      }
+      it('should return functions in a promise', function () {
+        var client = newInstance();
+        return client.connect()
+          .then(function () {
+            return client.metadata.getFunctions(keyspace, 'plus');
+          })
+          .then(function (funcArray) {
+            assert.ok(funcArray);
+            assert.strictEqual(funcArray.length, 2);
+          });
+      });
+    });
   });
   describe('#getFunction()', function () {
     it('should retrieve the metadata of a cql function', function (done) {
@@ -201,6 +230,40 @@ vdescribe('2.2', 'Metadata', function () {
         nonSyncClient.shutdown.bind(nonSyncClient)
       ], done);
     });
+    describe('with no callback specified', function () {
+      if(!helper.promiseSupport) {
+        it('should throw an ArgumentError', function (done) {
+          var client = newInstance();
+          util.series([
+            client.connect.bind(client),
+            function (next) {
+              assert.throws(function () {
+                client.metadata.getFunction(keyspace, 'plus', ['int', 'int']);
+              }, errors.ArgumentError);
+              next();
+            },
+            client.shutdown.bind(client)
+          ], done);
+        });
+        return;
+      }
+      it('should return function in a promise', function () {
+        var client = newInstance();
+        return client.connect()
+          .then(function () {
+            return client.metadata.getFunction(keyspace, 'plus', ['int', 'int']);
+          })
+          .then(function (func) {
+            assert.ok(func);
+            assert.strictEqual(func.name, 'plus');
+            assert.strictEqual(func.keyspaceName, keyspace);
+            assert.strictEqual(func.argumentTypes.length, 2);
+            assert.strictEqual(func.argumentTypes[0].code, types.dataTypes.int);
+            assert.strictEqual(func.argumentTypes[1].code, types.dataTypes.int);
+            assert.strictEqual(func.returnType.code, types.dataTypes.int);
+          });
+      });
+    });
   });
   describe('#getAggregates()', function () {
     it('should retrieve the metadata of cql aggregates', function (done) {
@@ -247,6 +310,37 @@ vdescribe('2.2', 'Metadata', function () {
         },
         client.shutdown.bind(client)
       ], done);
+    });
+    describe('with no callback specified', function () {
+      if(!helper.promiseSupport) {
+        it('should throw an ArgumentError', function (done) {
+          var client = newInstance();
+          util.series([
+            client.connect.bind(client),
+            function (next) {
+              assert.throws(function () {
+                client.metadata.getAggregates(keyspace, 'sum');
+              }, errors.ArgumentError);
+              next();
+            },
+            client.shutdown.bind(client)
+          ], done);
+        });
+        return;
+      }
+      it('should return aggregates in a promise', function () {
+        var client = newInstance();
+        return client.connect()
+          .then(function () {
+            return client.metadata.getAggregates(keyspace, 'sum');
+          })
+          .then(function (aggregatesArray) {
+            assert.ok(aggregatesArray);
+            assert.strictEqual(aggregatesArray.length, 2);
+            assert.strictEqual(aggregatesArray[0].name, 'sum');
+            assert.strictEqual(aggregatesArray[1].name, 'sum');
+          });
+      });
     });
   });
   describe('#getAggregate()', function () {
@@ -348,6 +442,41 @@ vdescribe('2.2', 'Metadata', function () {
         client.shutdown.bind(client),
         nonSyncClient.shutdown.bind(nonSyncClient)
       ], done);
+    });
+    describe('with no callback specified', function () {
+      if(!helper.promiseSupport) {
+        it('should throw an ArgumentError', function (done) {
+          var client = newInstance();
+          util.series([
+            client.connect.bind(client),
+            function (next) {
+              assert.throws(function () {
+                client.metadata.getAggregate(keyspace, 'sum', ['int'])
+              }, errors.ArgumentError);
+              next();
+            },
+            client.shutdown.bind(client)
+          ], done);
+        });
+        return;
+      }
+      it('should return aggregate in a promise', function () {
+        var client = newInstance();
+        return client.connect()
+          .then(function () {
+            return client.metadata.getAggregate(keyspace, 'sum', ['int']);
+          })
+          .then(function (aggregate) {
+            assert.ok(aggregate);
+            assert.strictEqual(aggregate.name, 'sum');
+            assert.strictEqual(aggregate.keyspaceName, keyspace);
+            assert.strictEqual(aggregate.argumentTypes.length, 1);
+            assert.strictEqual(aggregate.argumentTypes[0].code, types.dataTypes.int);
+            assert.strictEqual(aggregate.returnType.code, types.dataTypes.int);
+            assert.strictEqual(aggregate.stateFunction, 'plus');
+            assert.strictEqual(aggregate.initCondition, '1');
+          });
+      });
     });
   });
 });

--- a/test/integration/short/udf-tests.js
+++ b/test/integration/short/udf-tests.js
@@ -87,7 +87,7 @@ vdescribe('2.2', 'Metadata', function () {
       if(!helper.promiseSupport) {
         it('should throw an ArgumentError', function (done) {
           var client = newInstance();
-          util.series([
+          utils.series([
             client.connect.bind(client),
             function (next) {
               assert.throws(function () {
@@ -234,7 +234,7 @@ vdescribe('2.2', 'Metadata', function () {
       if(!helper.promiseSupport) {
         it('should throw an ArgumentError', function (done) {
           var client = newInstance();
-          util.series([
+          utils.series([
             client.connect.bind(client),
             function (next) {
               assert.throws(function () {
@@ -315,7 +315,7 @@ vdescribe('2.2', 'Metadata', function () {
       if(!helper.promiseSupport) {
         it('should throw an ArgumentError', function (done) {
           var client = newInstance();
-          util.series([
+          utils.series([
             client.connect.bind(client),
             function (next) {
               assert.throws(function () {
@@ -447,7 +447,7 @@ vdescribe('2.2', 'Metadata', function () {
       if(!helper.promiseSupport) {
         it('should throw an ArgumentError', function (done) {
           var client = newInstance();
-          util.series([
+          utils.series([
             client.connect.bind(client),
             function (next) {
               assert.throws(function () {

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -44,6 +44,7 @@ var helper = {
       return value;
     });
   },
+  promiseSupport: (typeof Promise === 'function'),
   /**
    * @type {ClientOptions}
    */

--- a/test/unit/client-tests.js
+++ b/test/unit/client-tests.js
@@ -113,7 +113,7 @@ describe('Client', function () {
       });
     });
     context('with no callback specified', function () {
-      if (typeof Promise !== 'function') {
+      if (!helper.promiseSupport) {
         it('should throw an ArgumentError', function () {
           var Client = require('../../lib/client');
           var client = new Client(helper.baseOptions);
@@ -466,7 +466,7 @@ describe('Client', function () {
       helper.compareProps(queryOptions, previousQueryOptions, Object.keys(queryOptions), ['executionProfile']);
     });
     context('with no callback specified', function () {
-      if (typeof Promise !== 'function') {
+      if (!helper.promiseSupport) {
         it('should throw an error', function () {
           var Client = require('../../lib/client');
           var client = new Client(helper.baseOptions);
@@ -543,7 +543,7 @@ describe('Client', function () {
       });
     });
     context('with no callback specified', function () {
-      if (typeof Promise !== 'function') {
+      if (!helper.promiseSupport) {
         it('should throw an error', function () {
           var Client = require('../../lib/client');
           var client = new Client(helper.baseOptions);
@@ -755,7 +755,7 @@ describe('Client', function () {
       })
     });
     context('with no callback specified', function () {
-      if (typeof Promise !== 'function') {
+      if (!helper.promiseSupport) {
         it('should not throw an error', function () {
           var Client = require('../../lib/client');
           var client = new Client(helper.baseOptions);

--- a/test/unit/client-tests.js
+++ b/test/unit/client-tests.js
@@ -112,6 +112,28 @@ describe('Client', function () {
         });
       });
     });
+    context('with no callback specified', function () {
+      if (typeof Promise !== 'function') {
+        it('should throw an ArgumentError', function () {
+          var Client = require('../../lib/client');
+          var client = new Client(helper.baseOptions);
+          assert.throws(function () {
+            client.connect();
+          }, errors.ArgumentError);
+        });
+        return;
+      }
+      it('should return a promise', function (done) {
+        var Client = require('../../lib/client');
+        var client = new Client(helper.baseOptions);
+        var p = client.connect();
+        helper.assertInstanceOf(p, Promise);
+        p.catch(function (err) {
+          helper.assertInstanceOf(err, errors.NoHostAvailableError);
+          done();
+        });
+      });
+    });
   });
   describe('#_getPrepared()', function () {
     var Client = rewire('../../lib/client.js');
@@ -368,18 +390,6 @@ describe('Client', function () {
         }
       ], done);
     });
-    it('should throw argument error when last parameter is not a function', function () {
-      var client = newConnectedInstance();
-      assert.throws(function () {
-        client.execute('QUERY', [], {});
-      }, errors.ArgumentError);
-      assert.throws(function () {
-        client.execute('QUERY', []);
-      }, errors.ArgumentError);
-      assert.throws(function () {
-        client.execute('QUERY');
-      }, errors.ArgumentError);
-    });
     it('should pass optional parameters as null when not defined', function () {
       var client = newConnectedInstance();
       var params = null;
@@ -455,6 +465,38 @@ describe('Client', function () {
       client.execute('Q1', [], { consistency: types.consistencies.all, executionProfile: profile }, utils.noop);
       helper.compareProps(queryOptions, previousQueryOptions, Object.keys(queryOptions), ['executionProfile']);
     });
+    context('with no callback specified', function () {
+      if (typeof Promise !== 'function') {
+        it('should throw an error', function () {
+          var Client = require('../../lib/client');
+          var client = new Client(helper.baseOptions);
+          assert.throws(function () {
+            client.execute('Q', [ 1, 2 ], { prepare: true });
+          }, errors.ArgumentError);
+        });
+        return;
+      }
+      it('should return a promise', function (done) {
+        var Client = require('../../lib/client');
+        var client = new Client(helper.baseOptions);
+        var p = client.execute('Q', [ 1, 2 ], { prepare: true });
+        helper.assertInstanceOf(p, Promise);
+        p.catch(function (err) {
+          helper.assertInstanceOf(err, errors.NoHostAvailableError);
+          done();
+        });
+      });
+      it('should reject the promise when an ExecutionProfile is not found', function (done) {
+        var Client = require('../../lib/client');
+        var client = new Client(helper.baseOptions);
+        var p = client.execute('Q', [ 1, 2 ], { executionProfile: 'non_existent' });
+        helper.assertInstanceOf(p, Promise);
+        p.catch(function (err) {
+          helper.assertInstanceOf(err, errors.ArgumentError);
+          done();
+        });
+      });
+    });
   });
   describe('#eachRow()', function () {
     it('should pass optional parameters as null when not defined', function () {
@@ -498,6 +540,38 @@ describe('Client', function () {
         assert.ifError(err);
         assert.strictEqual(connectCalled, true);
         done();
+      });
+    });
+    context('with no callback specified', function () {
+      if (typeof Promise !== 'function') {
+        it('should throw an error', function () {
+          var Client = require('../../lib/client');
+          var client = new Client(helper.baseOptions);
+          assert.throws(function () {
+            client.batch(['Q'], { prepare: false });
+          }, errors.ArgumentError);
+        });
+        return;
+      }
+      it('should return a promise', function (done) {
+        var Client = require('../../lib/client');
+        var client = new Client(helper.baseOptions);
+        var p = client.batch(['Q'], null);
+        helper.assertInstanceOf(p, Promise);
+        p.catch(function (err) {
+          helper.assertInstanceOf(err, errors.NoHostAvailableError);
+          done();
+        });
+      });
+      it('should reject the promise when queries is not an Array', function (done) {
+        var Client = require('../../lib/client');
+        var client = new Client(helper.baseOptions);
+        var p = client.batch('Q', null);
+        helper.assertInstanceOf(p, Promise);
+        p.catch(function (err) {
+          helper.assertInstanceOf(err, errors.ArgumentError);
+          done();
+        });
       });
     });
   });
@@ -679,6 +753,25 @@ describe('Client', function () {
           }, 20);
         });
       })
+    });
+    context('with no callback specified', function () {
+      if (typeof Promise !== 'function') {
+        it('should not throw an error', function () {
+          var Client = require('../../lib/client');
+          var client = new Client(helper.baseOptions);
+          assert.doesNotThrow(function () {
+            client.shutdown();
+          });
+        });
+        return;
+      }
+      it('should return a promise', function (done) {
+        var Client = require('../../lib/client');
+        var client = new Client(helper.baseOptions);
+        var p = client.shutdown();
+        helper.assertInstanceOf(p, Promise);
+        p.then(done);
+      });
     });
   });
   describe('#_waitForSchemaAgreement()', function () {

--- a/test/unit/metadata-tests.js
+++ b/test/unit/metadata-tests.js
@@ -1727,7 +1727,20 @@ describe('Metadata', function () {
   });
   describe('#getFunction()', function () {
     context('with no callback specified', function () {
-      it('should not throw');
+      if (!helper.promiseSupport) {
+        it('should throw an ArgumentError', function () {
+          var metadata = newInstance();
+          assert.throws(function () {
+            metadata.getFunction('ks1', 'fn1', []);
+          }, errors.ArgumentError);
+        });
+        return;
+      }
+      it('should return a Promise', function () {
+        var metadata = newInstance();
+        var p = metadata.getFunction('ks1', 'fn1', []);
+        helper.assertInstanceOf(p, Promise);
+      });
     });
     it('should callback in error if keyspace or name are not provided', function (done) {
       var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
@@ -2228,4 +2241,9 @@ function getTokenizer() {
   t.hash = function (b) { return b[0]};
   t.compare = function (a, b) { if (a > b) return 1; if (a < b) return -1; return 0 };
   return t;
+}
+
+/** @returns {Metadata} */
+function newInstance() {
+  return new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
 }

--- a/test/unit/metadata-tests.js
+++ b/test/unit/metadata-tests.js
@@ -1726,13 +1726,8 @@ describe('Metadata', function () {
     });
   });
   describe('#getFunction()', function () {
-    it('should throw if callback is not provided', function () {
-      var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
-      metadata.keyspaces['ks_udf'] = { functions: {}};
-      assert.throws(function () {
-        //noinspection JSCheckFunctionSignatures
-        metadata.getFunction('ks_udf', 'plus', []);
-      }, errors.ArgumentError);
+    context('with no callback specified', function () {
+      it('should not throw');
     });
     it('should callback in error if keyspace or name are not provided', function (done) {
       var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));


### PR DESCRIPTION
Some info:
- The _promisification_ of the methods is done explicitly one by one, it could have been done per prototype (like a script at the end of each module) but I think this way is easier for user to trace.
- Provided a way to "bring your own Promise module" by exposing a `promiseFactory` method. I've ran a quick microbenchmark using default factory and bluebird and I didn't find any significant difference in performance.
- For callback based invocations (current), it adds 2 extra method invocations but the expected performance is the same.
- Changed the `examples` folder to run only on nodejs versions greater than > 0.12. I've adapted all the examples to use promises as it is much easier to read than using an external control flow library like `async` and the callback based API.
- Adapted most of the docs for the same reason.
- Added a new doc entry for "Promise and callback-based API"
