### PR TITLE
ControlConnection: reconnection refactoring

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -649,6 +649,7 @@ Client.prototype._shutdownCb = function (callback) {
     self.connected = false;
     self.isShuttingDown = true;
     var hosts = self.hosts.values();
+    // Shutdown the ControlConnection before shutting down the pools
     self.controlConnection.shutdown();
     // go through all the host and shut down their pools
     utils.each(hosts, function (h, next) {

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -77,7 +77,6 @@ function ControlConnection(options, profileManager, context) {
   this.nodeStatusChangeTimeout = null;
   this.reconnectionTimeout = null;
   this.hostIterator = null;
-  this.hostListenerRemover = null;
   this.triedHosts = null;
   if (context && context.borrowHostConnection) {
     this.borrowHostConnection = context.borrowHostConnection;
@@ -161,11 +160,18 @@ ControlConnection.prototype.init = function (callback) {
   });
 };
 
-ControlConnection.prototype.setHostListeners = function () {
+ControlConnection.prototype.setHealthListeners = function () {
   var host = this.host;
   var connection = this.connection;
   var self = this;
   var wasRefreshCalled = 0;
+
+  function removeListeners() {
+    host.removeListener('down', downOrIgnoredHandler);
+    host.removeListener('ignore', downOrIgnoredHandler);
+    connection.removeListener('socketClose', socketClosedHandler);
+  }
+
   function startReconnecting(hostDown) {
     if (wasRefreshCalled++ !== 0) {
       // Prevent multiple calls to reconnect
@@ -181,23 +187,23 @@ ControlConnection.prototype.setHostListeners = function () {
     else {
       self.log('warning', f('Connection to %s used by the ControlConnection was closed', host.address));
     }
-    self.markConnectionAsUnusable();
+    removeListeners();
+    self.host = null;
+    self.connection = null;
     self.refresh();
   }
+
   function downOrIgnoredHandler() {
     startReconnecting(true);
   }
+
   function socketClosedHandler() {
     startReconnecting(false);
   }
+
   host.once('down', downOrIgnoredHandler);
   host.once('ignore', downOrIgnoredHandler);
   connection.once('socketClose', socketClosedHandler);
-  self.hostListenerRemover = function () {
-    host.removeListener('down', downOrIgnoredHandler);
-    host.removeListener('ignore', downOrIgnoredHandler);
-    connection.removeListener('socketClose', socketClosedHandler);
-  };
 };
 
 /**
@@ -242,7 +248,6 @@ ControlConnection.prototype.borrowAConnection = function (callback) {
       }
       self.host = host;
       self.connection = connection;
-      self.setHostListeners();
       callback();
     });
 };
@@ -250,28 +255,6 @@ ControlConnection.prototype.borrowAConnection = function (callback) {
 /** Default implementation for borrowing connections, that can be injected at constructor level */
 ControlConnection.prototype.borrowHostConnection = function (host, callback) {
   host.borrowConnection(callback);
-};
-
-/**
- * Gets info and subscribe to events on an specific connection
- * @param {Boolean} initializing Determines if the cc is being initialized and
- * it's the first time that trying to retrieve host information
- * @param {Function} callback
- */
-ControlConnection.prototype.refreshOnConnection = function (initializing, callback) {
-  var c = this.connection;
-  var self = this;
-  utils.series([
-    function getLocalAndPeersInfo(next) {
-      self.refreshHosts(initializing, next);
-    },
-    function subscribeConnectionEvents(next) {
-      c.on('nodeTopologyChange', self.nodeTopologyChangeHandler.bind(self));
-      c.on('nodeStatusChange', self.nodeStatusChangeHandler.bind(self));
-      c.on('nodeSchemaChange', self.nodeSchemaChangeHandler.bind(self));
-      var request = new requests.RegisterRequest(['TOPOLOGY_CHANGE', 'STATUS_CHANGE', 'SCHEMA_CHANGE']);
-      c.sendStream(request, null, next);
-    }], callback);
 };
 
 /**
@@ -386,7 +369,7 @@ ControlConnection.prototype.refresh = function (reuseQueryPlan, callback) {
     function getConnectionTask(next) {
       self.borrowAConnection(next);
     },
-    function refreshOnConnectionTask(next) {
+    function getLocalAndPeersInfo(next) {
       if (initializing) {
         self.log('info', f('ControlConnection using protocol version %d, connected to %s',
           self.protocolVersion, self.host.address));
@@ -394,10 +377,25 @@ ControlConnection.prototype.refresh = function (reuseQueryPlan, callback) {
       else {
         self.log('info', f('ControlConnection connected to %s', self.host.address));
       }
-      self.refreshOnConnection(initializing, next);
+      self.refreshHosts(initializing, next);
+    },
+    function subscribeConnectionEvents(next) {
+      self.connection.on('nodeTopologyChange', self.nodeTopologyChangeHandler.bind(self));
+      self.connection.on('nodeStatusChange', self.nodeStatusChangeHandler.bind(self));
+      self.connection.on('nodeSchemaChange', self.nodeSchemaChangeHandler.bind(self));
+      var request = new requests.RegisterRequest(['TOPOLOGY_CHANGE', 'STATUS_CHANGE', 'SCHEMA_CHANGE']);
+      self.connection.sendStream(request, null, next);
     }
   ], function refreshSeriesEnd(err) {
     if (!err) {
+      if (!self.connection.connected) {
+        // Before refreshSeriesEnd() was invoked, the connection changed to a "not connected" state.
+        // We have to avoid subscribing to 'down' or 'socketClosed' events after it was down / connection closed.
+        // The connection is no longer valid and we should retry the whole thing
+        self.log('info', f('Connection to %s was closed before finishing refresh', self.host.address));
+        return self.refresh(false, callback);
+      }
+      self.setHealthListeners();
       self.reconnectionSchedule = self.reconnectionPolicy.newSchedule();
       self.emit('newConnection', null, self.connection, self.host);
       self.log('info', f('ControlConnection connected to %s and up to date', self.host.address));
@@ -413,7 +411,10 @@ ControlConnection.prototype.refresh = function (reuseQueryPlan, callback) {
     }
     self.log('error', 'ControlConnection failed to retrieve topology and keyspaces information', err);
     self.triedHosts[self.host.address] = err;
-    self.markConnectionAsUnusable(err);
+    if (err && err.isSocketError) {
+      self.host.removeFromPool(self.connection);
+    }
+    self.connection = null;
     // Retry the whole thing with the same query plan, in the background or foreground
     self.refresh(true, callback);
   });
@@ -429,16 +430,6 @@ ControlConnection.prototype.noOpenConnectionHandler = function () {
   setTimeout(function controlConnectionReconnection() {
     self.refresh();
   }, delay);
-};
-
-ControlConnection.prototype.markConnectionAsUnusable = function (err) {
-  this.log('info', 'Connection used by the ControlConnection is unusable', err);
-  this.hostListenerRemover();
-  if (err && err.isSocketError) {
-    this.host.removeFromPool(this.connection);
-  }
-  this.host = null;
-  this.connection = null;
 };
 
 /**

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -165,19 +165,30 @@ ControlConnection.prototype.setHostListeners = function () {
   var host = this.host;
   var connection = this.connection;
   var self = this;
-  function downOrIgnoredHandler() {
-    self.log('warning', f('Host %s used by the ControlConnection DOWN', host.address));
-    self.markConnectionAsUnusable();
-    self.refresh();
-  }
-  function socketClosedHandler() {
+  var wasRefreshCalled = 0;
+  function startReconnecting(hostDown) {
+    if (wasRefreshCalled++ !== 0) {
+      // Prevent multiple calls to reconnect
+      return;
+    }
     if (self.isShuttingDown) {
       // Don't attempt to reconnect when the ControlConnection is being shutdown
       return;
     }
-    self.log('warning', f('Connection to %s used by the ControlConnection was closed', host.address));
+    if (hostDown) {
+      self.log('warning', f('Host %s used by the ControlConnection DOWN', host.address));
+    }
+    else {
+      self.log('warning', f('Connection to %s used by the ControlConnection was closed', host.address));
+    }
     self.markConnectionAsUnusable();
     self.refresh();
+  }
+  function downOrIgnoredHandler() {
+    startReconnecting(true);
+  }
+  function socketClosedHandler() {
+    startReconnecting(false);
   }
   host.once('down', downOrIgnoredHandler);
   host.once('ignore', downOrIgnoredHandler);
@@ -297,7 +308,7 @@ ControlConnection.prototype.refreshHosts = function (newNodesUp, callback) {
     function getPeersInfo(next) {
       var request = new requests.QueryRequest(selectPeers, null, null);
       c.sendStream(request, null, function (err, result) {
-        self.setPeersInfo(newNodesUp, result, next);
+        self.setPeersInfo(newNodesUp, err, result, next);
       });
     },
     function getKeyspaces(next) {
@@ -366,6 +377,7 @@ ControlConnection.prototype.refresh = function (reuseQueryPlan, callback) {
       self.profileManager.getDefaultLoadBalancing().newQueryPlan(null, null, function onNewPlan(err, iterator) {
         if (err) {
           self.log('error', 'ControlConnection could not retrieve a query plan to determine which hosts to use', err);
+          return next(err);
         }
         self.hostIterator = iterator;
         next();
@@ -412,6 +424,7 @@ ControlConnection.prototype.refresh = function (reuseQueryPlan, callback) {
  */
 ControlConnection.prototype.noOpenConnectionHandler = function () {
   var delay = this.reconnectionSchedule.next().value;
+  this.log('warning', f('ControlConnection could not reconnect, scheduling reconnection in %dms', delay));
   var self = this;
   setTimeout(function controlConnectionReconnection() {
     self.refresh();
@@ -608,12 +621,13 @@ ControlConnection.prototype.setLocalInfo = function (endPoint, result) {
 
 /**
  * @param {Boolean} newNodesUp
+ * @param {Error} err
  * @param {ResultSet} result
  * @param {Function} callback
  */
-ControlConnection.prototype.setPeersInfo = function (newNodesUp, result, callback) {
-  if (!result || !result.rows) {
-    return callback();
+ControlConnection.prototype.setPeersInfo = function (newNodesUp, err, result, callback) {
+  if (!result || !result.rows || err) {
+    return callback(err);
   }
   var self = this;
   //A map of peers, could useful for in case there are discrepancies

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -12,6 +12,7 @@ var EventDebouncer = require('./metadata/event-debouncer');
 var requests = require('./requests');
 var utils = require('./utils');
 var types = require('./types');
+var f = util.format;
 
 var selectPeers = "SELECT peer,data_center,rack,tokens,rpc_address,release_version FROM system.peers";
 var selectLocal = "SELECT * FROM system.local WHERE key='local'";
@@ -22,14 +23,23 @@ var schemaChangeTypes = {
   updated: 'UPDATED',
   dropped: 'DROPPED'
 };
+
 /**
- * Represents a connection used by the driver to receive events and to check the status of the cluster
+ * Creates a new instance of <code>ControlConnection</code>.
+ * @classdesc
+ * Represents a connection used by the driver to receive events and to check the status of the cluster.
+ * It uses an existing connection from the hosts' connection pool.
+ * Failover is performed by going through the query plan and attempting to use a connection to any of the hosts. If
+ * no reconnection could be made (including refreshing the metadata), a new query plan is obtained to get the status of
+ * the hosts. When all nodes are marked as down, it listens to hosts' "up" event to attempt to get a new
+ * connection.
  * @param {Object} options
  * @param {ProfileManager} profileManager
+ * @param {{borrowHostConnection: function}} [context] An object containing methods to allow dependency injection.
  * @extends EventEmitter
  * @constructor
  */
-function ControlConnection(options, profileManager) {
+function ControlConnection(options, profileManager, context) {
   this.protocolVersion = null;
   this.hosts = new HostMap();
   //noinspection JSUnresolvedFunction
@@ -40,8 +50,10 @@ function ControlConnection(options, profileManager) {
    */
   this.metadata = new Metadata(this.options, this);
   this.addressTranslator = this.options.policies.addressResolution;
-  this.loadBalancingPolicy = this.options.policies.loadBalancing;
+  this.reconnectionPolicy = this.options.policies.reconnection;
+  this.reconnectionSchedule = this.reconnectionPolicy.newSchedule();
   this.initialized = false;
+  this.isShuttingDown = false;
   /**
    * Host used by the control connection
    * @type {Host|null}
@@ -63,6 +75,13 @@ function ControlConnection(options, profileManager) {
   this.topologyChangeTimeout = null;
   /** Timeout used for delayed handling of node status changes */
   this.nodeStatusChangeTimeout = null;
+  this.reconnectionTimeout = null;
+  this.hostIterator = null;
+  this.hostListenerRemover = null;
+  this.triedHosts = null;
+  if (context && context.borrowHostConnection) {
+    this.borrowHostConnection = context.borrowHostConnection;
+  }
 }
 
 util.inherits(ControlConnection, events.EventEmitter);
@@ -125,9 +144,8 @@ ControlConnection.prototype.init = function (callback) {
         next(err);
       });
     },
-    this.getConnection.bind(this),
-    function tryInitOnConnection(next) {
-      self.refreshOnConnection(true, next);
+    function startRefresh(next) {
+      self.refresh(false, next);
     }
   ], function seriesFinished(err) {
     self.initialized = !err;
@@ -143,170 +161,98 @@ ControlConnection.prototype.init = function (callback) {
   });
 };
 
-/**
- * Gets a connection to any Host in the pool.
- * If its the first time, it will try to create a connection to a host present in the contactPoints in order.
- * @param {Function} callback
- * @emits ControlConnection#newConnection When a new connection is acquired
- */
-ControlConnection.prototype.getConnection = function (callback) {
+ControlConnection.prototype.setHostListeners = function () {
+  var host = this.host;
+  var connection = this.connection;
   var self = this;
-  function done(err, c, host) {
-    if (!err) {
-      if (c) {
-        self.connection = c;
-        self.encoder = c.encoder;
-        self.host = host;
-      }
-      else {
-        // Make sure that an error is being thrown
-        err = new errors.DriverInternalError('No connection could be acquired but no error was found');
-      }
+  function downOrIgnoredHandler() {
+    self.log('warning', f('Host %s used by the ControlConnection DOWN', host.address));
+    self.markConnectionAsUnusable();
+    self.refresh();
+  }
+  function socketClosedHandler() {
+    if (self.isShuttingDown) {
+      // Don't attempt to reconnect when the ControlConnection is being shutdown
+      return;
     }
-    callback(err);
-    self.emit('newConnection', err, c, host);
+    self.log('warning', f('Connection to %s used by the ControlConnection was closed', host.address));
+    self.markConnectionAsUnusable();
+    self.refresh();
   }
-  if (!this.initialized) {
-    //it is the first time
-    this.log('info', 'Getting first connection');
-    return this.getFirstConnection(function (err, c, host) {
-      if (!err && c) {
-        self.protocolVersion = c.protocolVersion;
-        self.log('info', 'Control connection using protocol version ' + self.protocolVersion);
-      }
-      done(err, c, host);
-    });
-  }
-  this.log('info', 'Trying to acquire a connection to a new host');
-  this.getConnectionToNewHost(done);
+  host.once('down', downOrIgnoredHandler);
+  host.once('ignore', downOrIgnoredHandler);
+  connection.once('socketClose', socketClosedHandler);
+  self.hostListenerRemover = function () {
+    host.removeListener('down', downOrIgnoredHandler);
+    host.removeListener('ignore', downOrIgnoredHandler);
+    connection.removeListener('socketClose', socketClosedHandler);
+  };
 };
 
 /**
- * Gets an open connection to using the provided hosts Array, without using the load balancing policy.
- * Invoked before the Client can access topology of the cluster.
- * @param {Function} callback
+ * Iterates through the hostIterator and gets the following open connection.
+ * @param callback
  */
-ControlConnection.prototype.getFirstConnection = function (callback) {
-  var connection = null;
-  var index = -1;
-  var openingErrors = {};
-  var hosts = this.hosts.values();
-  var host = null;
-  utils.whilst(function condition () {
-    return !connection && (++index < hosts.length);
-  }, function iterator(next) {
-    host = hosts[index];
-    host.borrowConnection(function (err, c) {
-      if (err) {
-        openingErrors[host.address] = err;
-      }
-      else {
-        connection = c;
-      }
-      next();
-    });
-  }, function done(err) {
-    if (!connection) {
-      err = new errors.NoHostAvailableError(openingErrors);
-    }
-    callback(err, connection, host);
-  });
-};
-
-/**
- * Acquires a connection to a host according to the load balancing policy.
- * If its not possible to connect, it subscribes to the hosts UP event.
- * @param {Function} callback
- */
-ControlConnection.prototype.getConnectionToNewHost = function (callback) {
+ControlConnection.prototype.borrowAConnection = function (callback) {
   var self = this;
   var host;
   var connection = null;
-  this.profileManager.getDefaultLoadBalancing().newQueryPlan(null, null, function (err, iterator) {
-    if (err) {
-      var message = 'Control connection could not retrieve a query plan to determine which hosts to use, ' +
-        'using current hosts map';
-      self.log('error', message, err);
-      iterator = utils.arrayIterator(self.hosts.values());
-    }
-    //use iterator
-    utils.whilst(
-      function condition() {
-        //while there isn't a valid connection
-        if (connection) {
-          return false;
-        }
-        var item = iterator.next();
-        host = item.value;
-        return (!item.done);
-      },
-      function whileIterator(next) {
+  utils.whilst(
+    function condition() {
+      // while there isn't a valid connection
+      if (connection) {
+        return false;
+      }
+      var item = self.hostIterator.next();
+      host = item.value;
+      return (!item.done);
+    },
+    function whileIterator(next) {
+      if (self.initialized) {
+        // Only check distance once the load-balancing policies have been initialized
         var distance = self.profileManager.getDistance(host);
-        if (!host.isUp()) {
+        if (!host.isUp() || distance === types.distance.ignored) {
           return next();
         }
-        if (distance === types.distance.ignored) {
-          return next();
-        }
-        host.borrowConnection(function (err, c) {
-          //move next if there was an error
-          connection = c;
-          next();
-        });
-      },
-      function whilstEnded() {
-        if (!connection) {
-          self.listenHostsForUp();
-          // Callback in error as no connection could be acquired
-          return callback(new errors.NoHostAvailableError(null));
-        }
-        callback(null, connection, host);
+      }
+      self.borrowHostConnection(host, function borrowConnectionCallback(err, c) {
+        self.triedHosts[host.address] = err;
+        connection = c;
+        next();
       });
-  });
+    },
+    function whilstEnded() {
+      if (!connection) {
+        return callback(new errors.NoHostAvailableError(self.triedHosts));
+      }
+      if (!self.initialized) {
+        self.protocolVersion = connection.protocolVersion;
+        self.encoder = connection.encoder;
+      }
+      self.host = host;
+      self.connection = connection;
+      self.setHostListeners();
+      callback();
+    });
 };
 
-/**
- * Subscribe to the UP event of all current hosts to reconnect when one
- * of them are back up.
- */
-ControlConnection.prototype.listenHostsForUp = function () {
-  var self = this;
-  var hostArray = this.hosts.values();
-  function onUp() {
-    //unsubscribe from all host
-    hostArray.forEach(function (host) {
-      host.removeListener('up', onUp);
-    });
-    self.refresh();
-  }
-  //All hosts are DOWN, we should subscribe to the UP event
-  //of each host as the HostConnectionPool is attempting to reconnect
-  hostArray.forEach(function (host) {
-    host.on('up', onUp);
-  });
+/** Default implementation for borrowing connections, that can be injected at constructor level */
+ControlConnection.prototype.borrowHostConnection = function (host, callback) {
+  host.borrowConnection(callback);
 };
 
 /**
  * Gets info and subscribe to events on an specific connection
- * @param {Boolean} firstTime Determines if the cc is being initialized and
+ * @param {Boolean} initializing Determines if the cc is being initialized and
  * it's the first time that trying to retrieve host information
  * @param {Function} callback
  */
-ControlConnection.prototype.refreshOnConnection = function (firstTime, callback) {
+ControlConnection.prototype.refreshOnConnection = function (initializing, callback) {
   var c = this.connection;
   var self = this;
-  self.log('info', 'Connection acquired to ' + self.host.address + ', refreshing nodes list');
   utils.series([
     function getLocalAndPeersInfo(next) {
-      var host = self.host;
-      function downOrIgnoredHandler() {
-        host.removeListener('down', downOrIgnoredHandler);
-        host.removeListener('ignore', downOrIgnoredHandler);
-        self.hostDownHandler();
-      }
-      host.once('down', downOrIgnoredHandler);
-      host.once('ignore', downOrIgnoredHandler);
-      self.refreshHosts(firstTime, next);
+      self.refreshHosts(initializing, next);
     },
     function subscribeConnectionEvents(next) {
       c.on('nodeTopologyChange', self.nodeTopologyChangeHandler.bind(self));
@@ -314,17 +260,7 @@ ControlConnection.prototype.refreshOnConnection = function (firstTime, callback)
       c.on('nodeSchemaChange', self.nodeSchemaChangeHandler.bind(self));
       var request = new requests.RegisterRequest(['TOPOLOGY_CHANGE', 'STATUS_CHANGE', 'SCHEMA_CHANGE']);
       c.sendStream(request, null, next);
-    }],
-    function initDone(err) {
-      if (err) {
-        // An error occurred, the ControlConnection will still reconnect as it's listening to host 'down' event
-        self.log('error', 'ControlConnection could not be initialized', err);
-      }
-      else {
-        self.log('info', 'ControlConnection connected to ' + self.host.address + ' and is up to date');
-      }
-      callback(err);
-    });
+    }], callback);
 };
 
 /**
@@ -333,9 +269,7 @@ ControlConnection.prototype.refreshOnConnection = function (firstTime, callback)
  * @param {Function} [callback]
  */
 ControlConnection.prototype.refreshHosts = function (newNodesUp, callback) {
-  if (!callback) {
-    callback = function () {};
-  }
+  callback = callback || utils.noop;
   // it's possible that this was called as a result of a topology change, but the connection was lost
   // between scheduling time and now.
   if (!this.connection) {
@@ -378,35 +312,120 @@ ControlConnection.prototype.refreshHosts = function (newNodesUp, callback) {
   ], callback);
 };
 
-ControlConnection.prototype.hostDownHandler = function () {
-  this.log('warning', 'Host ' + this.host.address + ' used by the ControlConnection DOWN');
+/**
+ * Acquires a connection and refreshes topology and keyspace metadata.
+ * <p>If it fails obtaining a connection:</p>
+ * <ul>
+ *   <li>
+ *     When its initializing, it should:
+ *     <ul>
+ *       <li>Continue iterating through the hosts</li>
+ *       <li>When there aren't any more hosts, it should invoke callback with the inner errors</li>
+ *     </ul>
+ *   </li>
+ *   <li>
+ *     When its running in the background, it should:
+ *     <ul>
+ *       <li>Continue iterating through the hosts</li>
+ *       <li>
+ *         When there aren't any more hosts, it should:
+ *         <ul>
+ *           <li>Schedule reconnection</li>
+ *           <li>Invoke callback with the inner errors</li>
+ *         </ul>
+ *       </li>
+ *     </ul>
+ *   </li>
+ * </ul>
+ * <p>If it fails obtaining the metadata, it should:</p>
+ * <ul>
+ *   <li>It should mark connection and/or host unusable</li>
+ *   <li>Retry using the same iterator from query plan / host list</li>
+ * </ul>
+ * @param {Boolean} [reuseQueryPlan]
+ * @param {Function} [callback]
+ */
+ControlConnection.prototype.refresh = function (reuseQueryPlan, callback) {
+  var initializing = !this.initialized;
+  callback = callback || utils.noop;
+  // Reset the state of the host field, that way we can identify when the query plan was exhausted
   this.host = null;
-  this.connection = null;
-  this.refresh();
+  var self = this;
+  utils.series([
+    function getHostIterator(next) {
+      if (reuseQueryPlan) {
+        return next();
+      }
+      self.triedHosts = {};
+      if (initializing) {
+        self.log('info', 'Getting first connection');
+        self.hostIterator = utils.arrayIterator(self.hosts.values());
+        return next();
+      }
+      self.log('info', 'Trying to acquire a connection to a new host');
+      self.profileManager.getDefaultLoadBalancing().newQueryPlan(null, null, function onNewPlan(err, iterator) {
+        if (err) {
+          self.log('error', 'ControlConnection could not retrieve a query plan to determine which hosts to use', err);
+        }
+        self.hostIterator = iterator;
+        next();
+      });
+    },
+    function getConnectionTask(next) {
+      self.borrowAConnection(next);
+    },
+    function refreshOnConnectionTask(next) {
+      if (initializing) {
+        self.log('info', f('ControlConnection using protocol version %d, connected to %s',
+          self.protocolVersion, self.host.address));
+      }
+      else {
+        self.log('info', f('ControlConnection connected to %s', self.host.address));
+      }
+      self.refreshOnConnection(initializing, next);
+    }
+  ], function refreshSeriesEnd(err) {
+    if (!err) {
+      self.reconnectionSchedule = self.reconnectionPolicy.newSchedule();
+      self.emit('newConnection', null, self.connection, self.host);
+      self.log('info', f('ControlConnection connected to %s and up to date', self.host.address));
+      return callback();
+    }
+    if (!self.host) {
+      self.log('error', 'ControlConnection failed to acquire a connection', err);
+      if (!initializing) {
+        self.noOpenConnectionHandler();
+      }
+      self.emit('newConnection', err);
+      return callback(err);
+    }
+    self.log('error', 'ControlConnection failed to retrieve topology and keyspaces information', err);
+    self.triedHosts[self.host.address] = err;
+    self.markConnectionAsUnusable(err);
+    // Retry the whole thing with the same query plan, in the background or foreground
+    self.refresh(true, callback);
+  });
 };
 
 /**
- * Acquires a connection and refreshes topology metadata.
- * @param {Function} [callback]
+ * There isn't an open connection at the moment, try again later.
  */
-ControlConnection.prototype.refresh = function (callback) {
+ControlConnection.prototype.noOpenConnectionHandler = function () {
+  var delay = this.reconnectionSchedule.next().value;
   var self = this;
-  utils.series([
-    this.getConnection.bind(this),
-    function (next) {
-      if (!self.connection) {
-        return next();
-      }
-      self.refreshOnConnection(false, next);
-    }], function doneRefreshing(err) {
+  setTimeout(function controlConnectionReconnection() {
+    self.refresh();
+  }, delay);
+};
 
-    if (err || !self.connection) {
-      self.log('error', 'ControlConnection was not able to reconnect');
-    }
-    if (callback) {
-      callback(err);
-    }
-  });
+ControlConnection.prototype.markConnectionAsUnusable = function (err) {
+  this.log('info', 'Connection used by the ControlConnection is unusable', err);
+  this.hostListenerRemover();
+  if (err && err.isSocketError) {
+    this.host.removeFromPool(this.connection);
+  }
+  this.host = null;
+  this.connection = null;
 };
 
 /**
@@ -656,11 +675,13 @@ ControlConnection.prototype.getAddressForPeerHost = function (row, defaultPort, 
   var peer = row['peer'];
   var bindAllAddress = '0.0.0.0';
   if (!address) {
-    this.log('error', util.format('No rpc_address found for host %s in %s\'s peers system table. %s will be ignored.', peer, this.host.address, peer));
+    this.log('error', f('No rpc_address found for host %s in %s\'s peers system table. %s will be ignored.',
+      peer, this.host.address, peer));
     return callback(null);
   }
   if (address.toString() === bindAllAddress) {
-    this.log('warning', util.format('Found host with 0.0.0.0 as rpc_address, using listen_address (%s) to contact it instead. If this is incorrect you should avoid the use of 0.0.0.0 server side.', peer));
+    this.log('warning', f('Found host with 0.0.0.0 as rpc_address, using listen_address (%s) to contact it instead.' +
+      ' If this is incorrect you should avoid the use of 0.0.0.0 server side.', peer));
     address = peer;
   }
   this.addressTranslator.translate(address.toString(), defaultPort, callback);
@@ -699,6 +720,7 @@ ControlConnection.prototype.query = function (cqlQuery, waitReconnect, callback)
   }
   function queryOnConnection() {
     var request = new requests.QueryRequest(cqlQuery, null, null);
+    //TODO: Handle socket error => remove from pool
     self.connection.sendStream(request, null, callback);
   }
   if (!this.connection) {
@@ -727,16 +749,19 @@ ControlConnection.prototype.getEncoder = function () {
 
 ControlConnection.prototype.shutdown = function () {
   // no need for callback as it all sync
+  this.isShuttingDown = true;
   this.debouncer.shutdown();
   // Emit a "newConnection" event with Error, as it may clear timeouts that were waiting new connections
   this.emit('newConnection', new errors.DriverError('ControlConnection is being shutdown'));
-  // Cancel other timers
+  // Cancel timers
   clearTimeout(this.topologyChangeTimeout);
   clearTimeout(this.nodeStatusChangeTimeout);
+  clearTimeout(this.reconnectionTimeout);
 };
 
 /**
  * Uses the DNS protocol to resolve a IPv4 and IPv6 addresses (A and AAAA records) for the hostname
+ * @private
  * @param name
  * @param callback
  */

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -28,11 +28,7 @@ var schemaChangeTypes = {
  * Creates a new instance of <code>ControlConnection</code>.
  * @classdesc
  * Represents a connection used by the driver to receive events and to check the status of the cluster.
- * It uses an existing connection from the hosts' connection pool.
- * Failover is performed by going through the query plan and attempting to use a connection to any of the hosts. If
- * no reconnection could be made (including refreshing the metadata), a new query plan is obtained to get the status of
- * the hosts. When all nodes are marked as down, it listens to hosts' "up" event to attempt to get a new
- * connection.
+ * <p>It uses an existing connection from the hosts' connection pool to maintain the driver metadata up-to-date.</p>
  * @param {Object} options
  * @param {ProfileManager} profileManager
  * @param {{borrowHostConnection: function}} [context] An object containing methods to allow dependency injection.
@@ -177,6 +173,7 @@ ControlConnection.prototype.setHealthListeners = function () {
       // Prevent multiple calls to reconnect
       return;
     }
+    removeListeners();
     if (self.isShuttingDown) {
       // Don't attempt to reconnect when the ControlConnection is being shutdown
       return;
@@ -187,7 +184,6 @@ ControlConnection.prototype.setHealthListeners = function () {
     else {
       self.log('warning', f('Connection to %s used by the ControlConnection was closed', host.address));
     }
-    removeListeners();
     self.host = null;
     self.connection = null;
     self.refresh();

--- a/lib/metadata/schema-parser.js
+++ b/lib/metadata/schema-parser.js
@@ -359,7 +359,7 @@ SchemaParserV1.prototype.getKeyspaces = function (waitReconnect, callback) {
         row['keyspace_name'],
         row['durable_writes'],
         row['strategy_class'],
-        JSON.parse(row['strategy_options']));
+        JSON.parse(row['strategy_options'] || null));
       keyspaces[ksInfo.name] = ksInfo;
     }
     callback(null, keyspaces);

--- a/test/integration/short/client-pool-tests.js
+++ b/test/integration/short/client-pool-tests.js
@@ -847,9 +847,10 @@ describe('Client', function () {
       ], done);
     });
     it('should reconnect in the background', function (done) {
+      var reconnectionDelay = 500;
       var client = newInstance({
         pooling: { heartBeatInterval: 0, warmup: true },
-        policies: { reconnection: new policies.reconnection.ConstantReconnectionPolicy(1000) }
+        policies: { reconnection: new policies.reconnection.ConstantReconnectionPolicy(reconnectionDelay) }
       });
       utils.series([
         client.connect.bind(client),
@@ -880,6 +881,7 @@ describe('Client', function () {
         },
         helper.toTask(helper.ccmHelper.startNode, null, 3),
         helper.waitOnHostUp(client, 3),
+        helper.delay(reconnectionDelay * 2),
         function assertReconnected(next) {
           assert.strictEqual('3', helper.lastOctetOf(client.controlConnection.host));
           client.hosts.forEach(function (host) {

--- a/test/integration/short/error-tests.js
+++ b/test/integration/short/error-tests.js
@@ -90,17 +90,13 @@ describe('Client', function () {
     });
     it('should callback with functionFailure error when the cql function throws an error', function (done) {
       var client = setupInfo.client;
-      utils.series([
-        function (next) {
-          client.execute('SELECT ks_func.div(v1,v2) FROM ks_func.tbl1 where id = 1', function (err) {
-            helper.assertInstanceOf(err, errors.ResponseError);
-            assert.strictEqual(err.code, types.responseErrorCodes.functionFailure);
-            assert.strictEqual(err.keyspace, 'ks_func');
-            assert.strictEqual(err.functionName, 'div');
-            next();
-          });
-        },
-      ], done);
+      client.execute('SELECT ks_func.div(v1,v2) FROM ks_func.tbl1 where id = 1', function (err) {
+        helper.assertInstanceOf(err, errors.ResponseError);
+        assert.strictEqual(err.code, types.responseErrorCodes.functionFailure);
+        assert.strictEqual(err.keyspace, 'ks_func');
+        assert.strictEqual(err.functionName, 'div');
+        done();
+      });
     });
   });
 });

--- a/test/integration/short/error-tests.js
+++ b/test/integration/short/error-tests.js
@@ -16,6 +16,17 @@ describe('Client', function () {
     var failWritesKs = helper.getRandomName('ks');
     var setupInfo = helper.setup(2, {
       keyspace: commonKs,
+      clientOptions: {
+        policies: { retry: new helper.FallthroughRetryPolicy() }
+      },
+      queries: [
+        'CREATE TABLE read_fail_tbl(pk int, cc int, v int, primary key (pk, cc))',
+        helper.createKeyspaceCql('ks_func'),
+        'CREATE TABLE ks_func.tbl1 (id int PRIMARY KEY, v1 int, v2 int)',
+        'INSERT INTO ks_func.tbl1 (id, v1, v2) VALUES (1, 1, 0)',
+        "CREATE FUNCTION ks_func.div(a int, b int) RETURNS NULL ON NULL INPUT" +
+        " RETURNS int LANGUAGE java AS 'return a / b;'"
+      ],
       ccmOptions: {
         yaml: ['tombstone_failure_threshold:1000', 'enable_user_defined_functions:true'],
         jvmArgs: ['-Dcassandra.test.fail_writes_ks=' + failWritesKs]
@@ -24,7 +35,6 @@ describe('Client', function () {
     it('should callback with readFailure error when tombstone overwhelmed on replica', function (done) {
       var client = setupInfo.client;
       utils.series([
-        helper.toTask(client.execute, client, "CREATE TABLE read_fail_tbl(pk int, cc int, v int, primary key (pk, cc))"),
         function generateTombstones(next) {
           utils.timesSeries(2000, function (n, timesNext) {
             client.execute('INSERT INTO read_fail_tbl (pk, cc, v) VALUES (1, ?, null)', [n], {prepare: true}, function (err, result) {
@@ -81,10 +91,6 @@ describe('Client', function () {
     it('should callback with functionFailure error when the cql function throws an error', function (done) {
       var client = setupInfo.client;
       utils.series([
-        helper.toTask(client.execute, client, helper.createKeyspaceCql('ks_func')),
-        helper.toTask(client.execute, client, 'CREATE TABLE ks_func.tbl1 (id int PRIMARY KEY, v1 int, v2 int)'),
-        helper.toTask(client.execute, client, 'INSERT INTO ks_func.tbl1 (id, v1, v2) VALUES (1, 1, 0)'),
-        helper.toTask(client.execute, client, "CREATE FUNCTION ks_func.div(a int, b int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return a / b;'"),
         function (next) {
           client.execute('SELECT ks_func.div(v1,v2) FROM ks_func.tbl1 where id = 1', function (err) {
             helper.assertInstanceOf(err, errors.ResponseError);

--- a/test/unit/control-connection-tests.js
+++ b/test/unit/control-connection-tests.js
@@ -363,6 +363,7 @@ function getFakeConnection(endpoint, queryResults) {
   var c = new events.EventEmitter();
   c.protocolVersion = types.protocolVersion.maxSupported;
   c.endpoint = endpoint;
+  c.connected = true;
   c.requests = [];
   var queryResultKeys = Object.keys(queryResults);
   var defaultResult = { rows: [ {} ] };

--- a/test/unit/control-connection-tests.js
+++ b/test/unit/control-connection-tests.js
@@ -11,6 +11,7 @@ var utils = require('../../lib/utils');
 var Metadata = require('../../lib/metadata');
 var types = require('../../lib/types');
 var errors = require('../../lib/errors');
+var policies = require('../../lib/policies');
 var clientOptions = require('../../lib/client-options');
 var ProfileManager = require('../../lib/execution-profile').ProfileManager;
 
@@ -21,7 +22,7 @@ describe('ControlConnection', function () {
       helper.assertInstanceOf(cc.metadata, Metadata);
     });
   });
-  xdescribe('#init()', function () {
+  describe('#init()', function () {
     this.timeout(20000);
     var useLocalhost;
     before(function (done) {
@@ -34,12 +35,17 @@ describe('ControlConnection', function () {
       });
     });
     function testResolution(CcMock, expectedHosts, done) {
-      var cc = new CcMock(clientOptions.extend({ contactPoints: ['my-host-name'] }));
-      cc.getConnection = helper.callbackNoop;
-      cc.refreshOnConnection = helper.callbackNoop;
+      var cc = new CcMock(clientOptions.extend({ contactPoints: ['my-host-name'] }), null, getContext({
+        queryResults: { 'system\\.peers': {
+          rows: expectedHosts
+            .filter(function (address) { return address !== '1:9042'; })
+            .map(function (address) { return { 'rpc_address': address.split(':')[0] }; })
+        }}
+      }));
       cc.init(function (err) {
-        assert.ifError(err);
         var hosts = cc.hosts.values();
+        cc.shutdown();
+        assert.ifError(err);
         assert.deepEqual(hosts.map(function (h) { return h.address; }), expectedHosts);
         done();
       });
@@ -48,10 +54,9 @@ describe('ControlConnection', function () {
       if (!useLocalhost) {
         return done();
       }
-      var cc = new ControlConnection(clientOptions.extend({ contactPoints: ['localhost'] }));
-      cc.getConnection = helper.callbackNoop;
-      cc.refreshOnConnection = helper.callbackNoop;
+      var cc = newInstance({ contactPoints: [ 'localhost' ] }, getContext());
       cc.init(function (err) {
+        cc.shutdown();
         assert.ifError(err);
         var hosts = cc.hosts.values();
         assert.strictEqual(hosts.length, 2);
@@ -63,10 +68,9 @@ describe('ControlConnection', function () {
       if (!useLocalhost) {
         return done();
       }
-      var cc = new ControlConnection(clientOptions.extend({ contactPoints: ['localhost:9999'] }));
-      cc.getConnection = helper.callbackNoop;
-      cc.refreshOnConnection = helper.callbackNoop;
+      var cc = newInstance({ contactPoints: [ 'localhost:9999' ] }, getContext());
       cc.init(function (err) {
+        cc.shutdown();
         assert.ifError(err);
         var hosts = cc.hosts.values();
         assert.ok(hosts.length >= 1);
@@ -134,88 +138,63 @@ describe('ControlConnection', function () {
       });
       testResolution(ControlConnectionMock, [ '123:9042' ], done);
     });
-  });
-  xdescribe('#nodeSchemaChangeHandler()', function () {
-    it('should update keyspace metadata information', function () {
-      var cc = new ControlConnection(clientOptions.extend({}, helper.baseOptions));
-      cc.log = helper.noop;
-      var ksName = 'ks1';
-      var refreshedKeyspaces = [];
-      var refreshedObjects = [];
-      cc.scheduleKeyspaceRefresh = function (name, b, cb) {
-        refreshedKeyspaces.push(name);
-        if (cb) {
-          cb();
-        }
-      };
-      cc.scheduleObjectRefresh = function (h, ks, cqlObject) {
-        h();
-        refreshedObjects.push(ks + '-' + (cqlObject || ''));
-      };
-      cc.metadata.keyspaces = {};
-      cc.metadata.keyspaces[ksName] = { tables: { 'tbl1': {} }, views: {} };
-      cc.nodeSchemaChangeHandler({schemaChangeType: 'DROPPED', keyspace: ksName, isKeyspace: true});
-      assert.strictEqual(refreshedKeyspaces.length, 0);
-      assert.deepEqual(refreshedObjects, [ ksName + '-' ]);
-      cc.nodeSchemaChangeHandler({ schemaChangeType: 'CREATED', keyspace: ksName, isKeyspace: true});
-      assert.deepEqual(refreshedKeyspaces, [ ksName ]);
-      cc.nodeSchemaChangeHandler({ schemaChangeType: 'UPDATED', keyspace: ksName, isKeyspace: true});
-      assert.deepEqual(refreshedKeyspaces, [ ksName, ksName ]);
-      cc.nodeSchemaChangeHandler({ schemaChangeType: 'UPDATED', keyspace: ksName, isKeyspace: true});
-      assert.deepEqual(refreshedKeyspaces, [ ksName, ksName, ksName ]);
-      cc.metadata.keyspaces[ksName] = { tables: { 'tbl1': {} }, views: {} };
-      cc.nodeSchemaChangeHandler({ schemaChangeType: 'UPDATED', keyspace: ksName, table: 'tbl1'});
-      // clears the internal state
-      assert.ok(!cc.metadata.keyspaces[ksName].tables['tbl1']);
+    it('should continue iterating through the hosts when borrowing a connection fails', function (done) {
+      var hosts = [];
+      var cc = newInstance({ contactPoints: [ '::1', '::2' ] }, getContext({ hosts: hosts, failBorrow: [ 0 ] }));
+      cc.init(function (err) {
+        cc.shutdown();
+        assert.ifError(err);
+        assert.strictEqual(hosts.length, 2);
+        assert.ok(cc.initialized);
+        done();
+      });
+    });
+    it('should callback with NoHostAvailableError when borrowing all connections fail', function (done) {
+      var hosts = [];
+      var cc = newInstance({ contactPoints: [ '::1', '::2' ] }, getContext({ hosts: hosts, failBorrow: [ 0, 1] }));
+      cc.init(function (err) {
+        cc.shutdown();
+        helper.assertInstanceOf(err, errors.NoHostAvailableError);
+        assert.strictEqual(Object.keys(err.innerErrors).length, 2);
+        assert.strictEqual(hosts.length, 2);
+        assert.ok(!cc.initialized);
+        done();
+      });
+    });
+    it('should continue iterating through the hosts when metadata retrieval fails', function (done) {
+      var hosts = [];
+      var cc = newInstance({ contactPoints: [ '::1', '::2' ] }, getContext({
+        hosts: hosts, queryResults: { '::1': 'Test error, failed query' }
+      }));
+      cc.init(function (err) {
+        cc.shutdown();
+        assert.ifError(err);
+        done();
+      });
+    });
+    it('should listen to socketClose and reconnect', function (done) {
+      var state = {};
+      var hostsTried = [];
+      var lbp = new policies.loadBalancing.RoundRobinPolicy();
+      var cc = newInstance({ contactPoints: [ '::1', '::2' ], policies: { loadBalancing: lbp } }, getContext({
+        state: state, hosts: hostsTried
+      }));
+      cc.init(function (err) {
+        assert.ifError(err);
+        assert.ok(state.connection);
+        assert.strictEqual(hostsTried.length, 1);
+        lbp.init(null, cc.hosts, utils.noop);
+        state.connection.emit('socketClose');
+        setImmediate(function () {
+          // Attempted reconnection and succeeded
+          assert.strictEqual(hostsTried.length, 2);
+          cc.shutdown();
+          done();
+        });
+      });
     });
   });
-  xdescribe('#nodeStatusChangeHandler()', function () {
-    it('should call event address toString() to get', function () {
-      var options = clientOptions.extend({}, helper.baseOptions);
-      var toStringCalled = false;
-      var hostsGetCalled = false;
-      var cc = newInstance(options);
-      cc.hosts = { get : function () { hostsGetCalled = true;}};
-      var event = { inet: { address: { toString: function () { toStringCalled = true; return 'host1';}}}};
-      cc.nodeStatusChangeHandler(event);
-      assert.strictEqual(toStringCalled, true);
-      assert.strictEqual(hostsGetCalled, true);
-    });
-    it('should set the node down when distance is ignored', function () {
-      var downSet = 0;
-      var options = clientOptions.extend({}, helper.baseOptions);
-      var cc = newInstance(options);
-      cc.hosts = { 
-        get : function () { 
-          return {
-            setDown: function () { downSet++; },
-            setDistance: function () { return types.distance.ignored; }
-          };
-        }
-      };
-      var event = { inet: { address: { toString: function () { return 'host1';}}}};
-      cc.nodeStatusChangeHandler(event);
-      assert.strictEqual(downSet, 1);
-    });
-    it('should not set the node down when distance is not ignored', function () {
-      var downSet = 0;
-      var options = clientOptions.extend({}, helper.baseOptions);
-      var cc = newInstance(options);
-      cc.hosts = { 
-        get : function () { 
-          return {
-            setDown: function () { downSet++;},
-            datacenter: 'dc1',
-            setDistance: helper.noop
-          };
-        }
-      };
-      var event = { inet: { address: { toString: function () { return 'host1';}}}};
-      cc.nodeStatusChangeHandler(event);
-      assert.strictEqual(downSet, 0);
-    });
-  });
-  xdescribe('#getAddressForPeerHost()', function() {
+  describe('#getAddressForPeerHost()', function() {
     it('should handle null, 0.0.0.0 and valid addresses', function (done) {
       var options = clientOptions.extend({}, helper.baseOptions);
       var cc = newInstance(options);
@@ -248,15 +227,16 @@ describe('ControlConnection', function () {
         }
       ], done);
     });
-    it('should call the AddressTranslator', function () {
+    it('should call the AddressTranslator', function (done) {
       var options = clientOptions.extend({}, helper.baseOptions);
       var address = null;
       var port = null;
-      options.policies.addressResolution = { translate: function (addr, p, cb) {
+      options.policies.addressResolution = policies.defaultAddressTranslator();
+      options.policies.addressResolution.translate = function (addr, p, cb) {
         address = addr;
         port = p;
         cb(addr + ':' + p);
-      }};
+      };
       var cc = newInstance(options);
       cc.host = new Host('2.2.2.2', 1, options);
       cc.log = helper.noop;
@@ -265,15 +245,15 @@ describe('ControlConnection', function () {
         assert.strictEqual(endPoint, '5.2.3.4:9055');
         assert.strictEqual(address, '5.2.3.4');
         assert.strictEqual(port, 9055);
+        done();
       });
     });
   });
-  xdescribe('#setPeersInfo()', function () {
+  describe('#setPeersInfo()', function () {
     it('should use not add invalid addresses', function () {
       var options = clientOptions.extend({}, helper.baseOptions);
       var cc = newInstance(options);
       cc.host = new Host('18.18.18.18', 1, options);
-      cc.log = helper.noop;
       var rows = [
         //valid rpc address
         {'rpc_address': getInet([5, 4, 3, 2]), peer: getInet([1, 1, 1, 1])},
@@ -284,8 +264,7 @@ describe('ControlConnection', function () {
         //should use peer address
         {'rpc_address': getInet([0, 0, 0, 0]), peer: getInet([5, 5, 5, 5])}
       ];
-      //noinspection JSCheckFunctionSignatures
-      cc.setPeersInfo(true, {rows: rows}, function (err) {
+      cc.setPeersInfo(true, null, { rows: rows }, function (err) {
         assert.ifError(err);
         assert.strictEqual(cc.hosts.length, 3);
         assert.ok(cc.hosts.get('5.4.3.2:9042'));
@@ -296,17 +275,13 @@ describe('ControlConnection', function () {
     it('should set the host datacenter and cassandra version', function () {
       var options = clientOptions.extend({}, helper.baseOptions);
       var cc = newInstance(options);
-      //dummy
-      cc.host = new Host('18.18.18.18', 1, options);
-      cc.log = helper.noop;
       var rows = [
         //valid rpc address
         {'rpc_address': getInet([5, 4, 3, 2]), peer: getInet([1, 1, 1, 1]), data_center: 'dc100', release_version: '2.1.4'},
         //valid rpc address
         {'rpc_address': getInet([9, 8, 7, 6]), peer: getInet([1, 1, 1, 1]), data_center: 'dc101', release_version: '2.1.4'}
       ];
-      //noinspection JSCheckFunctionSignatures
-      cc.setPeersInfo(true, {rows: rows}, function (err) {
+      cc.setPeersInfo(true, null, { rows: rows }, function (err) {
         assert.ifError(err);
         assert.strictEqual(cc.hosts.length, 2);
         assert.ok(cc.hosts.get('5.4.3.2:9042'));
@@ -318,65 +293,52 @@ describe('ControlConnection', function () {
       });
     });
   });
-  xdescribe('#refreshOnConnection()', function () {
-    it('should subscribe to current host events first in case IO fails', function (done) {
-      var options = clientOptions.extend({}, helper.baseOptions);
-      var cc = newInstance(options);
-      cc.host = new Host('18.18.18.18:9042', 1, options);
-      cc.log = helper.noop;
-      var fakeError = new Error('fake error');
-      var hostDownCalled;
-      cc.connectionUnusable = function () {
-        hostDownCalled = true;
-      };
-      cc.refreshHosts = function (up, cb) {
-        //for this to fail, there should be a query executing in parallel that resulted in host.setDown()
-        cc.host.setDown();
-        cb(fakeError);
-      };
-      cc.refreshOnConnection(false, function (err) {
-        assert.strictEqual(err, fakeError);
-        assert.strictEqual(hostDownCalled, true);
-        cc.host.shutdown(helper.noop);
-        done();
-      });
-    });
-  });
   describe('#refresh()', function () {
-    it('should schedule reconnection when it cant borrow a connection');
-    it('should check if the host is ignored');
-  });
-  describe('#init()', function () {
-    it('should continue iterating through the hosts when borrowing a connection fails', function (done) {
-      var hosts = [];
-      var cc = newInstance({ contactPoints: [ '::1', '::2' ] }, getContext({ hosts: hosts, failBorrow: [ 0 ] }));
+    it('should schedule reconnection when it cant borrow a connection', function (done) {
+      var state = {};
+      var hostsTried = [];
+      var lbp = new policies.loadBalancing.RoundRobinPolicy();
+      lbp.queryPlanCount = 0;
+      lbp.newQueryPlan = function (ks, o, cb) {
+        if (lbp.queryPlanCount++ === 0) {
+          // Return an empty query plan the first time
+          return cb(null, utils.arrayIterator([]));
+        }
+        return cb(null, utils.arrayIterator(lbp.hosts.values()));
+      };
+      var rp = new policies.reconnection.ConstantReconnectionPolicy(10);
+      rp.nextDelayCount = 0;
+      rp.newSchedule = function () {
+        return {
+          next: function () {
+            rp.nextDelayCount++;
+            return { value: 10, done: false};
+          }
+        };
+      };
+      var cc = newInstance({ contactPoints: [ '::1', '::2' ], policies: { loadBalancing: lbp, reconnection: rp } },
+        getContext({ state: state, hosts: hostsTried }));
       cc.init(function (err) {
-        cc.shutdown();
         assert.ifError(err);
-        assert.strictEqual(hosts.length, 2);
-        assert.ok(cc.initialized);
-        done();
-      });
-    });
-    it('should callback with NoHostAvailableError when borrowing all connections fail', function (done) {
-      var hosts = [];
-      var cc = newInstance({ contactPoints: [ '::1', '::2' ] }, getContext({ hosts: hosts, failBorrow: [ 0, 1] }));
-      cc.init(function (err) {
-        cc.shutdown();
-        helper.assertInstanceOf(err, errors.NoHostAvailableError);
-        assert.strictEqual(Object.keys(err.innerErrors).length, 2);
-        assert.strictEqual(hosts.length, 2);
-        assert.ok(!cc.initialized);
-        done();
-      });
-    });
-    it('should continue iterating through the hosts when metadata retrieval fails', function (done) {
-      var hosts = [];
-      var cc = newInstance({ contactPoints: [ '::1', '::2' ] }, getContext({ hosts: hosts, failQuery: [ '::1' ] }));
-      cc.init(function (err) {
-        cc.shutdown();
-        assert.ifError(err);
-        done();
+        assert.ok(state.connection);
+        assert.strictEqual(hostsTried.length, 1);
+        lbp.init(null, cc.hosts, utils.noop);
+        state.connection.emit('socketClose');
+        var previousConnection = state.connection;
+        setImmediate(function () {
+          // Attempted reconnection and there isn't a host available
+          assert.strictEqual(hostsTried.length, 1);
+          // Scheduled reconnection
+          assert.strictEqual(rp.nextDelayCount, 1);
+          setTimeout(function () {
+            // Reconnected
+            assert.strictEqual(hostsTried.length, 2);
+            // Changed connection
+            assert.notEqual(state.connection, previousConnection);
+            cc.shutdown();
+            done();
+          }, 20);
+        });
       });
     });
   });
@@ -396,47 +358,54 @@ function newInstance(options, context) {
   return new ControlConnection(options, new ProfileManager(options), context);
 }
 
-function getFakeConnection(endpoint, failQuery) {
-  failQuery = failQuery || [];
+function getFakeConnection(endpoint, queryResults) {
+  queryResults = queryResults || {};
   var c = new events.EventEmitter();
   c.protocolVersion = types.protocolVersion.maxSupported;
   c.endpoint = endpoint;
   c.requests = [];
+  var queryResultKeys = Object.keys(queryResults);
+  var defaultResult = { rows: [ {} ] };
   c.sendStream = function (request, options, cb) {
     c.requests.push(request);
-    var fail = false;
-    for (var i = 0; i < failQuery.length; i++) {
-      var re = new RegExp(failQuery[i]);
+    var result;
+    for (var i = 0; i < queryResultKeys.length; i++) {
+      var key = queryResultKeys[i];
+      var re = new RegExp(key);
       if (re.test(request.query) || re.test(endpoint)) {
-        fail = true;
+        result = queryResults[key];
         break;
       }
     }
-    if (fail) {
-      return cb(new Error('Test error, failed query'));
+    if (typeof result === 'string') {
+      return cb(new Error(result));
     }
-    cb(null, { rows: [ {} ] });
+    cb(null, result || defaultResult);
   };
   return c;
 }
 
 /**
  * Gets the ControlConnection context
- * @param {{hosts: Array|undefined, failBorrow: Array|undefined, failQuery: Array|undefined}} options
+ * @param {{hosts: Array|undefined, failBorrow: Array|undefined, queryResults: Object|undefined,
+ *   state: Object|undefined}} [options]
  */
 function getContext(options) {
   options = options || {};
   // hosts that the ControlConnection used to borrow a connection
   var hosts = options.hosts || [];
+  var state = options.state || {};
   var failBorrow = options.failBorrow || [];
   return {
     borrowHostConnection: function (h, callback) {
       var i = hosts.length;
       hosts.push(h);
+      state.host = h;
       if (failBorrow.indexOf(i) >= 0) {
         return callback(new Error('Test error'));
       }
-      return callback(null, getFakeConnection(h.address, options.failQuery));
+      state.connection = getFakeConnection(h.address, options.queryResults);
+      return callback(null, state.connection);
     }
   };
 }


### PR DESCRIPTION
Fixes: NODEJS-360

- Unified all the failover logic in a single method
- Reuse the query plan and move to the next host when there is a connection fail while reconnecting.
- Allow injection at constructor level
- Use a reconnection schedule instead of listening to `'up'` events from hosts as listening to events is more prone to race conditions.