### PR TITLE
Expose protocol versions and make negotiation more resilient

### DIFF
--- a/doc/features/native-protocol/README.md
+++ b/doc/features/native-protocol/README.md
@@ -11,9 +11,11 @@ By default, the driver uses the highest protocol version supported by the driver
 to limit the protocol version to use, you do so in the protocol options.
 
 ```javascript
-const client = new Client({
-   contactPoints: ['1.2.3.4'],
-   protocolOptions: { maxVersion: 2}
+const cassandra = require('cassandra-driver');
+const protocolVersion = cassandra.types.protocolVersion;
+const client = new cassandra.Client({
+   contactPoints: [ 'host1', 'host2' ],
+   protocolOptions: { maxVersion: protocolVersion.v3 }
 });
 ```
 
@@ -34,14 +36,17 @@ version when initializing the client:
 
 ```javascript
 const client = new Client({
-   contactPoints: ['1.2.3.4'],
-   protocolOptions: { maxVersion: 2}
+   contactPoints: [ 'host1', 'host2' ],
+   protocolOptions: { maxVersion: protocolVersion.v2 }
 });
 ```
 
 And switching it to the highest protocol version once the upgrade is completed, by leaving the maximum protocol version
-unspecified:
+unspecified or by using `protocolVersion.maxSupported`:
 
 ```javascript
-const client = new Client({ contactPoints: ['1.2.3.4'] });
+const client = new Client({
+   contactPoints: [ 'host1', 'host2' ],
+   protocolOptions: { maxVersion: protocolVersion.maxSupported }
+});
 ```

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -75,66 +75,104 @@ function extend(baseOptions, userOptions) {
         'the following values are valid contact points: ipAddress, hostName or ipAddress:port', i, hostName));
     }
   }
