### PR TITLE
Updating connection pooling docs

### DIFF
--- a/doc/features/connection-pooling/README.md
+++ b/doc/features/connection-pooling/README.md
@@ -27,8 +27,8 @@ const options = {
    contactPoints: ['1.2.3.4'],
    pooling: {
       coreConnectionsPerHost: {
-        [distance.local] = 2,
-        [distance.remote] = 1
+        [distance.local]: 2,
+        [distance.remote]: 1
       } 
    }
 };


### PR DESCRIPTION
The connection pooling docs are using incorrect syntax for property assignment, `=` has been replaced with `:`.