### PR TITLE
Freeze mocha dependency on 2.5 line

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "long": "^2.2.0"
   },
   "devDependencies": {
-    "mocha": ">= 1.14.0",
+    "mocha": "~2.5.3",
     "rewire": ">= 2.1.0",
     "mocha-jenkins-reporter": ">= 0.1.9",
     "mocha-appveyor-reporter": ">= 0.2.1",


### PR DESCRIPTION
Many of mocha's dependencies where targeting node.js 4+, preventing builds with node.js < 4.

This should fix it while we maintain [support for Node.js 0.10+](https://datastax-oss.atlassian.net/browse/NODEJS-363).
