### PR TITLE
Declared methods as non enumerable

### DIFF
--- a/lib/types/row.js
+++ b/lib/types/row.js
@@ -17,49 +17,62 @@ function Row(columns) {
  * Returns the cell value.
  * @param {String|Number} columnName Name or index of the column
  */
-Row.prototype.get = function (columnName) {
-  if (typeof columnName === 'number') {
-    //its an index
-    return this[this.__columns[columnName].name];
-  }
-  return this[columnName];
-};
+Object.defineProperty(Row.prototype, "get", {
+    enumerable: false,
+    value: function (columnName) {
+        if (typeof columnName === 'number') {
+            //its an index
+            return this[this.__columns[columnName].name];
+        }
+        return this[columnName];
+    }
+});
 
 /**
  * Returns an array of the values of the row
  * @returns {Array}
  */
-Row.prototype.values = function () {
-  var valuesArray = [];
-  this.forEach(function (val) {
-    valuesArray.push(val);
-  });
-  return valuesArray;
-};
+Object.defineProperty(Row.prototype, "values", {
+        enumerable: false,
+        value: function () {
+            var valuesArray = [];
+            this.forEach(function (val) {
+                valuesArray.push(val);
+            });
+            return valuesArray;
+        }
+    }
+);
 
 /**
  * Returns an array of the column names of the row
  * @returns {Array}
  */
-Row.prototype.keys = function () {
-  var keysArray = [];
-  this.forEach(function (val, key) {
-    keysArray.push(key);
-  });
-  return keysArray;
-};
+Object.defineProperty(Row.prototype, "keys", {
+    enumerable: false,
+    value: function () {
+        var keysArray = [];
+        this.forEach(function (val, key) {
+            keysArray.push(key);
+        });
+        return keysArray;
+    }
+});
 
 /**
  * Executes the callback for each field in the row, containing the value as first parameter followed by the columnName
  * @param {Function} callback
  */
-Row.prototype.forEach = function (callback) {
-  for (var columnName in this) {
-    if (!this.hasOwnProperty(columnName)) {
-      continue;
+Object.defineProperty(Row.prototype, "forEach", {
+    enumerable: false,
+    value: function (callback) {
+        for (var columnName in this) {
+            if (!this.hasOwnProperty(columnName)) {
+                continue;
+            }
+            callback(this[columnName], columnName);
+        }
     }
-    callback(this[columnName], columnName);
-  }
-};
+});
 
 module.exports = Row;

--- a/lib/types/row.js
+++ b/lib/types/row.js
@@ -10,7 +10,7 @@ function Row(columns) {
     throw new Error('Columns not defined');
   }
   //Private non-enumerable properties, with double underscore to avoid interfering with column names
-  Object.defineProperty(this, '__columns', { value: columns, enumerable: false, writable: false});
+  Object.defineProperty(this, '__columns', { value: columns, enumerable: false, writable: false });
 }
 
 /**
@@ -18,14 +18,14 @@ function Row(columns) {
  * @param {String|Number} columnName Name or index of the column
  */
 Object.defineProperty(Row.prototype, "get", {
-    enumerable: false,
-    value: function (columnName) {
-        if (typeof columnName === 'number') {
-            //its an index
-            return this[this.__columns[columnName].name];
-        }
-        return this[columnName];
+  enumerable: false,
+  value: function (columnName) {
+    if (typeof columnName === 'number') {
+      //its an index
+      return this[this.__columns[columnName].name];
     }
+    return this[columnName];
+  }
 });
 
 /**
@@ -33,15 +33,15 @@ Object.defineProperty(Row.prototype, "get", {
  * @returns {Array}
  */
 Object.defineProperty(Row.prototype, "values", {
-        enumerable: false,
-        value: function () {
-            var valuesArray = [];
-            this.forEach(function (val) {
-                valuesArray.push(val);
-            });
-            return valuesArray;
-        }
-    }
+  enumerable: false,
+  value: function () {
+    var valuesArray = [];
+    this.forEach(function (val) {
+      valuesArray.push(val);
+    });
+    return valuesArray;
+  }
+}
 );
 
 /**
@@ -49,14 +49,14 @@ Object.defineProperty(Row.prototype, "values", {
  * @returns {Array}
  */
 Object.defineProperty(Row.prototype, "keys", {
-    enumerable: false,
-    value: function () {
-        var keysArray = [];
-        this.forEach(function (val, key) {
-            keysArray.push(key);
-        });
-        return keysArray;
-    }
+  enumerable: false,
+  value: function () {
+    var keysArray = [];
+    this.forEach(function (val, key) {
+      keysArray.push(key);
+    });
+    return keysArray;
+  }
 });
 
 /**
@@ -64,15 +64,15 @@ Object.defineProperty(Row.prototype, "keys", {
  * @param {Function} callback
  */
 Object.defineProperty(Row.prototype, "forEach", {
-    enumerable: false,
-    value: function (callback) {
-        for (var columnName in this) {
-            if (!this.hasOwnProperty(columnName)) {
-                continue;
-            }
-            callback(this[columnName], columnName);
-        }
+  enumerable: false,
+  value: function (callback) {
+    for (var columnName in this) {
+      if (!this.hasOwnProperty(columnName)) {
+        continue;
+      }
+      callback(this[columnName], columnName);
     }
+  }
 });
 
 module.exports = Row;


### PR DESCRIPTION
Declared the recently added methods to Row.prototype with Object.defineProperty setting enumerable to false. Previously, resultset rows could be used like a plain Object, including with for in/of loops. The last changes broke that behavior causing backwards incompatability. This fix will remedy that without effecting anything else.  Also as I side note, it would appear that if a database has any columns named "values" or "keys",  it would break this module.  I suggest that row objects should either behavior like plain objects as they did previously, or the row data should be moved into another variable instead of being directly on the instance.