### PR TITLE
Use query keyspace from prepared metadata

### DIFF
--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -207,6 +207,7 @@ function createQueryOptions(client, userOptions, rowCallback, logged) {
     fetchSize: ifUndefined(userOptions.fetchSize, defaultQueryOptions.fetchSize),
     hints: userOptions.hints,
     isIdempotent: ifUndefined(userOptions.isIdempotent, defaultQueryOptions.isIdempotent),
+    keyspace: userOptions.keyspace,
     logged: ifUndefined(userOptions.logged, logged),
     pageState: userOptions.pageState,
     prepare: ifUndefined(userOptions.prepare, defaultQueryOptions.prepare),

--- a/lib/client.js
+++ b/lib/client.js
@@ -179,6 +179,12 @@ var warmupLimit = 32;
  *   determine if an statement can be retried in case of request error or write timeout.
  * </p>
  * <p>Default: <code>false</code>.</p>
+ * @property {String} [keyspace] Specifies the keyspace for the query. Used for routing within the driver, this
+ * property is suitable when the query operates on a different keyspace than the current {@link Client#keyspace}.
+ * <p>
+ *   This property should only be set manually by the user when the query operates on a different keyspace than
+ *   the current {@link Client#keyspace} and using either batch or non-prepared query executions.
+ * </p>
  * @property {Boolean} [logged] Determines if the batch should be written to the batchlog. Only valid for
  * [Client#batch()]{@link Client#batch}, it will be ignored by other methods. Default: true.
  * @property {Buffer|String} [pageState] Buffer or string token representing the paging state.
@@ -1090,6 +1096,9 @@ Client.prototype._setQueryOptions = function (options, params, meta, callback) {
         //it is filled by the user
         //or it is not prepared
         return next();
+      }
+      if (!options.keyspace && meta.keyspace) {
+        options.keyspace = meta.keyspace;
       }
       if (util.isArray(meta.partitionKeys)) {
         //the partition keys are provided as part of the metadata

--- a/lib/policies/load-balancing.js
+++ b/lib/policies/load-balancing.js
@@ -41,9 +41,10 @@ LoadBalancingPolicy.prototype.getDistance = function (host) {
  * Returns an iterator with the hosts for a new query.
  * Each new query will call this method. The first host in the result will
  * then be used to perform the query.
- * @param {String} keyspace Name of the keyspace
- * @param queryOptions options evaluated for this execution
- * @param {Function} callback
+ * @param {String} keyspace Name of currently logged keyspace at <code>Client</code> level.
+ * @param {QueryOptions} queryOptions Options related to this query execution.
+ * @param {Function} callback The function to be invoked with the error as first parameter and the host iterator as
+ * second parameter.
  */
 LoadBalancingPolicy.prototype.newQueryPlan = function (keyspace, queryOptions, callback) {
   callback(new Error('You must implement a query plan for the LoadBalancingPolicy class'));
@@ -61,9 +62,11 @@ function RoundRobinPolicy() {
 util.inherits(RoundRobinPolicy, LoadBalancingPolicy);
 
 /**
- * @param {String} keyspace Name of the keyspace
- * @param queryOptions options evaluated for this execution
- * @param {Function} callback
+ * Returns an iterator with the hosts to be used as coordinator for a query.
+ * @param {String} keyspace Name of currently logged keyspace at <code>Client</code> level.
+ * @param {QueryOptions} queryOptions Options related to this query execution.
+ * @param {Function} callback The function to be invoked with the error as first parameter and the host iterator as
+ * second parameter.
  */
 RoundRobinPolicy.prototype.newQueryPlan = function (keyspace, queryOptions, callback) {
   if (!this.hosts) {
@@ -199,9 +202,10 @@ DCAwareRoundRobinPolicy.prototype._sliceNodesByDc = function() {
 /**
  * It returns an iterator that yields local nodes first and remotes nodes afterwards.
  * The amount of remote nodes returned will depend on the usedHostsPerRemoteDc
- * @param {String} keyspace Name of the keyspace
- * @param queryOptions
- * @param {Function} callback
+ * @param {String} keyspace Name of currently logged keyspace at <code>Client</code> level.
+ * @param {QueryOptions} queryOptions Options related to this query execution.
+ * @param {Function} callback The function to be invoked with the error as first parameter and the host iterator as
+ * second parameter.
  */
 DCAwareRoundRobinPolicy.prototype.newQueryPlan = function (keyspace, queryOptions, callback) {
   if (!this.hosts) {
@@ -262,18 +266,20 @@ TokenAwarePolicy.prototype.getDistance = function (host) {
 
 /**
  * Returns the hosts to use for a new query.
- * The returned plan will first return replicas (whose HostDistance
- * for the child policy is local) for the query if it can determine
- * them is not.
- * Following what it will return the plan of the child policy.
- * @param {String} keyspace Name of the keyspace
- * @param queryOptions
- * @param {Function} callback
+ * The returned plan will return local replicas first, if replicas can be determined, followed by the plan of the
+ * child policy.
+ * @param {String} keyspace Name of currently logged keyspace at <code>Client</code> level.
+ * @param {QueryOptions} queryOptions Options related to this query execution.
+ * @param {Function} callback The function to be invoked with the error as first parameter and the host iterator as
+ * second parameter.
  */
 TokenAwarePolicy.prototype.newQueryPlan = function (keyspace, queryOptions, callback) {
   var routingKey;
   if (queryOptions) {
     routingKey = queryOptions.routingKey;
+    if (queryOptions.keyspace) {
+      keyspace = queryOptions.keyspace;
+    }
   }
   var replicas;
   if (routingKey) {

--- a/test/integration/short/client-execute-prepared-tests.js
+++ b/test/integration/short/client-execute-prepared-tests.js
@@ -609,6 +609,30 @@ describe('Client', function () {
         }
       ], done);
     });
+    describe('with a different keyspace', function () {
+      it('should fill in the keyspace in the query options passed to the lbp', function (done) {
+        var lbp = new loadBalancing.RoundRobinPolicy();
+        lbp.newQueryPlanOriginal = lbp.newQueryPlan;
+        var queryOptionsArray = [];
+        lbp.newQueryPlan = function (query, queryOptions, callback) {
+          queryOptionsArray.push(queryOptions);
+          lbp.newQueryPlanOriginal(query, queryOptions, callback);
+        };
+        var client = newInstance({ policies: { loadBalancing: lbp}});
+        utils.series([
+          client.connect.bind(client),
+          function query(next) {
+            client.execute('SELECT * FROM system.local WHERE key = ?', [ 'local' ], { prepare: true }, next);
+          },
+          client.shutdown.bind(client),
+          function assertResults(next) {
+            var queryOptions = queryOptionsArray[queryOptionsArray.length - 1];
+            assert.strictEqual(queryOptions.keyspace, 'system');
+            next();
+          }
+        ], done);
+      });
+    });
     describe('with udt and tuple', function () {
       before(function (done) {
         var client = setupInfo.client;

--- a/test/integration/short/client-execute-prepared-tests.js
+++ b/test/integration/short/client-execute-prepared-tests.js
@@ -618,7 +618,7 @@ describe('Client', function () {
           queryOptionsArray.push(queryOptions);
           lbp.newQueryPlanOriginal(query, queryOptions, callback);
         };
-        var client = newInstance({ policies: { loadBalancing: lbp}});
+        var client = newInstance({ keyspace: commonKs, policies: { loadBalancing: lbp}});
         utils.series([
           client.connect.bind(client),
           function query(next) {

--- a/test/integration/short/load-balancing-tests.js
+++ b/test/integration/short/load-balancing-tests.js
@@ -10,6 +10,7 @@ var loadBalancing = require('../../../lib/policies/load-balancing');
 var RoundRobinPolicy = loadBalancing.RoundRobinPolicy;
 var TokenAwarePolicy = loadBalancing.TokenAwarePolicy;
 var WhiteListPolicy = loadBalancing.WhiteListPolicy;
+var vdescribe = helper.vdescribe;
 
 context('with a reusable 3 node cluster', function () {
   this.timeout(180000);
@@ -25,7 +26,7 @@ context('with a reusable 3 node cluster', function () {
       'ALTER KEYSPACE system_traces WITH replication = {\'class\': \'SimpleStrategy\', \'replication_factor\': \'1\'}'
     ]
   });
-  describe('WhiteListPolicy', function () {
+  vdescribe('2.0', 'WhiteListPolicy', function () {
     it('should use the hosts in the white list only', function (done) {
       var policy = new WhiteListPolicy(new RoundRobinPolicy(), ['127.0.0.1:9042', '127.0.0.2:9042']);
       var client = newInstance(policy);
@@ -42,7 +43,7 @@ context('with a reusable 3 node cluster', function () {
       });
     });
   });
-  describe('TokenAwarePolicy', function () {
+  vdescribe('2.0', 'TokenAwarePolicy', function () {
     it('should target the correct partition with logged keyspace', function (done) {
       utils.series([
         function testCaseWithSimpleStrategy(next) {

--- a/test/integration/short/load-balancing-tests.js
+++ b/test/integration/short/load-balancing-tests.js
@@ -2,151 +2,148 @@
 var assert = require('assert');
 var util = require('util');
 
-var helper = require('../../test-helper.js');
-var Client = require('../../../lib/client.js');
-var utils = require('../../../lib/utils.js');
-var loadBalancing = require('../../../lib/policies/load-balancing.js');
+var helper = require('../../test-helper');
+var Client = require('../../../lib/client');
+var utils = require('../../../lib/utils');
+var types = require('../../../lib/types');
+var loadBalancing = require('../../../lib/policies/load-balancing');
 var RoundRobinPolicy = loadBalancing.RoundRobinPolicy;
 var TokenAwarePolicy = loadBalancing.TokenAwarePolicy;
 var WhiteListPolicy = loadBalancing.WhiteListPolicy;
 
-
-describe('TokenAwarePolicy', function () {
+context('with a reusable 3 node cluster', function () {
   this.timeout(180000);
-  it('should use primary replica according to Murmur single dc', function (done) {
-    var keyspace = 'ks1';
-    var table = 'table1';
-    var testClient = new Client(helper.baseOptions);
-    utils.series([
-      helper.ccmHelper.start('3'),
-      testClient.connect.bind(testClient),
-      function createKs(next) {
-        testClient.execute(helper.createKeyspaceCql(keyspace, 1), next);
-      },
-      function createTable(next) {
-        var query = util.format('CREATE TABLE %s.%s (id int primary key, name int)', keyspace, table);
-        testClient.execute(query, next);
-      },
-      testClient.shutdown.bind(testClient),
-      function testCase(next) {
-        //Pre-calculated based on Murmur
-        //This test can be improved using query tracing, consistency all and checking hops
-        var expectedPartition = {
-          '1': '2',
-          '2': '2',
-          '3': '1',
-          '4': '3',
-          '5': '2',
-          '6': '3',
-          '7': '3',
-          '8': '2',
-          '9': '1',
-          '10': '2'
-        };
-        var client = new Client({
-          policies: { loadBalancing: new TokenAwarePolicy(new RoundRobinPolicy())},
-          keyspace: keyspace,
-          contactPoints: helper.baseOptions.contactPoints
-        });
-        utils.times(100, function (n, timesNext) {
-          var id = (n % 10) + 1;
-          var query = util.format('INSERT INTO %s (id, name) VALUES (%s, %s)', table, id, id);
-          client.execute(query, null, { routingKey: new Buffer([0, 0, 0, id])}, function (err, result) {
-            assert.ifError(err);
-            //for murmur id = 1, it go to replica 2
-            var address = result.info.queriedHost;
-            assert.strictEqual(helper.lastOctetOf(address), expectedPartition[id.toString()]);
-            timesNext();
-          });
-        }, helper.finish(client, next));
-      },
-      helper.ccmHelper.remove
-    ], done);
+  helper.setup(3, {
+    queries: [
+      'CREATE KEYSPACE ks_simple_rp1 WITH replication = {\'class\': \'SimpleStrategy\', \'replication_factor\' : 1}',
+      'CREATE KEYSPACE ks_network_rp1 WITH replication = {\'class\': \'NetworkTopologyStrategy\', \'datacenter1\' : 1}',
+      'CREATE KEYSPACE ks_network_rp2 WITH replication = {\'class\': \'NetworkTopologyStrategy\', \'datacenter1\' : 2}',
+      'CREATE TABLE ks_simple_rp1.table_a (id int primary key, name int)',
+      'CREATE TABLE ks_network_rp1.table_b (id int primary key, name int)',
+      'CREATE TABLE ks_network_rp2.table_c (id int primary key, name int)'
+    ]
   });
-  it('should target the correct partition', function (done) {
-    var keyspace1 = 'ks1';
-    var keyspace2 = 'ks2';
-    var table = 'table1';
-
-    function testCase(ks, next) {
-      var client = new Client({
-        policies: { loadBalancing: new TokenAwarePolicy(new RoundRobinPolicy())},
-        keyspace: ks,
-        contactPoints: helper.baseOptions.contactPoints
-      });
-      utils.timesSeries(10, function (n, timesNext) {
-        var id = (n % 10) + 1;
-        var query = util.format('INSERT INTO %s (id, name) VALUES (?, ?)', table);
-        client.execute(query, [id, id], { traceQuery: true, prepare: true}, function (err, result) {
+  describe('WhiteListPolicy', function () {
+    it('should use the hosts in the white list only', function (done) {
+      var policy = new WhiteListPolicy(new RoundRobinPolicy(), ['127.0.0.1:9042', '127.0.0.2:9042']);
+      var client = newInstance(policy);
+      utils.timesLimit(100, 20, function (n, next) {
+        client.execute(helper.queries.basic, function (err, result) {
           assert.ifError(err);
-          var coordinator = result.info.queriedHost;
-          var traceId = result.info.traceId;
-          client.metadata.getTrace(traceId, function (err, trace) {
-            assert.ifError(err);
-            trace.events.forEach(function (event) {
-              //no network hops in the server
-              assert.strictEqual(
-                helper.lastOctetOf(event['source'].toString()),
-                helper.lastOctetOf(coordinator.toString()));
-            });
-            timesNext();
-          });
+          var lastOctet = helper.lastOctetOf(result.info.queriedHost);
+          assert.ok(lastOctet === '1' || lastOctet === '2');
+          next();
         });
-      }, helper.finish(client, next));
-    }
-
-    var testClient = new Client(helper.baseOptions);
-    utils.series([
-      helper.ccmHelper.start('3'),
-      testClient.connect.bind(testClient),
-      function createKs1(next) {
-        testClient.execute(helper.createKeyspaceCql(keyspace1, 1), next);
-      },
-      function createKs2(next) {
-        var query = util.format("CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', " +
-          "'%s' : %d}", keyspace2, testClient.hosts.values()[0].datacenter, 1);
-        testClient.execute(query, next);
-      },
-      function createTable1(next) {
-        var query = util.format('CREATE TABLE %s.%s (id int primary key, name int)', keyspace1, table);
-        testClient.execute(query, next);
-      },
-      function createTable2(next) {
-        var query = util.format('CREATE TABLE %s.%s (id int primary key, name int)', keyspace2, table);
-        testClient.execute(query, next);
-      },
-      function testCaseWithKs1(next) {
-        testCase(keyspace1, next);
-      },
-      function testCaseWithKs2(next) {
-        testCase(keyspace2, next);
-      },
-      testClient.shutdown.bind(testClient),
-      helper.ccmHelper.remove
-    ], done);
-  });
-});
-
-describe('WhiteListPolicy', function () {
-  this.timeout(180000);
-  before(helper.ccmHelper.start(3));
-  after(helper.ccmHelper.remove);
-  it('should use the hosts in the white list only', function (done) {
-    var policy = new WhiteListPolicy(new RoundRobinPolicy(), ['127.0.0.1:9042', '127.0.0.2:9042']);
-    var client = newInstance(policy);
-    utils.timesLimit(100, 20, function (n, next) {
-      client.execute('SELECT * FROM system.local', function (err, result) {
+      }, function (err) {
         assert.ifError(err);
-        var lastOctet = helper.lastOctetOf(result.info.queriedHost);
-        assert.ok(lastOctet === '1' || lastOctet === '2');
-        next();
+        client.shutdown(done);
       });
-    }, function (err) {
-      assert.ifError(err);
-      client.shutdown(done);
+    });
+  });
+  describe('TokenAwarePolicy', function () {
+    it('should target the correct partition with logged keyspace', function (done) {
+      utils.series([
+        function testCaseWithSimpleStrategy(next) {
+          testNoHops('ks_simple_rp1', 'table_a', 1, next);
+        },
+        function testCaseWithNetworkStrategy(next) {
+          testNoHops('ks_network_rp1', 'table_b', 1, next);
+        },
+        function testCaseWithNetworkStrategyAndRp2(next) {
+          testNoHops('ks_network_rp2', 'table_c', 2, next);
+        }
+      ], done);
+    });
+    it('should target the correct partition on a different keyspace', function (done) {
+      testNoHops('ks_simple_rp1', 'ks_network_rp2.table_c', 2, done);
+    });
+    it('should balance between replicas with logged keyspace', function (done) {
+      testAllReplicasAreUsedAsCoordinator('ks_network_rp2', 'table_c', 2, done);
+    });
+    it('should balance between replicas on a different keyspace', function (done) {
+      testAllReplicasAreUsedAsCoordinator('ks_simple_rp1', 'ks_network_rp2.table_c', 2, done);
     });
   });
 });
+
+/**
+ * Check that the trace event sources only shows nodes that are replicas to fulfill a consistency ALL query.
+ * @param {String} loggedKeyspace
+ * @param {String} table
+ * @param {Number} expectedSourcesLength
+ * @param {Function} done
+ */
+function testNoHops(loggedKeyspace, table, expectedSourcesLength, done) {
+  var client = new Client({
+    policies: { loadBalancing: new TokenAwarePolicy(new RoundRobinPolicy()) },
+    keyspace: loggedKeyspace,
+    contactPoints: helper.baseOptions.contactPoints
+  });
+  var query = util.format('INSERT INTO %s (id, name) VALUES (?, ?)', table);
+  var queryOptions = { traceQuery: true, prepare: true, consistency: types.consistencies.all };
+  utils.timesLimit(50, 16, function (n, timesNext) {
+    var params = [ n, n ];
+    client.execute(query, params, queryOptions, function (err, result) {
+      assert.ifError(err);
+      client.metadata.getTrace(result.info.traceId, function (err, trace) {
+        assert.ifError(err);
+        // Check where the events are coming from
+        var sources = {};
+        trace.events.forEach(function (event) {
+          sources[helper.lastOctetOf(event['source'].toString())] = true;
+        });
+        assert.strictEqual(Object.keys(sources).length, expectedSourcesLength);
+        timesNext();
+      });
+    });
+  }, helper.finish(client, done));
+}
+
+/**
+ * Check that the coordinator of a given query and parameters are the same as the ones in the sources
+ * @param {String} loggedKeyspace
+ * @param {String} table
+ * @param {Number} expectedReplicas
+ * @param {Function} done
+ */
+function testAllReplicasAreUsedAsCoordinator(loggedKeyspace, table, expectedReplicas, done) {
+  var client = new Client({
+    policies: { loadBalancing: new TokenAwarePolicy(new RoundRobinPolicy()) },
+    keyspace: loggedKeyspace,
+    contactPoints: helper.baseOptions.contactPoints
+  });
+  var query = util.format('INSERT INTO %s (id, name) VALUES (?, ?)', table);
+  var queryOptions = { traceQuery: true, prepare: true, consistency: types.consistencies.all };
+  utils.timesSeries(10, function (i, nextParameters) {
+    var params = [ i, i ];
+    var coordinators = {};
+    var replicas = {};
+    utils.times(10, function (n, timesNext) {
+      client.execute(query, params, queryOptions, function (err, result) {
+        assert.ifError(err);
+        coordinators[helper.lastOctetOf(result.info.queriedHost)] = true;
+        if (n !== 0) {
+          // Only check the trace once
+          return timesNext();
+        }
+        client.metadata.getTrace(result.info.traceId, function (err, trace) {
+          assert.ifError(err);
+          // Check where the events are coming from
+          trace.events.forEach(function (event) {
+            replicas[helper.lastOctetOf(event['source'].toString())] = true;
+          });
+          timesNext();
+        });
+      });
+    }, function (err) {
+      assert.ifError(err);
+      assert.strictEqual(Object.keys(replicas).length, expectedReplicas);
+      assert.deepEqual(Object.keys(replicas).sort(), Object.keys(coordinators).sort());
+      nextParameters();
+    });
+  }, helper.finish(client, done));
+}
+
 
 function newInstance(policy) {
   var options = utils.deepExtend({}, helper.baseOptions, { policies: { loadBalancing: policy}});

--- a/test/integration/short/load-balancing-tests.js
+++ b/test/integration/short/load-balancing-tests.js
@@ -20,7 +20,9 @@ context('with a reusable 3 node cluster', function () {
       'CREATE KEYSPACE ks_network_rp2 WITH replication = {\'class\': \'NetworkTopologyStrategy\', \'datacenter1\' : 2}',
       'CREATE TABLE ks_simple_rp1.table_a (id int primary key, name int)',
       'CREATE TABLE ks_network_rp1.table_b (id int primary key, name int)',
-      'CREATE TABLE ks_network_rp2.table_c (id int primary key, name int)'
+      'CREATE TABLE ks_network_rp2.table_c (id int primary key, name int)',
+      // Try to prevent consistency issues in the query trace
+      'ALTER KEYSPACE system_traces WITH replication = {\'class\': \'SimpleStrategy\', \'replication_factor\': \'1\'}'
     ]
   });
   describe('WhiteListPolicy', function () {


### PR DESCRIPTION
- Fill in query keyspace from prepared metadata and use it from the token-aware policy.
- Refactor load-balancing integration tests to reuse a single 3-node cluster and assert that the replicas are being targeted by the lbp.