### PR TITLE
Handle Thrift secondary index metadata

### DIFF
--- a/lib/metadata/schema-index.js
+++ b/lib/metadata/schema-index.js
@@ -98,10 +98,10 @@ Index.fromColumnRows = function (columnRows, columnsByName) {
     var c = columnsByName[row['column_name']];
     var target;
     var options = JSON.parse(row['index_options']);
-    if (typeof options['index_keys'] !== 'undefined') {
+    if (options !== null && options['index_keys'] !== undefined) {
       target = util.format("keys(%s)", c.name);
     }
-    else if (typeof options['index_keys_and_values'] !== 'undefined') {
+    else if (options !== null && options['index_keys_and_values'] !== undefined) {
       target = util.format("entries(%s)", c.name);
     }
     else if (c.type.options.frozen && (c.type.code === types.dataTypes.map || c.type.code === types.dataTypes.list ||

--- a/test/unit/metadata-tests.js
+++ b/test/unit/metadata-tests.js
@@ -1493,6 +1493,46 @@ describe('Metadata', function () {
         });
       });
     });
+    describe('with Thrift secondary index', function () {
+      it('should parse tables from Thrift with secondary indexes', function (done) {
+        var tableRow = {
+          keyspace_name: 'ks1', columnfamily_name: 'ThriftSecondaryIndexTest', bloom_filter_fp_chance: null,
+          caching: {"keys":"ALL", "rows_per_partition":"NONE"}, cf_id: "121d4950-41fd-11e7-ac8d-e1535f74c6ee",
+          column_aliases: [], comparator: 'org.apache.cassandra.db.marshal.UTF8Type',
+          compaction_strategy_options: '{}',
+          compression_parameters: '{"sstable_compression":"org.apache.cassandra.io.compress.LZ4Compressor"}',
+          default_validator: 'org.apache.cassandra.db.marshal.BytesType', key_aliases: '["key"]',
+          key_validator: 'org.apache.cassandra.db.marshal.UTF8Type', type: 'Standard' };
+        var columnRows = [
+          { keyspace_name: 'ks1', columnfamily_name: 'ThriftSecondaryIndexTest', column_name: 'ACCOUNT',
+            component_index: null, index_name: 'ACCOUNT1', index_options: 'null', index_type: 'KEYS', type: 'regular',
+            validator: 'org.apache.cassandra.db.marshal.UTF8Type' },
+          { keyspace_name: 'ks1', columnfamily_name: 'ThriftSecondaryIndexTest', column_name: 'USER',
+            component_index: null, index_name: 'USER1', index_options: 'null', index_type: 'KEYS', type: 'regular',
+            validator: 'org.apache.cassandra.db.marshal.UTF8Type' },
+          { keyspace_name: 'ks1', columnfamily_name: 'ThriftSecondaryIndexTest', column_name: 'key',
+            component_index: null, index_name: null, index_options: 'null', index_type: null, type: 'partition_key',
+            validator: 'org.apache.cassandra.db.marshal.UTF8Type' }
+        ];
+        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.setCassandraVersion([2, 1]);
+        metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
+        metadata.getTable('ks_tbl_meta', 'ThriftSecondaryIndexTest', function (err, table) {
+          assert.ifError(err);
+          assert.ok(table);
+          assert.strictEqual(table.isCompact, true);
+          assert.strictEqual(table.columns.length, 3);
+          assert.strictEqual(table.partitionKeys.length, 1);
+          assert.strictEqual(table.clusteringKeys.length, 0);
+          assert.strictEqual(table.indexes.length, 2);
+          assert.strictEqual(table.indexes[0].name, 'ACCOUNT1');
+          assert.strictEqual(table.indexes[0].target, 'ACCOUNT');
+          assert.strictEqual(table.indexes[1].name, 'USER1');
+          assert.strictEqual(table.indexes[1].target, 'USER');
+          done();
+        });
+      });
+    });
   });
   describe('#getFunctions()', function () {
     it('should return an empty array when not found', function (done) {


### PR DESCRIPTION
CQL table schema retrieval was failing for a column family originally created using thrift with secondary indexes, for example:
```
create column family ThriftSecondaryIndexTest
  with column_type = 'Standard'
  and comparator = 'UTF8Type'
  and default_validation_class = 'BytesType'
  and key_validation_class = 'UTF8Type'
  and column_metadata = [
    {column_name : 'USER',
    validation_class : UTF8Type,
    index_name : 'USER1',
    index_type : 0},
    {column_name : 'ACCOUNT',
    validation_class : UTF8Type,
    index_name : 'ACCOUNT1',
    index_type : 0}];
```

This can not be reproduced using only the CQL interface so I wasn't able to cover it using an integration test.