### PR TITLE
Remove Buffer constructor usages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,6 +90,7 @@ module.exports = {
     "no-useless-return": "error",
     "no-void": "error",
     "no-with": "error",
+    "no-buffer-constructor": "error",
     radix: "error"
   },
   "globals": {

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
     - node_modules
 script:
   - if [ "$TRAVIS_NODE_VERSION" != "0.10" ] && [ "$TRAVIS_NODE_VERSION" != "0.12" ]; then
-      npm install -g eslint@3;
+      npm install -g eslint@4;
       npm run eslint;
     fi
   - npm test

--- a/lib/auth/plain-text-auth-provider.js
+++ b/lib/auth/plain-text-auth-provider.js
@@ -2,6 +2,7 @@
 var util = require('util');
 
 var provider = require('./provider.js');
+var utils = require('../utils');
 var AuthProvider = provider.AuthProvider;
 var Authenticator = provider.Authenticator;
 /**
@@ -46,10 +47,10 @@ util.inherits(PlainTextAuthenticator, Authenticator);
 
 PlainTextAuthenticator.prototype.initialResponse = function (callback) {
   var initialToken = Buffer.concat([
-    new Buffer([0]),
-    new Buffer(this.username, 'utf8'),
-    new Buffer([0]),
-    new Buffer(this.password, 'utf8')
+    utils.allocBufferFromArray([0]),
+    utils.allocBufferFromString(this.username, 'utf8'),
+    utils.allocBufferFromArray([0]),
+    utils.allocBufferFromString(this.password, 'utf8')
   ]);
   callback(null, initialToken);
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -1164,7 +1164,7 @@ Client.prototype._setQueryOptions = function (options, params, meta, callback) {
     try {
       if (typeof options.pageState === 'string') {
         //pageState can be a hex string
-        options.pageState = new Buffer(options.pageState, 'hex');
+        options.pageState = utils.allocBufferFromString(options.pageState, 'hex');
       }
       //noinspection JSAccessibilityCheck
       self._getEncoder().setRoutingKey(paramsInfo.params, options, paramsInfo.keys);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -417,9 +417,9 @@ Connection.prototype.sendStream = function (request, options, callback) {
   var streamId = this.getStreamId();
   if (streamId === null) {
     self.log('info',
-        'Enqueuing ' +
-        this.pendingWrites.length +
-        ', if this message is recurrent consider configuring more connections per host or lowering the pressure');
+      'Enqueuing ' +
+      this.pendingWrites.length +
+      ', if this message is recurrent consider configuring more connections per host or lowering the pressure');
     return this.pendingWrites.push({request: request, options: options, callback: callback});
   }
   this.log('verbose', 'Sending stream #' + streamId);

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -9,8 +9,8 @@ var BigDecimal = types.BigDecimal;
 var utils = require('./utils');
 
 var uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-var int16Zero = new Buffer([0, 0]);
-var int32Zero = new Buffer([0, 0, 0, 0]);
+var int16Zero = utils.allocBufferFromArray([0, 0]);
+var int32Zero = utils.allocBufferFromArray([0, 0, 0, 0]);
 var complexTypeNames = Object.freeze({
   list      : 'org.apache.cassandra.db.marshal.ListType',
   set       : 'org.apache.cassandra.db.marshal.SetType',
@@ -58,8 +58,8 @@ var singleFqTypeNamesLength = Object.keys(singleTypeNames).reduce(function (prev
   return current.length > previous ? current.length : previous;
 }, 0);
 var durationTypeName = 'org.apache.cassandra.db.marshal.DurationType';
-var nullValueBuffer = new Buffer([255, 255, 255, 255]);
-var unsetValueBuffer = new Buffer([255, 255, 255, 254]);
+var nullValueBuffer = utils.allocBufferFromArray([255, 255, 255, 255]);
+var unsetValueBuffer = utils.allocBufferFromArray([255, 255, 255, 254]);
 
 /**
  * Serializes and deserializes to and from a CQL type and a Javascript Type.
@@ -280,7 +280,7 @@ function defineInstanceMembers() {
     if (typeof value !== 'number') {
       throw new TypeError('Expected Number, obtained ' + util.inspect(value));
     }
-    var buf = new Buffer(4);
+    var buf = utils.allocBufferUnsafe(4);
     buf.writeFloatBE(value, 0);
     return buf;
   };
@@ -288,7 +288,7 @@ function defineInstanceMembers() {
     if (typeof value !== 'number') {
       throw new TypeError('Expected Number, obtained ' + util.inspect(value));
     }
-    var buf = new Buffer(8);
+    var buf = utils.allocBufferUnsafe(8);
     buf.writeDoubleBE(value, 0);
     return buf;
   };
@@ -472,7 +472,7 @@ function defineInstanceMembers() {
     if (typeof value !== 'string') {
       throw new TypeError('Not a valid text value, expected String obtained ' + util.inspect(value));
     }
-    return new Buffer(value, encoding);
+    return utils.allocBufferFromString(value, encoding);
   };
   this.encodeUtf8String = function (value) {
     return this.encodeString(value, 'utf8');
@@ -508,7 +508,7 @@ function defineInstanceMembers() {
    * @private
    */
   this.encodeBoolean = function (value) {
-    return new Buffer([(value ? 1 : 0)]);
+    return utils.allocBufferFromArray([(value ? 1 : 0)]);
   };
   /**
    * @param {Number|String} value
@@ -518,7 +518,7 @@ function defineInstanceMembers() {
     if (isNaN(value)) {
       throw new TypeError('Expected Number, obtained ' + util.inspect(value));
     }
-    var buf = new Buffer(4);
+    var buf = utils.allocBufferUnsafe(4);
     buf.writeInt32BE(value, 0);
     return buf;
   };
@@ -530,7 +530,7 @@ function defineInstanceMembers() {
     if (isNaN(value)) {
       throw new TypeError('Expected Number, obtained ' + util.inspect(value));
     }
-    var buf = new Buffer(2);
+    var buf = utils.allocBufferUnsafe(2);
     buf.writeInt16BE(value, 0);
     return buf;
   };
@@ -542,7 +542,7 @@ function defineInstanceMembers() {
     if (isNaN(value)) {
       throw new TypeError('Expected Number, obtained ' + util.inspect(value));
     }
-    var buf = new Buffer(1);
+    var buf = utils.allocBufferUnsafe(1);
     buf.writeInt8(value, 0);
     return buf;
   };
@@ -651,7 +651,7 @@ function defineInstanceMembers() {
         totalLength += 4;
         continue;
       }
-      var lengthBuffer = new Buffer(4);
+      var lengthBuffer = utils.allocBufferUnsafe(4);
       lengthBuffer.writeInt32BE(item.length, 0);
       parts.push(lengthBuffer);
       parts.push(item);
@@ -675,7 +675,7 @@ function defineInstanceMembers() {
         totalLength += 4;
         continue;
       }
-      var lengthBuffer = new Buffer(4);
+      var lengthBuffer = utils.allocBufferUnsafe(4);
       lengthBuffer.writeInt32BE(item.length, 0);
       parts.push(lengthBuffer);
       parts.push(item);
@@ -1131,7 +1131,7 @@ function defineInstanceMembers() {
     };
     var udtInfo = {
       keyspace: udtParams[0],
-      name: new Buffer(udtParams[1], 'hex').toString(),
+      name: utils.allocBufferFromString(udtParams[1], 'hex').toString(),
       fields: []
     };
     for (var i = 2; i < udtParams.length; i++) {
@@ -1139,7 +1139,7 @@ function defineInstanceMembers() {
       var separatorIndex = p.indexOf(':');
       var fieldType = this.parseFqTypeName(p, separatorIndex + 1, p.length - (separatorIndex + 1));
       udtInfo.fields.push({
-        name: new Buffer(p.substr(0, separatorIndex), 'hex').toString(),
+        name: utils.allocBufferFromString(p.substr(0, separatorIndex), 'hex').toString(),
         type: fieldType
       });
     }
@@ -1386,7 +1386,7 @@ function getLengthBufferV2(value) {
   if (!value) {
     return int16Zero;
   }
-  var lengthBuffer = new Buffer(2);
+  var lengthBuffer = utils.allocBufferUnsafe(2);
   if (typeof value === 'number') {
     lengthBuffer.writeUInt16BE(value, 0);
   }
@@ -1406,7 +1406,7 @@ function getLengthBufferV3(value) {
   if (!value) {
     return int32Zero;
   }
-  var lengthBuffer = new Buffer(4);
+  var lengthBuffer = utils.allocBufferUnsafe(4);
   if (typeof value === 'number') {
     lengthBuffer.writeInt32BE(value, 0);
   }
@@ -1495,7 +1495,7 @@ function parseParams(value, startIndex, length, open, close) {
  * @private
  */
 function concatRoutingKey(parts, totalLength) {
-  var routingKey = new Buffer(totalLength);
+  var routingKey = utils.allocBufferUnsafe(totalLength);
   var offset = 0;
   parts.forEach(function (item) {
     routingKey.writeInt16BE(item.length, offset);

--- a/lib/metadata/schema-parser.js
+++ b/lib/metadata/schema-parser.js
@@ -505,7 +505,7 @@ SchemaParserV1.prototype._parseTableOrView = function (tableInfo, tableRow, colu
       tableInfo.isCompact = (
         //clustering keys are not marked as composite
         !comparator.isComposite ||
-          //only 1 column not part of the partition or clustering keys
+        //only 1 column not part of the partition or clustering keys
         (!comparator.hasCollections && tableInfo.clusteringKeys.length !== comparator.types.length - 1)
       );
     }

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -2,6 +2,7 @@
 
 var util = require('util');
 var types = require('./types');
+var utils = require('./utils');
 var MutableLong = require('./types/mutable-long');
 var Integer = types.Integer;
 
@@ -276,7 +277,7 @@ util.inherits(RandomTokenizer, Tokenizer);
  */
 RandomTokenizer.prototype.hash = function (value) {
   if (util.isArray(value)) {
-    value = new Buffer(value);
+    value = utils.allocBufferFromArray(value);
   }
   var hashedValue = this._crypto.createHash('md5').update(value).digest();
   return Integer.fromBuffer(hashedValue).abs();
@@ -317,7 +318,7 @@ ByteOrderedTokenizer.prototype.stringify = function (value) {
 };
 
 ByteOrderedTokenizer.prototype.parse = function (value) {
-  return new Buffer(value);
+  return utils.allocBufferFromString(value);
 };
 
 exports.Murmur3Tokenizer = Murmur3Tokenizer;

--- a/lib/types/big-decimal.js
+++ b/lib/types/big-decimal.js
@@ -55,7 +55,7 @@ BigDecimal.fromBuffer = function (buf) {
  */
 BigDecimal.toBuffer = function (value) {
   var unscaledValueBuffer = Integer.toBuffer(value._intVal);
-  var scaleBuffer = new Buffer(4);
+  var scaleBuffer = utils.allocBufferUnsafe(4);
   scaleBuffer.writeInt32BE(value._scale, 0);
   return Buffer.concat([scaleBuffer, unscaledValueBuffer], scaleBuffer.length + unscaledValueBuffer.length);
 };

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -5,6 +5,7 @@ var errors = require('../errors');
 var TimeUuid = require('./time-uuid');
 var Uuid = require('./uuid');
 var protocolVersion = require('./protocol-version');
+var utils = require('../utils');
 
 /** @module types */
 /**
@@ -305,10 +306,10 @@ function timeuuid(options, buffer, offset) {
       date = options.msecs;
     }
     if (util.isArray(options.node)) {
-      nodeId = new Buffer(options.node);
+      nodeId = utils.allocBufferFromArray(options.node);
     }
     if (typeof options.clockseq === 'number') {
-      clockId = new Buffer(2);
+      clockId = utils.allocBufferUnsafe(2);
       clockId.writeUInt16BE(options.clockseq, 0);
     }
     if (typeof options.nsecs === 'number') {
@@ -333,7 +334,7 @@ function uuid(options, buffer, offset) {
   var uuid;
   if (options) {
     if (util.isArray(options.random)) {
-      uuid = new Uuid(new Buffer(options.random));
+      uuid = new Uuid(utils.allocBufferFromArray(options.random));
     }
   }
   if (!uuid) {
@@ -442,7 +443,7 @@ FrameHeader.fromBuffer = function (buf, offset) {
 
 /** @returns {Buffer} */
 FrameHeader.prototype.toBuffer = function () {
-  var buf = new Buffer(FrameHeader.size(this.version));
+  var buf = utils.allocBufferUnsafe(FrameHeader.size(this.version));
   buf.writeUInt8(this.version, 0);
   buf.writeUInt8(this.flags, 1);
   var offset = 3;
@@ -476,7 +477,7 @@ Long.toBuffer = function (value) {
   if (!(value instanceof Long)) {
     throw new TypeError('Expected Long, obtained ' + util.inspect(value));
   }
-  var buffer = new Buffer(8);
+  var buffer = utils.allocBufferUnsafe(8);
   buffer.writeUInt32BE(value.getHighBitsUnsigned(), 0);
   buffer.writeUInt32BE(value.getLowBitsUnsigned(), 4);
   return buffer;

--- a/lib/types/inet-address.js
+++ b/lib/types/inet-address.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var utils = require('../utils');
+
 /** @module types */
 /**
  * Creates a new instance of InetAddress
@@ -35,14 +37,14 @@ function InetAddress(buffer) {
  */
 InetAddress.fromString = function (value) {
   if (!value) {
-    return new InetAddress(new Buffer([0, 0, 0, 0]));
+    return new InetAddress(utils.allocBufferFromArray([0, 0, 0, 0]));
   }
   var ipv4Pattern = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
   var ipv6Pattern = /^[\da-f:.]+$/i;
   var parts;
   if (ipv4Pattern.test(value)) {
     parts = value.split('.');
-    return new InetAddress(new Buffer(parts));
+    return new InetAddress(utils.allocBufferFromArray(parts));
   }
   if (!ipv6Pattern.test(value)) {
     throw new TypeError('Value could not be parsed as InetAddress: ' + value);
@@ -51,7 +53,7 @@ InetAddress.fromString = function (value) {
   if (parts.length < 3) {
     throw new TypeError('Value could not be parsed as InetAddress: ' + value);
   }
-  var buffer = new Buffer(16);
+  var buffer = utils.allocBufferUnsafe(16);
   var filling = 8 - parts.length + 1;
   var applied = false;
   var offset = 0;

--- a/lib/types/integer.js
+++ b/lib/types/integer.js
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 /** @module types */
+
+var utils = require('../utils');
+
 /**
  * Constructs a two's-complement integer an array containing bits of the
  * integer in 32-bit (signed) pieces, given in little-endian order (i.e.,
@@ -225,7 +228,7 @@ Integer.toBuffer = function (value) {
   var bits = value.bits_;
   if (bits.length === 0) {
     //[0] or [0xffffffff]
-    return new Buffer([value.sign_]);
+    return utils.allocBufferFromArray([value.sign_]);
   }
   //the high bits might need to be represented in less than 4 bytes
   var highBits = bits[bits.length-1];
@@ -254,7 +257,7 @@ Integer.toBuffer = function (value) {
     //its positive but it lost the byte containing the sign bit
     high.unshift(0);
   }
-  var buf = new Buffer(high.length + ((bits.length-1) * 4));
+  var buf = utils.allocBufferUnsafe(high.length + ((bits.length-1) * 4));
   for (var j = 0; j < high.length; j++) {
     var b = high[j];
     if (sign === -1) {

--- a/lib/types/local-date.js
+++ b/lib/types/local-date.js
@@ -208,7 +208,7 @@ LocalDate.prototype.toBuffer = function () {
   //days since unix epoch
   var daysSinceEpoch = isNaN(this.date.getTime()) ? this._value : Math.floor(this.date.getTime() / millisecondsPerDay);
   var value = daysSinceEpoch + dateCenter;
-  var buf = new Buffer(4);
+  var buf = utils.allocBufferUnsafe(4);
   buf.writeUInt32BE(value, 0);
   return buf;
 };

--- a/lib/types/local-time.js
+++ b/lib/types/local-time.js
@@ -201,7 +201,7 @@ LocalTime.prototype.inspect = function () {
  * @returns {Buffer}
  */
 LocalTime.prototype.toBuffer = function () {
-  var buffer = new Buffer(8);
+  var buffer = utils.allocBufferUnsafe(8);
   buffer.writeUInt32BE(this.value.getHighBitsUnsigned(), 0);
   buffer.writeUInt32BE(this.value.getLowBitsUnsigned(), 4);
   return buffer;

--- a/lib/types/time-uuid.js
+++ b/lib/types/time-uuid.js
@@ -4,6 +4,8 @@ var crypto = require('crypto');
 var Long = require('long');
 
 var Uuid = require('./uuid');
+var utils = require('../utils');
+
 /** @module types */
 /**
  * Oct 15, 1582 in milliseconds since unix epoch
@@ -92,14 +94,16 @@ TimeUuid.fromString = function (value) {
  * Returns the smaller possible type 1 uuid with the provided Date.
  */
 TimeUuid.min = function (date, ticks) {
-  return new TimeUuid(date, ticks, new Buffer('808080808080', 'hex'), new Buffer('8080', 'hex'));
+  return new TimeUuid(
+    date, ticks, utils.allocBufferFromString('808080808080', 'hex'), utils.allocBufferFromString('8080', 'hex'));
 };
 
 /**
  * Returns the biggest possible type 1 uuid with the provided Date.
  */
 TimeUuid.max = function (date, ticks) {
-  return new TimeUuid(date, ticks, new Buffer('7f7f7f7f7f7f', 'hex'), new Buffer('7f7f', 'hex'));
+  return new TimeUuid(
+    date, ticks, utils.allocBufferFromString('7f7f7f7f7f7f', 'hex'), utils.allocBufferFromString('7f7f', 'hex'));
 };
 
 /**
@@ -181,7 +185,7 @@ function writeTime(buffer, time, ticks) {
 function getClockId(clockId) {
   var buffer = clockId;
   if (typeof clockId === 'string') {
-    buffer = new Buffer(clockId, 'ascii');
+    buffer = utils.allocBufferFromString(clockId, 'ascii');
   }
   if (!(buffer instanceof Buffer)) {
     //Generate
@@ -202,7 +206,7 @@ function getClockId(clockId) {
 function getNodeId(nodeId) {
   var buffer = nodeId;
   if (typeof nodeId === 'string') {
-    buffer = new Buffer(nodeId, 'ascii');
+    buffer = utils.allocBufferFromString(nodeId, 'ascii');
   }
   if (!(buffer instanceof Buffer)) {
     //Generate
@@ -272,7 +276,7 @@ function generateBuffer(date, ticks, nodeId, clockId) {
   var timeWithTicks = getTimeWithTicks(date, ticks);
   nodeId = getNodeId(nodeId);
   clockId = getClockId(clockId);
-  var buffer = new Buffer(16);
+  var buffer = utils.allocBufferUnsafe(16);
   //Positions 0-7 Timestamp
   writeTime(buffer, timeWithTicks.time, timeWithTicks.ticks);
   //Position 8-9 Clock

--- a/lib/types/uuid.js
+++ b/lib/types/uuid.js
@@ -1,5 +1,7 @@
 'use strict';
+
 var crypto = require('crypto');
+var utils = require('../utils');
 
 /** @module types */
 
@@ -27,7 +29,7 @@ Uuid.fromString = function (value) {
   if (typeof value !== 'string' || value.length !== 36) {
     throw new Error('Invalid string representation of Uuid, it should be in the 00000000-0000-0000-0000-000000000000');
   }
-  return new Uuid(new Buffer(value.replace(/-/g, ''), 'hex'));
+  return new Uuid(utils.allocBufferFromString(value.replace(/-/g, ''), 'hex'));
 };
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,6 +37,7 @@ var allocBufferFromString = Buffer.from || allocBufferFromStringDeprecated;
 var allocBufferFromArray = Buffer.from || allocBufferFromArrayDeprecated;
 
 function allocBufferDeprecated(size) {
+  // eslint-disable-next-line
   return new Buffer(size);
 }
 
@@ -50,6 +51,7 @@ function allocBufferFromStringDeprecated(text, encoding) {
   if (typeof text !== 'string') {
     throw new TypeError('Expected string, obtained ' + util.inspect(text));
   }
+  // eslint-disable-next-line
   return new Buffer(text, encoding);
 }
 
@@ -57,6 +59,7 @@ function allocBufferFromArrayDeprecated(arr) {
   if (!Array.isArray(arr)) {
     throw new TypeError('Expected Array, obtained ' + util.inspect(arr));
   }
+  // eslint-disable-next-line
   return new Buffer(arr);
 }
 
@@ -64,7 +67,7 @@ function allocBufferFromArrayDeprecated(arr) {
  * Creates a copy of a buffer
  */
 function copyBuffer(buf) {
-  var targetBuffer = new Buffer(buf.length);
+  var targetBuffer = allocBufferUnsafe(buf.length);
   buf.copy(targetBuffer);
   return targetBuffer;
 }
@@ -165,14 +168,12 @@ function deepExtend(target) {
       // a native single type
       // or not existent
       // or is not an anonymous object (not class instance)
-      //noinspection JSUnresolvedVariable
       if (!targetProp ||
         targetType === 'number' ||
         targetType === 'string' ||
         util.isArray(targetProp) ||
         util.isDate(targetProp) ||
-        targetProp.constructor.name !== 'Object'
-        ) {
+        targetProp.constructor.name !== 'Object') {
         target[prop] = source[prop];
       }
       else {
@@ -271,7 +272,8 @@ function binarySearch(arr, key, compareFunc) {
       return mid;
     }
   }
-  return ~low;  // key not found
+  // key not found
+  return ~low;
 }
 
 /**

--- a/lib/writers.js
+++ b/lib/writers.js
@@ -26,13 +26,13 @@ FrameWriter.prototype.add = function(buf) {
 };
 
 FrameWriter.prototype.writeShort = function(num) {
-  var buf = new Buffer(2);
+  var buf = utils.allocBufferUnsafe(2);
   buf.writeUInt16BE(num, 0);
   this.add(buf);
 };
 
 FrameWriter.prototype.writeInt = function(num) {
-  var buf = new Buffer(4);
+  var buf = utils.allocBufferUnsafe(4);
   buf.writeInt32BE(num, 0);
   this.add(buf);
 };
@@ -83,7 +83,7 @@ FrameWriter.prototype.writeShortBytes = function(bytes) {
  * @param {Number} num Value of the byte, a number between 0 and 255.
  */
 FrameWriter.prototype.writeByte = function (num) {
-  this.add(new Buffer([num]));
+  this.add(utils.allocBufferFromArray([num]));
 };
 
 FrameWriter.prototype.writeString = function(str) {
@@ -91,7 +91,7 @@ FrameWriter.prototype.writeString = function(str) {
     throw new Error("can not write undefined");
   }
   var len = Buffer.byteLength(str, 'utf8');
-  var buf = new Buffer(2 + len);
+  var buf = utils.allocBufferUnsafe(2 + len);
   buf.writeUInt16BE(len, 0);
   buf.write(str, 2, buf.length-2, 'utf8');
   this.add(buf);
@@ -99,7 +99,7 @@ FrameWriter.prototype.writeString = function(str) {
 
 FrameWriter.prototype.writeLString = function(str) {
   var len = Buffer.byteLength(str, 'utf8');
-  var buf = new Buffer(4 + len);
+  var buf = utils.allocBufferUnsafe(4 + len);
   buf.writeInt32BE(len, 0);
   buf.write(str, 4, buf.length-4, 'utf8');
   this.add(buf);

--- a/test/integration/long/client-metadata-tests.js
+++ b/test/integration/long/client-metadata-tests.js
@@ -48,7 +48,7 @@ describe('Client', function () {
       var client = newInstance({ isMetadataSyncEnabled: false });
       client.connect(function (err) {
         assert.ifError(err);
-        var replicas = client.getReplicas('sampleks1', new Buffer([0, 0, 0, 1]));
+        var replicas = client.getReplicas('sampleks1', utils.allocBufferFromArray([0, 0, 0, 1]));
         assert.strictEqual(null, replicas);
         done();
       });
@@ -57,7 +57,7 @@ describe('Client', function () {
       var client = newInstance();
       client.connect(function (err) {
         assert.ifError(err);
-        var replicas = client.getReplicas(null, new Buffer([0, 0, 0, 1]));
+        var replicas = client.getReplicas(null, utils.allocBufferFromArray([0, 0, 0, 1]));
         assert.ok(replicas);
         assert.strictEqual(replicas.length, 1);
         //pre-calculated based on murmur3
@@ -112,7 +112,7 @@ describe('Client', function () {
           var position = utils.binarySearch(client.metadata.ring, token, client.metadata.tokenizer.compare);
           assert.ok(position >= 0);
         }
-        client.execute('select key from system.local', [], { routingKey: new Buffer(2)}, function (err) {
+        client.execute('select key from system.local', [], { routingKey: utils.allocBufferUnsafe(2)}, function (err) {
           assert.ifError(err);
           done();
         });
@@ -122,7 +122,7 @@ describe('Client', function () {
 });
 
 function validateMurmurReplicas(client) {
-  var replicas = client.getReplicas('sampleks1', new Buffer([0, 0, 0, 1]));
+  var replicas = client.getReplicas('sampleks1', utils.allocBufferFromArray([0, 0, 0, 1]));
   assert.ok(replicas);
   //2 replicas per each dc
   assert.strictEqual(replicas.length, 4);
@@ -135,7 +135,7 @@ function validateMurmurReplicas(client) {
   assert.strictEqual(lastOctets[2], '4');
   assert.strictEqual(lastOctets[3], '8');
 
-  replicas = client.getReplicas('sampleks1', new Buffer([0, 0, 0, 3]));
+  replicas = client.getReplicas('sampleks1', utils.allocBufferFromArray([0, 0, 0, 3]));
   assert.ok(replicas);
   //2 replicas per each dc
   assert.strictEqual(replicas.length, 4);

--- a/test/integration/long/load-balancing-tests.js
+++ b/test/integration/long/load-balancing-tests.js
@@ -94,7 +94,7 @@ describe('TokenAwarePolicy', function () {
       utils.times(100, function (n, timesNext) {
         var id = (n % 10) + 1;
         var query = util.format('INSERT INTO %s (id, name) VALUES (%s, %s)', table, id, id);
-        client.execute(query, null, {routingKey: new Buffer([0, 0, 0, id])}, function (err, result) {
+        client.execute(query, null, {routingKey: utils.allocBufferFromArray([0, 0, 0, id])}, function (err, result) {
           assert.ifError(err);
           //for murmur id = 1, it go to replica 2
           var address = result.info.queriedHost;
@@ -108,7 +108,7 @@ describe('TokenAwarePolicy', function () {
     var keyspace1 = 'ks1';
     var keyspace2 = 'ks2';
     // Resolves to token -4069959284402364209 which should have primary replica of 3 and 7 with 3 being the closest replica.
-    var routingKey = new Buffer([0, 0, 0, 1]);
+    var routingKey = utils.allocBufferFromArray([0, 0, 0, 1]);
 
     var client_dc2 = new Client({
       policies: { loadBalancing: new TokenAwarePolicy(new DCAwareRoundRobinPolicy())},

--- a/test/integration/long/stress-tests.js
+++ b/test/integration/long/stress-tests.js
@@ -136,7 +136,7 @@ describe('Client', function () {
         var options = {
           prepare: 1,
           consistency: types.consistencies.quorum};
-        var buf = new Buffer(i * 1024);
+        var buf = utils.allocBuffer(i * 1024);
         buf.write(i + ' dummy values ' + (new Array(100)).join(i.toString()));
         clientInsert.execute(insertQuery, [types.uuid(), buf.length, buf], options, next);
       }, callback);

--- a/test/integration/short/client-execute-prepared-tests.js
+++ b/test/integration/short/client-execute-prepared-tests.js
@@ -110,7 +110,7 @@ describe('Client', function () {
       });
     });
     it('should serialize all guessed types', function (done) {
-      var values = [types.Uuid.random(), 'as', '111', null, new types.Long(0x1001, 0x0109AA), 1, new Buffer([1, 240]),
+      var values = [types.Uuid.random(), 'as', '111', null, new types.Long(0x1001, 0x0109AA), 1, utils.allocBufferFromArray([1, 240]),
         true, new Date(1221111111), types.InetAddress.fromString('10.12.0.1'), null, null, null];
       var columnNames = 'id, ascii_sample, text_sample, int_sample, bigint_sample, double_sample, blob_sample, ' +
         'boolean_sample, timestamp_sample, inet_sample, timeuuid_sample, list_sample, set_sample';

--- a/test/integration/short/client-execute-tests.js
+++ b/test/integration/short/client-execute-tests.js
@@ -74,7 +74,7 @@ describe('Client', function () {
       var client = setupInfo.client;
       var columns = 'id, timeuuid_sample, text_sample, double_sample, timestamp_sample, blob_sample, list_sample';
       //a precision a float32 can represent
-      var values = [types.Uuid.random(), types.TimeUuid.now(), 'text sample 1', 133, new Date(121212211), new Buffer(100), ['one', 'two']];
+      var values = [types.Uuid.random(), types.TimeUuid.now(), 'text sample 1', 133, new Date(121212211), utils.allocBufferUnsafe(100), ['one', 'two']];
       //no hint
       insertSelectTest(client, table, columns, values, null, done);
     });
@@ -656,7 +656,7 @@ describe('Client', function () {
       vit('2.1', 'should allow tuple parameter hints', function (done) {
         var client = setupInfo.client;
         var id = types.Uuid.random();
-        var tuple = new types.Tuple('Surf Rider', 110, new Buffer('0f0f', 'hex'));
+        var tuple = new types.Tuple('Surf Rider', 110, utils.allocBufferFromString('0f0f', 'hex'));
         utils.series([
           function insert(next) {
             var query ='INSERT INTO tbl_tuples (id, tuple_col) VALUES (?, ?)';

--- a/test/integration/short/custom-payload-tests.js
+++ b/test/integration/short/custom-payload-tests.js
@@ -29,7 +29,7 @@ describe('custom payload', function () {
     vit('2.2', 'should encode and decode the payload with rows response', function (done) {
       var client = newInstance();
       var payload = {
-        'key1': new Buffer('val1')
+        'key1': utils.allocBufferFromString('val1')
       };
       utils.series([
         client.connect.bind(client),
@@ -49,7 +49,7 @@ describe('custom payload', function () {
     vit('2.2', 'should encode and decode the payload with void response', function (done) {
       var client = newInstance();
       var payload = {
-        'key2': new Buffer('val2')
+        'key2': utils.allocBufferFromString('val2')
       };
       utils.series([
         client.connect.bind(client),
@@ -70,7 +70,7 @@ describe('custom payload', function () {
     vit('2.2', 'should encode and decode the payload and trace', function (done) {
       var client = newInstance();
       var payload = {
-        'key3': new Buffer('val3')
+        'key3': utils.allocBufferFromString('val3')
       };
       utils.series([
         client.connect.bind(client),
@@ -94,8 +94,8 @@ describe('custom payload', function () {
     vit('2.2', 'should encode and decode the payload with rows response', function (done) {
       var client = newInstance();
       var payload = {
-        'key-prep1': new Buffer('val-prep1'),
-        'key-prep2': new Buffer('val-prep2')
+        'key-prep1': utils.allocBufferFromString('val-prep1'),
+        'key-prep2': utils.allocBufferFromString('val-prep2')
       };
       utils.series([
         client.connect.bind(client),
@@ -119,7 +119,7 @@ describe('custom payload', function () {
     vit('2.2', 'should encode and decode the payload', function (done) {
       var client = newInstance();
       var payload = {
-        'key-batch1': new Buffer('val-batch1')
+        'key-batch1': utils.allocBufferFromString('val-batch1')
       };
       utils.series([
         client.connect.bind(client),
@@ -144,7 +144,7 @@ describe('custom payload', function () {
     vit('2.2', 'should encode and decode the payload with warnings', function (done) {
       var client = newInstance();
       var payload = {
-        'key-batch2': new Buffer('val-batch2')
+        'key-batch2': utils.allocBufferFromString('val-batch2')
       };
       utils.series([
         client.connect.bind(client),
@@ -174,7 +174,7 @@ describe('custom payload', function () {
     vit('2.2', 'should encode and decode the payload', function (done) {
       var client = newInstance();
       var payload = {
-        'key-batch-prep1': new Buffer('val-batch-prep1')
+        'key-batch-prep1': utils.allocBufferFromString('val-batch-prep1')
       };
       utils.series([
         client.connect.bind(client),

--- a/test/other/memory/basic-profile.js
+++ b/test/other/memory/basic-profile.js
@@ -16,7 +16,7 @@ var helper = require('../../test-helper.js');
 var cassandra = require('../../../index.js');
 var Client = cassandra.Client;
 var types = cassandra.types;
-var utils = require('../../../lib/utils.js');
+var utils = require('../../../lib/utils');
 
 var client = new Client(utils.extend({ encoding: { copyBuffer: true}}, helper.baseOptions));
 var keyspace = helper.getRandomName('ks');
@@ -48,7 +48,8 @@ utils.series([
     global.gc();
     utils.timesLimit(10000, 500, function (v, timesNext) {
       var n = counter++;
-      client.execute(query, [types.Uuid.random(), n, new Buffer(generateAsciiString(1024), 'utf8')], {prepare: true}, function (err) {
+      var buffer = utils.allocBufferFromString(generateAsciiString(1024), 'utf8');
+      client.execute(query, [types.Uuid.random(), n, buffer], {prepare: true}, function (err) {
         if ((callbackCounter++) % 1000 === 0) {
           console.log('Inserted', callbackCounter);
         }

--- a/test/other/memory/profile-keeping-ref.js
+++ b/test/other/memory/profile-keeping-ref.js
@@ -16,7 +16,7 @@ var helper = require('../../test-helper.js');
 var cassandra = require('../../../index.js');
 var Client = cassandra.Client;
 var types = cassandra.types;
-var utils = require('../../../lib/utils.js');
+var utils = require('../../../lib/utils');
 
 var client = new Client(utils.extend({ encoding: { copyBuffer: true}}, helper.baseOptions));
 var keyspace = helper.getRandomName('ks');
@@ -50,7 +50,8 @@ utils.series([
     global.gc();
     utils.timesLimit(totalLength, 500, function (v, timesNext) {
       var n = counter++;
-      client.execute(query, [types.uuid(), n, types.Long.fromNumber(n), new Buffer(generateAsciiString(1024))], {prepare: 1}, function (err) {
+      var buffer = utils.allocBufferFromString(generateAsciiString(1024));
+      client.execute(query, [types.uuid(), n, types.Long.fromNumber(n), buffer], {prepare: 1}, function (err) {
         if ((callbackCounter++) % 1000 === 0) {
           console.log('Inserted', callbackCounter);
         }

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -234,10 +234,7 @@ var helper = {
   createKeyspaceCql: function (keyspace, replicationFactor, durableWrites) {
     return util.format('CREATE KEYSPACE %s' +
       ' WITH replication = {\'class\': \'SimpleStrategy\', \'replication_factor\' : %d}' +
-      ' AND durable_writes = %s;',
-      keyspace,
-      replicationFactor || 1,
-      !!durableWrites
+      ' AND durable_writes = %s;', keyspace, replicationFactor || 1, !!durableWrites
     );
   },
   assertValueEqual: function (val1, val2) {
@@ -796,9 +793,9 @@ Ccm.prototype.spawn = function (processName, params, callback) {
     var err = null;
     if (code !== 0) {
       err = new Error(
-          'Error executing ' + originalProcessName + ':\n' +
-          info.stderr.join('\n') +
-          info.stdout.join('\n')
+        'Error executing ' + originalProcessName + ':\n' +
+        info.stderr.join('\n') +
+        info.stdout.join('\n')
       );
       err.info = info;
     }

--- a/test/unit/basic-tests.js
+++ b/test/unit/basic-tests.js
@@ -33,7 +33,7 @@ describe('types', function () {
         ['789456'            ,  '00000000000c0bd0'],
         ['888888888888888888',  '0c55f7bc23038e38']
       ].forEach(function (item) {
-        var buffer = new Buffer(item[1], 'hex');
+        var buffer = utils.allocBufferFromString(item[1], 'hex');
         var value = Long.fromBuffer(buffer);
         assert.strictEqual(value.toString(), item[0]);
         assert.strictEqual(Long.toBuffer(value).toString('hex'), buffer.toString('hex'),
@@ -90,7 +90,7 @@ describe('types', function () {
     /* eslint-enable no-multi-spaces */
     it('should create from buffer', function () {
       values.forEach(function (item) {
-        var buffer = new Buffer(item[0], 'hex');
+        var buffer = utils.allocBufferFromString(item[0], 'hex');
         var value = Integer.fromBuffer(buffer);
         assert.strictEqual(value.toString(), item[1]);
       });
@@ -337,18 +337,18 @@ describe('types', function () {
           buf.push(item);
         }
       });
-      stream.add(new Buffer('Jimmy'));
-      stream.add(new Buffer(' '));
-      stream.add(new Buffer('McNulty'));
+      stream.add(utils.allocBufferFromString('Jimmy'));
+      stream.add(utils.allocBufferFromString(' '));
+      stream.add(utils.allocBufferFromString('McNulty'));
       stream.add(null);
     });
 
     it('should buffer until is read', function (done) {
       var buf = [];
       var stream = new types.ResultStream();
-      stream.add(new Buffer('Stringer'));
-      stream.add(new Buffer(' '));
-      stream.add(new Buffer('Bell'));
+      stream.add(utils.allocBufferFromString('Stringer'));
+      stream.add(utils.allocBufferFromString(' '));
+      stream.add(utils.allocBufferFromString('Bell'));
       stream.add(null);
 
       stream.on('end', function streamEnd() {
@@ -366,8 +366,8 @@ describe('types', function () {
     it('should be readable until the end', function (done) {
       var buf = [];
       var stream = new types.ResultStream();
-      stream.add(new Buffer('Omar'));
-      stream.add(new Buffer(' '));
+      stream.add(utils.allocBufferFromString('Omar'));
+      stream.add(utils.allocBufferFromString(' '));
 
       stream.on('end', function streamEnd() {
         assert.equal(Buffer.concat(buf).toString(), 'Omar Little');
@@ -380,7 +380,7 @@ describe('types', function () {
         }
       });
 
-      stream.add(new Buffer('Little'));
+      stream.add(utils.allocBufferFromString('Little'));
       stream.add(null);
     });
 
@@ -426,7 +426,7 @@ describe('types', function () {
     it('should be serializable to json', function () {
       var i;
       var columns = [{name: 'col1', type: { code: dataTypes.varchar}}, {name: 'col2', type: { code: dataTypes.varchar}}];
-      var row = new types.Row(columns, [new Buffer('val1'), new Buffer('val2')]);
+      var row = new types.Row(columns, [utils.allocBufferFromString('val1'), utils.allocBufferFromString('val2')]);
       row['col1'] = 'val1';
       row['col2'] = 'val2';
       assert.strictEqual(JSON.stringify(row), JSON.stringify({col1: 'val1', col2: 'val2'}));
@@ -452,7 +452,7 @@ describe('types', function () {
       assert.strictEqual(JSON.stringify(row), expected);
       rowValues = [
         types.BigDecimal.fromString("1.762"),
-        new types.InetAddress(new Buffer([192, 168, 0, 1])),
+        new types.InetAddress(utils.allocBufferFromArray([192, 168, 0, 1])),
         null];
       columns = [
         {name: 'cdecimal', type: { code: dataTypes.decimal}},
@@ -484,7 +484,7 @@ describe('types', function () {
       assert.notEqual(val, types.uuid());
     });
     it('should fill in the values in a buffer', function () {
-      var buf = new Buffer(16);
+      var buf = utils.allocBufferUnsafe(16);
       var val = types.uuid(null, buf);
       assert.strictEqual(val, buf);
     });
@@ -499,7 +499,7 @@ describe('types', function () {
       assert.notEqual(val, types.timeuuid());
     });
     it('should fill in the values in a buffer', function () {
-      var buf = new Buffer(16);
+      var buf = utils.allocBufferUnsafe(16);
       var val = types.timeuuid(null, buf);
       assert.strictEqual(val, buf);
     });
@@ -757,7 +757,7 @@ describe('writers', function () {
       var queue = new writers.WriteQueue(socketMock, encoder, options);
       var request = {
         write: function () {
-          return new Buffer(10);
+          return utils.allocBufferUnsafe(10);
         }
       };
       function itemCallback() {

--- a/test/unit/big-decimal-tests.js
+++ b/test/unit/big-decimal-tests.js
@@ -1,7 +1,8 @@
 'use strict';
-var assert = require('assert');
 
+var assert = require('assert');
 var types = require('../../lib/types');
+var utils = require('../../lib/utils');
 
 describe('BigDecimal', function () {
   var BigDecimal = types.BigDecimal;
@@ -66,7 +67,7 @@ describe('BigDecimal', function () {
   describe('fromBuffer()', function () {
     it('should convert from buffer (scale + unscaledValue in BE)', function () {
       hexToDecimalValues.forEach(function (item) {
-        var buffer = new Buffer(item[0], 'hex');
+        var buffer = utils.allocBufferFromString(item[0], 'hex');
         var value = BigDecimal.fromBuffer(buffer);
         assert.strictEqual(value.toString(), item[1]);
       });
@@ -115,7 +116,7 @@ describe('BigDecimal', function () {
         var first = BigDecimal.fromString(item[0]);
         var second = BigDecimal.fromString(item[1]);
         assert.strictEqual(first.subtract(second).toString(), item[2]);
-          //check mutations
+        // check mutations
         assert.strictEqual(first.toString(), item[0]);
       });
     });
@@ -135,7 +136,7 @@ describe('BigDecimal', function () {
         var first = BigDecimal.fromString(item[0]);
         var second = BigDecimal.fromString(item[1]);
         assert.strictEqual(first.add(second).toString(), item[2]);
-          //check mutations
+        // check mutations
         assert.strictEqual(first.toString(), item[0]);
       });
     });
@@ -157,7 +158,7 @@ describe('BigDecimal', function () {
         var first = BigDecimal.fromString(item[0]);
         var second = BigDecimal.fromString(item[1]);
         assert.strictEqual(first.compare(second), item[2]);
-          //check mutations
+        // check mutations
         assert.strictEqual(first.toString(), item[0]);
       });
     });

--- a/test/unit/client-tests.js
+++ b/test/unit/client-tests.js
@@ -147,7 +147,7 @@ describe('Client', function () {
       //make it async
       setTimeout(function () {
         prepareCounter++;
-        cb(null, {id: new Buffer([0]), meta: {}});
+        cb(null, {id: utils.allocBufferFromArray([0]), meta: {}});
       }, 50);
     };
     Client.__set__("RequestHandler", requestHandlerMock);
@@ -244,7 +244,7 @@ describe('Client', function () {
       var requestHandlerMock = function () {};
       var client = newConnectedInstance(requestHandlerMock);
       client._getPrepared = function (q, o, cb) { cb (null,
-        new Buffer(0), { columns: [{name: 'abc', type: 2}, {name: 'def', type: 2}]});
+        utils.allocBufferUnsafe(0), { columns: [{name: 'abc', type: 2}, {name: 'def', type: 2}]});
       };
       requestHandlerMock.prototype.send = function (req) {
         assert.ok(req);
@@ -256,7 +256,7 @@ describe('Client', function () {
     it('should keep the parameters if an array is provided', function (done) {
       var requestHandlerMock = function () {};
       var client = newConnectedInstance(requestHandlerMock);
-      client._getPrepared = function (q, o, cb) { cb (null, new Buffer(0), {columns: [{name: 'abc', type: 2}]});};
+      client._getPrepared = function (q, o, cb) { cb (null, utils.allocBufferUnsafe(0), {columns: [{name: 'abc', type: 2}]});};
       requestHandlerMock.prototype.send = function (req) {
         assert.ok(req);
         assert.strictEqual(util.inspect(req.params), util.inspect([101]));
@@ -268,7 +268,7 @@ describe('Client', function () {
       var requestHandlerMock = function () {};
       requestHandlerMock.prototype.send = helper.callbackNoop;
       var client = newConnectedInstance(requestHandlerMock);
-      client._getPrepared = function (q, o, cb) { cb (null, new Buffer(0), {columns: [{name: 'abc', type: 2}]});};
+      client._getPrepared = function (q, o, cb) { cb (null, utils.allocBufferUnsafe(0), {columns: [{name: 'abc', type: 2}]});};
       utils.series([function (next) {
         //noinspection JSAccessibilityCheck
         client._executeAsPrepared('SELECT ...', {not_the_same_name: 100}, queryOptions, function (err) {
@@ -305,7 +305,7 @@ describe('Client', function () {
       var requestHandlerMock = function () {};
       var client = newConnectedInstance(requestHandlerMock);
       client._getPrepared = function (q, o, cb) {
-        cb(null, new Buffer([1]), { columns: [
+        cb(null, utils.allocBufferFromArray([1]), { columns: [
           { name: 'key1', type: { code: types.dataTypes.int} },
           { name: 'key2', type: { code: types.dataTypes.int} }
         ]});
@@ -691,8 +691,8 @@ describe('Client', function () {
       var client = newConnectedInstance(handlerMock);
       client.metadata = new Metadata(client.options);
       //q2 and q4 are prepared
-      client.metadata.getPreparedInfo(null, 'q2').queryId = new Buffer(3);
-      client.metadata.getPreparedInfo(null, 'q4').queryId = new Buffer(3);
+      client.metadata.getPreparedInfo(null, 'q2').queryId = utils.allocBufferUnsafe(3);
+      client.metadata.getPreparedInfo(null, 'q4').queryId = utils.allocBufferUnsafe(3);
       client.batch(['q1', 'q2', 'q3', 'q4', 'q5'], {prepare: 1}, function (err) {
         assert.ifError(err);
         assert.ok(called);
@@ -714,8 +714,8 @@ describe('Client', function () {
       var client = newConnectedInstance(handlerMock);
       client.metadata = new Metadata(client.options);
       //q3 and q4 are prepared
-      client.metadata.getPreparedInfo(null, 'q3').queryId = new Buffer(3);
-      client.metadata.getPreparedInfo(null, 'q4').queryId = new Buffer(3);
+      client.metadata.getPreparedInfo(null, 'q3').queryId = utils.allocBufferUnsafe(3);
+      client.metadata.getPreparedInfo(null, 'q4').queryId = utils.allocBufferUnsafe(3);
       //q2 is being prepared
       var q2Info = client.metadata.getPreparedInfo(null, 'q2');
       q2Info.preparing = true;
@@ -730,7 +730,7 @@ describe('Client', function () {
       });
       setTimeout(function () {
         q2Info.preparing = false;
-        q2Info.queryId = new Buffer(1);
+        q2Info.queryId = utils.allocBufferUnsafe(1);
         preparingCallbackCalled = true;
         q2Info.dummyCb();
       }, 80);
@@ -1027,7 +1027,7 @@ describe('Client', function () {
           { type: types.dataTypes.text }
         ]
       };
-      var options = { prepare: true, routingKey: new Buffer(2)};
+      var options = { prepare: true, routingKey: utils.allocBufferUnsafe(2)};
       client._setQueryOptions(options, [1, 'two'], meta, function (err) {
         assert.ifError(err);
         assert.strictEqual(options.hints.length, 2);

--- a/test/unit/control-connection-tests.js
+++ b/test/unit/control-connection-tests.js
@@ -260,7 +260,7 @@ describe('ControlConnection', function () {
         //valid rpc address
         {'rpc_address': getInet([9, 8, 7, 6]), peer: getInet([1, 1, 1, 1])},
         //should not be added
-        {'rpc_address': null, peer: new Buffer([1, 1, 1, 1])},
+        {'rpc_address': null, peer: utils.allocBufferFromArray([1, 1, 1, 1])},
         //should use peer address
         {'rpc_address': getInet([0, 0, 0, 0]), peer: getInet([5, 5, 5, 5])}
       ];
@@ -349,7 +349,7 @@ describe('ControlConnection', function () {
  * @returns {exports.InetAddress}
  */
 function getInet(bytes) {
-  return new types.InetAddress(new Buffer(bytes));
+  return new types.InetAddress(utils.allocBufferFromArray(bytes));
 }
 
 /** @return {ControlConnection} */

--- a/test/unit/inet-address-tests.js
+++ b/test/unit/inet-address-tests.js
@@ -1,13 +1,14 @@
 'use strict';
 var assert = require('assert');
 var helper = require('../test-helper');
+var utils = require('../../lib/utils');
 var InetAddress = require('../../lib/types').InetAddress;
 
 describe('InetAddress', function () {
   describe('constructor', function () {
     it('should validate the Buffer length', function () {
       assert.throws(function () {
-        return new InetAddress(new Buffer(10));
+        return new InetAddress(utils.allocBufferUnsafe(10));
       }, TypeError);
       assert.throws(function () {
         return new InetAddress(null);
@@ -16,38 +17,38 @@ describe('InetAddress', function () {
         return new InetAddress();
       }, TypeError);
       assert.doesNotThrow(function () {
-        return new InetAddress(new Buffer(16));
+        return new InetAddress(utils.allocBufferUnsafe(16));
       }, TypeError);
       assert.doesNotThrow(function () {
-        return new InetAddress(new Buffer(4));
+        return new InetAddress(utils.allocBufferUnsafe(4));
       }, TypeError);
     });
   });
   describe('#toString()', function () {
     it('should convert IPv6 to string representation', function () {
-      var val = new InetAddress(new Buffer('aabb0000eeff00112233445566778899', 'hex'));
+      var val = new InetAddress(utils.allocBufferFromString('aabb0000eeff00112233445566778899', 'hex'));
       assert.strictEqual(val.version, 6);
       assert.strictEqual(val.toString(), 'aabb::eeff:11:2233:4455:6677:8899');
-      val = new InetAddress(new Buffer('aabbccddeeff00112233445566778899', 'hex'));
+      val = new InetAddress(utils.allocBufferFromString('aabbccddeeff00112233445566778899', 'hex'));
       assert.strictEqual(val.toString(), 'aabb:ccdd:eeff:11:2233:4455:6677:8899');
-      val = new InetAddress(new Buffer('aabb0000000000112233445566778899', 'hex'));
+      val = new InetAddress(utils.allocBufferFromString('aabb0000000000112233445566778899', 'hex'));
       assert.strictEqual(val.toString(), 'aabb::11:2233:4455:6677:8899');
-      val = new InetAddress(new Buffer('aabb0001000100112233445500000000', 'hex'));
+      val = new InetAddress(utils.allocBufferFromString('aabb0001000100112233445500000000', 'hex'));
       assert.strictEqual(val.toString(), 'aabb:1:1:11:2233:4455::');
-      val = new InetAddress(new Buffer('00000000000100112233445500aa00bb', 'hex'));
+      val = new InetAddress(utils.allocBufferFromString('00000000000100112233445500aa00bb', 'hex'));
       assert.strictEqual(val.toString(), '::1:11:2233:4455:aa:bb');
-      val = new InetAddress(new Buffer('000000000000000022330000000000bb', 'hex'));
+      val = new InetAddress(utils.allocBufferFromString('000000000000000022330000000000bb', 'hex'));
       assert.strictEqual(val.toString(), '::2233:0:0:bb');
-      val = new InetAddress(new Buffer('00000000000000000000000000000001', 'hex'));
+      val = new InetAddress(utils.allocBufferFromString('00000000000000000000000000000001', 'hex'));
       assert.strictEqual(val.toString(), '::1');
     });
     it('should convert IPv4 to string representation', function () {
-      var val = new InetAddress(new Buffer([127, 0, 0, 1]));
+      var val = new InetAddress(utils.allocBufferFromArray([127, 0, 0, 1]));
       assert.strictEqual(val.version, 4);
       assert.strictEqual(val.toString(), '127.0.0.1');
-      val = new InetAddress(new Buffer([198, 168, 1, 1]));
+      val = new InetAddress(utils.allocBufferFromArray([198, 168, 1, 1]));
       assert.strictEqual(val.toString(), '198.168.1.1');
-      val = new InetAddress(new Buffer([10, 12, 254, 32]));
+      val = new InetAddress(utils.allocBufferFromArray([10, 12, 254, 32]));
       assert.strictEqual(val.toString(), '10.12.254.32');
     });
   });
@@ -55,11 +56,11 @@ describe('InetAddress', function () {
     it('should return true when the bytes are the same', function () {
       var hex1 = 'aabb0000eeff00112233445566778899';
       var hex2 = 'ffff0000eeff00112233445566778899';
-      var buf1 = new Buffer(hex1, 'hex');
+      var buf1 = utils.allocBufferFromString(hex1, 'hex');
       var val1 = new InetAddress(buf1);
-      var val2 = new InetAddress(new Buffer(hex2, 'hex'));
+      var val2 = new InetAddress(utils.allocBufferFromString(hex2, 'hex'));
       assert.ok(val1.equals(new InetAddress(buf1)));
-      assert.ok(val1.equals(new InetAddress(new Buffer(hex1, 'hex'))));
+      assert.ok(val1.equals(new InetAddress(utils.allocBufferFromString(hex1, 'hex'))));
       assert.ok(!val1.equals(val2));
     });
   });

--- a/test/unit/load-balancing-tests.js
+++ b/test/unit/load-balancing-tests.js
@@ -480,7 +480,7 @@ describe('TokenAwarePolicy', function () {
     utils.series([
       helper.toTask(policy.init, policy, client, new HostMap()),
       function (next) {
-        policy.newQueryPlan(null, {routingKey: new Buffer(16)}, function (err, iterator) {
+        policy.newQueryPlan(null, {routingKey: utils.allocBufferUnsafe(16)}, function (err, iterator) {
           var hosts = helper.iteratorToArray(iterator);
           assert.ok(hosts);
           assert.strictEqual(hosts.length, 4);
@@ -507,7 +507,7 @@ describe('TokenAwarePolicy', function () {
       helper.toTask(policy.init, policy, client, new HostMap()),
       function (next) {
         utils.timesLimit(100, 32, function (n, timesNext) {
-          policy.newQueryPlan(null, { routingKey: new Buffer(16) }, function (err, iterator) {
+          policy.newQueryPlan(null, { routingKey: utils.allocBufferUnsafe(16) }, function (err, iterator) {
             var hosts = helper.iteratorToArray(iterator);
             assert.strictEqual(hosts.length, 5);
             assert.deepEqual(hosts.map(toAddress).slice(0, 3).sort(), ['repl2_local', 'repl4_local', 'repl5_local']);

--- a/test/unit/protocol-stream-tests.js
+++ b/test/unit/protocol-stream-tests.js
@@ -3,6 +3,7 @@ var assert = require('assert');
 
 var Protocol = require('../../lib/streams').Protocol;
 var types = require('../../lib/types');
+var utils = require('../../lib/utils');
 
 describe('Protocol', function () {
   it('should emit a single frame with 0-length body', function () {
@@ -118,7 +119,7 @@ describe('Protocol', function () {
 function generateBuffer(version, frameBodyLengths) {
   var buffers = frameBodyLengths.map(function (bodyLength, index) {
     var header = new types.FrameHeader(version, 0, index, 0, bodyLength);
-    return Buffer.concat([ header.toBuffer(), new Buffer(bodyLength) ]);
+    return Buffer.concat([ header.toBuffer(), utils.allocBuffer(bodyLength) ]);
   });
   return Buffer.concat(buffers);
 }

--- a/test/unit/request-handler-tests.js
+++ b/test/unit/request-handler-tests.js
@@ -250,7 +250,7 @@ describe('RequestHandler', function () {
       var handler = newInstance();
       handler.request = {};
       handler.host = {};
-      handler._prepareAndRetry(new Buffer(0), function (err) {
+      handler._prepareAndRetry(utils.allocBufferUnsafe(0), function (err) {
         helper.assertInstanceOf(err, errors.DriverInternalError);
         done();
       });
@@ -260,12 +260,12 @@ describe('RequestHandler', function () {
       handler.request = {};
       handler.host = {};
       handler.request = new requests.BatchRequest([
-        { info: { queryId: new Buffer('10')}, query: '1'},
-        { info: { queryId: new Buffer('20')}, query: '2'}
+        { info: { queryId: utils.allocBufferFromString('10')}, query: '1'},
+        { info: { queryId: utils.allocBufferFromString('20')}, query: '2'}
       ], {});
       var connection = { prepareOnce: function (q, cb) {
         queriesPrepared.push(q);
-        setImmediate(function () { cb(null, { id: new Buffer(q)});});
+        setImmediate(function () { cb(null, { id: utils.allocBufferFromString(q)});});
       }};
       handler.connection = connection;
       var queriesPrepared = [];
@@ -274,7 +274,7 @@ describe('RequestHandler', function () {
         assert.strictEqual(handler.connection, connection);
         setImmediate(cb);
       };
-      handler._prepareAndRetry(new Buffer(0), function (err) {
+      handler._prepareAndRetry(utils.allocBufferUnsafe(0), function (err) {
         assert.ifError(err);
         assert.strictEqual(queriesPrepared.toString(), handler.request.queries.map(function (x) {return x.query; }).toString());
         done();
@@ -285,12 +285,12 @@ describe('RequestHandler', function () {
       handler.request = {};
       handler.host = {};
       handler.request = new requests.BatchRequest([
-        { info: { queryId: new Buffer('zz')}, query: 'SAME QUERY'},
-        { info: { queryId: new Buffer('zz')}, query: 'SAME QUERY'}
+        { info: { queryId: utils.allocBufferFromString('zz')}, query: 'SAME QUERY'},
+        { info: { queryId: utils.allocBufferFromString('zz')}, query: 'SAME QUERY'}
       ], {});
       var connection = { prepareOnce: function (q, cb) {
         queriesPrepared.push(q);
-        setImmediate(function () { cb(null, { id: new Buffer(q)});});
+        setImmediate(function () { cb(null, { id: utils.allocBufferFromString(q)});});
       }};
       handler.connection = connection;
       var queriesPrepared = [];
@@ -299,7 +299,7 @@ describe('RequestHandler', function () {
         assert.strictEqual(handler.connection, connection);
         setImmediate(cb);
       };
-      handler._prepareAndRetry(new Buffer(0), function (err) {
+      handler._prepareAndRetry(utils.allocBufferUnsafe(0), function (err) {
         assert.ifError(err);
         //Only 1 query
         assert.strictEqual(queriesPrepared.length, 1);
@@ -352,7 +352,7 @@ describe('RequestHandler', function () {
                 { type: { code: types.dataTypes.text, info: null}, name: 'col1'},
                 { type: { code: types.dataTypes.list, info: { code: types.dataTypes.uuid, info: null}}, name: 'col2'}
               ],
-              pageState: new Buffer('1234aa', 'hex')},
+              pageState: utils.allocBufferFromString('1234aa', 'hex')},
             flags: utils.emptyObject
           });
         });
@@ -419,7 +419,7 @@ describe('RequestHandler', function () {
               { type: { code: types.dataTypes.text, info: null}, name: 'col1'},
               { type: { code: types.dataTypes.list, info: { code: types.dataTypes.uuid, info: null}}, name: 'col2'}
             ],
-            pageState: new Buffer('1234aa', 'hex')
+            pageState: utils.allocBufferFromString('1234aa', 'hex')
           }});
         });
       }};

--- a/test/unit/tokenizer-tests.js
+++ b/test/unit/tokenizer-tests.js
@@ -5,6 +5,7 @@ var tokenizer = require('../../lib/tokenizer');
 var Murmur3Tokenizer = tokenizer.Murmur3Tokenizer;
 var RandomTokenizer = tokenizer.RandomTokenizer;
 var types = require('../../lib/types');
+var utils = require('../../lib/utils');
 var MutableLong = require('../../lib/types/mutable-long');
 var helper = require('../test-helper');
 
@@ -82,8 +83,8 @@ describe('Murmur3Tokenizer', function () {
         [
           [[1, 2, 3, 4], '11748876857495436398853550283091289647'],
           [[1, 2, 3, 4, 5, 6], '141904934057871337334287797400233978956'],
-          [new Buffer('fffafa000102030405fe', 'hex'), '93979376327542758013347018124903879310'],
-          [new Buffer('f000ee0000', 'hex'), '155172302213453714586395175393246848871']
+          [utils.allocBufferFromString('fffafa000102030405fe', 'hex'), '93979376327542758013347018124903879310'],
+          [utils.allocBufferFromString('f000ee0000', 'hex'), '155172302213453714586395175393246848871']
         ].forEach(function (item) {
           assert.strictEqual(t.hash(item[0]).toString(), item[1]);
         });

--- a/test/unit/uuid-tests.js
+++ b/test/unit/uuid-tests.js
@@ -1,7 +1,8 @@
 'use strict';
+
 var assert = require('assert');
 var helper = require('../test-helper');
-
+var utils = require('../../lib/utils');
 var Uuid = require('../../lib/types').Uuid;
 var TimeUuid = require('../../lib/types').TimeUuid;
 
@@ -9,7 +10,7 @@ describe('Uuid', function () {
   describe('constructor', function () {
     it('should validate the Buffer length', function () {
       assert.throws(function () {
-        return new Uuid(new Buffer(10));
+        return new Uuid(utils.allocBufferUnsafe(10));
       });
       assert.throws(function () {
         return new Uuid(null);
@@ -18,27 +19,27 @@ describe('Uuid', function () {
         return new Uuid();
       });
       assert.doesNotThrow(function () {
-        return new Uuid(new Buffer(16));
+        return new Uuid(utils.allocBufferUnsafe(16));
       });
     });
   });
   describe('#toString()', function () {
     it('should convert to string representation', function () {
-      var val = new Uuid(new Buffer('aabbccddeeff00112233445566778899', 'hex'));
+      var val = new Uuid(utils.allocBufferFromString('aabbccddeeff00112233445566778899', 'hex'));
       assert.strictEqual(val.toString(), 'aabbccdd-eeff-0011-2233-445566778899');
-      val = new Uuid(new Buffer('a1b1ccddeeff00112233445566778899', 'hex'));
+      val = new Uuid(utils.allocBufferFromString('a1b1ccddeeff00112233445566778899', 'hex'));
       assert.strictEqual(val.toString(), 'a1b1ccdd-eeff-0011-2233-445566778899');
-      val = new Uuid(new Buffer('ffb1ccddeeff00112233445566778800', 'hex'));
+      val = new Uuid(utils.allocBufferFromString('ffb1ccddeeff00112233445566778800', 'hex'));
       assert.strictEqual(val.toString(), 'ffb1ccdd-eeff-0011-2233-445566778800');
     });
   });
   describe('#equals', function () {
     it('should return true only when the values are equal', function () {
-      var val = new Uuid(new Buffer('aabbccddeeff00112233445566778899', 'hex'));
-      var val2 = new Uuid(new Buffer('ffffffffffff00000000000000000000', 'hex'));
-      var val3 = new Uuid(new Buffer('ffffffffffff00000000000000000001', 'hex'));
+      var val = new Uuid(utils.allocBufferFromString('aabbccddeeff00112233445566778899', 'hex'));
+      var val2 = new Uuid(utils.allocBufferFromString('ffffffffffff00000000000000000000', 'hex'));
+      var val3 = new Uuid(utils.allocBufferFromString('ffffffffffff00000000000000000001', 'hex'));
       assert.strictEqual(val.equals(val), true);
-      assert.strictEqual(val.equals(new Uuid(new Buffer('aabbccddeeff00112233445566778899', 'hex'))), true);
+      assert.strictEqual(val.equals(new Uuid(utils.allocBufferFromString('aabbccddeeff00112233445566778899', 'hex'))), true);
       assert.strictEqual(val.equals(val2), false);
       assert.strictEqual(val.equals(val3), false);
       assert.strictEqual(val2.equals(val3), false);
@@ -47,10 +48,10 @@ describe('Uuid', function () {
   });
   describe('#getBuffer()', function () {
     it('should return the Buffer representation', function () {
-      var buf = new Buffer(16);
+      var buf = utils.allocBufferUnsafe(16);
       var val = new Uuid(buf);
       assert.strictEqual(val.getBuffer().toString('hex'), buf.toString('hex'));
-      buf = new Buffer('ffffccddeeff00222233445566778813', 'hex');
+      buf = utils.allocBufferFromString('ffffccddeeff00222233445566778813', 'hex');
       val = new Uuid(buf);
       assert.strictEqual(val.getBuffer().toString('hex'), buf.toString('hex'));
     });
@@ -110,19 +111,19 @@ describe('TimeUuid', function () {
   describe('constructor()', function () {
     it('should generate based on the parameters', function () {
       //Gregorian calendar epoch
-      var val = new TimeUuid(new Date(-12219292800000), 0, new Buffer([0,0,0,0,0,0]), new Buffer([0,0]));
+      var val = new TimeUuid(new Date(-12219292800000), 0, utils.allocBufferFromArray([0,0,0,0,0,0]), utils.allocBufferFromArray([0,0]));
       assert.strictEqual(val.toString(), '00000000-0000-1000-8000-000000000000');
-      val = new TimeUuid(new Date(-12219292800000 + 1000), 0, new Buffer([0,0,0,0,0,0]), new Buffer([0,0]));
+      val = new TimeUuid(new Date(-12219292800000 + 1000), 0, utils.allocBufferFromArray([0,0,0,0,0,0]), utils.allocBufferFromArray([0,0]));
       assert.strictEqual(val.toString(), '00989680-0000-1000-8000-000000000000');
       //unix  epoch
-      val = new TimeUuid(new Date(0), 0, new Buffer([0,0,0,0,0,0]), new Buffer([0,0]));
+      val = new TimeUuid(new Date(0), 0, utils.allocBufferFromArray([0,0,0,0,0,0]), utils.allocBufferFromArray([0,0]));
       assert.strictEqual(val.toString(), '13814000-1dd2-11b2-8000-000000000000');
-      val = new TimeUuid(new Date(0), 0, new Buffer([255,255,255,255,255,255]), new Buffer([255,255]));
+      val = new TimeUuid(new Date(0), 0, utils.allocBufferFromArray([255,255,255,255,255,255]), utils.allocBufferFromArray([255,255]));
       assert.strictEqual(val.toString(), '13814000-1dd2-11b2-bfff-ffffffffffff');
-      val = new TimeUuid(new Date(0), 0, new Buffer([1,1,1,1,1,1]), new Buffer([1,1]));
+      val = new TimeUuid(new Date(0), 0, utils.allocBufferFromArray([1,1,1,1,1,1]), utils.allocBufferFromArray([1,1]));
       assert.strictEqual(val.toString(), '13814000-1dd2-11b2-8101-010101010101');
 
-      val = new TimeUuid(new Date('2015-01-10 5:05:05 GMT+0000'), 0, new Buffer([1,1,1,1,1,1]), new Buffer([1,1]));
+      val = new TimeUuid(new Date('2015-01-10 5:05:05 GMT+0000'), 0, utils.allocBufferFromArray([1,1,1,1,1,1]), utils.allocBufferFromArray([1,1]));
       assert.strictEqual(val.toString(), '3d555680-9886-11e4-8101-010101010101');
     });
   });
@@ -142,7 +143,7 @@ describe('TimeUuid', function () {
   });
   describe('#getNodeId()', function () {
     it('should get the node id of the Uuid representation', function () {
-      var val = new TimeUuid(new Date(), 0, new Buffer([1, 2, 3, 4, 5, 6]));
+      var val = new TimeUuid(new Date(), 0, utils.allocBufferFromArray([1, 2, 3, 4, 5, 6]));
       helper.assertInstanceOf(val.getNodeId(), Buffer);
       assert.strictEqual(val.getNodeId().toString('hex'), '010203040506');
       val = new TimeUuid(new Date(), 0, 'host01');


### PR DESCRIPTION
Removed constructor usages.

Added eslint rule `no-buffer-constructor` on `.eslintrc.js`. Switched to eslint 4 as it's [a rule added on v4](https://eslint.org/docs/rules/no-buffer-constructor).