### PR TITLE
Replace dead link with live library link

### DIFF
--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -8,7 +8,7 @@ var protocolVersion = require('./protocol-version');
 
 /** @module types */
 /**
- * Long constructor, wrapper of the internal library used: {@link http://docs.closure-library.googlecode.com/git/class_goog_math_Long.html Google Closure Long}.
+ * Long constructor, wrapper of the internal library used: {@link https://github.com/dcodeIO/long.js Long.js}.
  * @constructor
  */
 var Long = require('long');


### PR DESCRIPTION
It appears the [existing link to the Google Closure library is dead](http://docs.closure-library.googlecode.com/git/class_goog_math_Long.html). I linked [instead to the `long.js` library](https://github.com/dcodeIO/long.js ) I think the `nodejs-driver` uses.