### PR TITLE
NODEJS-333: Reduce number of configurations to build in jenkins on commit

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,33 @@
+schedules:
+  commit:
+    # per commit job for all branches to run a subset of configs.
+    schedule: per_commit
+    matrix:
+      exclude:
+        # Exclude all 0.12 and 4 builds.
+        - nodejs: ['0.12', '4']
+        # Only build with latest for 0.10
+        - nodejs: '0.10'
+          cassandra: ['1.2', '2.0', '2.1', '2.2', '3.0']
+        # Only build with 1.2 and latest for 0.10
+        - nodejs: '6'
+          cassandra: ['2.0', '2.1', '2.2', '3.0']
+  nightly:
+    # nightly job for primary branches to run all configs.
+    schedule: nightly
+    branches:
+      # regex matches primary branch format (2.1, 3.x, 3.0.x, 3.1.x, master, etc).
+      include: ["/((\\d+(\\.[\\dx]+)+)|master)/"]
+  adhoc:
+    # adhoc job for non-primary braches that doesn't have a schedule but may be used to run all configs.
+    schedule: adhoc
+    branches: 
+      exclude: ["/((\\d+(\\.[\\dx]+)+)|master)/"]
 nodejs:
-  - "0.10"
-  - "0.12"
-  - "4"
-  - "6"
+  - '0.10'
+  - '0.12'
+  - '4'
+  - '6'
 os:
   - ubuntu/trusty64
 cassandra:
@@ -11,7 +36,7 @@ cassandra:
   - 2.1
   - 2.2
   - 3.0
-  - 3.7
+  - 3.9
 build:
   - type: envinject
     properties: |


### PR DESCRIPTION
On commit for all branches create a 'per_commit' job that runs the
following configurations:

  * nodejs 0.10 with latest C*
  * nodejs 6 with C* 1.2 and latest

On primary branches, create a 'nightly' job that runs all
configurations nightly if there were any changes.

Note that the 'nightly' jobs wont be created until the build.yaml lands on those branches.