### PR TITLE
Connection: Remove excessive verbose logging

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -434,7 +434,6 @@ Connection.prototype.sendStream = function (request, options, callback) {
  * @private
  */
 Connection.prototype._write = function (operation, streamId) {
-  this.log('verbose', 'Sending stream #' + streamId);
   operation.streamId = streamId;
   var self = this;
   this.writeQueue.push(operation, function writeCallback (err) {
@@ -520,7 +519,6 @@ Connection.prototype.freeStreamId = function(header) {
     this.emit('drain');
   }
   this._writeNext();
-  this.log('verbose', 'Done receiving frame #' + streamId);
 };
 
 Connection.prototype._writeNext = function () {
@@ -589,7 +587,6 @@ Connection.prototype.handleRow = function (header, row, meta, rowLength, flags) 
   if (!operation) {
     return this.log('error', 'The server replied with a wrong streamId #' + streamId);
   }
-  this.log('verbose', 'Received streaming frame #' + streamId);
   operation.setResultRow(row, meta, rowLength, flags);
 };
 


### PR DESCRIPTION
I've been benchmarking possible ways to limit the overhead of verbose message generation and event emission on the Connection.

The final solution is simple enough, just remove the excess (instead of "sending" & "sent", leave only "sent" logs; similar for "received" and "done"). I've tested using delayed string evaluation, a wrapper with references to the actual values, but there isn't any significant difference (again: string manipulation seems to be highly optimized on v8).

Removing these log message (even if they are not consumed) causes an increase in throughput of 7% under Node.js 6 and 3.6% under Node.js 8:

Node.js 6
- Baseline: 17176.23 req/sec
- This pr: 18381.51 req/sec (+7%)

Node.js 8
- Baseline: 33742.75 req/sec
- This pr: 34966.87 req/sec (+3.6%)

It uses the throughput test, with a single node cluster with 320 max outstanding requests.

_oh my, look at those Node.js 8 numbers!_ 😃