-  if (!options.policies) {
-    throw new TypeError('policies not defined in options');
-  }
-  if (!(options.policies.loadBalancing instanceof policies.loadBalancing.LoadBalancingPolicy)) {
-    throw new TypeError('Load balancing policy must be an instance of LoadBalancingPolicy');
-  }
-  if (!(options.policies.reconnection instanceof policies.reconnection.ReconnectionPolicy)) {
-    throw new TypeError('Reconnection policy must be an instance of ReconnectionPolicy');
-  }
-  if (!(options.policies.retry instanceof policies.retry.RetryPolicy)) {
-    throw new TypeError('Retry policy must be an instance of RetryPolicy');
-  }
-  if (!(options.policies.addressResolution instanceof policies.addressResolution.AddressTranslator)) {
-    throw new TypeError('Address resolution policy must be an instance of AddressTranslator');
-  }
-  if (options.policies.timestampGeneration !== null &&
-      !(options.policies.timestampGeneration instanceof policies.timestampGeneration.TimestampGenerator)) {
-    throw new TypeError('Timestamp generation policy must be an instance of TimestampGenerator');
+  if (!options.logEmitter) {
+    options.logEmitter = function () {};
   }
   if (!options.queryOptions) {
     throw new TypeError('queryOptions not defined in options');
   }
-  if (!options.protocolOptions) {
+  validatePoliciesOptions(options.policies);
+  validateProtocolOptions(options.protocolOptions);
+  validateSocketOptions(options.socketOptions);
+  options.encoding = options.encoding || {};
+  validateEncodingOptions(options.encoding);
+  if (options.profiles && !util.isArray(options.profiles)) {
+    throw new TypeError('profiles must be an Array of ExecutionProfile instances');
+  }
+  return options;
+}
+
+/**
+ * Validates the policies from the client options.
+ * @param {ClientOptions.policies} policiesOptions
+ * @private
+ */
+function validatePoliciesOptions(policiesOptions) {
+  if (!policiesOptions) {
+    throw new TypeError('policies not defined in options');
+  }
+  if (!(policiesOptions.loadBalancing instanceof policies.loadBalancing.LoadBalancingPolicy)) {
+    throw new TypeError('Load balancing policy must be an instance of LoadBalancingPolicy');
+  }
+  if (!(policiesOptions.reconnection instanceof policies.reconnection.ReconnectionPolicy)) {
+    throw new TypeError('Reconnection policy must be an instance of ReconnectionPolicy');
+  }
+  if (!(policiesOptions.retry instanceof policies.retry.RetryPolicy)) {
+    throw new TypeError('Retry policy must be an instance of RetryPolicy');
+  }
+  if (!(policiesOptions.addressResolution instanceof policies.addressResolution.AddressTranslator)) {
+    throw new TypeError('Address resolution policy must be an instance of AddressTranslator');
+  }
+  if (policiesOptions.timestampGeneration !== null &&
+    !(policiesOptions.timestampGeneration instanceof policies.timestampGeneration.TimestampGenerator)) {
+    throw new TypeError('Timestamp generation policy must be an instance of TimestampGenerator');
+  }
+}
+
+/**
+ * Validates the protocol options.
+ * @param {ClientOptions.protocolOptions} protocolOptions
+ * @private
+ */
+function validateProtocolOptions(protocolOptions) {
+  if (!protocolOptions) {
     throw new TypeError('protocolOptions not defined in options');
   }
-  if (!options.socketOptions) {
+  var version = protocolOptions.maxVersion;
+  if (version && (typeof version !== 'number' || !types.protocolVersion.isSupported(version))) {
+    throw new TypeError(util.format('protocolOptions.maxVersion provided (%s) is invalid', version));
+  }
+}
+
+/**
+ * Validates the socket options.
+ * @param {ClientOptions.socketOptions} socketOptions
+ * @private
+ */
+function validateSocketOptions(socketOptions) {
+  if (!socketOptions) {
     throw new TypeError('socketOptions not defined in options');
   }
-  if (typeof options.socketOptions.readTimeout !== 'number') {
+  if (typeof socketOptions.readTimeout !== 'number') {
     throw new TypeError('socketOptions.readTimeout must be a Number');
   }
-  if (typeof options.socketOptions.coalescingThreshold !== 'number' || options.socketOptions.coalescingThreshold <= 0) {
+  if (typeof socketOptions.coalescingThreshold !== 'number' || socketOptions.coalescingThreshold <= 0) {
     throw new TypeError('socketOptions.coalescingThreshold must be a positive Number');
   }
-  if (!options.logEmitter) {
-    options.logEmitter = function () {};
-  }
-  if (!options.encoding) {
-    options.encoding = {};
-  }
-  if (options.encoding.map) {
-    var mapConstructor = options.encoding.map;
+}
+
+/**
+ * Validates the encoding options.
+ * @param {ClientOptions.encoding} encodingOptions
+ * @private
+ */
+function validateEncodingOptions(encodingOptions) {
+  if (encodingOptions.map) {
+    var mapConstructor = encodingOptions.map;
     if (typeof mapConstructor !== 'function' ||
       typeof mapConstructor.prototype.forEach !== 'function' ||
       typeof mapConstructor.prototype.set !== 'function') {
       throw new TypeError('Map constructor not valid');
     }
   }
-  if (options.encoding.set) {
-    var setConstructor = options.encoding.set;
+  if (encodingOptions.set) {
+    var setConstructor = encodingOptions.set;
     if (typeof setConstructor !== 'function' ||
       typeof setConstructor.prototype.forEach !== 'function' ||
       typeof setConstructor.prototype.add !== 'function') {
       throw new TypeError('Set constructor not valid');
     }
   }
-  if (options.profiles && !util.isArray(options.profiles)) {
-    throw new TypeError('profiles must be an Array of ExecutionProfile instances');
-  }
-  return options;
 }
 
 /**
@@ -220,15 +258,14 @@ function ifUndefined3(v1, v2, v3) {
 }
 
 function getTimestamp(client, userOptions, defaultValue) {
-  var value = defaultValue;
   if (typeof userOptions.timestamp !== 'undefined') {
-    value = userOptions.timestamp;
+    return userOptions.timestamp;
   }
-  else if (client.controlConnection.protocolVersion > 2 && client.options.policies.timestampGeneration) {
-    // Use the timestamp generator
-    value = client.options.policies.timestampGeneration.next(client);
+  var timestampGenerator = client.options.policies.timestampGeneration;
+  if (types.protocolVersion.supportsTimestamp(client.controlConnection.protocolVersion) && timestampGenerator) {
+    return timestampGenerator.next(client);
   }
-  return value;
+  return defaultValue;
 }
 
 /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -17,6 +17,7 @@ var clientOptions = require('./client-options');
  */
 var warmupLimit = 32;
 
+
 /**
  * Client options
  * @typedef {Object} ClientOptions
@@ -369,10 +370,11 @@ Client.prototype._connectCb = function (callback) {
     function setPoolOptionsAndWarmup(next) {
       //Set the pooling options depending on the protocol version
       var coreConnectionsPerHost = clientOptions.coreConnectionsPerHostV3;
-      if (self.controlConnection.protocolVersion < 3) {
+      if (!types.protocolVersion.uses2BytesStreamIds(self.controlConnection.protocolVersion)) {
         coreConnectionsPerHost = clientOptions.coreConnectionsPerHostV2;
       }
-      self.options.pooling = utils.deepExtend({}, { coreConnectionsPerHost: coreConnectionsPerHost }, self.options.pooling);
+      self.options.pooling = utils.deepExtend(
+        {}, { coreConnectionsPerHost: coreConnectionsPerHost }, self.options.pooling);
       if (!self.options.pooling.warmup) {
         return next();
       }
@@ -1069,10 +1071,11 @@ Client.prototype._getEncoder = function () {
  * @private
  */
 Client.prototype._setQueryOptions = function (options, params, meta, callback) {
-  var protocolVersion = this.controlConnection.protocolVersion;
-  if (!options.prepare && params && !util.isArray(params) && protocolVersion < 3) {
+  var version = this.controlConnection.protocolVersion;
+  if (!options.prepare && params && !util.isArray(params) && !types.protocolVersion.supportsNamedParameters(version)) {
     //Only Cassandra 2.1 and above supports named parameters
-    return callback(new errors.ArgumentError('Named parameters for simple statements are not supported, use prepare flag'));
+    return callback(
+      new errors.ArgumentError('Named parameters for simple statements are not supported, use prepare flag'));
   }
   var paramsInfo;
   var self = this;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -15,12 +15,11 @@ var StreamIdStack = require('./stream-id-stack');
 
 /**  @const */
 var idleQuery = 'SELECT key from system.local';
-/**  @const */
-var maxProtocolVersion = 4;
+
 /**
  * Represents a connection to a Cassandra node
  * @param {String} endpoint An string containing ip address and port of the host
- * @param {Number} protocolVersion
+ * @param {Number|null} protocolVersion
  * @param {ClientOptions} options
  * @extends EventEmitter
  * @constructor
@@ -37,13 +36,13 @@ function Connection(endpoint, protocolVersion, options) {
   this.port = endpoint.substr(portSeparatorIndex + 1);
   Object.defineProperty(this, "options", { value: options, enumerable: false, writable: false});
   if (protocolVersion === null) {
-    //Set initial protocol version
-    protocolVersion = maxProtocolVersion;
-    if (options.protocolOptions.maxVersion > 0 && options.protocolOptions.maxVersion < maxProtocolVersion) {
-      //limit the protocol version
+    // Set initial protocol version
+    protocolVersion = types.protocolVersion.maxSupported;
+    if (options.protocolOptions.maxVersion) {
+      // User provided the protocol version
       protocolVersion = options.protocolOptions.maxVersion;
     }
-    //Allow to check version using this connection instance
+    // Allow to check version using this connection instance
     this.checkingVersion = true;
   }
   this.protocolVersion = protocolVersion;
@@ -160,11 +159,11 @@ Connection.prototype.startup = function (callback) {
   }
   var self = this;
   this.sendStream(new requests.StartupRequest(), null, function responseCallback(err, response) {
-    if (err && self.checkingVersion && self.protocolVersion > 1) {
+    if (err && self.checkingVersion) {
       var invalidProtocol = (err instanceof errors.ResponseError &&
         err.code === types.responseErrorCodes.protocolError &&
         err.message.indexOf('Invalid or unsupported protocol version') >= 0);
-      if (!invalidProtocol && self.protocolVersion > 3) {
+      if (!invalidProtocol && types.protocolVersion.canStartupResponseErrorBeWrapped(self.protocolVersion)) {
         //For some versions of Cassandra, the error is wrapped into a server error
         //See CASSANDRA-9451
         invalidProtocol = (err instanceof errors.ResponseError &&
@@ -172,9 +171,19 @@ Connection.prototype.startup = function (callback) {
           err.message.indexOf('ProtocolException: Invalid or unsupported protocol version') > 0);
       }
       if (invalidProtocol) {
-        self.log('info', 'Protocol v' + self.protocolVersion + ' not supported, using v' + self.protocol.version);
-        self.decreaseVersion();
-        //The host closed the connection, close the socket
+        // The server can respond with a message using the lower protocol version supported
+        // or using the same version as the one provided
+        var lowerVersion = self.protocol.version;
+        if (lowerVersion === self.protocolVersion) {
+          lowerVersion = types.protocolVersion.getLowerSupported(self.protocolVersion);
+        }
+        if (!lowerVersion) {
+          return startupCallback(
+            new Error('Connection was unable to STARTUP using protocol version ' + self.protocolVersion));
+        }
+        self.log('info', 'Protocol v' + self.protocolVersion + ' not supported, using v' + lowerVersion);
+        self.decreaseVersion(lowerVersion);
+        // The host closed the connection, close the socket and start the connection flow again
         setImmediate(function decreasingVersionClosing() {
           self.close(function decreasingVersionOpening() {
             // Attempt to open with the correct protocol version
@@ -220,11 +229,12 @@ Connection.prototype.connectionReady = function (callback) {
   callback();
 };
 
-Connection.prototype.decreaseVersion = function () {
+/** @param {Number} lowerVersion */
+Connection.prototype.decreaseVersion = function (lowerVersion) {
   // The response already has the max protocol version supported by the Cassandra host.
-  this.protocolVersion = this.protocol.version;
-  this.encoder.setProtocolVersion(this.protocolVersion);
-  this.streamIds.setVersion(this.protocolVersion);
+  this.protocolVersion = lowerVersion;
+  this.encoder.setProtocolVersion(lowerVersion);
+  this.streamIds.setVersion(lowerVersion);
 };
 
 /**

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -97,7 +97,7 @@ function defineInstanceMembers() {
     this.decodeCollectionLength = decodeCollectionLengthV3;
     this.getLengthBuffer = getLengthBufferV3;
     this.collectionLengthSize = 4;
-    if (this.protocolVersion < 3) {
+    if (!types.protocolVersion.uses4BytesCollectionLength(this.protocolVersion)) {
       this.decodeCollectionLength = decodeCollectionLengthV2;
       this.getLengthBuffer = getLengthBufferV2;
       this.collectionLengthSize = 2;
@@ -1270,8 +1270,9 @@ Encoder.prototype.encode = function (value, typeInfo) {
     return value;
   }
   if (value === types.unset) {
-    if (this.protocolVersion < 4) {
-      throw new TypeError('Unset value can not be used for this version of Cassandra, protocol version: ' + this.protocolVersion);
+    if (!types.protocolVersion.supportsUnset(this.protocolVersion)) {
+      throw new TypeError('Unset value can not be used for this version of Cassandra, protocol version: ' +
+        this.protocolVersion);
     }
     return value;
   }

--- a/lib/readers.js
+++ b/lib/readers.js
@@ -268,7 +268,7 @@ FrameReader.prototype.readMetadata = function (kind) {
   var flags = this.readInt();
 
   var columnLength = this.readInt();
-  if (this.header.version > 3 && isPrepared) {
+  if (types.protocolVersion.supportsPreparedPartitionKey(this.header.version) && isPrepared) {
     //read the pk columns
     meta.partitionKeys = new Array(this.readInt());
     for (i = 0; i < meta.partitionKeys.length; i++) {
@@ -380,7 +380,7 @@ FrameReader.prototype.readEvent = function () {
 
 FrameReader.prototype.parseSchemaChange = function () {
   var result;
-  if (this.header.version < 3) {
+  if (!types.protocolVersion.supportsSchemaChangeFullMetadata(this.header.version)) {
     //v1/v2: 3 strings, the table value can be empty
     result = {
       eventType: types.protocolEvents.schemaChange,

--- a/lib/requests.js
+++ b/lib/requests.js
@@ -93,7 +93,7 @@ ExecuteRequest.prototype.writeQueryParameters = function (frameWriter, encoder) 
   //v2: <consistency><flags>[<n><value_1>...<value_n>][<result_page_size>][<paging_state>][<serial_consistency>]
   //v3: <consistency><flags>[<n>[name_1]<value_1>...[name_n]<value_n>][<result_page_size>][<paging_state>][<serial_consistency>][<timestamp>]
   var flags = 0;
-  if (this.version > 1) {
+  if (types.protocolVersion.supportsPaging(this.version)) {
     flags |= (this.params && this.params.length) ? queryFlag.values : 0;
     flags |= (this.options.fetchSize > 0) ? queryFlag.pageSize : 0;
     flags |= this.options.pageState ? queryFlag.withPagingState : 0;
@@ -115,7 +115,7 @@ ExecuteRequest.prototype.writeQueryParameters = function (frameWriter, encoder) 
       frameWriter.writeBytes(encoder.encode(paramValue, this.hints[i]));
     }
   }
-  if (this.version === 1) {
+  if (!types.protocolVersion.supportsPaging(this.version)) {
     if (!this.params || !this.params.length) {
       //zero parameters
       frameWriter.writeShort(0);
@@ -170,7 +170,7 @@ QueryRequest.prototype.write = function (encoder) {
     frameWriter.writeCustomPayload(this.options.customPayload);
   }
   frameWriter.writeLString(this.query);
-  if (this.version === 1) {
+  if (!types.protocolVersion.supportsPaging(this.version)) {
     frameWriter.writeShort(this.consistency);
   }
   else {
@@ -313,7 +313,7 @@ BatchRequest.prototype.write = function (encoder) {
     });
   }, this);
   frameWriter.writeShort(this.options.consistency);
-  if (this.version >= 3) {
+  if (types.protocolVersion.supportsTimestamp(this.version)) {
     //Batch flags
     var flags = this.options.serialConsistency ? batchFlag.withSerialConsistency : 0;
     flags |= this.options.timestamp ? batchFlag.withDefaultTimestamp : 0;

--- a/lib/stream-id-stack.js
+++ b/lib/stream-id-stack.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var types = require('./types');
+
 /**
  * Group size
  * @type {number}
@@ -57,7 +59,7 @@ function StreamIdStack(version) {
  */
 StreamIdStack.prototype.setVersion = function (version) {
   //128 or 32K stream ids depending on the protocol version
-  this.maxGroups = version < 3 ? 1 : maxGroupsFor2Bytes;
+  this.maxGroups = types.protocolVersion.uses2BytesStreamIds(version) ? maxGroupsFor2Bytes : 1;
 };
 
 /**

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -4,6 +4,7 @@ var util = require('util');
 var errors = require('../errors');
 var TimeUuid = require('./time-uuid');
 var Uuid = require('./uuid');
+var protocolVersion = require('./protocol-version');
 
 /** @module types */
 /**
@@ -11,6 +12,7 @@ var Uuid = require('./uuid');
  * @constructor
  */
 var Long = require('long');
+
 
 /**
  * Consistency levels
@@ -401,7 +403,7 @@ function FrameHeader(version, flags, streamId, opcode, bodyLength) {
  * @returns {Number}
  */
 FrameHeader.size = function (version) {
-  if (version >= 3) {
+  if (protocolVersion.uses2BytesStreamIds(version)) {
     return 9;
   }
   return 8;
@@ -428,7 +430,7 @@ FrameHeader.fromBuffer = function (buf, offset) {
   }
   var version = buf[offset++] & 0x7F;
   var flags = buf.readUInt8(offset++);
-  if (version < 3) {
+  if (!protocolVersion.uses2BytesStreamIds(version)) {
     streamId = buf.readInt8(offset++);
   }
   else {
@@ -444,7 +446,7 @@ FrameHeader.prototype.toBuffer = function () {
   buf.writeUInt8(this.version, 0);
   buf.writeUInt8(this.flags, 1);
   var offset = 3;
-  if (this.version < 3) {
+  if (!protocolVersion.uses2BytesStreamIds(this.version)) {
     buf.writeInt8(this.streamId, 2);
   }
   else {
@@ -549,6 +551,7 @@ exports.getDataTypeNameByCode = getDataTypeNameByCode;
 exports.distance = distance;
 exports.frameFlags = frameFlags;
 exports.protocolEvents = protocolEvents;
+exports.protocolVersion = protocolVersion;
 exports.responseErrorCodes = responseErrorCodes;
 exports.resultKind = resultKind;
 exports.timeuuid = timeuuid;

--- a/lib/types/protocol-version.js
+++ b/lib/types/protocol-version.js
@@ -10,7 +10,7 @@
  * @property {Number} v5 Cassandra protocol v5, in beta from Apache Cassandra 3.x+. Currently not supported by the
  * driver.
  * @property {Number} maxSupported Returns the higher protocol version that is supported by this driver.
- * @property {Number} maxSupported Returns the lower protocol version that is supported by this driver.
+ * @property {Number} minSupported Returns the lower protocol version that is supported by this driver.
  * @property {Function} isSupported A function that returns a boolean determining whether a given protocol version
  * is supported.
  * @alias module:types~protocolVersion
@@ -103,11 +103,13 @@ var protocolVersion = {
     return (version >= this.v3);
   },
   /**
-   * When using certain versions
-   * @param version
+   * Startup responses using protocol v4+ can be a SERVER_ERROR wrapping a ProtocolException, this method returns true
+   * when is possible to receive such error.
+   * @param {Number} version
+   * @return {boolean}
+   * @ignore
    */
   canStartupResponseErrorBeWrapped: function (version) {
-    // Startup responses using protocol v4+ can be a SERVER_ERROR wrapping a ProtocolException
     return (version >= this.v4);
   },
   /**
@@ -115,6 +117,7 @@ var protocolVersion = {
    * Returns zero when there isn't a lower supported version.
    * @param {Number} version
    * @return {Number}
+   * @ignore
    */
   getLowerSupported: function (version) {
     if (version >= this.v5) {

--- a/lib/types/protocol-version.js
+++ b/lib/types/protocol-version.js
@@ -1,0 +1,130 @@
+'use strict';
+
+/**
+ * Contains information for the different protocol versions supported by the driver.
+ * @type {Object}
+ * @property {Number} v1 Cassandra protocol v1, supported in Apache Cassandra 1.2-->2.2.
+ * @property {Number} v2 Cassandra protocol v2, supported in Apache Cassandra 2.0-->2.2.
+ * @property {Number} v3 Cassandra protocol v3, supported in Apache Cassandra 2.1-->3.x.
+ * @property {Number} v4 Cassandra protocol v4, supported in Apache Cassandra 2.2-->3.x.
+ * @property {Number} v5 Cassandra protocol v5, in beta from Apache Cassandra 3.x+. Currently not supported by the
+ * driver.
+ * @property {Number} maxSupported Returns the higher protocol version that is supported by this driver.
+ * @property {Number} maxSupported Returns the lower protocol version that is supported by this driver.
+ * @property {Function} isSupported A function that returns a boolean determining whether a given protocol version
+ * is supported.
+ * @alias module:types~protocolVersion
+ */
+var protocolVersion = {
+  // Strict equality operators to compare versions are allowed, other comparison operators are discouraged. Instead,
+  // use a function that checks if a functionality is present on a certain version, for maintainability purposes.
+  v1: 0x01,
+  v2: 0x02,
+  v3: 0x03,
+  v4: 0x04,
+  v5: 0x05,
+  maxSupported: 0x04,
+  minSupported: 0x01,
+  isSupported: function (version) {
+    return (version <= 0x04 && version >= 0x01);
+  },
+  /**
+   * Determines whether the protocol supports partition key indexes in the `prepared` RESULT responses.
+   * @param {Number} version
+   * @returns {Boolean}
+   * @ignore
+   */
+  supportsPreparedPartitionKey: function (version) {
+    return (version >= this.v4);
+  },
+  /**
+   * Determines whether the protocol supports up to 4 strings (ie: change_type, target, keyspace and table) in the
+   * schema change responses.
+   * @param version
+   * @return {boolean}
+   * @ignore
+   */
+  supportsSchemaChangeFullMetadata: function (version) {
+    return (version >= this.v3);
+  },
+  /**
+   * Determines whether the protocol supports paging state and serial consistency parameters in QUERY and EXECUTE
+   * requests.
+   * @param version
+   * @return {boolean}
+   * @ignore
+   */
+  supportsPaging: function (version) {
+    return (version >= this.v2);
+  },
+  /**
+   * Determines whether the protocol supports timestamps parameters in BATCH, QUERY and EXECUTE requests.
+   * @param {Number} version
+   * @return {boolean}
+   * @ignore
+   */
+  supportsTimestamp: function (version) {
+    return (version >= this.v3);
+  },
+  /**
+   * Determines whether the protocol supports named parameters in QUERY and EXECUTE requests.
+   * @param {Number} version
+   * @return {boolean}
+   * @ignore
+   */
+  supportsNamedParameters: function (version) {
+    return (version >= this.v3);
+  },
+  /**
+   * Determines whether the protocol supports unset parameters.
+   * @param {Number} version
+   * @return {boolean}
+   * @ignore
+   */
+  supportsUnset: function (version) {
+    return (version >= this.v4);
+  },
+  /**
+   * Determines whether the protocol supports timestamp and serial consistency parameters in BATCH requests.
+   * @param {Number} version
+   * @return {boolean}
+   * @ignore
+   */
+  uses2BytesStreamIds: function (version) {
+    return (version >= this.v3);
+  },
+  /**
+   * Determines whether the collection length is encoded using 32 bits.
+   * @param {Number} version
+   * @return {boolean}
+   * @ignore
+   */
+  uses4BytesCollectionLength: function (version) {
+    return (version >= this.v3);
+  },
+  /**
+   * When using certain versions
+   * @param version
+   */
+  canStartupResponseErrorBeWrapped: function (version) {
+    // Startup responses using protocol v4+ can be a SERVER_ERROR wrapping a ProtocolException
+    return (version >= this.v4);
+  },
+  /**
+   * Gets the first version number that is supported, lower than the one provided.
+   * Returns zero when there isn't a lower supported version.
+   * @param {Number} version
+   * @return {Number}
+   */
+  getLowerSupported: function (version) {
+    if (version >= this.v5) {
+      return this.v4;
+    }
+    if (version <= this.v1) {
+      return 0;
+    }
+    return version - 1;
+  }
+};
+
+module.exports = protocolVersion;

--- a/test/integration/short/connection-tests.js
+++ b/test/integration/short/connection-tests.js
@@ -30,6 +30,16 @@ describe('Connection', function () {
         localCon.close(done);
       });
     });
+    vit('3.0', 'should callback in error when protocol version is not supported server side', function (done) {
+      // Attempting to connect with protocol v2
+      var localCon = newInstance(null, 2);
+      localCon.open(function (err) {
+        helper.assertInstanceOf(err, Error);
+        assert.ok(!localCon.connected);
+        helper.assertContains(err.message, 'protocol version');
+        localCon.close(done);
+      });
+    });
     vit('2.0', 'should limit the max protocol version based on the protocolOptions', function (done) {
       var options = utils.extend({}, defaultOptions);
       options.protocolOptions.maxVersion = getProtocolVersion() - 1;

--- a/test/unit/basic-tests.js
+++ b/test/unit/basic-tests.js
@@ -711,6 +711,20 @@ describe('clientOptions', function () {
         });
       });
     });
+    it('should validate protocolOptions.maxVersion', function () {
+      assert.throws(function () {
+        clientOptions.extend({
+          contactPoints: ['host1'],
+          protocolOptions: { maxVersion: '1' }
+        });
+      }, TypeError);
+      assert.throws(function () {
+        clientOptions.extend({
+          contactPoints: ['host1'],
+          protocolOptions: { maxVersion: 16 }
+        });
+      }, TypeError);
+    });
   });
   describe('#defaultOptions()', function () {
     var options = clientOptions.defaultOptions();


### PR DESCRIPTION
Introduced protocol versions and internal functions that check if a feature is supported by a provided protocol version.

I'm not very happy for including the protocol version "enum" in the types module, but as we are using instance members (`protocolVersion` is an object instance), I didn't want to pollute the root module. It's also consistent with the rest of object instances (as enums) exposed in the driver.

`protocolVersion` object is exposed and can be used when selecting a max protocol version:

```javascript
const client = new cassandra.Client({ 
  contactPoints: [ 'host1', 'host2' ],
  protocolOptions: { maxVersion: cassandra.types.protocolVersion.v3 }
});
```

It should work with any server version (w/ or wo/ CASSANDRA-11464)