### PR TITLE
Test: Add helper.setup() method

### DIFF
--- a/test/integration/short/client-execute-prepared-tests.js
+++ b/test/integration/short/client-execute-prepared-tests.js
@@ -17,18 +17,12 @@ describe('Client', function () {
   describe('#execute(query, params, {prepare: 1}, callback)', function () {
     var commonKs = helper.getRandomName('ks');
     var commonTable = commonKs + '.' + helper.getRandomName('table');
-    before(function (done) {
-      var client = newInstance({ pooling: { heartBeatInterval: 0}});
-      utils.series([
-        helper.ccmHelper.start(3),
-        helper.toTask(client.execute, client, helper.createKeyspaceCql(commonKs, 3)),
-        helper.toTask(client.execute, client, helper.createTableWithClusteringKeyCql(commonTable)),
-        client.shutdown.bind(client)
-      ], done);
+    var setupInfo = helper.setup(3, {
+      keyspace: commonKs,
+      queries: [ helper.createTableWithClusteringKeyCql(commonTable) ]
     });
-    after(helper.ccmHelper.remove);
     it('should execute a prepared query with parameters on all hosts', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       var query = util.format('SELECT * FROM %s WHERE id1 = ?', commonTable);
       utils.timesSeries(3, function (n, next) {
         client.execute(query, [types.Uuid.random()], {prepare: 1}, function (err, result) {
@@ -41,7 +35,7 @@ describe('Client', function () {
       }, done);
     });
     it('should callback with error when query is invalid', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       var query = 'SELECT WILL FAIL';
       client.execute(query, ['system'], {prepare: 1}, function (err) {
         assert.ok(err);
@@ -51,7 +45,7 @@ describe('Client', function () {
       });
     });
     it('should prepare and execute a query without parameters', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       client.execute(helper.queries.basic, null, {prepare: 1}, function (err, result) {
         assert.ifError(err);
         assert.ok(result);
@@ -60,7 +54,7 @@ describe('Client', function () {
       });
     });
     it('should prepare and execute a queries in parallel', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       var queries = [
         helper.queries.basic,
         helper.queries.basicNoResults,
@@ -84,7 +78,7 @@ describe('Client', function () {
       }, done);
     });
     it('should fail following times if it fails to prepare', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       utils.series([function (seriesNext) {
         //parallel
         utils.times(10, function (n, next) {
@@ -107,7 +101,7 @@ describe('Client', function () {
       }], done);
     });
     it('should fail if the type does not match', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       client.execute(util.format('SELECT * FROM %s WHERE id1 = ?', commonTable), [1000], {prepare: 1}, function (err) {
         helper.assertInstanceOf(err, Error);
         helper.assertInstanceOf(err, TypeError);
@@ -119,21 +113,21 @@ describe('Client', function () {
         true, new Date(1221111111), types.InetAddress.fromString('10.12.0.1'), null, null, null];
       var columnNames = 'id, ascii_sample, text_sample, int_sample, bigint_sample, double_sample, blob_sample, ' +
         'boolean_sample, timestamp_sample, inet_sample, timeuuid_sample, list_sample, set_sample';
-      serializationTest(values, columnNames, done);
+      serializationTest(setupInfo.client, values, columnNames, done);
     });
     it('should serialize all null values', function (done) {
       var values = [types.Uuid.random(), null, null, null, null, null, null, null, null, null, null, null, null];
       var columnNames = 'id, ascii_sample, text_sample, int_sample, bigint_sample, double_sample, blob_sample, boolean_sample, timestamp_sample, inet_sample, timeuuid_sample, list_sample, set_sample';
-      serializationTest(values, columnNames, done);
+      serializationTest(setupInfo.client, values, columnNames, done);
     });
     it('should use prepared metadata to determine the type of params in query', function (done) {
       var values = [types.Uuid.random(), types.TimeUuid.now(), [1, 1000, 0], {k: '1'}, 1, -100019, ['arr'], types.InetAddress.fromString('192.168.1.1')];
       var columnNames = 'id, timeuuid_sample, list_sample2, map_sample, int_sample, float_sample, set_sample, inet_sample';
-      serializationTest(values, columnNames, done);
+      serializationTest(setupInfo.client, values, columnNames, done);
     });
     vit('2.0', 'should support IN clause with 1 marker', function (done) {
-      var client = newInstance();
-      client.execute(util.format('SELECT * FROM %s WHERE id1 IN ?', commonTable), [[Uuid.random(), Uuid.random()]], {prepare: 1}, function (err, result) {
+      var query = util.format('SELECT * FROM %s WHERE id1 IN ?', commonTable);
+      setupInfo.client.execute(query, [ [ Uuid.random(), Uuid.random() ] ], { prepare: true }, function (err, result) {
         assert.ifError(err);
         assert.ok(result);
         assert.strictEqual(typeof result.rows.length, 'number');
@@ -141,7 +135,10 @@ describe('Client', function () {
       });
     });
     vit('2.0', 'should use pageState and fetchSize', function (done) {
-      var client = newInstance();
+      var client = newInstance({
+        keyspace: setupInfo.keyspace,
+        queryOptions: { consistency: types.consistencies.quorum }
+      });
       var pageState;
       var metaPageState;
       var keyspace = helper.getRandomName('ks');
@@ -180,11 +177,12 @@ describe('Client', function () {
             assert.strictEqual(result.rows.length, 30);
             seriesNext();
           });
-        }
+        },
+        client.shutdown.bind(client)
       ], done);
     });
     it('should encode and decode varint values', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       var keyspace = helper.getRandomName('ks');
       var table = keyspace + '.' + helper.getRandomName('table');
       var expectedRows = {};
@@ -220,7 +218,7 @@ describe('Client', function () {
       ], done);
     });
     it('should encode and decode decimal values', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       var keyspace = helper.getRandomName('ks');
       var table = keyspace + '.' + helper.getRandomName('table');
       var expectedRows = {};
@@ -259,9 +257,8 @@ describe('Client', function () {
     });
     describe('with named parameters', function () {
       vit('2.0', 'should allow an array of parameters', function (done) {
-        var client = newInstance();
         var query = util.format('SELECT * FROM %s WHERE id1 = :id1', commonTable);
-        client.execute(query, [Uuid.random()], {prepare: 1}, function (err, result) {
+        setupInfo.client.execute(query, [ Uuid.random() ], { prepare: 1 }, function (err, result) {
           assert.ifError(err);
           assert.ok(result && result.rows);
           assert.strictEqual(typeof result.rows.length, 'number');
@@ -269,9 +266,8 @@ describe('Client', function () {
         });
       });
       vit('2.0', 'should allow associative array of parameters', function (done) {
-        var client = newInstance();
         var query = util.format('SELECT * FROM %s WHERE id1 = :id1', commonTable);
-        client.execute(query, {'id1': Uuid.random()}, {prepare: 1}, function (err, result) {
+        setupInfo.client.execute(query, {'id1': Uuid.random()}, {prepare: 1}, function (err, result) {
           assert.ifError(err);
           assert.ok(result && result.rows);
           assert.strictEqual(typeof result.rows.length, 'number');
@@ -279,9 +275,8 @@ describe('Client', function () {
         });
       });
       vit('2.0', 'should be case insensitive', function (done) {
-        var client = newInstance();
         var query = util.format('SELECT * FROM %s WHERE id1 = :ID1', commonTable);
-        client.execute(query, {'iD1': Uuid.random()}, {prepare: 1}, function (err, result) {
+        setupInfo.client.execute(query, {'iD1': Uuid.random()}, {prepare: 1}, function (err, result) {
           assert.ifError(err);
           assert.ok(result && result.rows);
           assert.strictEqual(typeof result.rows.length, 'number');
@@ -289,9 +284,8 @@ describe('Client', function () {
         });
       });
       vit('2.0', 'should allow objects with other props as parameters', function (done) {
-        var client = newInstance();
         var query = util.format('SELECT * FROM %s WHERE id1 = :ID1', commonTable);
-        client.execute(query, {'ID1': Uuid.random(), other: 'value'}, {prepare: 1}, function (err, result) {
+        setupInfo.client.execute(query, {'ID1': Uuid.random(), other: 'value'}, {prepare: 1}, function (err, result) {
           assert.ifError(err);
           assert.ok(result && result.rows);
           assert.strictEqual(typeof result.rows.length, 'number');
@@ -420,9 +414,8 @@ describe('Client', function () {
       ], done);
     });
     vit('2.1', 'should support protocol level timestamp', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       var id = Uuid.random();
-      //noinspection JSCheckFunctionSignatures
       var timestamp = types.generateTimestamp(new Date(), 456);
       utils.series([
         function insert(next) {
@@ -512,20 +505,18 @@ describe('Client', function () {
       client.execute(query, params, {prepare: true}, function (err, result) {
         assert.ifError(err);
         assert.ok(result.info.warnings);
-        assert.strictEqual(result.info.warnings.length, 1);
+        assert.ok(result.info.warnings.length >= 1);
         helper.assertContains(result.info.warnings[0], 'batch');
-        helper.assertContains(result.info.warnings[0], 'exceeding');
         assert.ok(loggedMessage);
         client.shutdown(done);
       });
     });
     it('should support hardcoded parameters that are part of the routing key', function (done) {
-      var client = newInstance({ keyspace: commonKs});
+      var client = setupInfo.client;
       var table = helper.getRandomName('tbl');
       var createQuery = util.format('CREATE TABLE %s (a int, b int, c int, d int, ' +
         'PRIMARY KEY ((a, b, c)))', table);
       utils.series([
-        client.connect.bind(client),
         helper.toTask(client.execute, client, createQuery),
         function (next) {
           var query = util.format('SELECT * FROM %s WHERE c = ? AND a = ? AND b = 0', table);
@@ -533,8 +524,7 @@ describe('Client', function () {
             assert.ifError(err);
             next();
           });
-        },
-        client.shutdown.bind(client)
+        }
       ], done);
     });
     it('should allow undefined value as a null or unset depending on the protocol version', function (done) {
@@ -566,10 +556,9 @@ describe('Client', function () {
       ], done);
     });
     it('should not allow collections with null or unset values', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       var tid = types.TimeUuid.now();
       utils.series([
-        client.connect.bind(client),
         function testListWithNull(next) {
           var query = util.format('INSERT INTO %s (id1, id2, list_sample) VALUES (?, ?, ?)', commonTable);
           client.execute(query, [Uuid.random(), tid, [tid, null]], { prepare: true}, function (err) {
@@ -617,26 +606,23 @@ describe('Client', function () {
             helper.assertInstanceOf(err, TypeError);
             next();
           });
-        },
-        client.shutdown.bind(client)
+        }
       ], done);
     });
     describe('with udt and tuple', function () {
       before(function (done) {
-        var client = newInstance({ keyspace: commonKs });
+        var client = setupInfo.client;
         utils.series([
-          client.connect.bind(client),
           helper.toTask(client.execute, client, 'CREATE TYPE phone (alias text, number text, country_code int, other boolean)'),
           helper.toTask(client.execute, client, 'CREATE TYPE address (street text, "ZIP" int, phones set<frozen<phone>>)'),
           helper.toTask(client.execute, client, 'CREATE TABLE tbl_udts (id uuid PRIMARY KEY, phone_col frozen<phone>, address_col frozen<address>)'),
-          helper.toTask(client.execute, client, 'CREATE TABLE tbl_tuples (id uuid PRIMARY KEY, tuple_col1 tuple<text,int>, tuple_col2 tuple<uuid,bigint,boolean>)'),
-          client.shutdown.bind(client)
+          helper.toTask(client.execute, client, 'CREATE TABLE tbl_tuples (id uuid PRIMARY KEY, tuple_col1 tuple<text,int>, tuple_col2 tuple<uuid,bigint,boolean>)')
         ], done);
       });
       vit('2.1', 'should encode objects into udt', function (done) {
         var insertQuery = 'INSERT INTO tbl_udts (id, phone_col, address_col) VALUES (?, ?, ?)';
         var selectQuery = 'SELECT id, phone_col, address_col FROM tbl_udts WHERE id = ?';
-        var client = newInstance({ keyspace: commonKs, queryOptions: { prepare: true}});
+        var client = newInstance({ keyspace: commonKs, queryOptions: { prepare: true }});
         var id = Uuid.random();
         var phone = { alias: 'work2', number: '555 9012', country_code: 54};
         var address = { street: 'DayMan', ZIP: 28111, phones: [ { alias: 'personal'} ]};
@@ -661,7 +647,8 @@ describe('Client', function () {
               assert.strictEqual(addressResult.phones[0].number, null);
               next();
             });
-          }
+          },
+          client.shutdown.bind(client)
         ], done);
       });
       vit('2.1', 'should handle changes in table schema with udts', function (done) {
@@ -769,11 +756,9 @@ describe('Client', function () {
       var insertQuery = 'INSERT INTO tbl_smallints (id, smallint_sample, tinyint_sample) VALUES (?, ?, ?)';
       var selectQuery = 'SELECT id, smallint_sample, tinyint_sample FROM tbl_smallints WHERE id = ?';
       before(function (done) {
-        var client = newInstance({ keyspace: commonKs });
-        utils.series([
-          client.connect.bind(client),
-          helper.toTask(client.execute, client, 'CREATE TABLE tbl_smallints (id uuid PRIMARY KEY, smallint_sample smallint, tinyint_sample tinyint, text_sample text)')
-        ], done);
+        var query = 'CREATE TABLE tbl_smallints ' +
+          '(id uuid PRIMARY KEY, smallint_sample smallint, tinyint_sample tinyint, text_sample text)';
+        setupInfo.client.execute(query, done);
       });
       vit('2.2', 'should encode and decode smallint and tinyint values as Number', function (done) {
         var values = [
@@ -782,7 +767,7 @@ describe('Client', function () {
           [Uuid.random(), -1, -2],
           [Uuid.random(), -130, -128]
         ];
-        var client = newInstance({ keyspace: commonKs });
+        var client = setupInfo.client;
         utils.eachSeries(values, function (params, next) {
           client.execute(insertQuery, params, { prepare: true}, function (err) {
             assert.ifError(err);
@@ -807,12 +792,9 @@ describe('Client', function () {
       var insertQuery = 'INSERT INTO tbl_datetimes (id, date_sample, time_sample) VALUES (?, ?, ?)';
       var selectQuery = 'SELECT id, date_sample, time_sample FROM tbl_datetimes WHERE id = ?';
       before(function (done) {
-        var client = newInstance({ keyspace: commonKs });
-        utils.series([
-          client.connect.bind(client),
-          helper.toTask(client.execute, client, 'CREATE TABLE tbl_datetimes (id uuid PRIMARY KEY, date_sample date, time_sample time, text_sample text)'),
-          client.shutdown.bind(client)
-        ], done);
+        var query = 'CREATE TABLE tbl_datetimes ' +
+          '(id uuid PRIMARY KEY, date_sample date, time_sample time, text_sample text)';
+        setupInfo.client.execute(query, done);
       });
       vit('2.2', 'should encode and decode date and time values as LocalDate and LocalTime', function (done) {
         var values = [
@@ -822,7 +804,7 @@ describe('Client', function () {
           [Uuid.random(), new LocalDate(1983, 2, 24), new LocalTime(types.Long.fromString('86399999999999'))],
           [Uuid.random(), new LocalDate(-2147483648), new LocalTime(types.Long.fromString('6311999549933'))]
         ];
-        var client = newInstance({ keyspace: commonKs });
+        var client = setupInfo.client;
         utils.eachSeries(values, function (params, next) {
           client.execute(insertQuery, params, { prepare: true}, function (err) {
             assert.ifError(err);
@@ -840,7 +822,7 @@ describe('Client', function () {
               next();
             });
           });
-        }, helper.finish(client, done));
+        }, done);
       });
     });
     describe('with unset', function () {
@@ -891,16 +873,8 @@ describe('Client', function () {
       });
     });
     describe('with secondary indexes', function() {
-      var keyspace = helper.getRandomName('ks');
-      before(function createSchema(done) {
-        var client = newInstance();
-        utils.series([
-          helper.toTask(client.execute, client, helper.createKeyspaceCql(keyspace, 3)),
-          client.shutdown.bind(client)
-        ], done);
-      });
       it('should be able to retrieve using simple index', function(done) {
-        var client = newInstance({ keyspace: keyspace });
+        var client = setupInfo.client;
         var table = helper.getRandomName('tbl');
         utils.series([
           helper.toTask(client.execute, client, util.format("CREATE TABLE %s (k int PRIMARY KEY, v int)", table)),
@@ -924,12 +898,11 @@ describe('Client', function () {
               assert.deepEqual(keys, [0, 10, 20, 30, 40, 50, 60, 70, 80, 90]);
               seriesNext();
             });
-          },
-          client.shutdown.bind(client)
+          }
         ],done);
       });
       vit('2.1', 'should be able to retrieve using index on frozen list', function(done) {
-        var client = newInstance({ keyspace: keyspace });
+        var client = setupInfo.client;
         var table = helper.getRandomName('tbl');
         utils.series([
           helper.toTask(client.execute, client, util.format("CREATE TABLE %s (k int PRIMARY KEY, v frozen<list<int>>)", table)),
@@ -950,12 +923,11 @@ describe('Client', function () {
               assert.deepEqual(row['v'], [20,19,18]);
               seriesNext();
             });
-          },
-          client.shutdown.bind(client)
+          }
         ],done);
       });
       vit('2.1', 'should be able to retrieve using index on map keys', function(done) {
-        var client = newInstance({ keyspace: keyspace });
+        var client = setupInfo.client;
         var table = helper.getRandomName('tbl');
         utils.series([
           helper.toTask(client.execute, client, util.format("CREATE TABLE %s (k int PRIMARY KEY, v map<text,int>)", table)),
@@ -987,12 +959,11 @@ describe('Client', function () {
               assert.deepEqual(keys, [0, 10, 20, 30, 40, 50, 60, 70, 80, 90]);
               seriesNext();
             });
-          },
-          client.shutdown.bind(client)
+          }
         ], done);
       });
       vit('2.1', 'should be able to retrieve using index on map values', function(done) {
-        var client = newInstance({ keyspace: keyspace });
+        var client = setupInfo.client;
         var table = helper.getRandomName('tbl');
         utils.series([
           helper.toTask(client.execute, client, util.format("CREATE TABLE %s (k int PRIMARY KEY, v map<text,int>)", table)),
@@ -1022,12 +993,11 @@ describe('Client', function () {
               assert.deepEqual(rows[1]['v'], {'key1' : 100, 'keyt10' : 990});
               seriesNext();
             });
-          },
-          client.shutdown.bind(client)
+          }
         ], done);
       });
       vit('2.2', 'should be able to retrieve using index on map entries', function(done) {
-        var client = newInstance({ keyspace: keyspace });
+        var client = setupInfo.client;
         var table = helper.getRandomName('tbl');
         utils.series([
           helper.toTask(client.execute, client, util.format("CREATE TABLE %s (k int PRIMARY KEY, v map<text,int>)", table)),
@@ -1052,27 +1022,19 @@ describe('Client', function () {
               assert.deepEqual(rows[0]['v'], {'key1' : 100, 'keyt10' : 990});
               seriesNext();
             });
-          },
-          client.shutdown.bind(client)
+          }
         ], done);
       });
     });
     vdescribe('3.0', 'with materialized views', function () {
       var keyspace = 'ks_view_prepared';
       before(function createTables(done) {
-        var client = newInstance();
         var queries = [
           "CREATE KEYSPACE ks_view_prepared WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",
           "CREATE TABLE ks_view_prepared.scores (user TEXT, game TEXT, year INT, month INT, day INT, score INT, PRIMARY KEY (user, game, year, month, day))",
           "CREATE MATERIALIZED VIEW ks_view_prepared.alltimehigh AS SELECT user FROM scores WHERE game IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL PRIMARY KEY (game, score, user, year, month, day) WITH CLUSTERING ORDER BY (score desc)"
         ];
-        utils.eachSeries(queries, client.execute.bind(client), function (err) {
-          client.shutdown();
-          if (err) {
-            return done(err);
-          }
-          setTimeout(done, 2000);
-        });
+        utils.eachSeries(queries, setupInfo.client.execute.bind(setupInfo.client), helper.wait(2000, done));
       });
       it('should choose the correct coordinator based on the partition key', function (done) {
         var client = new Client({
@@ -1112,8 +1074,7 @@ function newInstance(options) {
   return new Client(options);
 }
 
-function serializationTest(values, columns, done) {
-  var client = newInstance();
+function serializationTest(client, values, columns, done) {
   var keyspace = helper.getRandomName('ks');
   var table = keyspace + '.' + helper.getRandomName('table');
   utils.series([

--- a/test/integration/short/client-execute-tests.js
+++ b/test/integration/short/client-execute-tests.js
@@ -16,21 +16,9 @@ describe('Client', function () {
     var keyspace = helper.getRandomName('ks');
     var table = keyspace + '.' + helper.getRandomName('table');
     var selectAllQuery = 'SELECT * FROM ' + table;
-    before(function (done) {
-      var client = newInstance();
-      utils.series([
-        helper.ccmHelper.start(1),
-        function (next) {
-          client.execute(helper.createKeyspaceCql(keyspace, 1), next);
-        },
-        function (next) {
-          client.execute(helper.createTableCql(table), next);
-        }
-      ], done);
-    });
-    after(helper.ccmHelper.remove);
+    var setupInfo = helper.setup(1, { keyspace: keyspace, queries: [ helper.createTableCql(table) ] });
     it('should execute a basic query', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       client.execute(helper.queries.basic, function (err, result) {
         assert.equal(err, null);
         assert.notEqual(result, null);
@@ -39,7 +27,7 @@ describe('Client', function () {
       });
     });
     it('should callback with syntax error', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       client.connect(function (err) {
         assert.ifError(err);
         var query = 'SELECT WILL FAIL';
@@ -53,7 +41,7 @@ describe('Client', function () {
       });
     });
     it('should callback with an empty Array instance as rows when not found', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       client.execute(helper.queries.basicNoResults, function (err, result) {
         assert.ifError(err);
         assert.ok(result);
@@ -64,7 +52,7 @@ describe('Client', function () {
       });
     });
     it('should handle 500 parallel queries', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       utils.times(500, function (n, next) {
         client.execute(helper.queries.basic, [], next);
       }, done);
@@ -83,7 +71,7 @@ describe('Client', function () {
       ], done);
     });
     vit('2.0', 'should guess known types', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       var columns = 'id, timeuuid_sample, text_sample, double_sample, timestamp_sample, blob_sample, list_sample';
       //a precision a float32 can represent
       var values = [types.Uuid.random(), types.TimeUuid.now(), 'text sample 1', 133, new Date(121212211), new Buffer(100), ['one', 'two']];
@@ -91,7 +79,7 @@ describe('Client', function () {
       insertSelectTest(client, table, columns, values, null, done);
     });
     vit('2.0', 'should use parameter hints as number for simple types', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       var columns = 'id, text_sample, float_sample, int_sample';
       //a precision a float32 can represent
       var values = [types.Uuid.random(), 'text sample', 1000.0999755859375, -12];
@@ -102,14 +90,14 @@ describe('Client', function () {
       var columns = 'id, text_sample, float_sample, int_sample';
       var values = [types.Uuid.random(), 'text sample', -9, 1];
       var hints = [null, 'text', 'float', 'int'];
-      var client = newInstance();
+      var client = setupInfo.client;
       insertSelectTest(client, table, columns, values, hints, done);
     });
     vit('2.0', 'should use parameter hints as string for complex types partial', function (done) {
       var columns = 'id, map_sample, list_sample, set_sample';
       var values = [types.Uuid.random(), {val1: 'text sample1'}, ['list_text1'], ['set_text1']];
       var hints = [null, 'map', 'list', 'set'];
-      var client = newInstance();
+      var client = setupInfo.client;
       insertSelectTest(client, table, columns, values, hints, done);
     });
     vit('2.0', 'should use parameter hints as string for complex types complete', function (done) {
@@ -117,7 +105,7 @@ describe('Client', function () {
       var values = [types.Uuid.random(), {val1: 'text sample1'}, ['list_text1'], ['set_text1']];
       //complete info
       var hints = [null, 'map<text, text>', 'list<text>', 'set<text>'];
-      var client = newInstance();
+      var client = setupInfo.client;
       insertSelectTest(client, table, columns, values, hints, done);
     });
     vit('2.0', 'should use parameter hints for custom map polyfills', function (done) {
@@ -132,7 +120,7 @@ describe('Client', function () {
       insertSelectTest(client, table, columns, values, hints, done);
     });
     vit('2.0', 'should use pageState and fetchSize', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       var pageState = null;
       utils.series([
         function truncate(seriesNext) {
@@ -166,7 +154,7 @@ describe('Client', function () {
       ], done);
     });
     vit('2.0', 'should not autoPage', function (done) {
-      var client = newInstance({keyspace: keyspace});
+      var client = setupInfo.client;
       utils.series([
         function truncate(seriesNext) {
           client.execute('TRUNCATE ' + table, seriesNext);
@@ -189,7 +177,7 @@ describe('Client', function () {
     });
     if(helper.iteratorSupport) {
       vit('2.0', 'should return ResultSet compatible with @@iterator', function (done) {
-        var client = newInstance({keyspace: keyspace});
+        var client = setupInfo.client;
         utils.series([
           function truncate(seriesNext) {
             client.execute('TRUNCATE ' + table, seriesNext);
@@ -231,7 +219,7 @@ describe('Client', function () {
       });
     }
     vit('2.0', 'should callback in err when wrong hints are provided', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       var query = util.format('SELECT * FROM %s WHERE id IN (?, ?, ?)', table);
       //valid params
       var params = [types.Uuid.random(), types.Uuid.random(), types.Uuid.random()];
@@ -266,7 +254,7 @@ describe('Client', function () {
       ], done);
     });
     vit('2.1', 'should encode CONTAINS parameter', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       client.execute(util.format('CREATE INDEX list_sample_index ON %s(list_sample)', table), function (err) {
         assert.ifError(err);
         // Allow 1 second for index to build (otherwise an IndexNotAvailableException may be raised while index is building).
@@ -283,7 +271,7 @@ describe('Client', function () {
       });
     });
     it('should accept localOne and localQuorum consistencies', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       utils.series([
         function (next) {
           client.execute(selectAllQuery, [], {consistency: types.consistencies.localOne}, next);
@@ -309,11 +297,12 @@ describe('Client', function () {
             assert.strictEqual(result.info.achievedConsistency, types.consistencies.one);
             next();
           });
-        }
+        },
+        client.shutdown.bind(client)
       ], done);
     });
     vit('2.2', 'should accept unset as a valid value', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       var id = types.Uuid.random();
       utils.series([
         client.connect.bind(client),
@@ -331,8 +320,7 @@ describe('Client', function () {
             assert.strictEqual(row['double_sample'], null);
             next();
           });
-        },
-        client.shutdown.bind(client)
+        }
       ], done);
     });
     it('should handle several concurrent executes while the pool is not ready', function (done) {
@@ -357,10 +345,10 @@ describe('Client', function () {
             }, n * 5 + 50);
           }, parallelNext);
         }
-      ], done);
+      ], helper.finish(client, done));
     });
     it('should return the column definitions', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       //insert at least 1 row
       var insertQuery = util.format('INSERT INTO %s (id) VALUES (%s)', table, types.Uuid.random());
       utils.series([
@@ -400,7 +388,7 @@ describe('Client', function () {
       ], done);
     });
     it('should return rows that are serializable to json', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       var id = types.Uuid.random();
       var timeId = types.TimeUuid.now();
       utils.series([
@@ -456,10 +444,10 @@ describe('Client', function () {
             next();
           });
         }
-      ], done);
+      ], helper.finish(client, done));
     });
     vit('2.1', 'should support protocol level timestamp', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       var id = types.Uuid.random();
       var timestamp = types.generateTimestamp(new Date(), 777);
       utils.series([
@@ -480,7 +468,7 @@ describe('Client', function () {
       ], done);
     });
     it('should retrieve the trace id when queryTrace flag is set', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       var id = types.Uuid.random();
       utils.series([
         client.connect.bind(client),
@@ -514,7 +502,7 @@ describe('Client', function () {
       ], done);
     });
     it('should not retrieve trace id by default', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       client.execute('SELECT * FROM system.local', function (err, result) {
         assert.ifError(err);
         assert.ok(result.info);
@@ -523,7 +511,7 @@ describe('Client', function () {
       });
     });
     vit('2.2', 'should include the warning in the ResultSet', function (done) {
-      var client = newInstance();
+      var client = setupInfo.client;
       var loggedMessage = false;
       client.on('log', function (level, className, message) {
         if (loggedMessage || level !== 'warning') {
@@ -551,7 +539,7 @@ describe('Client', function () {
         helper.assertContains(result.info.warnings[0], 'batch');
         helper.assertContains(result.info.warnings[0], 'exceeding');
         assert.ok(loggedMessage);
-        client.shutdown(done);
+        done();
       });
     });
     describe('with udt and tuple', function () {
@@ -559,7 +547,7 @@ describe('Client', function () {
       var insertQuery = 'INSERT INTO tbl_udts (id, phone_col, address_col) VALUES (%s, %s, %s)';
       var selectQuery = 'SELECT id, phone_col, address_col FROM tbl_udts WHERE id = %s';
       before(function (done) {
-        var client = newInstance({ keyspace: keyspace });
+        var client = setupInfo.client;
         utils.series([
           client.connect.bind(client),
           helper.toTask(client.execute, client, 'CREATE TYPE phone (alias text, number text, country_code int, other boolean)'),
@@ -574,7 +562,7 @@ describe('Client', function () {
         ], done);
       });
       vit('2.1', 'should retrieve column information', function (done) {
-        var client = newInstance({ keyspace: keyspace });
+        var client = setupInfo.client;
         client.execute(util.format(selectQuery, sampleId), function (err, result) {
           assert.ifError(err);
           assert.ok(result.columns);
@@ -610,7 +598,7 @@ describe('Client', function () {
         });
       });
       vit('2.1', 'should parse udt row', function (done) {
-        var client = newInstance({ keyspace: keyspace });
+        var client = setupInfo.client;
         client.execute(util.format(selectQuery, sampleId), function (err, result) {
           assert.ifError(err);
           var row = result.first();
@@ -638,7 +626,7 @@ describe('Client', function () {
         var phone = { alias: 'home2', number: '555 0000', country_code: 34, other: true};
         var address = {street: 'NightMan2', ZIP: 90987, phones: [{ 'alias': 'personal2', 'number': '555 0001'}, {alias: 'work2'}]};
         var id = types.Uuid.random();
-        var client = newInstance({ keyspace: keyspace});
+        var client = setupInfo.client;
         utils.series([
           function insert(next) {
             var query = util.format(insertQuery, '?', '?', '?');
@@ -666,7 +654,7 @@ describe('Client', function () {
         ], done);
       });
       vit('2.1', 'should allow tuple parameter hints', function (done) {
-        var client = newInstance({ keyspace: keyspace});
+        var client = setupInfo.client;
         var id = types.Uuid.random();
         var tuple = new types.Tuple('Surf Rider', 110, new Buffer('0f0f', 'hex'));
         utils.series([
@@ -690,7 +678,7 @@ describe('Client', function () {
         ], done);
       });
       vit('2.2', 'should allow insertions as json', function (done) {
-        var client = newInstance({ keyspace: keyspace });
+        var client = setupInfo.client;
         var o = {
           id: types.Uuid.random(),
           address_col: {
@@ -700,7 +688,6 @@ describe('Client', function () {
             ]}
         };
         utils.series([
-          client.connect.bind(client),
           function insert(next) {
             var query = 'INSERT INTO tbl_udts JSON ?';
             client.execute(query, [JSON.stringify(o)], next);
@@ -716,8 +703,7 @@ describe('Client', function () {
               assert.strictEqual(row['address_col'].toString(), o.address_col.toString());
               next();
             });
-          },
-          client.shutdown.bind(client)
+          }
         ], done);
       });
     });
@@ -725,7 +711,7 @@ describe('Client', function () {
       vit('2.1', 'should allow named parameters', function (done) {
         var query = util.format('INSERT INTO %s (id, text_sample, bigint_sample) VALUES (:id, :myText, :myBigInt)', table);
         var values = { id: types.Uuid.random(), myText: 'hello', myBigInt: types.Long.fromNumber(2)};
-        var client = newInstance();
+        var client = setupInfo.client;
         client.execute(query, values, function (err) {
           assert.ifError(err);
           verifyRow(table, values.id, 'text_sample, bigint_sample', [values.myText, values.myBigInt], done);
@@ -734,7 +720,7 @@ describe('Client', function () {
       vit('2.1', 'should use parameter hints', function (done) {
         var query = util.format('INSERT INTO %s (id, int_sample, float_sample) VALUES (:id, :myInt, :myFloat)', table);
         var values = {id: types.Uuid.random(), myInt: 100, myFloat: 2.0999999046325684};
-        var client = newInstance();
+        var client = setupInfo.client;
         client.execute(query, values, { hints: {myFloat: 'float', myInt: {code: types.dataTypes.int}}}, function (err) {
           assert.ifError(err);
           verifyRow(table, values.id, 'int_sample, float_sample', [values.myInt, values.myFloat], done);
@@ -743,7 +729,7 @@ describe('Client', function () {
       vit('2.1', 'should allow parameters with different casings', function (done) {
         var query = util.format('INSERT INTO %s (id, text_sample, list_sample2) VALUES (:ID, :MyText, :mylist)', table);
         var values = { id: types.Uuid.random(), mytext: 'hello', myLIST: [ -1, 0, 500, 3]};
-        var client = newInstance();
+        var client = setupInfo.client;
         client.execute(query, values, { hints: { myLIST: 'list<int>'}}, function (err) {
           assert.ifError(err);
           verifyRow(table, values.id, 'text_sample, list_sample2', [values.mytext, values.myLIST], done);
@@ -755,9 +741,8 @@ describe('Client', function () {
       var insertQuery = 'INSERT INTO tbl_smallints (id, smallint_sample, tinyint_sample, text_sample) VALUES (%s, %s, %s, %s)';
       var selectQuery = 'SELECT id, smallint_sample, tinyint_sample, text_sample FROM tbl_smallints WHERE id = %s';
       before(function (done) {
-        var client = newInstance({ keyspace: keyspace });
+        var client = setupInfo.client;
         utils.series([
-          client.connect.bind(client),
           helper.toTask(client.execute, client, 'CREATE TABLE tbl_smallints (id uuid PRIMARY KEY, smallint_sample smallint, tinyint_sample tinyint, text_sample text)'),
           helper.toTask(client.execute, client, util.format(
             insertQuery, sampleId, 0x0200, 2, "'two'"))
@@ -765,7 +750,7 @@ describe('Client', function () {
       });
       vit('2.2', 'should retrieve smallint and tinyint values as Number', function (done) {
         var query = util.format(selectQuery, sampleId);
-        var client = newInstance({ keyspace: keyspace });
+        var client = setupInfo.client;
         client.execute(query, function (err, result) {
           assert.ifError(err);
           assert.ok(result);
@@ -779,7 +764,7 @@ describe('Client', function () {
         });
       });
       vit('2.2', 'should encode and decode smallint and tinyint values as Number', function (done) {
-        var client = newInstance({ keyspace: keyspace });
+        var client = setupInfo.client;
         var query = util.format(insertQuery, '?', '?', '?', '?');
         var id = types.Uuid.random();
         client.execute(query, [id, 10, 11, 'another text'], { hints: [null, 'smallint', 'tinyint']}, function (err) {
@@ -804,12 +789,9 @@ describe('Client', function () {
       var insertQuery = 'INSERT INTO tbl_datetimes (id, date_sample, time_sample) VALUES (?, ?, ?)';
       var selectQuery = 'SELECT id, date_sample, time_sample FROM tbl_datetimes WHERE id = ?';
       before(function (done) {
-        var client = newInstance({ keyspace: keyspace });
-        utils.series([
-          client.connect.bind(client),
-          helper.toTask(client.execute, client, 'CREATE TABLE tbl_datetimes (id uuid PRIMARY KEY, date_sample date, time_sample time, text_sample text)'),
-          client.shutdown.bind(client)
-        ], done);
+        var query = 'CREATE TABLE tbl_datetimes ' +
+          '(id uuid PRIMARY KEY, date_sample date, time_sample time, text_sample text)';
+        setupInfo.client.execute(query, done);
       });
       vit('2.2', 'should encode and decode date and time values as LocalDate and LocalTime', function (done) {
         var values = [
@@ -819,7 +801,7 @@ describe('Client', function () {
           [types.Uuid.random(), new LocalDate(1983, 2, 24), new LocalTime(types.Long.fromString('86399999999999'))],
           [types.Uuid.random(), new LocalDate(-2147483648), new LocalTime(types.Long.fromString('6311999549933'))]
         ];
-        var client = newInstance({ keyspace: keyspace });
+        var client = setupInfo.client;
         utils.eachSeries(values, function (params, next) {
           client.execute(insertQuery, params, function (err) {
             assert.ifError(err);
@@ -837,12 +819,12 @@ describe('Client', function () {
               next();
             });
           });
-        }, helper.finish(client, done));
+        }, done);
       });
     });
     describe('with json support', function () {
       before(function (done) {
-        var client = newInstance({ keyspace: keyspace });
+        var client = setupInfo.client;
         var query =
           'CREATE TABLE tbl_json (' +
           '  id uuid PRIMARY KEY,' +
@@ -854,13 +836,10 @@ describe('Client', function () {
           '  tup frozen<tuple<int, int>>,' +
           '  d date,' +
           '  t time)';
-        client.execute(query, function (err) {
-          assert.ifError(err);
-          client.shutdown(done);
-        });
+        client.execute(query, done);
       });
       vit('2.2', 'should allow insert of all ECMAScript types as json', function (done) {
-        var client = newInstance();
+        var client = setupInfo.client;
         var o = {
           id: types.Uuid.random(),
           text_sample: 'hello json',
@@ -875,7 +854,6 @@ describe('Client', function () {
           set_sample: ['a', 'b', 'x', 'zzzz']
         };
         utils.series([
-          client.connect.bind(client),
           function insert(next) {
             var query = util.format('INSERT INTO %s JSON ?', table);
             client.execute(query, [JSON.stringify(o)], next);
@@ -900,12 +878,11 @@ describe('Client', function () {
               assert.strictEqual(row['set_sample'].toString(), o.set_sample.toString());
               next();
             });
-          },
-          client.shutdown.bind(client)
+          }
         ], done);
       });
       vit('2.2', 'should allow insert of all non - ECMAScript types as json', function (done) {
-        var client = newInstance({ keyspace: keyspace });
+        var client = setupInfo.client;
         var o = {
           id:   types.Uuid.random(),
           tid:  types.TimeUuid.now(),
@@ -918,7 +895,6 @@ describe('Client', function () {
           t:    new types.LocalTime.fromMilliseconds(10160088, 123)
         };
         utils.series([
-          client.connect.bind(client),
           function insert(next) {
             var query = 'INSERT INTO tbl_json JSON ?';
             client.execute(query, [JSON.stringify(o)], next);
@@ -941,8 +917,7 @@ describe('Client', function () {
               assert.strictEqual(row['t'].toString(), o.t.toString());
               next();
             });
-          },
-          client.shutdown.bind(client)
+          }
         ], done);
       });
     });
@@ -974,7 +949,7 @@ describe('Client', function () {
           });
       });
       it('should reject the promise when there is a syntax error', function () {
-        var client = newInstance();
+        var client = setupInfo.client;
         return client.connect()
           .then(function () {
             return client.execute('SELECT INVALID QUERY');
@@ -984,7 +959,6 @@ describe('Client', function () {
           })
           .catch(function (err) {
             helper.assertInstanceOf(err, errors.ResponseError);
-            return client.shutdown();
           });
       });
     });

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -6,11 +6,49 @@ var policies = require('../lib/policies');
 var types = require('../lib/types');
 var utils = require('../lib/utils.js');
 var spawn = require('child_process').spawn;
+var Client = require('../lib/client');
 
 
 util.inherits(RetryMultipleTimes, policies.retry.RetryPolicy);
 
 var helper = {
+  /**
+   * Creates a ccm cluster, initializes a Client instance the before() and after() hooks, create
+   * @param {Number} nodeLength
+   * @param {Object} [options]
+   * @param {Object} [options.ccmOptions]
+   * @param {Boolean} [options.initClient] Determines whether to create a Client instance.
+   * @param {String} [options.keyspace] Name of the keyspace to create.
+   * @param {Number} [options.replicationFactor] Keyspace replication factor.
+   * @param {Array<String>} [options.queries] Queries to run after client creation.
+   */
+  setup: function (nodeLength, options) {
+    options = options || utils.emptyObject;
+    before(helper.ccmHelper.start(nodeLength || 1, options.ccmOptions));
+    var initClient = options.initClient !== false;
+    var client;
+    var keyspace;
+    if (initClient) {
+      client = new Client(helper.baseOptions);
+      before(client.connect.bind(client));
+      keyspace = options.keyspace || helper.getRandomName('ks');
+      before(helper.toTask(client.execute, client, helper.createKeyspaceCql(keyspace, options.replicationFactor)));
+      before(helper.toTask(client.execute, client, 'USE ' + keyspace));
+      if (options.queries) {
+        before(function (done) {
+          utils.eachSeries(options.queries, function (q, next) {
+            client.execute(q, next);
+          }, done);
+        });
+      }
+      after(client.shutdown.bind(client));
+    }
+    after(helper.ccmHelper.remove);
+    return {
+      client: client,
+      keyspace: keyspace
+    };
+  },
   /**
    * Sync throws the error
    * @type Function


### PR DESCRIPTION
Reduce test boilerplate code by introducing a setup method. I've used already started using it in a couple of fixtures, but the idea is to start using it for new tests.

I'll rebase #201 after this is merged.