### PR TITLE
Timestamp generation

### DIFF
--- a/doc/features/README.md
+++ b/doc/features/README.md
@@ -13,6 +13,7 @@ Cassandra (1.2+) using exclusively Cassandra's binary protocol and Cassandra Que
 - [Paging](paging)
 - [Native protocol](native-protocol)
 - [Parameterized queries](parameterized-queries)
+- [Query timestamps](query-timestamps)
 - [Query warnings](query-warnings)
 - [Tuning policies](tuning-policies)
 - [User-defined functions and aggregates](udfs)

--- a/doc/features/query-timestamps/README.md
+++ b/doc/features/query-timestamps/README.md
@@ -1,0 +1,64 @@
+# Query timestamps
+
+In Cassandra, each mutation has a microsecond-precision timestamp, which is used to order operations relative to
+each other.
+
+The timestamp can be provided by the client or assigned server-side based on the time the server processes the request.
+
+Letting the server assign the timestamp can be a problem when the order of the writes matter: with unlucky
+timing (different coordinators, network latency, etc.), two successive requests from the same client might be
+processed in a different order server-side, and end up with out-of-order timestamps.
+
+## Client-side generation
+
+### Using a timestamp generator
+
+When using Apache Cassandra 2.1+ or DataStax Enterprise 4.7+, it's possible to send the operation timestamp in the
+request. Starting from version 3.1 of the Node.js driver, the driver uses [`MononoticTimestampGenerator`][mtg] 
+by default to generate the request timestamps.
+
+You can provide a different generator when creating the `Client` instance:
+
+```javascript
+const client = new Client({
+  contactPoints: ['h1', 'h2'],
+  policies: {
+    timestampGeneration: new MyCustomTimestampGenerator()
+  }
+});
+```
+
+To implement a custom timestamp generator, you must implement `TimestampGenerator` base class.
+
+In addition, you can also set the default timestamp on a per-execution basis in the query options:
+
+```javascript
+session.execute(query, params, { timestamp: timestamp });
+```
+
+[mtg]: ../../api/module.policies/module.timestampGeneration/class.MonotonicTimestampGenerator/
+
+
+#### Accuracy
+
+As defined by ECMAScript, the `Date` object has millisecond resolution. The [`MononoticTimestampGenerator`][mtg]
+uses a incremental counter to generate the sub-millisecond part of the timestamp until the next clock tick.
+
+#### Monotonicity
+
+The [`MononoticTimestampGenerator`][mtg] implementation also guarantees that the returned timestamps will always be
+monotonically increasing, even if multiple updates happen under the same millisecond.
+
+Note that to guarantee such monotonicity, if more than one thousand timestamps are generated within the same
+millisecond, or in the event of a system clock skew, _the implementation might return timestamps that drift out into
+the future_. When this happens, the built-in generator log a periodic warning message. See their non-default
+constructors for ways to control the warning interval.
+
+
+### Provide the timestamp in the query
+
+Alternatively, if you are using a lower server version, you can explicitly provide the timestamp in your CQL query:
+
+```javascript
+client.execute('INSERT INTO my_table(c1, c2) VALUES (1, 1) USING TIMESTAMP 1482156745633040');
+```

--- a/doc/features/query-timestamps/README.md
+++ b/doc/features/query-timestamps/README.md
@@ -14,7 +14,7 @@ processed in a different order server-side, and end up with out-of-order timesta
 ### Using a timestamp generator
 
 When using Apache Cassandra 2.1+ or DataStax Enterprise 4.7+, it's possible to send the operation timestamp in the
-request. Starting from version 3.1 of the Node.js driver, the driver uses [`MononoticTimestampGenerator`][mtg] 
+request. Starting from version 3.2 of the Node.js driver, the driver uses [`MonotonicTimestampGenerator`][mtg] 
 by default to generate the request timestamps.
 
 You can provide a different generator when creating the `Client` instance:
