### PR TITLE
DCAwareRoundRobinPolicy: Warn when local datacenter is not specified

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
   "env": {
-    "commonjs": true
+    "commonjs": true,
+    "es6": true
   },
   "extends": "eslint:recommended",
   "rules": {

--- a/lib/policies/load-balancing.js
+++ b/lib/policies/load-balancing.js
@@ -132,10 +132,12 @@ DCAwareRoundRobinPolicy.prototype.init = function (client, hosts, callback) {
   if (!this.localDc) {
     //get the first alive local, it should be local on top
     var hostsArray = hosts.values();
+    var dcHost;
     for (var i = 0; i < hostsArray.length; i++) {
       var h = hostsArray[i];
       if (h.datacenter) {
         this.localDc = h.datacenter;
+        dcHost = h;
         break;
       }
     }
@@ -143,6 +145,9 @@ DCAwareRoundRobinPolicy.prototype.init = function (client, hosts, callback) {
     if (!this.localDc) {
       return callback(new errors.DriverInternalError('Local datacenter could not be determined'));
     }
+    client.log('warning', 'No local DC was provided with DCAwareRoundRobinPolicy' + 
+      '.  Using discovered DC \'' + this.localDc + '\' from host ' + dcHost.address +
+      '.  Future releases will require local DC to be provided.');
   }
   callback();
 };

--- a/lib/policies/load-balancing.js
+++ b/lib/policies/load-balancing.js
@@ -145,9 +145,9 @@ DCAwareRoundRobinPolicy.prototype.init = function (client, hosts, callback) {
     if (!this.localDc) {
       return callback(new errors.DriverInternalError('Local datacenter could not be determined'));
     }
-    client.log('warning', 'No local DC was provided with DCAwareRoundRobinPolicy' + 
+    client.log('warning', 'No local Data Center was provided with DCAwareRoundRobinPolicy' + 
       '.  Using discovered DC \'' + this.localDc + '\' from host ' + dcHost.address +
-      '.  Future releases will require local DC to be provided.');
+      '.  Future releases will require local DC to be specified.');
   }
   callback();
 };

--- a/test/integration/short/client-pool-tests.js
+++ b/test/integration/short/client-pool-tests.js
@@ -936,8 +936,7 @@ describe('Client', function () {
           });
           client.connect(function (err) {
             assert.ifError(err);
-            assert.strictEqual(warnings.length, 1);
-            assert.ok(warnings[0].indexOf('pool') >= 0, 'warning does not contains the word pool: ' + warnings[0]);
+            assert.strictEqual(warnings.filter(w => w.indexOf('pool') >= 0).length, 1);
             client.shutdown(next);
           });
         }

--- a/test/integration/short/control-connection-tests.js
+++ b/test/integration/short/control-connection-tests.js
@@ -160,7 +160,7 @@ describe('ControlConnection', function () {
         cc.init.bind(cc),
         function initLbp(next) {
           lbp = cc.options.policies.loadBalancing;
-          lbp.init(null, cc.hosts, next);
+          lbp.init({ log: utils.noop }, cc.hosts, next);
         },
         function ensureConnected(next) {
           var hosts = cc.hosts.values();
@@ -202,7 +202,7 @@ describe('ControlConnection', function () {
         function initLbp(next) {
           assert.ok(cc.host);
           assert.strictEqual(helper.lastOctetOf(cc.host), '1');
-          cc.options.policies.loadBalancing.init(null, cc.hosts, next);
+          cc.options.policies.loadBalancing.init({ log: utils.noop }, cc.hosts, next);
         },
         function setHostDistance(next) {
           // the control connection host should be local or remote to trigger DOWN events

--- a/test/unit/load-balancing-tests.js
+++ b/test/unit/load-balancing-tests.js
@@ -449,6 +449,48 @@ describe('DCAwareRoundRobinPolicy', function () {
     ], done);
 
   });
+  it('should warn on init when no local DC was configured', function (done) {
+    var policy = new DCAwareRoundRobinPolicy();
+    var client = new Client(helper.baseOptions);
+    var logEvents = [];
+    client.on('log', function(level, className, message, furtherInfo) {
+      logEvents.push({level: level, className: className, message: message, furtherInfo: furtherInfo});
+    });
+    var hosts = new HostMap();
+    hosts.set('1', createHost('1', client.options));
+    utils.series([
+      function initPolicy(next) {
+        policy.init(client, hosts, next);
+      },
+      function checkLogs(next) {
+        assert.strictEqual(logEvents.length, 1);
+        var event = logEvents[0];
+        assert.strictEqual(event.level, 'warning');
+        assert.strictEqual(event.message, 'No local DC was provided with DCAwareRoundRobinPolicy.' +
+          '  Using discovered DC \'dc1\' from host 1.  Future releases will require local DC to be provided.');
+        next();
+      }
+    ], done);
+  });
+  it('should not warn on init when local DC was configured', function (done) {
+    var policy = new DCAwareRoundRobinPolicy('dc1');
+    var client = new Client(helper.baseOptions);
+    var logEvents = [];
+    client.on('log', function(level, className, message, furtherInfo) {
+      logEvents.push({level: level, className: className, message: message, furtherInfo: furtherInfo});
+    });
+    var hosts = new HostMap();
+    hosts.set('1', createHost('1', client.options));
+    utils.series([
+      function initPolicy(next) {
+        policy.init(client, hosts, next);
+      },
+      function checkLogs(next) {
+        assert.strictEqual(logEvents.length, 0);
+        next();
+      }
+    ], done);
+  });
 });
 describe('TokenAwarePolicy', function () {
   it('should use the childPolicy when no routingKey provided', function (done) {

--- a/test/unit/load-balancing-tests.js
+++ b/test/unit/load-balancing-tests.js
@@ -466,8 +466,8 @@ describe('DCAwareRoundRobinPolicy', function () {
         assert.strictEqual(logEvents.length, 1);
         var event = logEvents[0];
         assert.strictEqual(event.level, 'warning');
-        assert.strictEqual(event.message, 'No local DC was provided with DCAwareRoundRobinPolicy.' +
-          '  Using discovered DC \'dc1\' from host 1.  Future releases will require local DC to be provided.');
+        assert.strictEqual(event.message, 'No local Data Center was provided with DCAwareRoundRobinPolicy.' +
+          '  Using discovered DC \'dc1\' from host 1.  Future releases will require local DC to be specified.');
         next();
       }
     ], done);


### PR DESCRIPTION
For [NODEJS-378](https://datastax-oss.atlassian.net/browse/NODEJS-378).

If no `localDC` was configured with `DCAwareRoundRobinPolicy` a log message like the following will be emitted at `warning` level:

> warning -- No local DC was provided with DCAwareRoundRobinPolicy.  Using discovered DC 'datacenter1' from host 127.0.0.1:9042.  Future releases will require local DC to be provided.