@@ -51,7 +51,7 @@ monotonically increasing, even if multiple updates happen under the same millise
 
 Note that to guarantee such monotonicity, if more than one thousand timestamps are generated within the same
 millisecond, or in the event of a system clock skew, _the implementation might return timestamps that drift out into
-the future_. When this happens, the built-in generator log a periodic warning message. See their non-default
+the future_. When this happens, the built-in generator logs a periodic warning message. See their non-default
 constructors for ways to control the warning interval.
 
 

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -15,7 +15,8 @@ function defaultOptions () {
       addressResolution: policies.defaultAddressTranslator(),
       loadBalancing: policies.defaultLoadBalancingPolicy(),
       reconnection: policies.defaultReconnectionPolicy(),
-      retry: policies.defaultRetryPolicy()
+      retry: policies.defaultRetryPolicy(),
+      timestampGeneration: policies.defaultTimestampGenerator()
     },
     queryOptions: {
       consistency: types.consistencies.localOne,
@@ -89,6 +90,9 @@ function extend(baseOptions, userOptions) {
   if (!(options.policies.addressResolution instanceof policies.addressResolution.AddressTranslator)) {
     throw new TypeError('Address resolution policy must be an instance of AddressTranslator');
   }
+  if (!(options.policies.timestampGeneration instanceof policies.timestampGeneration.TimestampGenerator)) {
+    throw new TypeError('Timestamp generation policy must be an instance of TimestampGenerator');
+  }
   if (!options.queryOptions) {
     throw new TypeError('queryOptions not defined in options');
   }
@@ -153,6 +157,7 @@ function createQueryOptions(client, userOptions, rowCallback, logged) {
   // userOptions can be undefined and could be of type function (is an optional parameter)
   userOptions = (!userOptions || typeof userOptions === 'function') ? utils.emptyObject : userOptions;
   var defaultQueryOptions = client.options.queryOptions;
+
   // Using fixed property names is 2 order of magnitude faster than dynamically shallow clone objects
   var result = {
     autoPage: ifUndefined(userOptions.autoPage, defaultQueryOptions.autoPage),
@@ -175,7 +180,7 @@ function createQueryOptions(client, userOptions, rowCallback, logged) {
     routingNames: userOptions.routingNames,
     serialConsistency: ifUndefined3(
       userOptions.serialConsistency, profile.serialConsistency, defaultQueryOptions.serialConsistency),
-    timestamp: ifUndefined(userOptions.timestamp, defaultQueryOptions.timestamp),
+    timestamp: getTimestamp(client, userOptions, defaultQueryOptions.timestamp),
     traceQuery: ifUndefined(userOptions.traceQuery, defaultQueryOptions.traceQuery),
     // not part of query options
     rowCallback: rowCallback
@@ -211,6 +216,18 @@ function ifUndefined3(v1, v2, v3) {
     return v1;
   }
   return v2 !== undefined ? v2 : v3;
+}
+
+function getTimestamp(client, userOptions, defaultValue) {
+  var value = defaultValue;
+  if (typeof userOptions.timestamp !== 'undefined') {
+    value = userOptions.timestamp;
+  }
+  else if (client.controlConnection.protocolVersion > 2) {
+    // Use the timestamp generator
+    value = client.options.policies.timestampGeneration.next(client);
+  }
+  return value;
 }
 
 /**

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -90,7 +90,8 @@ function extend(baseOptions, userOptions) {
   if (!(options.policies.addressResolution instanceof policies.addressResolution.AddressTranslator)) {
     throw new TypeError('Address resolution policy must be an instance of AddressTranslator');
   }
-  if (!(options.policies.timestampGeneration instanceof policies.timestampGeneration.TimestampGenerator)) {
+  if (options.policies.timestampGeneration !== null &&
+      !(options.policies.timestampGeneration instanceof policies.timestampGeneration.TimestampGenerator)) {
     throw new TypeError('Timestamp generation policy must be an instance of TimestampGenerator');
   }
   if (!options.queryOptions) {
@@ -223,7 +224,7 @@ function getTimestamp(client, userOptions, defaultValue) {
   if (typeof userOptions.timestamp !== 'undefined') {
     value = userOptions.timestamp;
   }
-  else if (client.controlConnection.protocolVersion > 2) {
+  else if (client.controlConnection.protocolVersion > 2 && client.options.policies.timestampGeneration) {
     // Use the timestamp generator
     value = client.options.policies.timestampGeneration.next(client);
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -46,7 +46,13 @@ var warmupLimit = 32;
  * @property {RetryPolicy} policies.retry The retry policy.
  * @property {ReconnectionPolicy} policies.reconnection The reconnection policy to be used.
  * @property {AddressTranslator} policies.addressResolution The address resolution policy.
- * @property {TimestampGenerator} policies.timestampGeneration The client-side query timestamp generator.
+ * @property {TimestampGenerator} policies.timestampGeneration The client-side
+ * [query timestamp generator]{@link module:policies/timestampGeneration~TimestampGenerator}.
+ * <p>
+ *   Default: <code>[MonotonicTimestampGenerator]{@link module:policies/timestampGeneration~MonotonicTimestampGenerator}
+ *   </code>
+ * </p>
+ * <p>Use <code>null</code> to disable client-side timestamp generation.</p>
  * @property {QueryOptions} queryOptions Default options for all queries.
  * @property {Object} pooling Pooling options.
  * @property {Number} pooling.heartBeatInterval The amount of idle time in milliseconds that has to pass before the

--- a/lib/client.js
+++ b/lib/client.js
@@ -46,6 +46,7 @@ var warmupLimit = 32;
  * @property {RetryPolicy} policies.retry The retry policy.
  * @property {ReconnectionPolicy} policies.reconnection The reconnection policy to be used.
  * @property {AddressTranslator} policies.addressResolution The address resolution policy.
+ * @property {TimestampGenerator} policies.timestampGeneration The client-side query timestamp generator.
  * @property {QueryOptions} queryOptions Default options for all queries.
  * @property {Object} pooling Pooling options.
  * @property {Number} pooling.heartBeatInterval The amount of idle time in milliseconds that has to pass before the

--- a/lib/policies/index.js
+++ b/lib/policies/index.js
@@ -2,13 +2,15 @@
 
 /**
  * Contains driver tuning policies to determine [load balancing]{@link module:policies/loadBalancing},
- *  [retrying]{@link module:policies/retry} queries, [reconnecting]{@link module:policies/reconnection} to a node
- *  and [address resolution]{@link module:policies/addressResolution}.
+ *  [retrying]{@link module:policies/retry} queries, [reconnecting]{@link module:policies/reconnection} to a node,
+ *  [address resolution]{@link module:policies/addressResolution} and
+ *  [timestamp generation]{@link module:policies/timestampGeneration}.
  * <ul>
  *   <li>[policies/addressResolution]{@link module:policies/addressResolution}</li>
  *   <li>[policies/loadBalancing]{@link module:policies/loadBalancing}</li>
  *   <li>[policies/reconnection]{@link module:policies/reconnection}</li>
  *   <li>[policies/retry]{@link module:policies/retry}</li>
+ *   <li>[policies/timestampGeneration]{@link module:policies/timestampGeneration}</li>
  * </ul>
  * @module policies
  */
@@ -16,6 +18,7 @@ var addressResolution = exports.addressResolution = require('./address-resolutio
 var loadBalancing = exports.loadBalancing = require('./load-balancing');
 var reconnection = exports.reconnection = require('./reconnection');
 var retry = exports.retry = require('./retry');
+var timestampGeneration = exports.timestampGeneration = require('./timestamp-generation');
 
 /**
  * Returns a new instance of the default address translator policy used by the driver.
@@ -47,4 +50,12 @@ exports.defaultRetryPolicy = function () {
  */
 exports.defaultReconnectionPolicy = function () {
   return new reconnection.ExponentialReconnectionPolicy(1000, 10 * 60 * 1000, false);
+};
+
+/**
+ * Returns a new instance of the default timestamp generator used by the driver.
+ * @returns {TimestampGenerator}
+ */
+exports.defaultTimestampGenerator = function () {
+  return new timestampGeneration.MonotonicTimestampGenerator();
 };

--- a/lib/policies/index.js
+++ b/lib/policies/index.js
@@ -5,13 +5,6 @@
  *  [retrying]{@link module:policies/retry} queries, [reconnecting]{@link module:policies/reconnection} to a node,
  *  [address resolution]{@link module:policies/addressResolution} and
  *  [timestamp generation]{@link module:policies/timestampGeneration}.
- * <ul>
- *   <li>[policies/addressResolution]{@link module:policies/addressResolution}</li>
- *   <li>[policies/loadBalancing]{@link module:policies/loadBalancing}</li>
- *   <li>[policies/reconnection]{@link module:policies/reconnection}</li>
- *   <li>[policies/retry]{@link module:policies/retry}</li>
- *   <li>[policies/timestampGeneration]{@link module:policies/timestampGeneration}</li>
- * </ul>
  * @module policies
  */
 var addressResolution = exports.addressResolution = require('./address-resolution');

--- a/lib/policies/timestamp-generation.js
+++ b/lib/policies/timestamp-generation.js
@@ -1,0 +1,148 @@
+'use strict';
+
+var util = require('util');
+var Long = require('../types').Long;
+var errors = require('../errors');
+
+/** @module policies/timestampGeneration */
+
+/**
+ * Defines the maximum date in milliseconds that can be represented in microseconds using Number ((2 ^ 53) / 1000)
+ * @const
+ * @private
+ */
+var _maxSafeNumberDate = 9007199254740;
+
+/**
+ * A long representing the value 1000
+ * @const
+ * @private
+ */
+var _longOneThousand = Long.fromInt(1000);
+
+/**
+ * Creates a new instance of {@link TimestampGenerator}.
+ * @classdesc
+ * Generates client-side, microsecond-precision query timestamps.
+ * <p>
+ *   Given that Cassandra uses those timestamps to resolve conflicts, implementations should generate
+ *   monotonically increasing timestamps for successive invocations of {@link TimestampGenerator.next()}.
+ * </p>
+ * @constructor
+ */
+function TimestampGenerator() {
+
+}
+
+/**
+ * Returns the next timestamp.
+ * <p>
+ *   Implementors should enforce increasing monotonicity of timestamps, that is,
+ *   a timestamp returned should always be strictly greater that any previously returned
+ *   timestamp.
+ * <p/>
+ * <p>
+ *   Implementors should strive to achieve microsecond precision in the best possible way,
+ *   which is usually largely dependent on the underlying operating system's capabilities.
+ * </p>
+ * @param {Client} client The {@link Client} instance to generate timestamps to.
+ * @returns {Long|Number|null} the next timestamp (in microseconds). If it's equals to <code>null</code>, it won't be
+ * sent by the driver, letting the server to generate the timestamp.
+ * @abstract
+ */
+TimestampGenerator.prototype.next = function (client) {
+  throw new Error('next() must be implemented');
+};
+
+/**
+ * A timestamp generator that guarantees monotonically increasing timestamps and logs warnings when timestamps
+ * drift in the future.
+ * <p>
+ *   {@link Date} has millisecond precision and client timestamps require microsecond precision. This generator
+ *   keeps track of the last generated timestamp, and if the current time is within the same millisecond as the last,
+ *   it fills the microsecond portion of the new timestamp with the value of an incrementing counter.
+ * </p>
+ * @param {Number} [warningThreshold] Determines how far in the future timestamps are allowed to drift before a
+ * warning is logged, expressed in milliseconds. Default: <code>1000</code>.
+ * @param {Number} [minLogInterval] In case of multiple log events, it determines the time separation between log events,
+ * expressed in milliseconds. Use 0 to disable. Default: <code>1000</code>.
+ * @extends {TimestampGenerator}
+ * @constructor
+ */
+function MonotonicTimestampGenerator(warningThreshold, minLogInterval) {
+  if (warningThreshold < 0) {
+    throw new errors.ArgumentError('warningThreshold can not be lower than 0');
+  }
+  this._warningThreshold = warningThreshold || 1000;
+  this._minLogInterval = minLogInterval || 1000;
+  this._micros = -1;
+  this._lastDate = 0;
+  this._lastLogDate = 0;
+}
+
+util.inherits(MonotonicTimestampGenerator, TimestampGenerator);
+
+/**
+ * Returns the current time in milliseconds since UNIX epoch
+ * @returns {Number}
+ */
+MonotonicTimestampGenerator.prototype.getDate = function () {
+  return Date.now();
+};
+
+MonotonicTimestampGenerator.prototype.next = function (client) {
+  var date = this.getDate();
+  var drifted = 0;
+  if (date > this._lastDate) {
+    this._micros = 0;
+    this._lastDate = date;
+    return this._generateMicroseconds();
+  }
+
+  if (date < this._lastDate) {
+    drifted = this._lastDate - date;
+    date = this._lastDate;
+  }
+  if (++this._micros === 1000) {
+    this._micros = 0;
+    if (date === this._lastDate) {
+      // Move date 1 millisecond into the future
+      date++;
+      drifted++;
+    }
+  }
+  if (drifted >= this._warningThreshold) {
+    // Avoid logging an unbounded amount of times within a clock-skew event or during an interval when more than 1
+    // query is being issued by microsecond
+    var currentLogDate = Date.now();
+    if (this._minLogInterval > 0 && this._lastLogDate + this._minLogInterval <= currentLogDate){
+      var message = util.format(
+        'Timestamp generated using current date was %d milliseconds behind the last generated timestamp, returned ' +
+        'value will be artificially incremented to guarantee monotonicity.',
+        drifted);
+      this._lastLogDate = currentLogDate;
+      client.log('warning', message);
+    }
+  }
+  this._lastDate = date;
+  return this._generateMicroseconds();
+};
+
+/**
+ * @private
+ * @returns {Number|Long}
+ */
+MonotonicTimestampGenerator.prototype._generateMicroseconds = function () {
+  if (this._lastDate < _maxSafeNumberDate) {
+    // We are safe until Jun 06 2255, its faster to perform this operations on Number than on Long
+    // We hope to have native int64 by then :)
+    return this._lastDate * 1000 + this._micros;
+  }
+  return Long
+    .fromNumber(this._lastDate)
+    .multiply(_longOneThousand)
+    .add(Long.fromInt(this._micros));
+};
+
+exports.TimestampGenerator = TimestampGenerator;
+exports.MonotonicTimestampGenerator = MonotonicTimestampGenerator;

--- a/lib/policies/timestamp-generation.js
+++ b/lib/policies/timestamp-generation.js
@@ -115,21 +115,24 @@ MonotonicTimestampGenerator.prototype.next = function (client) {
       drifted++;
     }
   }
+  var lastDate = this._lastDate;
+  this._lastDate = date;
+  var result = this._generateMicroseconds();
   if (drifted >= this._warningThreshold) {
     // Avoid logging an unbounded amount of times within a clock-skew event or during an interval when more than 1
     // query is being issued by microsecond
     var currentLogDate = Date.now();
     if (this._minLogInterval > 0 && this._lastLogDate + this._minLogInterval <= currentLogDate){
       var message = util.format(
-        'Timestamp generated using current date was %d milliseconds behind the last generated timestamp (%d),' +
-        'returned value (%d) is being artificially incremented to guarantee monotonicity.',
-        drifted, this._lastDate, date);
+        'Timestamp generated using current date was %d milliseconds behind the last generated timestamp (which ' +
+        'millisecond portion was %d), the returned value (%s) is being artificially incremented to guarantee ' +
+        'monotonicity.',
+        drifted, lastDate, result);
       this._lastLogDate = currentLogDate;
       client.log('warning', message);
     }
   }
-  this._lastDate = date;
-  return this._generateMicroseconds();
+  return result;
 };
 
 /**

--- a/lib/policies/timestamp-generation.js
+++ b/lib/policies/timestamp-generation.js
@@ -64,8 +64,8 @@ TimestampGenerator.prototype.next = function (client) {
  * </p>
  * @param {Number} [warningThreshold] Determines how far in the future timestamps are allowed to drift before a
  * warning is logged, expressed in milliseconds. Default: <code>1000</code>.
- * @param {Number} [minLogInterval] In case of multiple log events, it determines the time separation between log events,
- * expressed in milliseconds. Use 0 to disable. Default: <code>1000</code>.
+ * @param {Number} [minLogInterval] In case of multiple log events, it determines the time separation between log
+ * events, expressed in milliseconds. Use 0 to disable. Default: <code>1000</code>.
  * @extends {TimestampGenerator}
  * @constructor
  */
@@ -74,7 +74,11 @@ function MonotonicTimestampGenerator(warningThreshold, minLogInterval) {
     throw new errors.ArgumentError('warningThreshold can not be lower than 0');
   }
   this._warningThreshold = warningThreshold || 1000;
-  this._minLogInterval = minLogInterval || 1000;
+  this._minLogInterval = 1000;
+  if (typeof minLogInterval === 'number') {
+    // A value under 1 will disable logging
+    this._minLogInterval = minLogInterval;
+  }
   this._micros = -1;
   this._lastDate = 0;
   this._lastLogDate = 0;
@@ -117,9 +121,9 @@ MonotonicTimestampGenerator.prototype.next = function (client) {
     var currentLogDate = Date.now();
     if (this._minLogInterval > 0 && this._lastLogDate + this._minLogInterval <= currentLogDate){
       var message = util.format(
-        'Timestamp generated using current date was %d milliseconds behind the last generated timestamp, returned ' +
-        'value will be artificially incremented to guarantee monotonicity.',
-        drifted);
+        'Timestamp generated using current date was %d milliseconds behind the last generated timestamp (%d),' +
+        'returned value (%d) is being artificially incremented to guarantee monotonicity.',
+        drifted, this._lastDate, date);
       this._lastLogDate = currentLogDate;
       client.log('warning', message);
     }

--- a/test/unit/basic-tests.js
+++ b/test/unit/basic-tests.js
@@ -9,6 +9,7 @@ var types = require('../../lib/types');
 var dataTypes = types.dataTypes;
 var loadBalancing = require('../../lib/policies/load-balancing.js');
 var retry = require('../../lib/policies/retry.js');
+var timestampGeneration = require('../../lib/policies/timestamp-generation');
 var Encoder = require('../../lib/encoder');
 var utils = require('../../lib/utils.js');
 var writers = require('../../lib/writers');
@@ -781,6 +782,10 @@ describe('exports', function () {
     assert.strictEqual(api.policies.reconnection, require('../../lib/policies/reconnection'));
     assert.strictEqual(typeof api.policies.reconnection.ReconnectionPolicy, 'function');
     helper.assertInstanceOf(api.policies.defaultReconnectionPolicy(), api.policies.reconnection.ReconnectionPolicy);
+    assert.strictEqual(api.policies.timestampGeneration, timestampGeneration);
+    assert.strictEqual(typeof timestampGeneration.TimestampGenerator, 'function');
+    assert.strictEqual(typeof timestampGeneration.MonotonicTimestampGenerator, 'function');
+    helper.assertInstanceOf(api.policies.defaultTimestampGenerator(), timestampGeneration.MonotonicTimestampGenerator);
     assert.strictEqual(api.auth, require('../../lib/auth'));
     //metadata module with classes
     assert.ok(api.metadata);

--- a/test/unit/client-tests.js
+++ b/test/unit/client-tests.js
@@ -465,6 +465,30 @@ describe('Client', function () {
       client.execute('Q1', [], { consistency: types.consistencies.all, executionProfile: profile }, utils.noop);
       helper.compareProps(queryOptions, previousQueryOptions, Object.keys(queryOptions), ['executionProfile']);
     });
+    it('should set the timestamp', function (done) {
+      var actualOptions;
+      var handlerMock = function () {};
+      handlerMock.prototype.send = function (request, options, callback) {
+        actualOptions = options;
+        callback(null, {});
+      };
+      var client = newConnectedInstance(handlerMock);
+      utils.eachSeries([1, 2, 3, 4], function (version, next) {
+        client.controlConnection.protocolVersion = version;
+        client.execute('Q', function (err) {
+          assert.ifError(err);
+          assert.ok(actualOptions);
+          if (version > 2) {
+            assert.ok(actualOptions.timestamp);
+            assert.ok((actualOptions.timestamp instanceof types.Long) || typeof actualOptions.timestamp === 'number');
+          }
+          else {
+            assert.strictEqual(actualOptions.timestamp, undefined);
+          }
+          next();
+        });
+      }, done);
+    });
     context('with no callback specified', function () {
       if (!helper.promiseSupport) {
         it('should throw an error', function () {
@@ -541,6 +565,30 @@ describe('Client', function () {
         assert.strictEqual(connectCalled, true);
         done();
       });
+    });
+    it('should set the timestamp', function (done) {
+      var actualOptions;
+      var handlerMock = function () {};
+      handlerMock.prototype.send = function (request, options, callback) {
+        actualOptions = options;
+        callback(null, {});
+      };
+      var client = newConnectedInstance(handlerMock);
+      utils.eachSeries([1, 2, 3, 4], function (version, next) {
+        client.controlConnection.protocolVersion = version;
+        client.batch(['q1', 'q2', 'q3'], function (err) {
+          assert.ifError(err);
+          assert.ok(actualOptions);
+          if (version > 2) {
+            assert.ok(actualOptions.timestamp);
+            assert.ok((actualOptions.timestamp instanceof types.Long) || typeof actualOptions.timestamp === 'number');
+          }
+          else {
+            assert.strictEqual(actualOptions.timestamp, undefined);
+          }
+          next();
+        });
+      }, done);
     });
     context('with no callback specified', function () {
       if (!helper.promiseSupport) {

--- a/test/unit/client-tests.js
+++ b/test/unit/client-tests.js
@@ -489,6 +489,22 @@ describe('Client', function () {
         });
       }, done);
     });
+    it('should not set the timestamp when timestampGeneration is null', function (done) {
+      var actualOptions;
+      var handlerMock = function () {};
+      handlerMock.prototype.send = function (request, options, callback) {
+        actualOptions = options;
+        callback(null, {});
+      };
+      var client = newConnectedInstance(handlerMock, { policies: { timestampGeneration: null }});
+      client.controlConnection.protocolVersion = 4;
+      client.execute('Q', function (err) {
+        assert.ifError(err);
+        assert.ok(actualOptions);
+        assert.strictEqual(actualOptions.timestamp, undefined);
+        done();
+      });
+    });
     context('with no callback specified', function () {
       if (!helper.promiseSupport) {
         it('should throw an error', function () {
@@ -1121,10 +1137,10 @@ function newProfileManager(options) {
   return new ProfileManager(getOptions(options));
 }
 
-function newConnectedInstance(requestHandlerMock) {
+function newConnectedInstance(requestHandlerMock, options) {
   var Client = rewire('../../lib/client.js');
   Client.__set__("RequestHandler", requestHandlerMock || function () {});
-  var client = new Client(helper.baseOptions);
+  var client = new Client(utils.extend({}, helper.baseOptions, options));
   client._getEncoder = function () { return new Encoder(2, {})};
   client.connect = helper.callbackNoop;
   return client;

--- a/test/unit/timestamp-tests.js
+++ b/test/unit/timestamp-tests.js
@@ -1,0 +1,80 @@
+'use strict';
+
+var assert = require('assert');
+var MonotonicTimestampGenerator = require('../../lib/policies/timestamp-generation').MonotonicTimestampGenerator;
+var Long = require('../../lib/types').Long;
+var helper = require('../test-helper');
+
+describe('MonotonicTimestampGenerator', function () {
+  describe('#next()', function () {
+    it('should return a Number when the current date is before Jun 06 2255', function () {
+      var g = new MonotonicTimestampGenerator();
+      g.getDate = function () {
+        return 9007199254739;
+      };
+      var value = g.next();
+      assert.strictEqual(typeof value, 'number');
+    });
+    it('should return a Long when the current date is after Jun 06 2255', function () {
+      var g = new MonotonicTimestampGenerator();
+      g.getDate = function () {
+        return 9007199254740;
+      };
+      var value = g.next();
+      helper.assertInstanceOf(value, Long);
+    });
+    it('should log a warning once when it drifted into the future', function (done) {
+      var g = new MonotonicTimestampGenerator(null, 50);
+      var counter = 0;
+      g.getDate = function () {
+        if (counter++ === 0) {
+          return 1000;
+        }
+        return 0;
+      };
+      var logs = [];
+      var client = {
+        log: function (level, message) {
+          logs.push({ level: level, message: message });
+        }
+      };
+      for (var i = 0; i < 200; i++) {
+        var value = g.next(client);
+        assert.strictEqual(value, 1000000 + i);
+      }
+      assert.strictEqual(logs.length, 1);
+      assert.strictEqual(logs[0].level, 'warning');
+      assert.strictEqual(logs[0].message.indexOf('Timestamp generated'), 0);
+      setTimeout(function () {
+        // A second warning should be issued
+        assert.strictEqual(g.next(client), 1000200);
+        assert.strictEqual(logs.length, 2);
+        assert.strictEqual(logs[1].level, 'warning');
+        done();
+      }, 100)
+    });
+    it('should use the current date', function () {
+      var g = new MonotonicTimestampGenerator();
+      var longThousand = Long.fromInt(1000);
+      var startDate = Long.fromNumber(Date.now()).multiply(longThousand);
+      var value = g.next();
+      var endDate = Long.fromNumber(Date.now()).multiply(longThousand);
+      var longValue = value instanceof Long ? value : Long.fromNumber(value);
+      assert.ok(longValue.greaterThanOrEqual(startDate));
+      assert.ok(longValue.lessThanOrEqual(endDate));
+    });
+    it('should increment the microseconds portion for the same date', function () {
+      var g = new MonotonicTimestampGenerator();
+      g.getDate = function () {
+        // Use a fixed date
+        return 1;
+      };
+      for (var i = 0; i < 1000; i++) {
+        var value = g.next();
+        assert.strictEqual(value, 1000 + i);
+      }
+      // Should drift into the future
+      assert.strictEqual(g.next(), 2000);
+    });
+  });
+});

--- a/test/unit/timestamp-tests.js
+++ b/test/unit/timestamp-tests.js
@@ -51,7 +51,7 @@ describe('MonotonicTimestampGenerator', function () {
         assert.strictEqual(logs.length, 2);
         assert.strictEqual(logs[1].level, 'warning');
         done();
-      }, 100)
+      }, 100);
     });
     it('should use the current date', function () {
       var g = new MonotonicTimestampGenerator();


### PR DESCRIPTION
Some notes:
- Similar to the `timestamp` query option, the generator api allows both `Long` instances and `Number` types, which increases the complexity a little but considering than with the integer part of the double (`2^53`) we can represents dates until year 2255 with microsecond precision, I think its worth the effort. Arithmetic operations are much slower with `Long` than with `Number`, let's hope that [`int64` representation](https://t.co/8LDnAEa44W) lands in ECMAScript before 2255 :)
- I've enabled timestamp generation by default, which is a behavioural change on a minor version but I can not think of any downside, as server-side generation seems worst and the if the user provides a `timestamp` per execution, it's precedes the generated value.
