### PR TITLE
Replace var with const / let

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,7 +92,9 @@ module.exports = {
     "no-void": "error",
     "no-with": "error",
     "no-buffer-constructor": "error",
-    radix: "error"
+    radix: "error",
+    "no-var": "error",
+    "prefer-const": "error"
   },
   "globals": {
     "Buffer": false,

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ It can be **piped** downstream and provides automatic pause/resume logic (it buf
 client.stream('SELECT time, val FROM temperature WHERE station_id=', [ 'abc' ])
   .on('readable', function () {
     // 'readable' is emitted as soon a row is received and parsed
-    var row;
+    let row;
     while (row = this.read()) {
       console.log('time %s and value %s', row.time, row.val);
     }

--- a/doc/doc-plugin.js
+++ b/doc/doc-plugin.js
@@ -4,10 +4,10 @@
  * Name of the doclets and the maximum amount of occurrences.
  * @private
  */
-var filterDoclets = {
+const filterDoclets = {
   'module:types': 1
 };
-var filtered = {};
+const filtered = {};
 
 exports.handlers = {
   newDoclet: function (e) {

--- a/doc/features/paging/README.md
+++ b/doc/features/paging/README.md
@@ -17,7 +17,7 @@ retrieving the following page after the previous rows were read (throttling).
 client.stream(query, parameters, options)
   .on('readable', function () {
     // readable is emitted as soon a row is received and parsed
-    var row;
+    let row;
     while (row = this.read()) {
       // process row
     }

--- a/doc/features/tuning-policies/README.md
+++ b/doc/features/tuning-policies/README.md
@@ -83,14 +83,14 @@ BlackListPolicy.prototype.getDistance = function (host) {
 };
 
 BlackListPolicy.prototype.newQueryPlan = function (keyspace, queryOptions, callback) {
-  var self = this;
+  const self = this;
   this.childPolicy.newQueryPlan(keyspace, queryOptions, function (iterator) {
     callback(self.filter(iterator));
   });
-}
+};
 
 BlackListPolicy.prototype.filter = function (childIterator) {
-  var self = this;
+  const self = this;
   return {
     next: function () {
       var item = childIterator.next();

--- a/examples/basic/basic-execute-flow.js
+++ b/examples/basic/basic-execute-flow.js
@@ -19,22 +19,22 @@ async.series([
     client.connect(next);
   },
   function createKeyspace(next) {
-    var query = "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3' }";
+    const query = "CREATE KEYSPACE IF NOT EXISTS examples WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3' }";
     client.execute(query, next);
   },
   function createTable(next) {
-    var query = "CREATE TABLE IF NOT EXISTS examples.basic (id uuid, txt text, val int, PRIMARY KEY(id))";
+    const query = "CREATE TABLE IF NOT EXISTS examples.basic (id uuid, txt text, val int, PRIMARY KEY(id))";
     client.execute(query, next);
   },
   function insert(next) {
-    var query = 'INSERT INTO examples.basic (id, txt, val) VALUES (?, ?, ?)';
+    const query = 'INSERT INTO examples.basic (id, txt, val) VALUES (?, ?, ?)';
     client.execute(query, [ id, 'Hello!', 100 ], { prepare: true}, next);
   },
   function select(next) {
-    var query = 'SELECT id, txt, val FROM examples.basic WHERE id = ?';
+    const query = 'SELECT id, txt, val FROM examples.basic WHERE id = ?';
     client.execute(query, [ id ], { prepare: true}, function (err, result) {
       if (err) return next(err);
-      var row = result.first();
+      const row = result.first();
       console.log('Obtained row: ', row);
       assert.strictEqual(row.id.toString(), id.toString());
       assert.strictEqual(row.txt, 'Hello!');

--- a/examples/metadata/metadata-keyspaces.js
+++ b/examples/metadata/metadata-keyspaces.js
@@ -1,5 +1,5 @@
 "use strict";
-var cassandra = require('cassandra-driver');
+const cassandra = require('cassandra-driver');
 
 const client = new cassandra.Client({ contactPoints: ['127.0.0.1'] });
 client.connect()

--- a/examples/metadata/metadata-table.js
+++ b/examples/metadata/metadata-table.js
@@ -1,6 +1,5 @@
 "use strict";
 const cassandra = require('cassandra-driver');
-const async = require('async');
 
 const client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
 

--- a/examples/runner.js
+++ b/examples/runner.js
@@ -1,9 +1,9 @@
 "use strict";
 
-var async = require('async');
-var exec = require('child_process').exec;
-var fs = require('fs');
-var path = require('path');
+const async = require('async');
+const exec = require('child_process').exec;
+const fs = require('fs');
+const path = require('path');
 
 /**
  * This script is used to check that the samples run correctly.
@@ -36,14 +36,14 @@ if (typeof Promise === 'undefined' || process.version.indexOf('v0.') === 0) {
 }
 
 var runnerFileName = path.basename(module.filename);
-var counter = 0;
-var failures = 0;
+let counter = 0;
+let failures = 0;
 async.eachSeries(getJsFiles(path.dirname(module.filename) + path.sep), function (file, next) {
   if (file.indexOf(runnerFileName) >= 0) {
     return next();
   }
 
-  var timedOut = false;
+  let timedOut = false;
   var timeout = setTimeout(function() {
     console.log("%s timed out after 10s", file);
     counter++;

--- a/examples/tuple/tuple-insert-select.js
+++ b/examples/tuple/tuple-insert-select.js
@@ -1,9 +1,7 @@
 "use strict";
-var cassandra = require('cassandra-driver');
-var async = require('async');
-var assert = require('assert');
+const cassandra = require('cassandra-driver');
 
-var client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
+const client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
 
 /**
  * Creates a table with a Tuple type, inserts a row and selects a row.

--- a/examples/udt/udt-insert-select.js
+++ b/examples/udt/udt-insert-select.js
@@ -1,6 +1,5 @@
 "use strict";
 const cassandra = require('cassandra-driver');
-const async = require('async');
 
 const client = new cassandra.Client({ contactPoints: ['127.0.0.1']});
 
@@ -36,7 +35,7 @@ client.connect()
     return client.execute(query, ['The Rolling Stones', address], { prepare: true});
   })
   .then(function () {
-    var query = 'SELECT name, address FROM examples.udt_tbl1 WHERE name = ?';
+    const query = 'SELECT name, address FROM examples.udt_tbl1 WHERE name = ?';
     return client.execute(query, ['The Rolling Stones'], { prepare: true });
   })
   .then(function (result) {

--- a/index.js
+++ b/index.js
@@ -1,12 +1,15 @@
-var clientOptions = require('./lib/client-options');
+'use strict';
+
+const clientOptions = require('./lib/client-options');
 exports.Client = require('./lib/client');
 exports.ExecutionProfile = require('./lib/execution-profile').ExecutionProfile;
 exports.types = require('./lib/types');
 exports.errors = require('./lib/errors');
 exports.policies = require('./lib/policies');
 exports.auth = require('./lib/auth');
+const Metadata = require('./lib/metadata');
 exports.metadata = {
-  Metadata: require('./lib/metadata')
+  Metadata: Metadata
 };
 exports.Encoder = require('./lib/encoder');
 /**

--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -3,7 +3,7 @@
  * Authentication module.
  * @module auth
  */
-var baseProvider = require('./provider.js');
+const baseProvider = require('./provider.js');
 exports.AuthProvider = baseProvider.AuthProvider;
 exports.Authenticator = baseProvider.Authenticator;
 exports.PlainTextAuthProvider = require('./plain-text-auth-provider.js');

--- a/lib/auth/plain-text-auth-provider.js
+++ b/lib/auth/plain-text-auth-provider.js
@@ -1,10 +1,10 @@
 'use strict';
-var util = require('util');
+const util = require('util');
 
-var provider = require('./provider.js');
-var utils = require('../utils');
-var AuthProvider = provider.AuthProvider;
-var Authenticator = provider.Authenticator;
+const provider = require('./provider.js');
+const utils = require('../utils');
+const AuthProvider = provider.AuthProvider;
+const Authenticator = provider.Authenticator;
 /**
  * Creates a new instance of the Authenticator provider
  * @classdesc Provides plain text [Authenticator]{@link module:auth~Authenticator} instances to be used when
@@ -13,7 +13,7 @@ var Authenticator = provider.Authenticator;
  * @example
  * var authProvider = new cassandra.auth.PlainTextAuthProvider('my_user', 'p@ssword1!');
  * //Set the auth provider in the clientOptions when creating the Client instance
- * var client = new Client({ contactPoints: contactPoints, authProvider: authProvider });
+ * const client = new Client({ contactPoints: contactPoints, authProvider: authProvider });
  * @param {String} username User name in plain text
  * @param {String} password Password in plain text
  * @alias module:auth~PlainTextAuthProvider
@@ -46,7 +46,7 @@ function PlainTextAuthenticator(username, password) {
 util.inherits(PlainTextAuthenticator, Authenticator);
 
 PlainTextAuthenticator.prototype.initialResponse = function (callback) {
-  var initialToken = Buffer.concat([
+  const initialToken = Buffer.concat([
     utils.allocBufferFromArray([0]),
     utils.allocBufferFromString(this.username, 'utf8'),
     utils.allocBufferFromArray([0]),

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -1,10 +1,10 @@
 "use strict";
-var util = require('util');
+const util = require('util');
 
-var policies = require('./policies');
-var types = require('./types');
-var utils = require('./utils');
-var errors = require('./errors');
+const policies = require('./policies');
+const types = require('./types');
+const utils = require('./utils');
+const errors = require('./errors');
 
 /**
  * @returns {ClientOptions}
@@ -67,12 +67,12 @@ function extend(baseOptions, userOptions) {
     userOptions = arguments[0];
     baseOptions = {};
   }
-  var options = utils.deepExtend(baseOptions, defaultOptions(), userOptions);
+  const options = utils.deepExtend(baseOptions, defaultOptions(), userOptions);
   if (!util.isArray(options.contactPoints) || options.contactPoints.length === 0) {
     throw new TypeError('Contacts points are not defined.');
   }
-  for (var i = 0; i < options.contactPoints.length; i++) {
-    var hostName = options.contactPoints[i];
+  for (let i = 0; i < options.contactPoints.length; i++) {
+    const hostName = options.contactPoints[i];
     if (!hostName) {
       throw new TypeError(util.format('Contact point %s (%s) is not a valid host name, ' +
         'the following values are valid contact points: ipAddress, hostName or ipAddress:port', i, hostName));
@@ -131,7 +131,7 @@ function validateProtocolOptions(protocolOptions) {
   if (!protocolOptions) {
     throw new TypeError('protocolOptions not defined in options');
   }
-  var version = protocolOptions.maxVersion;
+  const version = protocolOptions.maxVersion;
   if (version && (typeof version !== 'number' || !types.protocolVersion.isSupported(version))) {
     throw new TypeError(util.format('protocolOptions.maxVersion provided (%s) is invalid', version));
   }
@@ -161,7 +161,7 @@ function validateSocketOptions(socketOptions) {
  */
 function validateEncodingOptions(encodingOptions) {
   if (encodingOptions.map) {
-    var mapConstructor = encodingOptions.map;
+    const mapConstructor = encodingOptions.map;
     if (typeof mapConstructor !== 'function' ||
       typeof mapConstructor.prototype.forEach !== 'function' ||
       typeof mapConstructor.prototype.set !== 'function') {
@@ -169,7 +169,7 @@ function validateEncodingOptions(encodingOptions) {
     }
   }
   if (encodingOptions.set) {
-    var setConstructor = encodingOptions.set;
+    const setConstructor = encodingOptions.set;
     if (typeof setConstructor !== 'function' ||
       typeof setConstructor.prototype.forEach !== 'function' ||
       typeof setConstructor.prototype.add !== 'function') {
@@ -191,17 +191,17 @@ function validateEncodingOptions(encodingOptions) {
  * instance (doesn't throw the Error).
  */
 function createQueryOptions(client, userOptions, rowCallback, logged) {
-  var profile =
+  const profile =
     client.profileManager.getProfile(userOptions && userOptions.executionProfile);
   if (!profile) {
     return new errors.ArgumentError(util.format('Execution profile "%s" not found', userOptions.executionProfile));
   }
   // userOptions can be undefined and could be of type function (is an optional parameter)
   userOptions = (!userOptions || typeof userOptions === 'function') ? utils.emptyObject : userOptions;
-  var defaultQueryOptions = client.options.queryOptions;
+  const defaultQueryOptions = client.options.queryOptions;
 
   // Using fixed property names is 2 order of magnitude faster than dynamically shallow clone objects
-  var result = {
+  const result = {
     autoPage: ifUndefined(userOptions.autoPage, defaultQueryOptions.autoPage),
     captureStackTrace: ifUndefined(userOptions.captureStackTrace, defaultQueryOptions.captureStackTrace),
     consistency: ifUndefined3(userOptions.consistency, profile.consistency, defaultQueryOptions.consistency),
@@ -231,10 +231,10 @@ function createQueryOptions(client, userOptions, rowCallback, logged) {
   if (userOptions === utils.emptyObject) {
     return result;
   }
-  var userOptionsKeys = Object.keys(userOptions);
-  var key, value;
+  const userOptionsKeys = Object.keys(userOptions);
+  let key, value;
   // Use the fastest iteration of array
-  var i = userOptionsKeys.length;
+  let i = userOptionsKeys.length;
   while (i--) {
     key = userOptionsKeys[i];
     if (key === 'executionProfile') {
@@ -265,7 +265,7 @@ function getTimestamp(client, userOptions, defaultValue) {
   if (typeof userOptions.timestamp !== 'undefined') {
     return userOptions.timestamp;
   }
-  var timestampGenerator = client.options.policies.timestampGeneration;
+  const timestampGenerator = client.options.policies.timestampGeneration;
   if (types.protocolVersion.supportsTimestamp(client.controlConnection.protocolVersion) && timestampGenerator) {
     return timestampGenerator.next(client);
   }
@@ -275,14 +275,14 @@ function getTimestamp(client, userOptions, defaultValue) {
 /**
  * Core connections per host for protocol versions 1 and 2
  */
-var coreConnectionsPerHostV2 = {};
+const coreConnectionsPerHostV2 = {};
 coreConnectionsPerHostV2[types.distance.local] = 2;
 coreConnectionsPerHostV2[types.distance.remote] = 1;
 coreConnectionsPerHostV2[types.distance.ignored] = 0;
 /**
  * Core connections per host for protocol version 3 and above
  */
-var coreConnectionsPerHostV3 = {};
+const coreConnectionsPerHostV3 = {};
 coreConnectionsPerHostV3[types.distance.local] = 1;
 coreConnectionsPerHostV3[types.distance.remote] = 1;
 coreConnectionsPerHostV3[types.distance.ignored] = 0;

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,24 +1,27 @@
 "use strict";
-var events = require('events');
-var util = require('util');
+const events = require('events');
+const util = require('util');
 
-var utils = require('./utils.js');
-var errors = require('./errors.js');
-var types = require('./types');
-var ControlConnection = require('./control-connection');
-var ProfileManager = require('./execution-profile').ProfileManager;
-var RequestHandler = require('./request-handler');
-var PrepareHandler = require('./prepare-handler');
-var requests = require('./requests');
-var clientOptions = require('./client-options');
-var ClientState = require('./metadata/client-state');
+const utils = require('./utils.js');
+const errors = require('./errors.js');
+const types = require('./types');
+const ProfileManager = require('./execution-profile').ProfileManager;
+const requests = require('./requests');
+const clientOptions = require('./client-options');
+const ClientState = require('./metadata/client-state');
+
+// Allow injection of the following modules
+/* eslint-disable prefer-const */
+let ControlConnection = require('./control-connection');
+let RequestHandler = require('./request-handler');
+let PrepareHandler = require('./prepare-handler');
+/* eslint-enable prefer-const */
 
 /**
  * Max amount of pools being warmup in parallel, when warmup is enabled
- * @const {Number}
  * @private
  */
-var warmupLimit = 32;
+const warmupLimit = 32;
 
 
 /**
@@ -381,7 +384,7 @@ Client.prototype._connectCb = function (callback) {
     return;
   }
   this.connecting = true;
-  var self = this;
+  const self = this;
   utils.series([
     function initControlConnection(next) {
       self.controlConnection.init(next);
@@ -398,7 +401,7 @@ Client.prototype._connectCb = function (callback) {
     },
     function setPoolOptionsAndWarmup(next) {
       //Set the pooling options depending on the protocol version
-      var coreConnectionsPerHost = clientOptions.coreConnectionsPerHostV3;
+      let coreConnectionsPerHost = clientOptions.coreConnectionsPerHostV3;
       if (!types.protocolVersion.uses2BytesStreamIds(self.controlConnection.protocolVersion)) {
         coreConnectionsPerHost = clientOptions.coreConnectionsPerHostV2;
       }
@@ -510,8 +513,8 @@ Client.prototype.eachRow = function (query, params, options, rowCallback, callba
   }
   params = typeof params !== 'function' ? params : null;
   options = clientOptions.createQueryOptions(this, options, rowCallback);
-  var self = this;
-  var rowLength = 0;
+  const self = this;
+  let rowLength = 0;
   function nextPage() {
     self._innerExecute(query, params, options, pageCallback);
   }
@@ -563,7 +566,7 @@ Client.prototype.stream = function (query, params, options, callback) {
   // NOTE: the nodejs stream maintains yet another internal buffer 
   // we rely on the default stream implementation to keep memory 
   // usage reasonable.
-  var resultStream = new types.ResultStream({ objectMode: 1 });
+  const resultStream = new types.ResultStream({ objectMode: 1 });
   function onFinish(err, result) {
     if (err) {
       resultStream.emit('error', err);
@@ -586,7 +589,7 @@ Client.prototype.stream = function (query, params, options, callback) {
     resultStream.add(null);
     callback(err);
   }
-  var sync = true;
+  let sync = true;
   this.eachRow(query, params, options, function rowCallback(n, row) {
     resultStream.add(row);
   }, function eachRowFinished(err, result) {
@@ -627,7 +630,7 @@ Client.prototype.batch = function (queries, options, callback) {
  * @private
  */
 Client.prototype._batchCb = function (queries, options, callback) {
-  var self = this;
+  const self = this;
   if (!Array.isArray(queries)) {
     // We should throw (not callback) for an unexpected type
     throw new errors.ArgumentError('Queries should be an Array');
@@ -649,13 +652,13 @@ Client.prototype._batchCb = function (queries, options, callback) {
         return PrepareHandler.getPreparedMultiple(
           self, options.executionProfile.loadBalancing, queries, self.keyspace, next);
       }
-      var parsedQueries = new Array(queries.length);
-      for (var i = 0; i < queries.length; i++) {
-        var item = queries[i];
+      const parsedQueries = new Array(queries.length);
+      for (let i = 0; i < queries.length; i++) {
+        const item = queries[i];
         if (!item) {
           return next(new errors.ArgumentError(util.format('Invalid query at index %d', i)));
         }
-        var query = typeof item === 'string' ? item : item.query;
+        const query = typeof item === 'string' ? item : item.query;
         if (!query) {
           return next(errors.ArgumentError(util.format('Invalid query at index %d', i)));
         }
@@ -667,8 +670,8 @@ Client.prototype._batchCb = function (queries, options, callback) {
     if (err) {
       return callback(err);
     }
-    var request = new requests.BatchRequest(queryItems, options);
-    var handler = new RequestHandler(request, options, self);
+    const request = new requests.BatchRequest(queryItems, options);
+    const handler = new RequestHandler(request, options, self);
     handler.send(callback);
   });
 };
@@ -714,11 +717,11 @@ Client.prototype.shutdown = function (callback) {
  * @private
  */
 Client.prototype._shutdownCb = function (callback) {
-  var self = this;
+  const self = this;
   function doShutdown() {
     self.connected = false;
     self.isShuttingDown = true;
-    var hosts = self.hosts.values();
+    const hosts = self.hosts.values();
     // Shutdown the ControlConnection before shutting down the pools
     self.controlConnection.shutdown();
     self.options.policies.speculativeExecution.shutdown();
@@ -752,12 +755,12 @@ Client.prototype._waitForSchemaAgreement = function (connection, callback) {
   if (this.hosts.length === 1) {
     return setImmediate(callback);
   }
-  var self = this;
-  var start = new Date();
-  var maxWaitTime = this.options.protocolOptions.maxSchemaAgreementWaitSeconds * 1000;
+  const self = this;
+  const start = new Date();
+  const maxWaitTime = this.options.protocolOptions.maxSchemaAgreementWaitSeconds * 1000;
   this.log('info', 'Waiting for schema agreement');
-  var versionsMatch;
-  var peerVersions;
+  let versionsMatch;
+  let peerVersions;
   utils.whilst(function condition() {
     return !versionsMatch && (new Date() - start) < maxWaitTime;
   }, function fn(next) {
@@ -778,7 +781,7 @@ Client.prototype._waitForSchemaAgreement = function (connection, callback) {
       //check the different versions
       versionsMatch = true;
       localVersion = localVersion.toString();
-      for (var i = 0; i < peerVersions.length; i++) {
+      for (let i = 0; i < peerVersions.length; i++) {
         if (peerVersions[i].toString() !== localVersion) {
           versionsMatch = false;
           break;
@@ -802,7 +805,7 @@ Client.prototype._waitForSchemaAgreement = function (connection, callback) {
  * @internal
  */
 Client.prototype.handleSchemaAgreementAndRefresh = function (connection, event, callback) {
-  var self = this;
+  const self = this;
   this._waitForSchemaAgreement(connection, function agreementCb(err) {
     if (err) {
       //we issue a warning but we continue with the normal flow
@@ -832,7 +835,7 @@ Client.prototype._innerExecute = function (query, params, options, callback) {
   if (options.prepare) {
     return this._executeAsPrepared(query, params, options, callback);
   }
-  var self = this;
+  const self = this;
   utils.series([
     function connecting(next) {
       self.connect(next);
@@ -844,11 +847,11 @@ Client.prototype._innerExecute = function (query, params, options, callback) {
       });
     },
     function sendingQuery(next) {
-      var request = new requests.QueryRequest(
+      const request = new requests.QueryRequest(
         query,
         params,
         options);
-      var handler = new RequestHandler(request, options, self);
+      const handler = new RequestHandler(request, options, self);
       handler.send(next);
     }
   ], callback);
@@ -863,15 +866,15 @@ Client.prototype._innerExecute = function (query, params, options, callback) {
  * @private
  */
 Client.prototype._executeAsPrepared = function (query, params, options, callback) {
-  var queryId;
-  var meta;
-  var self = this;
+  let queryId;
+  let meta;
+  const self = this;
   utils.series([
     function connecting(next) {
       self.connect(next);
     },
     function preparing(next) {
-      var lbp = options.executionProfile.loadBalancing;
+      const lbp = options.executionProfile.loadBalancing;
       PrepareHandler.getPrepared(self, lbp, query, self.keyspace, function (err, id, m) {
         queryId = id;
         meta = m;
@@ -885,13 +888,13 @@ Client.prototype._executeAsPrepared = function (query, params, options, callback
       });
     },
     function sendingExecute(next) {
-      var request = new requests.ExecuteRequest(
+      const request = new requests.ExecuteRequest(
         query,
         queryId,
         params,
         options);
       request.query = query;
-      var handler = new RequestHandler(request, options, self);
+      const handler = new RequestHandler(request, options, self);
       handler.send(next);
     }
   ], callback);
@@ -902,7 +905,7 @@ Client.prototype._executeAsPrepared = function (query, params, options, callback
  * @private
  */
 Client.prototype._setHostListeners = function () {
-  var self = this;
+  const self = this;
   function getHostUpListener(emitter, h) {
     return (function hostUpListener() {
       emitter.emit('hostUp', h);
@@ -932,11 +935,11 @@ Client.prototype._setHostListeners = function () {
 };
 
 Client.prototype._warmup = function (callback) {
-  var self = this;
-  var hosts = this.hosts.values();
+  const self = this;
+  const hosts = this.hosts.values();
   utils.timesLimit(hosts.length, warmupLimit, function warmupEachCallback(i, next) {
-    var h = hosts[i];
-    var distance = self.profileManager.getDistance(h);
+    const h = hosts[i];
+    const distance = self.profileManager.getDistance(h);
     if (distance !== types.distance.local) {
       //do not warmup pool for remote or ignored hosts
       return next();
@@ -957,8 +960,7 @@ Client.prototype._warmup = function (callback) {
  * @private
  */
 Client.prototype._getEncoder = function () {
-  var encoder;
-  encoder = this.controlConnection.getEncoder();
+  const encoder = this.controlConnection.getEncoder();
   if (!encoder) {
     throw new errors.DriverInternalError('Encoder is not defined');
   }
@@ -974,14 +976,14 @@ Client.prototype._getEncoder = function () {
  * @private
  */
 Client.prototype._setQueryOptions = function (options, params, meta, callback) {
-  var version = this.controlConnection.protocolVersion;
+  const version = this.controlConnection.protocolVersion;
   if (!options.prepare && params && !util.isArray(params) && !types.protocolVersion.supportsNamedParameters(version)) {
     //Only Cassandra 2.1 and above supports named parameters
     return callback(
       new errors.ArgumentError('Named parameters for simple statements are not supported, use prepare flag'));
   }
-  var paramsInfo;
-  var self = this;
+  let paramsInfo;
+  const self = this;
   utils.series([
     function fillRoutingKeys(next) {
       if (options.routingKey || options.routingIndexes || options.routingNames || !meta) {
@@ -1051,7 +1053,6 @@ Client.prototype._setQueryOptions = function (options, params, meta, callback) {
         //pageState can be a hex string
         options.pageState = utils.allocBufferFromString(options.pageState, 'hex');
       }
-      //noinspection JSAccessibilityCheck
       self._getEncoder().setRoutingKey(paramsInfo.params, options, paramsInfo.keys);
     }
     catch (err) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,21 +1,25 @@
 "use strict";
-var net = require('net');
-var events = require('events');
-var util = require('util');
-var tls = require('tls');
 
-var Encoder = require('./encoder.js');
-var WriteQueue = require('./writers').WriteQueue;
-var requests = require('./requests');
-var streams = require('./streams');
-var utils = require('./utils');
-var types = require('./types');
-var errors = require('./errors');
-var StreamIdStack = require('./stream-id-stack');
-var OperationState = require('./operation-state');
+const events = require('events');
+const util = require('util');
+const tls = require('tls');
+
+const Encoder = require('./encoder.js');
+const WriteQueue = require('./writers').WriteQueue;
+const requests = require('./requests');
+const streams = require('./streams');
+const utils = require('./utils');
+const types = require('./types');
+const errors = require('./errors');
+const StreamIdStack = require('./stream-id-stack');
+const OperationState = require('./operation-state');
+
+// Allow injection of net module
+// eslint-disable-next-line prefer-const
+let net = require('net');
 
 /**  @const */
-var idleQuery = 'SELECT key from system.local';
+const idleQuery = 'SELECT key from system.local';
 
 /**
  * Represents a connection to a Cassandra node
@@ -32,7 +36,7 @@ function Connection(endpoint, protocolVersion, options) {
     throw new Error('EndPoint must contain the ip address and port separated by : symbol');
   }
   this.endpoint = endpoint;
-  var portSeparatorIndex = endpoint.lastIndexOf(':');
+  const portSeparatorIndex = endpoint.lastIndexOf(':');
   this.address = endpoint.substr(0, portSeparatorIndex);
   this.port = endpoint.substr(portSeparatorIndex + 1);
   Object.defineProperty(this, "options", { value: options, enumerable: false, writable: false});
@@ -84,11 +88,11 @@ Connection.prototype.bindSocketListeners = function() {
   this.netClient.removeAllListeners('timeout');
   // The socket is expected to be open at this point
   this.isSocketOpen = true;
-  var self = this;
+  const self = this;
   this.netClient.on('close', function() {
     self.log('info', 'Connection to ' + self.endpoint + ' closed');
     self.isSocketOpen = false;
-    var wasConnected = self.connected;
+    const wasConnected = self.connected;
     self.close();
     if (wasConnected) {
       // Emit only when it was closed unexpectedly
@@ -98,7 +102,7 @@ Connection.prototype.bindSocketListeners = function() {
 
   this.protocol = new streams.Protocol({ objectMode: true });
   this.parser = new streams.Parser({ objectMode: true }, this.encoder);
-  var resultEmitter = new streams.ResultEmitter({objectMode: true});
+  const resultEmitter = new streams.ResultEmitter({objectMode: true});
   resultEmitter.on('result', this.handleResult.bind(this));
   resultEmitter.on('row', this.handleRow.bind(this));
   resultEmitter.on('frameEnded', this.freeStreamId.bind(this));
@@ -117,7 +121,7 @@ Connection.prototype.bindSocketListeners = function() {
  * Note that when open() callbacks in error, the caller should immediately call {@link Connection#close}.
  */
 Connection.prototype.open = function (callback) {
-  var self = this;
+  const self = this;
   this.log('info', 'Connecting to ' + this.address + ':' + this.port);
   if (!this.options.sslOptions) {
     this.netClient = new net.Socket();
@@ -129,7 +133,7 @@ Connection.prototype.open = function (callback) {
   }
   else {
     //use TLS
-    var sslOptions = utils.extend({rejectUnauthorized: false}, this.options.sslOptions);
+    const sslOptions = utils.extend({rejectUnauthorized: false}, this.options.sslOptions);
     this.netClient = tls.connect(this.port, this.address, sslOptions, function tlsConnectCallback() {
       self.log('verbose', 'Secure socket connected to ' + self.address + ':' + self.port);
       self.bindSocketListeners();
@@ -140,7 +144,7 @@ Connection.prototype.open = function (callback) {
     self.errorConnecting(err, false, callback);
   });
   this.netClient.once('timeout', function connectTimedOut() {
-    var err = new types.DriverError('Connection timeout');
+    const err = new types.DriverError('Connection timeout');
     self.errorConnecting(err, true, callback);
   });
   this.netClient.setTimeout(this.options.socketOptions.connectTimeout);
@@ -159,10 +163,10 @@ Connection.prototype.startup = function (callback) {
   if (this._checkingVersion) {
     this.log('info', 'Trying to use protocol version ' + this.protocolVersion);
   }
-  var self = this;
+  const self = this;
   this.sendStream(new requests.StartupRequest(), null, function responseCallback(err, response) {
     if (err && self._checkingVersion) {
-      var invalidProtocol = (err instanceof errors.ResponseError &&
+      let invalidProtocol = (err instanceof errors.ResponseError &&
         err.code === types.responseErrorCodes.protocolError &&
         err.message.indexOf('Invalid or unsupported protocol version') >= 0);
       if (!invalidProtocol && types.protocolVersion.canStartupResponseErrorBeWrapped(self.protocolVersion)) {
@@ -175,7 +179,7 @@ Connection.prototype.startup = function (callback) {
       if (invalidProtocol) {
         // The server can respond with a message using the lower protocol version supported
         // or using the same version as the one provided
-        var lowerVersion = self.protocol.version;
+        let lowerVersion = self.protocol.version;
         if (lowerVersion === self.protocolVersion) {
           lowerVersion = types.protocolVersion.getLowerSupported(self.protocolVersion);
         }
@@ -259,13 +263,13 @@ Connection.prototype.clearAndInvokePending = function (innerError) {
   if (this.emitDrain) {
     this.emit('drain');
   }
-  var err = new types.DriverError('Socket was closed');
+  const err = new types.DriverError('Socket was closed');
   err.isSocketError = true;
   if (innerError) {
     err.innerError = innerError;
   }
   //copy all handlers
-  var operations = utils.objectValues(this._operations);
+  const operations = utils.objectValues(this._operations);
   //remove it from the map
   this._operations = {};
   if (operations.length > 0) {
@@ -277,7 +281,7 @@ Connection.prototype.clearAndInvokePending = function (innerError) {
     next();
   });
 
-  var pendingWritesCopy = this._pendingWrites;
+  const pendingWritesCopy = this._pendingWrites;
   this._pendingWrites = [];
   utils.each(pendingWritesCopy, function (operation, next) {
     operation.setResult(err);
@@ -294,8 +298,8 @@ Connection.prototype.startAuthenticating = function (authenticatorName, callback
   if (!this.options.authProvider) {
     return callback(new errors.AuthenticationError('Authentication provider not set'));
   }
-  var authenticator = this.options.authProvider.newAuthenticator(this.endpoint, authenticatorName);
-  var self = this;
+  const authenticator = this.options.authProvider.newAuthenticator(this.endpoint, authenticatorName);
+  const self = this;
   authenticator.initialResponse(function initialResponseCallback(err, token) {
     // Start the flow with the initial token
     if (err) {
@@ -312,21 +316,19 @@ Connection.prototype.startAuthenticating = function (authenticatorName, callback
  * @param {Function} callback
  */
 Connection.prototype.authenticate = function(authenticator, token, callback) {
-  var self = this;
-  var request = new requests.AuthResponseRequest(token);
+  const self = this;
+  let request = new requests.AuthResponseRequest(token);
   if (this.protocolVersion === 1) {
     //No Sasl support, use CREDENTIALS
-    //noinspection JSUnresolvedVariable
     if (!authenticator.username) {
       return callback(new errors.AuthenticationError('Only plain text authenticator providers allowed under protocol v1'));
     }
-    //noinspection JSUnresolvedVariable
     request = new requests.CredentialsRequest(authenticator.username, authenticator.password);
   }
   this.sendStream(request, null, function authResponseCallback(err, result) {
     if (err) {
       if (err instanceof errors.ResponseError && err.code === types.responseErrorCodes.badCredentials) {
-        var authError = new errors.AuthenticationError(err.message);
+        const authError = new errors.AuthenticationError(err.message);
         authError.additionalInfo = err;
         err = authError;
       }
@@ -364,8 +366,8 @@ Connection.prototype.changeKeyspace = function (keyspace, callback) {
     return;
   }
   this.toBeKeyspace = keyspace;
-  var query = util.format('USE "%s"', keyspace);
-  var self = this;
+  const query = util.format('USE "%s"', keyspace);
+  const self = this;
   this.sendStream(
     new requests.QueryRequest(query, null, null),
     null,
@@ -387,8 +389,8 @@ Connection.prototype.changeKeyspace = function (keyspace, callback) {
  * @param {function} callback
  */
 Connection.prototype.prepareOnce = function (query, callback) {
-  var name = ( this.keyspace || '' ) + query;
-  var info = this._preparing[name];
+  const name = ( this.keyspace || '' ) + query;
+  let info = this._preparing[name];
   if (this._preparing[name]) {
     //Its being already prepared
     return info.once('prepared', callback);
@@ -397,7 +399,7 @@ Connection.prototype.prepareOnce = function (query, callback) {
   info.setMaxListeners(0);
   info.once('prepared', callback);
   this._preparing[name] = info;
-  var self = this;
+  const self = this;
   this.sendStream(new requests.PrepareRequest(query), null, function (err, response) {
     info.emit('prepared', err, response);
     delete self._preparing[name];
@@ -412,9 +414,9 @@ Connection.prototype.prepareOnce = function (query, callback) {
  * @return {OperationState}
  */
 Connection.prototype.sendStream = function (request, options, callback) {
-  var self = this;
-  var operation = new OperationState(request, options, callback);
-  var streamId = this._getStreamId();
+  const self = this;
+  const operation = new OperationState(request, options, callback);
+  const streamId = this._getStreamId();
   if (streamId === null) {
     self.log('info',
       'Enqueuing ' +
@@ -435,7 +437,7 @@ Connection.prototype.sendStream = function (request, options, callback) {
  */
 Connection.prototype._write = function (operation, streamId) {
   operation.streamId = streamId;
-  var self = this;
+  const self = this;
   this.writeQueue.push(operation, function writeCallback (err) {
     if (err) {
       return operation.setResult(err);
@@ -460,10 +462,10 @@ Connection.prototype._setIdleTimeout = function () {
   if (!this.options.pooling.heartBeatInterval) {
     return;
   }
-  var self = this;
+  const self = this;
   // Scheduling the new timeout before de-scheduling the previous performs significantly better
   // than de-scheduling first, see nodejs implementation: https://github.com/nodejs/node/blob/master/lib/timers.js
-  var previousTimeout = this._idleTimeout;
+  const previousTimeout = this._idleTimeout;
   self._idleTimeout = setTimeout(function () {
     self._idleTimeoutHandler();
   }, self.options.pooling.heartBeatInterval);
@@ -477,7 +479,7 @@ Connection.prototype._setIdleTimeout = function () {
  * Function that gets executed once the idle timeout has passed to issue a request to keep the connection alive
  */
 Connection.prototype._idleTimeoutHandler = function () {
-  var self = this;
+  const self = this;
   if (this.sendingIdleQuery) {
     //don't issue another
     //schedule for next time
@@ -509,7 +511,7 @@ Connection.prototype._getStreamId = function() {
 };
 
 Connection.prototype.freeStreamId = function(header) {
-  var streamId = header.streamId;
+  const streamId = header.streamId;
   if (streamId < 0) {
     return;
   }
@@ -525,13 +527,13 @@ Connection.prototype._writeNext = function () {
   if (this._pendingWrites.length === 0) {
     return;
   }
-  var streamId = this._getStreamId();
+  const streamId = this._getStreamId();
   if (streamId === null) {
     // No streamId available
     return;
   }
-  var self = this;
-  var operation = this._pendingWrites.shift();
+  const self = this;
+  const operation = this._pendingWrites.shift();
   setImmediate(function writeNextPending() {
     self._write(operation, streamId);
   });
@@ -549,11 +551,11 @@ Connection.prototype.getInFlight = function () {
  * Handles a result and error response
  */
 Connection.prototype.handleResult = function (header, err, result) {
-  var streamId = header.streamId;
+  const streamId = header.streamId;
   if(streamId < 0) {
     return this.log('verbose', 'event received', header);
   }
-  var operation = this._operations[streamId];
+  const operation = this._operations[streamId];
   if (!operation) {
     return this.log('error', 'The server replied with a wrong streamId #' + streamId);
   }
@@ -579,11 +581,11 @@ Connection.prototype.handleNodeEvent = function (header, event) {
  * Handles a row response
  */
 Connection.prototype.handleRow = function (header, row, meta, rowLength, flags) {
-  var streamId = header.streamId;
+  const streamId = header.streamId;
   if(streamId < 0) {
     return this.log('verbose', 'Event received', header);
   }
-  var operation = this._operations[streamId];
+  const operation = this._operations[streamId];
   if (!operation) {
     return this.log('error', 'The server replied with a wrong streamId #' + streamId);
   }
@@ -610,7 +612,7 @@ Connection.prototype.close = function (callback) {
   // Set the socket as closed now (before socket.end() is called) to avoid being invoked more than once
   this.isSocketOpen = false;
   this.log('verbose', 'Closing connection to ' + this.endpoint);
-  var self = this;
+  const self = this;
   this.netClient.once('close', function (hadError) {
     if (hadError) {
       self.log('info', 'The socket closed with a transmission error');

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -1,24 +1,25 @@
 "use strict";
-var events = require('events');
-var util = require('util');
-var dns = require('dns');
-var net = require('net');
+const events = require('events');
+const util = require('util');
+const net = require('net');
 
-var errors = require('./errors');
-var Host = require('./host').Host;
-var HostMap = require('./host').HostMap;
-var Metadata = require('./metadata');
-var EventDebouncer = require('./metadata/event-debouncer');
-var requests = require('./requests');
-var utils = require('./utils');
-var types = require('./types');
-var f = util.format;
+const errors = require('./errors');
+const Host = require('./host').Host;
+const HostMap = require('./host').HostMap;
+const Metadata = require('./metadata');
+const EventDebouncer = require('./metadata/event-debouncer');
+const requests = require('./requests');
+const utils = require('./utils');
+const types = require('./types');
+const f = util.format;
+// eslint-disable-next-line prefer-const
+let dns = require('dns');
 
-var selectPeers = "SELECT peer,data_center,rack,tokens,rpc_address,release_version FROM system.peers";
-var selectLocal = "SELECT * FROM system.local WHERE key='local'";
-var newNodeDelay = 1000;
-var metadataQueryAbortTimeout = 2000;
-var schemaChangeTypes = {
+const selectPeers = "SELECT peer,data_center,rack,tokens,rpc_address,release_version FROM system.peers";
+const selectLocal = "SELECT * FROM system.local WHERE key='local'";
+const newNodeDelay = 1000;
+const metadataQueryAbortTimeout = 2000;
+const schemaChangeTypes = {
   created: 'CREATED',
   updated: 'UPDATED',
   dropped: 'DROPPED'
@@ -38,7 +39,6 @@ var schemaChangeTypes = {
 function ControlConnection(options, profileManager, context) {
   this.protocolVersion = null;
   this.hosts = new HostMap();
-  //noinspection JSUnresolvedFunction
   this.setMaxListeners(0);
   Object.defineProperty(this, "options", { value: options, enumerable: false, writable: false});
   /**
@@ -91,10 +91,10 @@ ControlConnection.prototype.init = function (callback) {
     //prevent multiple serial initializations
     return callback();
   }
-  var self = this;
+  const self = this;
   function addHost(address, port, cb) {
-    var endPoint = address + ':' + (port || self.options.protocolOptions.port);
-    var h = new Host(endPoint, self.protocolVersion, self.options, self.metadata);
+    const endPoint = address + ':' + (port || self.options.protocolOptions.port);
+    const h = new Host(endPoint, self.protocolVersion, self.options, self.metadata);
     self.hosts.set(endPoint, h);
     self.log('info', 'Adding host ' + endPoint);
     if (cb) {
@@ -106,14 +106,14 @@ ControlConnection.prototype.init = function (callback) {
       utils.each(self.options.contactPoints, function eachResolve(name, eachNext) {
         if (name.indexOf('[') === 0 && name.indexOf(']:') > 1) {
           // IPv6 host notation [ip]:port (RFC 3986 section 3.2.2)
-          var portSeparatorIndex = name.lastIndexOf(']:');
+          const portSeparatorIndex = name.lastIndexOf(']:');
           return addHost(name.substr(1, portSeparatorIndex - 1), name.substr(portSeparatorIndex + 2), eachNext);
         }
-        var host = name;
-        var port = null;
+        let host = name;
+        let port = null;
         if (name.indexOf(':') > 0) {
           // IPv4 or host name with port notation
-          var parts = name.split(':');
+          const parts = name.split(':');
           if (parts.length === 2) {
             host = parts[0];
             port = parts[1];
@@ -149,10 +149,10 @@ ControlConnection.prototype.init = function (callback) {
 };
 
 ControlConnection.prototype.setHealthListeners = function () {
-  var host = this.host;
-  var connection = this.connection;
-  var self = this;
-  var wasRefreshCalled = 0;
+  const host = this.host;
+  const connection = this.connection;
+  const self = this;
+  let wasRefreshCalled = 0;
 
   function removeListeners() {
     host.removeListener('down', downOrIgnoredHandler);
@@ -199,23 +199,23 @@ ControlConnection.prototype.setHealthListeners = function () {
  * @param callback
  */
 ControlConnection.prototype.borrowAConnection = function (callback) {
-  var self = this;
-  var host;
-  var connection = null;
+  const self = this;
+  let host;
+  let connection = null;
   utils.whilst(
     function condition() {
       // while there isn't a valid connection
       if (connection) {
         return false;
       }
-      var item = self.hostIterator.next();
+      const item = self.hostIterator.next();
       host = item.value;
       return (!item.done);
     },
     function whileIterator(next) {
       if (self.initialized) {
         // Only check distance once the load-balancing policies have been initialized
-        var distance = self.profileManager.getDistance(host);
+        const distance = self.profileManager.getDistance(host);
         if (!host.isUp() || distance === types.distance.ignored) {
           return next();
         }
@@ -259,25 +259,25 @@ ControlConnection.prototype.refreshHosts = function (newNodesUp, callback) {
     // this will be called again when there is a new connection.
     return;
   }
-  var self = this;
+  const self = this;
   if (!this.host.protocolVersion) {
     this.hosts.forEach(function (h) {
       h.setProtocolVersion(self.protocolVersion);
     });
   }
   this.log('info', 'Refreshing local and peers info');
-  var c = this.connection;
-  var host = this.host;
+  const c = this.connection;
+  const host = this.host;
   utils.series([
     function getLocalInfo(next) {
-      var request = new requests.QueryRequest(selectLocal, null, null);
+      const request = new requests.QueryRequest(selectLocal, null, null);
       c.sendStream(request, null, function (err, result) {
         self.setLocalInfo(c.endpoint, result);
         next(err);
       });
     },
     function getPeersInfo(next) {
-      var request = new requests.QueryRequest(selectPeers, null, null);
+      const request = new requests.QueryRequest(selectPeers, null, null);
       c.sendStream(request, null, function (err, result) {
         self.setPeersInfo(newNodesUp, err, result, next);
       });
@@ -328,11 +328,11 @@ ControlConnection.prototype.refreshHosts = function (newNodesUp, callback) {
  * @param {Function} [callback]
  */
 ControlConnection.prototype.refresh = function (reuseQueryPlan, callback) {
-  var initializing = !this.initialized;
+  const initializing = !this.initialized;
   callback = callback || utils.noop;
   // Reset the state of the host field, that way we can identify when the query plan was exhausted
   this.host = null;
-  var self = this;
+  const self = this;
   utils.series([
     function getHostIterator(next) {
       if (reuseQueryPlan) {
@@ -371,7 +371,7 @@ ControlConnection.prototype.refresh = function (reuseQueryPlan, callback) {
       self.connection.on('nodeTopologyChange', self.nodeTopologyChangeHandler.bind(self));
       self.connection.on('nodeStatusChange', self.nodeStatusChangeHandler.bind(self));
       self.connection.on('nodeSchemaChange', self.nodeSchemaChangeHandler.bind(self));
-      var request = new requests.RegisterRequest(['TOPOLOGY_CHANGE', 'STATUS_CHANGE', 'SCHEMA_CHANGE']);
+      const request = new requests.RegisterRequest(['TOPOLOGY_CHANGE', 'STATUS_CHANGE', 'SCHEMA_CHANGE']);
       self.connection.sendStream(request, null, next);
     }
   ], function refreshSeriesEnd(err) {
@@ -412,9 +412,9 @@ ControlConnection.prototype.refresh = function (reuseQueryPlan, callback) {
  * There isn't an open connection at the moment, try again later.
  */
 ControlConnection.prototype.noOpenConnectionHandler = function () {
-  var delay = this.reconnectionSchedule.next().value;
+  const delay = this.reconnectionSchedule.next().value;
   this.log('warning', f('ControlConnection could not reconnect, scheduling reconnection in %dms', delay));
-  var self = this;
+  const self = this;
   setTimeout(function controlConnectionReconnection() {
     self.refresh();
   }, delay);
@@ -433,7 +433,7 @@ ControlConnection.prototype.log = utils.log;
 ControlConnection.prototype.nodeTopologyChangeHandler = function (event) {
   this.log('info', 'Received topology change', event);
   // all hosts information needs to be refreshed as tokens might have changed
-  var self = this;
+  const self = this;
   clearTimeout(this.topologyChangeTimeout);
   // Use an additional timer to make sure that the refresh hosts is executed only AFTER the delay
   // In this case, the event debouncer doesn't help because it could not honor the sliding delay (ie: processNow)
@@ -446,16 +446,16 @@ ControlConnection.prototype.nodeTopologyChangeHandler = function (event) {
  * Handles a STATUS_CHANGE event
  */
 ControlConnection.prototype.nodeStatusChangeHandler = function (event) {
-  var self = this;
-  var addressToTranslate = event.inet.address.toString();
-  var port = this.options.protocolOptions.port;
+  const self = this;
+  const addressToTranslate = event.inet.address.toString();
+  const port = this.options.protocolOptions.port;
   this.addressTranslator.translate(addressToTranslate, port, function translateCallback(endPoint) {
-    var host = self.hosts.get(endPoint);
+    const host = self.hosts.get(endPoint);
     if (!host) {
       self.log('warning', 'Received status change event but host was not found: ' + addressToTranslate);
       return;
     }
-    var distance = self.profileManager.getDistance(host);
+    const distance = self.profileManager.getDistance(host);
     if (event.up) {
       if (distance === types.distance.ignored) {
         return host.setUp(true);
@@ -492,8 +492,8 @@ ControlConnection.prototype.nodeSchemaChangeHandler = function (event) {
  * @param {Function} [callback]
  */
 ControlConnection.prototype.handleSchemaChange = function (event, processNow, callback) {
-  var self = this;
-  var handler, cqlObject;
+  const self = this;
+  let handler, cqlObject;
   if (event.isKeyspace) {
     if (event.schemaChangeType === schemaChangeTypes.dropped) {
       handler = function removeKeyspace() {
@@ -505,7 +505,7 @@ ControlConnection.prototype.handleSchemaChange = function (event, processNow, ca
     }
     return this.scheduleKeyspaceRefresh(event.keyspace, processNow, callback);
   }
-  var ksInfo = this.metadata.keyspaces[event.keyspace];
+  const ksInfo = this.metadata.keyspaces[event.keyspace];
   if (!ksInfo) {
     // it hasn't been loaded and it is not part of the metadata, don't mind
     return;
@@ -561,8 +561,8 @@ ControlConnection.prototype.scheduleObjectRefresh = function (handler, keyspaceN
  * @param {Function} [callback]
  */
 ControlConnection.prototype.scheduleKeyspaceRefresh = function (keyspaceName, processNow, callback) {
-  var self = this;
-  var handler = function keyspaceRefreshHandler(cb) {
+  const self = this;
+  const handler = function keyspaceRefreshHandler(cb) {
     self.metadata.refreshKeyspace(keyspaceName, cb);
   };
   this.debouncer.eventReceived({ handler: handler, keyspace: keyspaceName, callback: callback}, processNow);
@@ -572,8 +572,8 @@ ControlConnection.prototype.scheduleKeyspaceRefresh = function (keyspaceName, pr
  * @param {Function} [callback]
  */
 ControlConnection.prototype.scheduleRefreshHosts = function (callback) {
-  var self = this;
-  var handler = function hostsRefreshHandler(cb) {
+  const self = this;
+  const handler = function hostsRefreshHandler(cb) {
     self.refreshHosts(false, cb);
   };
   this.debouncer.eventReceived({ handler: handler, all: true, callback: callback }, false);
@@ -584,8 +584,8 @@ ControlConnection.prototype.setLocalInfo = function (endPoint, result) {
     this.log('warning', 'No local info provided');
     return;
   }
-  var row = result.rows[0];
-  var localHost = this.hosts.get(endPoint);
+  const row = result.rows[0];
+  const localHost = this.hosts.get(endPoint);
   if (!localHost) {
     this.log('error', 'Localhost could not be found');
     return;
@@ -608,17 +608,17 @@ ControlConnection.prototype.setPeersInfo = function (newNodesUp, err, result, ca
   if (!result || !result.rows || err) {
     return callback(err);
   }
-  var self = this;
+  const self = this;
   //A map of peers, could useful for in case there are discrepancies
-  var peers = {};
-  var port = this.options.protocolOptions.port;
+  const peers = {};
+  const port = this.options.protocolOptions.port;
   utils.eachSeries(result.rows, function eachPeer(row, next) {
     self.getAddressForPeerHost(row, port, function getAddressForPeerCallback(endPoint) {
       if (!endPoint) {
         return next();
       }
       peers[endPoint] = true;
-      var host = self.hosts.get(endPoint);
+      let host = self.hosts.get(endPoint);
       if (!host) {
         host = new Host(endPoint, self.protocolVersion, self.options, self.metadata);
         if (!newNodesUp) {
@@ -641,7 +641,7 @@ ControlConnection.prototype.setPeersInfo = function (newNodesUp, err, result, ca
     if (self.hosts.length > result.rows.length + 1) {
       //There are hosts in the current state that don't belong (nodes removed or wrong contactPoints)
       self.log('info', 'Removing nodes from the pool');
-      var toRemove = [];
+      const toRemove = [];
       self.hosts.forEach(function (h) {
         //It is not a peer and it is not local host
         if (!peers[h.address] && h !== self.host) {
@@ -664,9 +664,9 @@ ControlConnection.prototype.setPeersInfo = function (newNodesUp, err, result, ca
  *  containing the ip address and port.
  */
 ControlConnection.prototype.getAddressForPeerHost = function (row, defaultPort, callback) {
-  var address = row['rpc_address'];
-  var peer = row['peer'];
-  var bindAllAddress = '0.0.0.0';
+  let address = row['rpc_address'];
+  const peer = row['peer'];
+  const bindAllAddress = '0.0.0.0';
   if (!address) {
     this.log('error', f('No rpc_address found for host %s in %s\'s peers system table. %s will be ignored.',
       peer, this.host.address, peer));
@@ -685,8 +685,9 @@ ControlConnection.prototype.getAddressForPeerHost = function (row, defaultPort, 
  * @param {Function} callback
  */
 ControlConnection.prototype.waitForReconnection = function (callback) {
-  var timeout;
-  var self = this;
+  // eslint-disable-next-line prefer-const
+  let timeout;
+  const self = this;
   function newConnectionListener(err) {
     clearTimeout(timeout);
     callback(err);
@@ -706,13 +707,13 @@ ControlConnection.prototype.waitForReconnection = function (callback) {
  * @param {Function} callback
  */
 ControlConnection.prototype.query = function (cqlQuery, waitReconnect, callback) {
-  var self = this;
+  const self = this;
   if (typeof waitReconnect === 'function') {
     callback = waitReconnect;
     waitReconnect = true;
   }
   function queryOnConnection() {
-    var request = typeof cqlQuery === 'string' ? new requests.QueryRequest(cqlQuery, null, null) : cqlQuery;
+    const request = typeof cqlQuery === 'string' ? new requests.QueryRequest(cqlQuery, null, null) : cqlQuery;
     self.connection.sendStream(request, null, callback);
   }
   if (!this.connection) {
@@ -756,10 +757,10 @@ ControlConnection.prototype.shutdown = function () {
  */
 ControlConnection.prototype.reset = function (callback) {
   // Reset the internal state of the ControlConnection for future initialization attempts
-  var currentHosts = this.hosts.clear();
+  const currentHosts = this.hosts.clear();
   // Set the shutting down flag temporarily to avoid reconnects.
   this.isShuttingDown = true;
-  var self = this;
+  const self = this;
   utils.each(currentHosts, function forEachHost(h, next) {
     h.shutdown(false, function () {
       // Ignore any shutdown error
@@ -779,7 +780,7 @@ ControlConnection.prototype.reset = function (callback) {
  * @param callback
  */
 function resolveAll(name, callback) {
-  var addresses = [];
+  const addresses = [];
   utils.parallel([
     function resolve4(next) {
       dns.resolve4(name, function resolve4Callback(err, arr) {

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -1,17 +1,17 @@
 "use strict";
-var util = require('util');
+const util = require('util');
 
-var types = require('./types');
-var dataTypes = types.dataTypes;
-var Long = types.Long;
-var Integer = types.Integer;
-var BigDecimal = types.BigDecimal;
-var utils = require('./utils');
+const types = require('./types');
+const dataTypes = types.dataTypes;
+const Long = types.Long;
+const Integer = types.Integer;
+const BigDecimal = types.BigDecimal;
+const utils = require('./utils');
 
-var uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-var int16Zero = utils.allocBufferFromArray([0, 0]);
-var int32Zero = utils.allocBufferFromArray([0, 0, 0, 0]);
-var complexTypeNames = Object.freeze({
+const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const int16Zero = utils.allocBufferFromArray([0, 0]);
+const int32Zero = utils.allocBufferFromArray([0, 0, 0, 0]);
+const complexTypeNames = Object.freeze({
   list      : 'org.apache.cassandra.db.marshal.ListType',
   set       : 'org.apache.cassandra.db.marshal.SetType',
   map       : 'org.apache.cassandra.db.marshal.MapType',
@@ -23,7 +23,7 @@ var complexTypeNames = Object.freeze({
   empty     : 'org.apache.cassandra.db.marshal.EmptyType',
   collection: 'org.apache.cassandra.db.marshal.ColumnToCollectionType'
 });
-var cqlNames = Object.freeze({
+const cqlNames = Object.freeze({
   frozen: 'frozen',
   list: 'list',
   'set': 'set',
@@ -32,7 +32,7 @@ var cqlNames = Object.freeze({
   empty: 'empty',
   duration: 'duration'
 });
-var singleTypeNames = Object.freeze({
+const singleTypeNames = Object.freeze({
   'org.apache.cassandra.db.marshal.UTF8Type':           dataTypes.varchar,
   'org.apache.cassandra.db.marshal.AsciiType':          dataTypes.ascii,
   'org.apache.cassandra.db.marshal.UUIDType':           dataTypes.uuid,
@@ -54,12 +54,12 @@ var singleTypeNames = Object.freeze({
   'org.apache.cassandra.db.marshal.IntegerType':        dataTypes.varint,
   'org.apache.cassandra.db.marshal.CounterColumnType':  dataTypes.counter
 });
-var singleFqTypeNamesLength = Object.keys(singleTypeNames).reduce(function (previous, current) {
+const singleFqTypeNamesLength = Object.keys(singleTypeNames).reduce(function (previous, current) {
   return current.length > previous ? current.length : previous;
 }, 0);
-var durationTypeName = 'org.apache.cassandra.db.marshal.DurationType';
-var nullValueBuffer = utils.allocBufferFromArray([255, 255, 255, 255]);
-var unsetValueBuffer = utils.allocBufferFromArray([255, 255, 255, 254]);
+const durationTypeName = 'org.apache.cassandra.db.marshal.DurationType';
+const nullValueBuffer = utils.allocBufferFromArray([255, 255, 255, 255]);
+const unsetValueBuffer = utils.allocBufferFromArray([255, 255, 255, 254]);
 
 /**
  * Serializes and deserializes to and from a CQL type and a Javascript Type.
@@ -103,14 +103,14 @@ function defineInstanceMembers() {
       this.collectionLengthSize = 2;
     }
   };
-  var customDecoders = {};
-  var customEncoders = {};
+  const customDecoders = {};
+  const customEncoders = {};
   // Decoding methods
   this.decodeBlob = function (bytes) {
     return this.handleBuffer(bytes);
   };
   this.decodeCustom = function (bytes, typeName) {
-    var handler = customDecoders[typeName];
+    const handler = customDecoders[typeName];
     if (handler) {
       return handler.call(this, bytes);
     }
@@ -165,12 +165,12 @@ function defineInstanceMembers() {
    * Reads a list from bytes
    */
   this.decodeList = function (bytes, subtype) {
-    var totalItems = this.decodeCollectionLength(bytes, 0);
-    var offset = this.collectionLengthSize;
-    var list = new Array(totalItems);
-    for(var i = 0; i < totalItems; i++) {
+    const totalItems = this.decodeCollectionLength(bytes, 0);
+    let offset = this.collectionLengthSize;
+    const list = new Array(totalItems);
+    for (let i = 0; i < totalItems; i++) {
       //bytes length of the item
-      var length = this.decodeCollectionLength(bytes, offset);
+      const length = this.decodeCollectionLength(bytes, offset);
       offset += this.collectionLengthSize;
       //slice it
       list[i] = this.decode(bytes.slice(offset, offset+length), subtype);
@@ -182,9 +182,9 @@ function defineInstanceMembers() {
    * Reads a Set from bytes
    */
   this.decodeSet = function (bytes, subtype) {
-    var arr = this.decodeList(bytes, subtype);
+    const arr = this.decodeList(bytes, subtype);
     if (this.encodingOptions.set) {
-      var setConstructor = this.encodingOptions.set;
+      const setConstructor = this.encodingOptions.set;
       return new setConstructor(arr);
     }
     return arr;
@@ -193,29 +193,29 @@ function defineInstanceMembers() {
    * Reads a map (key / value) from bytes
    */
   this.decodeMap = function (bytes, subtypes) {
-    var map;
-    var totalItems = this.decodeCollectionLength(bytes, 0);
-    var offset = this.collectionLengthSize;
-    var self = this;
+    let map;
+    const totalItems = this.decodeCollectionLength(bytes, 0);
+    let offset = this.collectionLengthSize;
+    const self = this;
     function readValues(callback, thisArg) {
-      for (var i = 0; i < totalItems; i++) {
-        var keyLength = self.decodeCollectionLength(bytes, offset);
+      for (let i = 0; i < totalItems; i++) {
+        const keyLength = self.decodeCollectionLength(bytes, offset);
         offset += self.collectionLengthSize;
-        var key = self.decode(bytes.slice(offset, offset + keyLength), subtypes[0]);
+        const key = self.decode(bytes.slice(offset, offset + keyLength), subtypes[0]);
         offset += keyLength;
-        var valueLength = self.decodeCollectionLength(bytes, offset);
+        const valueLength = self.decodeCollectionLength(bytes, offset);
         offset += self.collectionLengthSize;
         if (valueLength < 0) {
           callback.call(thisArg, key, null);
           continue;
         }
-        var value = self.decode(bytes.slice(offset, offset + valueLength), subtypes[1]);
+        const value = self.decode(bytes.slice(offset, offset + valueLength), subtypes[1]);
         offset += valueLength;
         callback.call(thisArg, key, value);
       }
     }
     if (this.encodingOptions.map) {
-      var mapConstructor = this.encodingOptions.map;
+      const mapConstructor = this.encodingOptions.map;
       map = new mapConstructor();
       readValues(map.set, map);
     }
@@ -243,14 +243,14 @@ function defineInstanceMembers() {
    * @private
    */
   this.decodeUdt = function (bytes, udtInfo) {
-    var result = {};
-    var offset = 0;
-    for (var i = 0; i < udtInfo.fields.length && offset < bytes.length; i++) {
+    const result = {};
+    let offset = 0;
+    for (let i = 0; i < udtInfo.fields.length && offset < bytes.length; i++) {
       //bytes length of the field value
-      var length = bytes.readInt32BE(offset);
+      const length = bytes.readInt32BE(offset);
       offset += 4;
       //slice it
-      var field = udtInfo.fields[i];
+      const field = udtInfo.fields[i];
       if (length < 0) {
         result[field.name] = null;
         continue;
@@ -261,10 +261,10 @@ function defineInstanceMembers() {
     return result;
   };
   this.decodeTuple = function (bytes, tupleInfo) {
-    var elements = new Array(tupleInfo.length);
-    var offset = 0;
-    for (var i = 0; i < tupleInfo.length; i++) {
-      var length = bytes.readInt32BE(offset);
+    const elements = new Array(tupleInfo.length);
+    let offset = 0;
+    for (let i = 0; i < tupleInfo.length; i++) {
+      const length = bytes.readInt32BE(offset);
       offset += 4;
       if (length < 0) {
         elements[i] = null;
@@ -280,7 +280,7 @@ function defineInstanceMembers() {
     if (typeof value !== 'number') {
       throw new TypeError('Expected Number, obtained ' + util.inspect(value));
     }
-    var buf = utils.allocBufferUnsafe(4);
+    const buf = utils.allocBufferUnsafe(4);
     buf.writeFloatBE(value, 0);
     return buf;
   };
@@ -288,7 +288,7 @@ function defineInstanceMembers() {
     if (typeof value !== 'number') {
       throw new TypeError('Expected Number, obtained ' + util.inspect(value));
     }
-    var buf = utils.allocBufferUnsafe(8);
+    const buf = utils.allocBufferUnsafe(8);
     buf.writeDoubleBE(value, 0);
     return buf;
   };
@@ -297,7 +297,7 @@ function defineInstanceMembers() {
    * @private
    */
   this.encodeTimestamp = function (value) {
-    var originalValue = value;
+    const originalValue = value;
     if (typeof value === 'string') {
       value = new Date(value);
     }
@@ -308,7 +308,6 @@ function defineInstanceMembers() {
         throw new TypeError('Invalid date: ' + originalValue);
       }
     }
-    //noinspection JSCheckFunctionSignatures
     return this.encodeLong(value);
   };
   /**
@@ -318,7 +317,7 @@ function defineInstanceMembers() {
    * @private
    */
   this.encodeDate = function (value) {
-    var originalValue = value;
+    const originalValue = value;
     try {
       if (typeof value === 'string') {
         value = types.LocalDate.fromString(value);
@@ -343,7 +342,7 @@ function defineInstanceMembers() {
    * @private
    */
   this.encodeTime = function (value) {
-    var originalValue = value;
+    const originalValue = value;
     try {
       if (typeof value === 'string') {
         value = types.LocalTime.fromString(value);
@@ -407,12 +406,11 @@ function defineInstanceMembers() {
     if (typeof value === 'string') {
       value = Long.fromString(value);
     }
-    var buf = null;
+    let buf = null;
     if (value instanceof Buffer) {
       buf = value;
     }
     if (value instanceof Long) {
-      //noinspection JSCheckFunctionSignatures
       buf = Long.toBuffer(value);
     }
     if (buf === null) {
@@ -432,7 +430,7 @@ function defineInstanceMembers() {
     if (typeof value === 'string') {
       value = Integer.fromString(value);
     }
-    var buf = null;
+    let buf = null;
     if (value instanceof Buffer) {
       buf = value;
     }
@@ -456,7 +454,7 @@ function defineInstanceMembers() {
     if (typeof value === 'string') {
       value = BigDecimal.fromString(value);
     }
-    var buf = null;
+    let buf = null;
     if (value instanceof Buffer) {
       buf = value;
     }
@@ -490,7 +488,7 @@ function defineInstanceMembers() {
     if (value instanceof Buffer) {
       return value;
     }
-    var handler = customEncoders[name];
+    const handler = customEncoders[name];
     if (handler) {
       return handler.call(this, value);
     }
@@ -518,7 +516,7 @@ function defineInstanceMembers() {
     if (isNaN(value)) {
       throw new TypeError('Expected Number, obtained ' + util.inspect(value));
     }
-    var buf = utils.allocBufferUnsafe(4);
+    const buf = utils.allocBufferUnsafe(4);
     buf.writeInt32BE(value, 0);
     return buf;
   };
@@ -530,7 +528,7 @@ function defineInstanceMembers() {
     if (isNaN(value)) {
       throw new TypeError('Expected Number, obtained ' + util.inspect(value));
     }
-    var buf = utils.allocBufferUnsafe(2);
+    const buf = utils.allocBufferUnsafe(2);
     buf.writeInt16BE(value, 0);
     return buf;
   };
@@ -542,7 +540,7 @@ function defineInstanceMembers() {
     if (isNaN(value)) {
       throw new TypeError('Expected Number, obtained ' + util.inspect(value));
     }
-    var buf = utils.allocBufferUnsafe(1);
+    const buf = utils.allocBufferUnsafe(1);
     buf.writeInt8(value, 0);
     return buf;
   };
@@ -553,14 +551,14 @@ function defineInstanceMembers() {
     if (value.length === 0) {
       return null;
     }
-    var parts = [];
+    const parts = [];
     parts.push(this.getLengthBuffer(value));
-    for (var i=0;i < value.length;i++) {
-      var val = value[i];
+    for (let i = 0;i < value.length;i++) {
+      const val = value[i];
       if (val === null || typeof val === 'undefined' || val === types.unset) {
         throw new TypeError('A collection can\'t contain null or unset values');
       }
-      var bytes = this.encode(val, subtype);
+      const bytes = this.encode(val, subtype);
       //include item byte length
       parts.push(this.getLengthBuffer(bytes));
       //include item
@@ -570,7 +568,7 @@ function defineInstanceMembers() {
   };
   this.encodeSet = function (value, subtype) {
     if (this.encodingOptions.set && value instanceof this.encodingOptions.set) {
-      var arr = [];
+      const arr = [];
       value.forEach(function (x) {
         arr.push(x);
       });
@@ -586,11 +584,11 @@ function defineInstanceMembers() {
    * @private
    */
   this.encodeMap = function (value, subtypes) {
-    var parts = [];
-    var propCounter = 0;
-    var keySubtype = null;
-    var valueSubtype = null;
-    var self = this;
+    const parts = [];
+    let propCounter = 0;
+    let keySubtype = null;
+    let valueSubtype = null;
+    const self = this;
     if (subtypes) {
       keySubtype = subtypes[0];
       valueSubtype = subtypes[1];
@@ -602,13 +600,13 @@ function defineInstanceMembers() {
       if (val === null || typeof val === 'undefined' || val === types.unset) {
         throw new TypeError('A map can\'t contain null or unset values');
       }
-      var keyBuffer = self.encode(key, keySubtype);
+      const keyBuffer = self.encode(key, keySubtype);
       //include item byte length
       parts.push(self.getLengthBuffer(keyBuffer));
       //include item
       parts.push(keyBuffer);
       //value
-      var valueBuffer = self.encode(val, valueSubtype);
+      const valueBuffer = self.encode(val, valueSubtype);
       //include item byte length
       parts.push(self.getLengthBuffer(valueBuffer));
       //include item
@@ -623,11 +621,11 @@ function defineInstanceMembers() {
     }
     else {
       //Use object
-      for (var key in value) {
+      for (const key in value) {
         if (!value.hasOwnProperty(key)) {
           continue;
         }
-        var val = value[key];
+        const val = value[key];
         addItem(val, key);
       }
     }
@@ -636,11 +634,11 @@ function defineInstanceMembers() {
     return Buffer.concat(parts);
   };
   this.encodeUdt = function (value, udtInfo) {
-    var parts = [];
-    var totalLength = 0;
-    for (var i = 0; i < udtInfo.fields.length; i++) {
-      var field = udtInfo.fields[i];
-      var item = this.encode(value[field.name], field.type);
+    const parts = [];
+    let totalLength = 0;
+    for (let i = 0; i < udtInfo.fields.length; i++) {
+      const field = udtInfo.fields[i];
+      const item = this.encode(value[field.name], field.type);
       if (!item) {
         parts.push(nullValueBuffer);
         totalLength += 4;
@@ -651,7 +649,7 @@ function defineInstanceMembers() {
         totalLength += 4;
         continue;
       }
-      var lengthBuffer = utils.allocBufferUnsafe(4);
+      const lengthBuffer = utils.allocBufferUnsafe(4);
       lengthBuffer.writeInt32BE(item.length, 0);
       parts.push(lengthBuffer);
       parts.push(item);
@@ -660,11 +658,11 @@ function defineInstanceMembers() {
     return Buffer.concat(parts, totalLength);
   };
   this.encodeTuple = function (value, tupleInfo) {
-    var parts = [];
-    var totalLength = 0;
-    for (var i = 0; i < tupleInfo.length; i++) {
-      var type = tupleInfo[i];
-      var item = this.encode(value.get(i), type);
+    const parts = [];
+    let totalLength = 0;
+    for (let i = 0; i < tupleInfo.length; i++) {
+      const type = tupleInfo[i];
+      const item = this.encode(value.get(i), type);
       if (!item) {
         parts.push(nullValueBuffer);
         totalLength += 4;
@@ -675,7 +673,7 @@ function defineInstanceMembers() {
         totalLength += 4;
         continue;
       }
-      var lengthBuffer = utils.allocBufferUnsafe(4);
+      const lengthBuffer = utils.allocBufferUnsafe(4);
       lengthBuffer.writeInt32BE(item.length, 0);
       parts.push(lengthBuffer);
       parts.push(item);
@@ -694,7 +692,7 @@ function defineInstanceMembers() {
    * @ignore
    */
   this.setRoutingKey = function (params, options, keys) {
-    var totalLength;
+    let totalLength;
     if (util.isArray(options.routingKey)) {
       if (options.routingKey.length === 1) {
         options.routingKey = options.routingKey[0];
@@ -702,8 +700,8 @@ function defineInstanceMembers() {
       }
       //Is a Composite key
       totalLength = 0;
-      for (var i = 0; i < options.routingKey.length; i++) {
-        var item = options.routingKey[i];
+      for (let i = 0; i < options.routingKey.length; i++) {
+        const item = options.routingKey[i];
         if (!item) {
           //An routing key part may be null/undefined if provided by user
           //Or when there is a hardcoded parameter in the query
@@ -723,7 +721,7 @@ function defineInstanceMembers() {
       // or there are no parameters to build the routing key
       return;
     }
-    var parts = [];
+    const parts = [];
     totalLength = 0;
     if (options.routingIndexes) {
       totalLength = this._encodeRoutingKeyParts(parts, options.routingIndexes, params, options.hints);
@@ -754,9 +752,9 @@ function defineInstanceMembers() {
    */
   this._encodeRoutingKeyParts = function (parts, routingIndexes, params, hints, keys) {
     hints = hints || utils.emptyArray;
-    var totalLength = 0;
-    for (var i = 0; i < routingIndexes.length; i++) {
-      var paramIndex = routingIndexes[i];
+    let totalLength = 0;
+    for (let i = 0; i < routingIndexes.length; i++) {
+      let paramIndex = routingIndexes[i];
       if (typeof paramIndex === 'undefined') {
         //probably undefined (parameter not found) or bad input from the user
         return 0;
@@ -765,7 +763,7 @@ function defineInstanceMembers() {
         //is composed of parameter names
         paramIndex = keys[paramIndex];
       }
-      var item = this.encode(params[paramIndex], hints[paramIndex]);
+      const item = this.encode(params[paramIndex], hints[paramIndex]);
       if (!item) {
         //bad input from the user
         return 0;
@@ -791,14 +789,14 @@ function defineInstanceMembers() {
     if (!length) {
       length = typeName.length;
     }
-    var dataType = {
+    const dataType = {
       code: 0,
       info: null,
       options: {
         frozen: false
       }
     };
-    var innerTypes;
+    let innerTypes;
     if (typeName.indexOf("'", startIndex) === startIndex) {
       //If quoted, this is a custom type.
       dataType.info = typeName.substr(startIndex+1, length-2);
@@ -870,7 +868,7 @@ function defineInstanceMembers() {
       dataType.code = dataTypes.tuple;
       return this._parseChildTypes(keyspace, dataType, innerTypes, udtResolver, callback);
     }
-    var quoted = typeName.indexOf('"', startIndex) === startIndex;
+    const quoted = typeName.indexOf('"', startIndex) === startIndex;
     if (quoted) {
       //Remove quotes
       startIndex++;
@@ -884,7 +882,7 @@ function defineInstanceMembers() {
     if (quoted) {
       typeName = typeName.replace('""', '"');
     }
-    var typeCode = dataTypes[typeName];
+    const typeCode = dataTypes[typeName];
     if (typeof typeCode === 'number') {
       dataType.code = typeCode;
       return callback(null, dataType);
@@ -919,7 +917,7 @@ function defineInstanceMembers() {
    * @private
    */
   this._parseChildTypes = function (keyspace, dataType, typeNames, udtResolver, callback) {
-    var self = this;
+    const self = this;
     utils.mapSeries(typeNames, function (name, next) {
       self.parseTypeName(keyspace, name.trim(), 0, null, udtResolver, next);
     }, function (err, childTypes) {
@@ -942,7 +940,7 @@ function defineInstanceMembers() {
    * @ignore
    */
   this.parseFqTypeName = function (typeName, startIndex, length) {
-    var dataType = {
+    const dataType = {
       code: 0,
       info: null,
       options: {
@@ -951,7 +949,7 @@ function defineInstanceMembers() {
       }
     };
     startIndex = startIndex || 0;
-    var innerTypes;
+    let innerTypes;
     if (!length) {
       length = typeName.length;
     }
@@ -978,7 +976,7 @@ function defineInstanceMembers() {
       if (startIndex > 0) {
         typeName = typeName.substr(startIndex, length);
       }
-      var typeCode = singleTypeNames[typeName];
+      const typeCode = singleTypeNames[typeName];
       if (typeof typeCode === 'number') {
         dataType.code = typeCode;
         return dataType;
@@ -1061,18 +1059,18 @@ function defineInstanceMembers() {
    * @ignore
    */
   this.parseKeyTypes = function (typesString) {
-    var i = 0;
-    var length = typesString.length;
-    var isComposite = typesString.indexOf(complexTypeNames.composite) === 0;
+    let i = 0;
+    let length = typesString.length;
+    const isComposite = typesString.indexOf(complexTypeNames.composite) === 0;
     if (isComposite) {
       i = complexTypeNames.composite.length + 1;
       length--;
     }
-    var types = [];
-    var startIndex = i;
-    var nested = 0;
-    var inCollectionType = false;
-    var hasCollections = false;
+    const types = [];
+    let startIndex = i;
+    let nested = 0;
+    let inCollectionType = false;
+    let hasCollections = false;
     //as collection types are not allowed, it is safe to split by ,
     while (++i < length) {
       switch (typesString[i]) {
@@ -1120,24 +1118,24 @@ function defineInstanceMembers() {
     };
   };
   this._parseUdtName = function (typeName, startIndex, length) {
-    var udtParams = parseParams(typeName, startIndex, length);
+    const udtParams = parseParams(typeName, startIndex, length);
     if (udtParams.length < 2) {
       //It should contain at least the keyspace, name of the udt and a type
       throw new TypeError('Not a valid type ' + typeName);
     }
-    var dataType = {
+    const dataType = {
       code: dataTypes.udt,
       info: null
     };
-    var udtInfo = {
+    const udtInfo = {
       keyspace: udtParams[0],
       name: utils.allocBufferFromString(udtParams[1], 'hex').toString(),
       fields: []
     };
-    for (var i = 2; i < udtParams.length; i++) {
-      var p = udtParams[i];
-      var separatorIndex = p.indexOf(':');
-      var fieldType = this.parseFqTypeName(p, separatorIndex + 1, p.length - (separatorIndex + 1));
+    for (let i = 2; i < udtParams.length; i++) {
+      const p = udtParams[i];
+      const separatorIndex = p.indexOf(':');
+      const fieldType = this.parseFqTypeName(p, separatorIndex + 1, p.length - (separatorIndex + 1));
       udtInfo.fields.push({
         name: utils.allocBufferFromString(p.substr(0, separatorIndex), 'hex').toString(),
         type: fieldType
@@ -1157,7 +1155,7 @@ function defineInstanceMembers() {
  */
 function setEncoders() {
   //decoders
-  var d = {};
+  const d = {};
   d[dataTypes.custom] = this.decodeCustom;
   d[dataTypes.ascii] = this.decodeAsciiString;
   d[dataTypes.bigint] = this.decodeLong;
@@ -1186,7 +1184,7 @@ function setEncoders() {
   d[dataTypes.tuple] = this.decodeTuple;
 
   //encoders
-  var e = {};
+  const e = {};
   e[dataTypes.custom] = this.encodeCustom;
   e[dataTypes.ascii] = this.encodeAsciiString;
   e[dataTypes.bigint] = this.encodeLong;
@@ -1232,7 +1230,7 @@ Encoder.prototype.decode = function (buffer, type) {
   if (buffer === null) {
     return null;
   }
-  var decoder = this.decoders[type.code];
+  const decoder = this.decoders[type.code];
   if (!decoder) {
     throw new Error('Unknown data type: ' + type.code);
   }
@@ -1277,7 +1275,7 @@ Encoder.prototype.encode = function (value, typeInfo) {
     return value;
   }
   /** @type {{code: Number, info: object}} */
-  var type = {
+  let type = {
     code: null,
     info: null
   };
@@ -1303,7 +1301,7 @@ Encoder.prototype.encode = function (value, typeInfo) {
       throw new TypeError('Target data type could not be guessed, you should use prepared statements for accurate type mapping. Value: ' + util.inspect(value));
     }
   }
-  var encoder = this.encoders[type.code];
+  const encoder = this.encoders[type.code];
   if (!encoder) {
     throw new Error('Type not supported ' + type.code);
   }
@@ -1318,9 +1316,9 @@ Encoder.prototype.encode = function (value, typeInfo) {
  * @internal
  */
 Encoder.guessDataType = function (value) {
-  var code = null;
-  var info = null;
-  var esTypeName = (typeof value);
+  let code = null;
+  let info = null;
+  const esTypeName = (typeof value);
   if (esTypeName === 'number') {
     code = dataTypes.double;
   }
@@ -1386,7 +1384,7 @@ function getLengthBufferV2(value) {
   if (!value) {
     return int16Zero;
   }
-  var lengthBuffer = utils.allocBufferUnsafe(2);
+  const lengthBuffer = utils.allocBufferUnsafe(2);
   if (typeof value === 'number') {
     lengthBuffer.writeUInt16BE(value, 0);
   }
@@ -1406,7 +1404,7 @@ function getLengthBufferV3(value) {
   if (!value) {
     return int32Zero;
   }
-  var lengthBuffer = utils.allocBufferUnsafe(4);
+  const lengthBuffer = utils.allocBufferUnsafe(4);
   if (typeof value === 'number') {
     lengthBuffer.writeInt32BE(value, 0);
   }
@@ -1467,11 +1465,11 @@ function decodeCollectionLengthV2(bytes, offset) {
 function parseParams(value, startIndex, length, open, close) {
   open = open || '(';
   close = close || ')';
-  var types = [];
-  var paramStart = startIndex;
-  var level = 0;
-  for (var i = startIndex; i < startIndex + length; i++) {
-    var c = value[i];
+  const types = [];
+  let paramStart = startIndex;
+  let level = 0;
+  for (let i = startIndex; i < startIndex + length; i++) {
+    const c = value[i];
     if (c === open) {
       level++;
     }
@@ -1495,10 +1493,10 @@ function parseParams(value, startIndex, length, open, close) {
  * @private
  */
 function concatRoutingKey(parts, totalLength) {
-  var routingKey = utils.allocBufferUnsafe(totalLength);
-  var offset = 0;
-  for (var i = 0; i < parts.length; i++) {
-    var item = parts[i];
+  const routingKey = utils.allocBufferUnsafe(totalLength);
+  let offset = 0;
+  for (let i = 0; i < parts.length; i++) {
+    const item = parts[i];
     routingKey.writeUInt16BE(item.length, offset);
     offset += 2;
     item.copy(routingKey, offset);

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,5 +1,5 @@
 "use strict";
-var util = require('util');
+const util = require('util');
 
 /**
  * Contains the error classes exposed by the driver.
@@ -34,9 +34,9 @@ function NoHostAvailableError(innerErrors, message) {
   if (!message) {
     this.message = 'All host(s) tried for query failed.';
     if (innerErrors) {
-      var hostList = Object.keys(innerErrors);
+      const hostList = Object.keys(innerErrors);
       if (hostList.length > 0) {
-        var host = hostList[0];
+        const host = hostList[0];
         this.message += util.format(' First host tried, %s: %s. See innerErrors.', host, innerErrors[host]);
       }
     }

--- a/lib/execution-profile.js
+++ b/lib/execution-profile.js
@@ -1,6 +1,6 @@
 "use strict";
-var utils = require('./utils');
-var types = require('./types');
+const utils = require('./utils');
+const types = require('./types');
 
 /**
  * Creates a new instance of {@link ExecutionProfile}.
@@ -101,10 +101,10 @@ ProfileManager.prototype.init = function (client, hosts, callback) {
  * @param {Host} host
  */
 ProfileManager.prototype.getDistance = function (host) {
-  var distance = types.distance.ignored;
+  let distance = types.distance.ignored;
   // this is performance critical: we can't use any other language features than for-loop :(
-  for (var i = 0; i < this._loadBalancingPolicies.length; i++) {
-    var d = this._loadBalancingPolicies[i].getDistance(host);
+  for (let i = 0; i < this._loadBalancingPolicies.length; i++) {
+    const d = this._loadBalancingPolicies[i].getDistance(host);
     if (d < distance) {
       distance = d;
       if (distance === types.distance.local) {

--- a/lib/host-connection-pool.js
+++ b/lib/host-connection-pool.js
@@ -1,14 +1,14 @@
 "use strict";
-var util = require('util');
-var events = require('events');
+const util = require('util');
+const events = require('events');
 
-var Connection = require('./connection');
-var utils = require('./utils');
-var defaultOptions = require('./client-options').defaultOptions();
+const Connection = require('./connection');
+const utils = require('./utils');
+const defaultOptions = require('./client-options').defaultOptions();
 
 // Used to get the index of the connection with less in-flight requests
-var connectionIndex = 0;
-var connectionIndexOverflow = Math.pow(2, 15);
+let connectionIndex = 0;
+const connectionIndexOverflow = Math.pow(2, 15);
 
 /**
  * Represents the possible states of the pool.
@@ -21,7 +21,7 @@ var connectionIndexOverflow = Math.pow(2, 15);
  *  - From shuttingDown to shutdown: Finished shutting down, the pool should not be reused.
  * @private
  */
-var state = {
+const state = {
   // Initial state: open / opening / ready to be opened
   initial: 0,
   // When the pool is being closed as part of a distance change
@@ -62,7 +62,7 @@ util.inherits(HostConnectionPool, events.EventEmitter);
  * @param {Function} callback
  */
 HostConnectionPool.prototype.borrowConnection = function (callback) {
-  var self = this;
+  const self = this;
   this.create(false, function afterCreating(err) {
     if (err) {
       return callback(err);
@@ -71,7 +71,7 @@ HostConnectionPool.prototype.borrowConnection = function (callback) {
       // Normally it should have callback in error, but better to handle this possibility
       return callback(new Error('No connection available'));
     }
-    var c = HostConnectionPool.minInFlight(self.connections);
+    const c = HostConnectionPool.minInFlight(self.connections);
     callback(null, c);
   });
 };
@@ -83,16 +83,16 @@ HostConnectionPool.prototype.borrowConnection = function (callback) {
  * @returns {Connection}
  */
 HostConnectionPool.minInFlight = function(connections) {
-  var length = connections.length;
+  const length = connections.length;
   if (length === 1) {
     return connections[0];
   }
-  var index = ++connectionIndex;
+  const index = ++connectionIndex;
   if (connectionIndex >= connectionIndexOverflow) {
     connectionIndex = 0;
   }
-  var current = connections[index % length];
-  var previous = connections[(index - 1) % length];
+  const current = connections[index % length];
+  const previous = connections[(index - 1) % length];
   if (previous.getInFlight() < current.getInFlight()) {
     return previous;
   }
@@ -125,11 +125,11 @@ HostConnectionPool.prototype.create = function (warmup, callback) {
     return;
   }
   this._creating = true;
-  var connectionsToCreate = this.coreConnectionsLength;
+  let connectionsToCreate = this.coreConnectionsLength;
   if (!warmup) {
     connectionsToCreate = 1;
   }
-  var self = this;
+  const self = this;
   utils.whilst(
     function condition() {
       return self.connections.length < connectionsToCreate;
@@ -159,8 +159,8 @@ HostConnectionPool.prototype.create = function (warmup, callback) {
 
 /** @returns {Connection} */
 HostConnectionPool.prototype._createConnection = function () {
-  var c = new Connection(this._address, this.protocolVersion, this.options);
-  var self = this;
+  const c = new Connection(this._address, this.protocolVersion, this.options);
+  const self = this;
   function connectionErrorCallback() {
     // The socket is not fully open / can not send heartbeat
     self.remove(c);
@@ -185,8 +185,8 @@ HostConnectionPool.prototype.clearNewConnectionAttempt = function () {
  * @param {Function} callback
  */
 HostConnectionPool.prototype._attemptNewConnection = function (callback) {
-  var c = this._createConnection();
-  var self = this;
+  const c = this._createConnection();
+  const self = this;
   this.once('open', callback);
   if (this._opening) {
     // wait for the event to fire
@@ -206,7 +206,7 @@ HostConnectionPool.prototype._attemptNewConnection = function (callback) {
       return self.emit('open', new Error('Connection closed'));
     }
     // use a copy of the connections array
-    var newConnections = self.connections.slice(0);
+    const newConnections = self.connections.slice(0);
     newConnections.push(c);
     self.connections = newConnections;
     self.log('info', util.format('Connection to %s opened successfully', self._address));
@@ -215,7 +215,7 @@ HostConnectionPool.prototype._attemptNewConnection = function (callback) {
 };
 
 HostConnectionPool.prototype.attemptNewConnectionImmediate = function () {
-  var self = this;
+  const self = this;
   function openConnection() {
     self.clearNewConnectionAttempt();
     self.scheduleNewConnectionAttempt(0);
@@ -236,13 +236,13 @@ HostConnectionPool.prototype.attemptNewConnectionImmediate = function () {
  */
 HostConnectionPool.prototype.remove = function (connection) {
   // locating an object by position in the array is O(n), but normally there should be between 1 to 8 connections.
-  var index = this.connections.indexOf(connection);
+  const index = this.connections.indexOf(connection);
   if (index < 0) {
     // it was already removed from the connections and it's closing
     return;
   }
   // remove the connection from the pool, using an pool copy
-  var newConnections = this.connections.slice(0);
+  const newConnections = this.connections.slice(0);
   newConnections.splice(index, 1);
   this.connections = newConnections;
   // close the connection
@@ -259,7 +259,7 @@ HostConnectionPool.prototype.scheduleNewConnectionAttempt = function (delay) {
   if (this.isClosing()) {
     return;
   }
-  var self = this;
+  const self = this;
   this._newConnectionTimeout = setTimeout(function newConnectionTimeoutExpired() {
     self._newConnectionTimeout = null;
     if (self.connections.length >= self.coreConnectionsLength) {
@@ -302,16 +302,16 @@ HostConnectionPool.prototype.drainAndShutdown = function () {
   }
   this._state = state.closing;
   this.clearNewConnectionAttempt();
-  var self = this;
+  const self = this;
   if (this.connections.length === 0) {
     return this._afterClosing();
   }
-  var connections = this.connections;
+  const connections = this.connections;
   this.connections = utils.emptyArray;
-  var closedConnections = 0;
+  let closedConnections = 0;
   this.log('info', util.format('Draining and closing %d connections to %s', connections.length, this._address));
-  for (var i = 0; i < connections.length; i++) {
-    var c = connections[i];
+  for (let i = 0; i < connections.length; i++) {
+    const c = connections[i];
     if (c.getInFlight() === 0) {
       getDelayedClose(c)();
       continue;
@@ -319,8 +319,9 @@ HostConnectionPool.prototype.drainAndShutdown = function () {
     c.emitDrain = true;
     c.once('drain', getDelayedClose(c));
   }
-  var wasClosed = false;
-  var checkShutdownTimeout;
+  let wasClosed = false;
+  // eslint-disable-next-line prefer-const
+  let checkShutdownTimeout;
   function getDelayedClose(connection) {
     return (function delayedClose() {
       connection.close();
@@ -338,7 +339,7 @@ HostConnectionPool.prototype.drainAndShutdown = function () {
     });
   }
   // Check that after sometime (readTimeout + 100ms) the connections have been drained
-  var delay = (this.options.socketOptions.readTimeout || defaultOptions.socketOptions.readTimeout) + 100;
+  const delay = (this.options.socketOptions.readTimeout || defaultOptions.socketOptions.readTimeout) + 100;
   checkShutdownTimeout = setTimeout(function checkShutdown() {
     wasClosed = true;
     connections.forEach(function connectionEach(c) {
@@ -349,7 +350,7 @@ HostConnectionPool.prototype.drainAndShutdown = function () {
 };
 
 HostConnectionPool.prototype._afterClosing = function () {
-  var self = this;
+  const self = this;
   function resetState() {
     if (self._state === state.shuttingDown) {
       self._state = state.shutDown;
@@ -379,7 +380,7 @@ HostConnectionPool.prototype.shutdown = function (callback) {
     this._state = state.shutDown;
     return callback();
   }
-  var previousState = this._state;
+  const previousState = this._state;
   this._state = state.shuttingDown;
   if (previousState === state.closing) {
     return this.once('close', callback);
@@ -389,7 +390,7 @@ HostConnectionPool.prototype.shutdown = function (callback) {
     // Its going to be emitted
     return;
   }
-  var self = this;
+  const self = this;
   this._closeAllConnections(function closeAllCallback() {
     self._state = state.shutDown;
     self.emit('shutdown');
@@ -399,7 +400,7 @@ HostConnectionPool.prototype.shutdown = function (callback) {
 /** @param {Function} [callback] */
 HostConnectionPool.prototype._closeAllConnections = function (callback) {
   callback = callback || utils.noop;
-  var connections = this.connections;
+  const connections = this.connections;
   // point to an empty array
   this.connections = utils.emptyArray;
   if (connections.length === 0) {

--- a/lib/host-connection-pool.js
+++ b/lib/host-connection-pool.js
@@ -310,6 +310,9 @@ HostConnectionPool.prototype.drainAndShutdown = function () {
   this.connections = utils.emptyArray;
   let closedConnections = 0;
   this.log('info', util.format('Draining and closing %d connections to %s', connections.length, this._address));
+  let wasClosed = false;
+  // eslint-disable-next-line prefer-const
+  let checkShutdownTimeout;
   for (let i = 0; i < connections.length; i++) {
     const c = connections[i];
     if (c.getInFlight() === 0) {
@@ -319,9 +322,6 @@ HostConnectionPool.prototype.drainAndShutdown = function () {
     c.emitDrain = true;
     c.once('drain', getDelayedClose(c));
   }
-  let wasClosed = false;
-  // eslint-disable-next-line prefer-const
-  let checkShutdownTimeout;
   function getDelayedClose(connection) {
     return (function delayedClose() {
       connection.close();

--- a/lib/host.js
+++ b/lib/host.js
@@ -1,11 +1,11 @@
 "use strict";
-var util = require('util');
-var events = require('events');
+const util = require('util');
+const events = require('events');
 
-var utils = require('./utils');
-var types = require('./types');
-var HostConnectionPool = require('./host-connection-pool');
-var PrepareHandler = require('./prepare-handler');
+const utils = require('./utils');
+const types = require('./types');
+const HostConnectionPool = require('./host-connection-pool');
+const PrepareHandler = require('./prepare-handler');
 
 /**
  * Creates a new Host instance.
@@ -27,7 +27,7 @@ function Host(address, protocolVersion, options, metadata) {
    * @type {HostConnectionPool}
    */
   Object.defineProperty(this, 'pool', { value: new HostConnectionPool(this, protocolVersion), enumerable: false});
-  var self = this;
+  const self = this;
   this.pool.on('open', this._onNewConnectionOpen.bind(this));
   this.pool.on('remove', function onConnectionRemovedFromPool() {
     self._checkPoolState();
@@ -153,7 +153,7 @@ Host.prototype.isUp = function () {
  * @returns {boolean}
  */
 Host.prototype.canBeConsideredAsUp = function () {
-  var self = this;
+  const self = this;
   function hasTimePassed() {
     return new Date().getTime() - self.setDownAt >= self.reconnectionDelay;
   }
@@ -167,7 +167,7 @@ Host.prototype.canBeConsideredAsUp = function () {
  * @ignore
  */
 Host.prototype.setDistance = function (distance) {
-  var previousDistance = this._distance;
+  const previousDistance = this._distance;
   this._distance = distance || types.distance.local;
   if (this.options.pooling.coreConnectionsPerHost) {
     this.pool.coreConnectionsLength = this.options.pooling.coreConnectionsPerHost[this._distance] || 0;
@@ -289,7 +289,7 @@ Host.prototype._onNewConnectionOpen = function (err) {
     this._checkPoolState();
     return;
   }
-  var self = this;
+  const self = this;
   function setUpAndContinue(err) {
     if (err) {
       self.log('warning', util.format('Failed re-preparing on host %s: %s', self.address, err), err);
@@ -301,7 +301,7 @@ Host.prototype._onNewConnectionOpen = function (err) {
     return setUpAndContinue();
   }
   this.log('info', util.format('Re-preparing all queries on host %s before setting it as UP', this.address));
-  var allPrepared = this._metadata.getAllPrepared();
+  const allPrepared = this._metadata.getAllPrepared();
   PrepareHandler.prepareAllQueries(this, allPrepared, setUpAndContinue);
 };
 
@@ -351,8 +351,8 @@ util.inherits(HostMap, events.EventEmitter);
  */
 HostMap.prototype.forEach = function (callback) {
   //Use a new reference, allowing the map to be modified.
-  var items = this._items;
-  for (var key in items) {
+  const items = this._items;
+  for (const key in items) {
     if (!items.hasOwnProperty(key)) {
       continue;
     }
@@ -390,8 +390,8 @@ HostMap.prototype.remove = function (key) {
   //clear cache
   this._values = null;
   //copy the values
-  var copy = utils.extend({}, this._items);
-  var h = copy[key];
+  const copy = utils.extend({}, this._items);
+  const h = copy[key];
   delete copy[key];
   this._items = copy;
   this.emit('remove', h);
@@ -406,10 +406,10 @@ HostMap.prototype.removeMultiple = function (keys) {
   //clear value cache
   this._values = null;
   //copy the values
-  var copy = utils.extend({}, this._items);
-  var removedHosts = [];
-  for (var i = 0; i < keys.length; i++) {
-    var h = copy[keys[i]];
+  const copy = utils.extend({}, this._items);
+  const removedHosts = [];
+  for (let i = 0; i < keys.length; i++) {
+    const h = copy[keys[i]];
     if (!h) {
       continue;
     }
@@ -432,7 +432,7 @@ HostMap.prototype.removeMultiple = function (keys) {
 HostMap.prototype.set = function (key, value) {
   //clear values cache
   this._values = null;
-  var originalValue = this._items[key];
+  const originalValue = this._items[key];
   if (originalValue) {
     //The internal structure does not change
     this._items[key] = value;
@@ -442,7 +442,7 @@ HostMap.prototype.set = function (key, value) {
     return;
   }
   //copy the values
-  var copy = utils.extend({}, this._items);
+  const copy = utils.extend({}, this._items);
   copy[key] = value;
   this._items = copy;
   this.emit('add', value);
@@ -475,8 +475,8 @@ HostMap.prototype.push = HostMap.prototype.set;
 HostMap.prototype.values = function () {
   if (!this._values) {
     //cache the values
-    var values = [];
-    for (var key in this._items) {
+    const values = [];
+    for (const key in this._items) {
       if (!this._items.hasOwnProperty(key)) {
         continue;
       }
@@ -492,12 +492,12 @@ HostMap.prototype.values = function () {
  * @returns {Array.<Host>} The previous items
  */
 HostMap.prototype.clear = function () {
-  var previousItems = this.values();
+  const previousItems = this.values();
   // Clear cache
   this._values = null;
   // Clear items
   this._items = {};
-  for (var i = 0; i < previousItems.length; i++) {
+  for (let i = 0; i < previousItems.length; i++) {
     this.emit('remove', previousItems[i]);
   }
   return previousItems;

--- a/lib/metadata/client-state.js
+++ b/lib/metadata/client-state.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var util = require('util');
-var errors = require('../errors');
+const util = require('util');
+const errors = require('../errors');
 
 /**
  * Creates a new instance of <code>ClientState</code>.
@@ -29,9 +29,9 @@ function ClientState(hosts, openConnections, inFlightQueries) {
  * @ignore
  */
 ClientState.from = function (client) {
-  var openConnections = {};
-  var inFlightQueries = {};
-  var hostArray = [];
+  const openConnections = {};
+  const inFlightQueries = {};
+  const hostArray = [];
   client.hosts.forEach(function each(host) {
     if (host.pool.connections.length === 0) {
       return;

--- a/lib/metadata/data-collection.js
+++ b/lib/metadata/data-collection.js
@@ -1,6 +1,6 @@
 "use strict";
-var util = require('util');
-var events = require('events');
+const util = require('util');
+const events = require('events');
 /**
  * Creates a new instance of DataCollection
  * @param {String} name Name of the data object.

--- a/lib/metadata/event-debouncer.js
+++ b/lib/metadata/event-debouncer.js
@@ -1,9 +1,9 @@
 "use strict";
 
-var util = require('util');
-var utils = require('../utils');
+const util = require('util');
+const utils = require('../utils');
 
-var _queueOverflowThreshold = 1000;
+const _queueOverflowThreshold = 1000;
 
 /**
  * Debounce protocol events by acting on those events with a sliding delay.
@@ -28,7 +28,7 @@ function EventDebouncer(delay, logger) {
 EventDebouncer.prototype.eventReceived = function (event, processNow) {
   event.callback = event.callback || utils.noop;
   this._queue = this._queue || { callbacks: [], keyspaces: {} };
-  var delay = !processNow ? this._delay : 0;
+  const delay = !processNow ? this._delay : 0;
   if (event.all) {
     // when an event marked with all is received, it supersedes all the rest of events
     // a full update (hosts + keyspaces + tokens) is going to be made
@@ -44,7 +44,7 @@ EventDebouncer.prototype.eventReceived = function (event, processNow) {
     return this._slideDelay(delay);
   }
   // Insert at keyspace level
-  var keyspaceEvents = this._queue.keyspaces[event.keyspace];
+  let keyspaceEvents = this._queue.keyspaces[event.keyspace];
   if (!keyspaceEvents) {
     keyspaceEvents = this._queue.keyspaces[event.keyspace] = { events: [] };
   }
@@ -61,9 +61,9 @@ EventDebouncer.prototype.eventReceived = function (event, processNow) {
  * @private
  * */
 EventDebouncer.prototype._slideDelay = function (delay) {
-  var self = this;
+  const self = this;
   function process() {
-    var q = self._queue;
+    const q = self._queue;
     self._queue = null;
     self._timeout = null;
     processQueue(q);
@@ -75,7 +75,7 @@ EventDebouncer.prototype._slideDelay = function (delay) {
     }
     return process();
   }
-  var previousTimeout = this._timeout;
+  const previousTimeout = this._timeout;
   // add the new timeout before removing the previous one performs better
   this._timeout = setTimeout(process, delay);
   if (previousTimeout) {
@@ -106,17 +106,17 @@ function processQueue (q) {
   if (q.mainEvent) {
     // refresh all by invoking 1 handler and invoke all pending callbacks
     return q.mainEvent.handler(function invokeCallbacks(err) {
-      for (var i = 0; i < q.callbacks.length; i++) {
+      for (let i = 0; i < q.callbacks.length; i++) {
         q.callbacks[i](err);
       }
     });
   }
   utils.each(Object.keys(q.keyspaces), function eachKeyspace(name, next) {
-    var keyspaceEvents = q.keyspaces[name];
+    const keyspaceEvents = q.keyspaces[name];
     if (keyspaceEvents.mainEvent) {
       // refresh a keyspace
       return keyspaceEvents.mainEvent.handler(function mainEventCallback(err) {
-        for (var i = 0; i < keyspaceEvents.events.length; i++) {
+        for (let i = 0; i < keyspaceEvents.events.length; i++) {
           keyspaceEvents.events[i].callback(err);
         }
         next();

--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -1,47 +1,47 @@
 "use strict";
-var events = require('events');
-var util = require('util');
+const events = require('events');
+const util = require('util');
 /**
  * Module containing classes and fields related to metadata.
  * @module metadata
  */
-var t = require('../tokenizer');
-var utils = require('../utils');
-var errors = require('../errors');
-var types = require('../types');
-var requests = require('../requests');
-var schemaParserFactory = require('./schema-parser');
+const t = require('../tokenizer');
+const utils = require('../utils');
+const errors = require('../errors');
+const types = require('../types');
+const requests = require('../requests');
+const schemaParserFactory = require('./schema-parser');
 
 /**
  * @const
  * @private
  */
-var _selectTraceSession = "SELECT * FROM system_traces.sessions WHERE session_id=%s";
+const _selectTraceSession = "SELECT * FROM system_traces.sessions WHERE session_id=%s";
 /**
  * @const
  * @private
  */
-var _selectTraceEvents = "SELECT * FROM system_traces.events WHERE session_id=%s";
+const _selectTraceEvents = "SELECT * FROM system_traces.events WHERE session_id=%s";
 /**
  * @const
  * @private
  */
-var _selectSchemaVersionPeers = "SELECT schema_version FROM system.peers";
+const _selectSchemaVersionPeers = "SELECT schema_version FROM system.peers";
 /**
  * @const
  * @private
  */
-var _selectSchemaVersionLocal = "SELECT schema_version FROM system.local";
+const _selectSchemaVersionLocal = "SELECT schema_version FROM system.local";
 /**
  * @const
  * @private
  */
-var _traceMaxAttemps = 5;
+const _traceMaxAttemps = 5;
 /**
  * @const
  * @private
  */
-var _traceAttemptDelay = 200;
+const _traceAttemptDelay = 200;
 
 /**
  * Represents cluster and schema information.
@@ -58,7 +58,7 @@ function Metadata (options, controlConnection) {
   Object.defineProperty(this, 'controlConnection', { value: controlConnection, enumerable: false, writable: false});
   this.keyspaces = {};
   this._schemaParser = schemaParserFactory.getByVersion(controlConnection, this.getUdt.bind(this));
-  var self = this;
+  const self = this;
   this._preparedQueries = new PreparedQueries(options.maxPrepared, function () {
     self.log.apply(self, arguments);
   });
@@ -99,25 +99,25 @@ Metadata.prototype.buildTokens = function (hosts) {
     return this.log('error', 'Tokenizer could not be determined');
   }
   //Get a sorted array of tokens
-  var allSorted = [];
+  const allSorted = [];
   //Get a map of <token, primaryHost>
-  var primaryReplicas = {};
+  const primaryReplicas = {};
   //Depending on the amount of tokens, this could be an expensive operation
-  var hostArray = hosts.values();
-  var parser = this.tokenizer.parse;
-  var compare = this.tokenizer.compare;
-  var stringify = this.tokenizer.stringify;
-  var datacenters = {};
+  const hostArray = hosts.values();
+  const parser = this.tokenizer.parse;
+  const compare = this.tokenizer.compare;
+  const stringify = this.tokenizer.stringify;
+  const datacenters = {};
   hostArray.forEach(function (h) {
     if (!h.tokens) {
       return;
     }
     h.tokens.forEach(function (tokenString) {
-      var token = parser(tokenString);
+      const token = parser(tokenString);
       utils.insertSorted(allSorted, token, compare);
       primaryReplicas[stringify(token)] = h;
     });
-    var dc = datacenters[h.datacenter];
+    let dc = datacenters[h.datacenter];
     if (!dc) {
       dc = datacenters[h.datacenter] = {
         hostLength: 0,
@@ -133,7 +133,7 @@ Metadata.prototype.buildTokens = function (hosts) {
   this.ring = allSorted;
   //Compute string versions as it's potentially expensive and frequently reused later
   this.ringTokensAsStrings = new Array(allSorted.length);
-  for (var i = 0; i < allSorted.length; i++) {
+  for (let i = 0; i < allSorted.length; i++) {
     this.ringTokensAsStrings[i] = stringify(allSorted[i]);
   }
   //Datacenter metadata (host length and racks)
@@ -162,7 +162,7 @@ Metadata.prototype.refreshKeyspace = function (name, callback) {
  */
 Metadata.prototype._refreshKeyspaceCb = function (name, callback) {
   this.log('info', util.format('Retrieving keyspace %s metadata', name));
-  var self = this;
+  const self = this;
   this._schemaParser.getKeyspace(name, function (err, ksInfo) {
     if (err) {
       self.log('error', 'There was an error while trying to retrieve keyspace information', err);
@@ -207,7 +207,7 @@ Metadata.prototype.refreshKeyspaces = function (waitReconnect, callback) {
  */
 Metadata.prototype._refreshKeyspacesCb = function (waitReconnect, callback) {
   this.log('info', 'Retrieving keyspaces metadata');
-  var self = this;
+  const self = this;
   this._schemaParser.getKeyspaces(waitReconnect, function getKeyspacesCallback(err, keyspaces) {
     if (err) {
       self.log('error', 'There was an error while trying to retrieve keyspaces information', err);
@@ -232,7 +232,7 @@ Metadata.prototype.getReplicas = function (keyspaceName, tokenBuffer) {
   if (!this.ring) {
     return null;
   }
-  var keyspace;
+  let keyspace;
   if (keyspaceName) {
     keyspace = this.keyspaces[keyspaceName];
     if (!keyspace) {
@@ -240,8 +240,8 @@ Metadata.prototype.getReplicas = function (keyspaceName, tokenBuffer) {
       return null;
     }
   }
-  var token = this.tokenizer.hash(tokenBuffer);
-  var i = utils.binarySearch(this.ring, token, this.tokenizer.compare);
+  const token = this.tokenizer.hash(tokenBuffer);
+  let i = utils.binarySearch(this.ring, token, this.tokenizer.compare);
   if (i < 0) {
     i = ~i;
   }
@@ -249,7 +249,7 @@ Metadata.prototype.getReplicas = function (keyspaceName, tokenBuffer) {
     //it circled back
     i = i % this.ring.length;
   }
-  var closestToken = this.ringTokensAsStrings[i];
+  const closestToken = this.ringTokensAsStrings[i];
 
   if (!keyspaceName) {
     return [this.primaryReplicas[closestToken]];
@@ -326,9 +326,9 @@ Metadata.prototype.getUdt = function (keyspaceName, name, callback) {
  * @private
  */
 Metadata.prototype._getUdtCb = function (keyspaceName, name, callback) {
-  var cache;
+  let cache;
   if (this.options.isMetadataSyncEnabled) {
-    var keyspace = this.keyspaces[keyspaceName];
+    const keyspace = this.keyspaces[keyspaceName];
     if (!keyspace) {
       return callback(null, null);
     }
@@ -365,9 +365,9 @@ Metadata.prototype.getTable = function (keyspaceName, name, callback) {
  * @private
  */
 Metadata.prototype._getTableCb = function (keyspaceName, name, callback) {
-  var cache;
+  let cache;
   if (this.options.isMetadataSyncEnabled) {
-    var keyspace = this.keyspaces[keyspaceName];
+    const keyspace = this.keyspaces[keyspaceName];
     if (!keyspace) {
       return callback(null, null);
     }
@@ -533,9 +533,9 @@ Metadata.prototype.getMaterializedView = function (keyspaceName, name, callback)
  * @private
  */
 Metadata.prototype._getMaterializedViewCb = function (keyspaceName, name, callback) {
-  var cache;
+  let cache;
   if (this.options.isMetadataSyncEnabled) {
-    var keyspace = this.keyspaces[keyspaceName];
+    const keyspace = this.keyspaces[keyspaceName];
     if (!keyspace) {
       return callback(null, null);
     }
@@ -553,9 +553,9 @@ Metadata.prototype._getMaterializedViewCb = function (keyspaceName, name, callba
  * @private
  */
 Metadata.prototype._getFunctions = function (keyspaceName, name, aggregate, callback) {
-  var cache;
+  let cache;
   if (this.options.isMetadataSyncEnabled) {
-    var keyspace = this.keyspaces[keyspaceName];
+    const keyspace = this.keyspaces[keyspaceName];
     if (!keyspace) {
       return callback(null, null);
     }
@@ -599,7 +599,7 @@ Metadata.prototype._getSingleFunctionCb = function (keyspaceName, name, signatur
     if (err) {
       return callback(err, null);
     }
-    var f;
+    let f;
     if (functionsMap) {
       f = functionsMap['(' + signature.join(',') + ')'];
     }
@@ -639,12 +639,12 @@ Metadata.prototype.getTrace = function (traceId, consistency, callback) {
  * @private
  */
 Metadata.prototype._getTraceCb = function (traceId, consistency, callback) {
-  var trace;
-  var attempts = 0;
-  var requestOptions = { consistency: consistency };
-  var sessionRequest = new requests.QueryRequest(util.format(_selectTraceSession, traceId), null, requestOptions);
-  var eventsRequest = new requests.QueryRequest(util.format(_selectTraceEvents, traceId), null, requestOptions);
-  var self = this;
+  let trace;
+  let attempts = 0;
+  const requestOptions = { consistency: consistency };
+  const sessionRequest = new requests.QueryRequest(util.format(_selectTraceSession, traceId), null, requestOptions);
+  const eventsRequest = new requests.QueryRequest(util.format(_selectTraceEvents, traceId), null, requestOptions);
+  const self = this;
   utils.whilst(function condition() {
     return !trace && (attempts++ < _traceMaxAttemps);
   }, function iterator(next) {
@@ -652,7 +652,7 @@ Metadata.prototype._getTraceCb = function (traceId, consistency, callback) {
       if (err) {
         return next(err);
       }
-      var sessionRow = result.rows[0];
+      const sessionRow = result.rows[0];
       if (!sessionRow || !sessionRow['duration']) {
         return setTimeout(next, _traceAttemptDelay);
       }
@@ -698,11 +698,11 @@ Metadata.prototype._getTraceCb = function (traceId, consistency, callback) {
  * @ignore
  */
 Metadata.prototype.adaptUserHints = function (keyspace, hints, callback) {
-  var udts = [];
+  const udts = [];
   //check for udts and get the metadata
   function checkUdtTypes(type) {
     if (type.code === types.dataTypes.udt) {
-      var udtName = type.info.split('.');
+      const udtName = type.info.split('.');
       type.info = {
         keyspace: udtName[0],
         name: udtName[1]
@@ -729,13 +729,13 @@ Metadata.prototype.adaptUserHints = function (keyspace, hints, callback) {
       checkUdtTypes(type.info[1]);
     }
   }
-  for (var i = 0; i < hints.length; i++) {
-    var hint = hints[i];
+  for (let i = 0; i < hints.length; i++) {
+    const hint = hints[i];
     if (typeof hint !== 'string') {
       continue;
     }
     try {
-      var type = types.dataTypes.getByName(hint);
+      const type = types.dataTypes.getByName(hint);
       checkUdtTypes(type);
       hints[i] = type;
     }
@@ -743,7 +743,7 @@ Metadata.prototype.adaptUserHints = function (keyspace, hints, callback) {
       return callback(err);
     }
   }
-  var self = this;
+  const self = this;
   utils.each(udts, function (type, next) {
     self.getUdt(type.info.keyspace, type.info.name, function (err, udtInfo) {
       if (err) {
@@ -766,9 +766,9 @@ Metadata.prototype.adaptUserHints = function (keyspace, hints, callback) {
  * @ignore
  */
 Metadata.prototype.getLocalSchemaVersion = function (connection, callback) {
-  var request = new requests.QueryRequest(_selectSchemaVersionLocal, null, null);
+  const request = new requests.QueryRequest(_selectSchemaVersionLocal, null, null);
   connection.sendStream(request, utils.emptyObject, function (err, result) {
-    var version;
+    let version;
     if (!err && result && result.rows && result.rows.length === 1) {
       version = result.rows[0]['schema_version'];
     }
@@ -784,12 +784,12 @@ Metadata.prototype.getLocalSchemaVersion = function (connection, callback) {
  * @ignore
  */
 Metadata.prototype.getPeersSchemaVersions = function (connection, callback) {
-  var request = new requests.QueryRequest(_selectSchemaVersionPeers, null, null);
+  const request = new requests.QueryRequest(_selectSchemaVersionPeers, null, null);
   connection.sendStream(request, utils.emptyObject, function (err, result) {
-    var versions = [];
+    const versions = [];
     if (!err && result && result.rows) {
-      for (var i = 0; i < result.rows.length; i++) {
-        var schemaVersion = result.rows[i]['schema_version'];
+      for (let i = 0; i < result.rows.length; i++) {
+        const schemaVersion = result.rows[i]['schema_version'];
         if (schemaVersion) {
           versions.push(schemaVersion);
         }
@@ -819,8 +819,8 @@ PreparedQueries.prototype._getKey = function (keyspace, query) {
 };
 
 PreparedQueries.prototype.getOrAdd = function (keyspace, query) {
-  var key = this._getKey(keyspace, query);
-  var info = this._mapByKey[key];
+  const key = this._getKey(keyspace, query);
+  let info = this._mapByKey[key];
   if (info) {
     return info;
   }
@@ -839,12 +839,12 @@ PreparedQueries.prototype._validateOverflow = function () {
   if (this.length < this._maxPrepared) {
     return;
   }
-  var toRemove = [];
+  const toRemove = [];
   this._logger('warning',
     'Prepared statements exceeded maximum. This could be caused by preparing queries that contain parameters');
-  var existingKeys = Object.keys(this._mapByKey);
-  for (var i = 0; i < existingKeys.length && this.length - toRemove.length < this._maxPrepared; i++) {
-    var info = this._mapByKey[existingKeys[i]];
+  const existingKeys = Object.keys(this._mapByKey);
+  for (let i = 0; i < existingKeys.length && this.length - toRemove.length < this._maxPrepared; i++) {
+    const info = this._mapByKey[existingKeys[i]];
     if (!info.queryId) {
       // Only remove queries that contain queryId
       continue;

--- a/lib/metadata/materialized-view.js
+++ b/lib/metadata/materialized-view.js
@@ -1,7 +1,6 @@
 "use strict";
-var util = require('util');
-var DataCollection = require('./data-collection');
-//noinspection JSValidateJSDoc
+const util = require('util');
+const DataCollection = require('./data-collection');
 /**
  * Creates a new MaterializedView.
  * @param {String} name Name of the View.
@@ -29,7 +28,6 @@ function MaterializedView(name) {
   this.includeAllColumns = false;
 }
 
-//noinspection JSCheckFunctionSignatures
 util.inherits(MaterializedView, DataCollection);
 
 module.exports = MaterializedView;

--- a/lib/metadata/schema-index.js
+++ b/lib/metadata/schema-index.js
@@ -1,10 +1,10 @@
 "use strict";
-var util = require('util');
-var utils = require('../utils');
-var types = require('../types');
+const util = require('util');
+const utils = require('../utils');
+const types = require('../types');
 
 /** @private */
-var kind = {
+const kind = {
   custom: 0,
   keys: 1,
   composites: 2
@@ -76,7 +76,7 @@ Index.fromRows = function (indexRows) {
     return utils.emptyArray;
   }
   return indexRows.map(function (row) {
-    var options = row['options'];
+    const options = row['options'];
     return new Index(row['index_name'], options['target'], getKindByName(row['kind']), options);
   });
 };
@@ -88,16 +88,16 @@ Index.fromRows = function (indexRows) {
  * @returns {Array.<Index>}
  */
 Index.fromColumnRows = function (columnRows, columnsByName) {
-  var result = [];
-  for (var i = 0; i < columnRows.length; i++) {
-    var row = columnRows[i];
-    var indexName = row['index_name'];
+  const result = [];
+  for (let i = 0; i < columnRows.length; i++) {
+    const row = columnRows[i];
+    const indexName = row['index_name'];
     if (!indexName) {
       continue;
     }
-    var c = columnsByName[row['column_name']];
-    var target;
-    var options = JSON.parse(row['index_options']);
+    const c = columnsByName[row['column_name']];
+    let target;
+    const options = JSON.parse(row['index_options']);
     if (options !== null && options['index_keys'] !== undefined) {
       target = util.format("keys(%s)", c.name);
     }

--- a/lib/metadata/schema-parser.js
+++ b/lib/metadata/schema-parser.js
@@ -1,35 +1,35 @@
 "use strict";
-var util = require('util');
-var events = require('events');
-var types = require('../types');
-var utils = require('../utils');
-var errors = require('../errors');
-var TableMetadata = require('./table-metadata');
-var Aggregate = require('./aggregate');
-var SchemaFunction = require('./schema-function');
-var Index = require('./schema-index');
-var MaterializedView = require('./materialized-view');
+const util = require('util');
+const events = require('events');
+const types = require('../types');
+const utils = require('../utils');
+const errors = require('../errors');
+const TableMetadata = require('./table-metadata');
+const Aggregate = require('./aggregate');
+const SchemaFunction = require('./schema-function');
+const Index = require('./schema-index');
+const MaterializedView = require('./materialized-view');
 /**
  * @module metadata/schemaParser
  * @ignore
  */
 
-var _selectAllKeyspacesV1 = "SELECT * FROM system.schema_keyspaces";
-var _selectSingleKeyspaceV1 = "SELECT * FROM system.schema_keyspaces where keyspace_name = '%s'";
-var _selectAllKeyspacesV2 = "SELECT * FROM system_schema.keyspaces";
-var _selectSingleKeyspaceV2 = "SELECT * FROM system_schema.keyspaces where keyspace_name = '%s'";
-var _selectTableV1 = "SELECT * FROM system.schema_columnfamilies WHERE keyspace_name='%s' AND columnfamily_name='%s'";
-var _selectTableV2 = "SELECT * FROM system_schema.tables WHERE keyspace_name='%s' AND table_name='%s'";
-var _selectColumnsV1 = "SELECT * FROM system.schema_columns WHERE keyspace_name='%s' AND columnfamily_name='%s'";
-var _selectColumnsV2 = "SELECT * FROM system_schema.columns WHERE keyspace_name='%s' AND table_name='%s'";
-var _selectIndexesV2 = "SELECT * FROM system_schema.indexes WHERE keyspace_name='%s' AND table_name='%s'";
-var _selectUdtV1 = "SELECT * FROM system.schema_usertypes WHERE keyspace_name='%s' AND type_name='%s'";
-var _selectUdtV2 = "SELECT * FROM system_schema.types WHERE keyspace_name='%s' AND type_name='%s'";
-var _selectFunctionsV1 = "SELECT * FROM system.schema_functions WHERE keyspace_name = '%s' AND function_name = '%s'";
-var _selectFunctionsV2 = "SELECT * FROM system_schema.functions WHERE keyspace_name = '%s' AND function_name = '%s'";
-var _selectAggregatesV1 = "SELECT * FROM system.schema_aggregates WHERE keyspace_name = '%s' AND aggregate_name = '%s'";
-var _selectAggregatesV2 = "SELECT * FROM system_schema.aggregates WHERE keyspace_name = '%s' AND aggregate_name = '%s'";
-var _selectMaterializedViewV2 = "SELECT * FROM system_schema.views WHERE keyspace_name = '%s' AND view_name = '%s'";
+const _selectAllKeyspacesV1 = "SELECT * FROM system.schema_keyspaces";
+const _selectSingleKeyspaceV1 = "SELECT * FROM system.schema_keyspaces where keyspace_name = '%s'";
+const _selectAllKeyspacesV2 = "SELECT * FROM system_schema.keyspaces";
+const _selectSingleKeyspaceV2 = "SELECT * FROM system_schema.keyspaces where keyspace_name = '%s'";
+const _selectTableV1 = "SELECT * FROM system.schema_columnfamilies WHERE keyspace_name='%s' AND columnfamily_name='%s'";
+const _selectTableV2 = "SELECT * FROM system_schema.tables WHERE keyspace_name='%s' AND table_name='%s'";
+const _selectColumnsV1 = "SELECT * FROM system.schema_columns WHERE keyspace_name='%s' AND columnfamily_name='%s'";
+const _selectColumnsV2 = "SELECT * FROM system_schema.columns WHERE keyspace_name='%s' AND table_name='%s'";
+const _selectIndexesV2 = "SELECT * FROM system_schema.indexes WHERE keyspace_name='%s' AND table_name='%s'";
+const _selectUdtV1 = "SELECT * FROM system.schema_usertypes WHERE keyspace_name='%s' AND type_name='%s'";
+const _selectUdtV2 = "SELECT * FROM system_schema.types WHERE keyspace_name='%s' AND type_name='%s'";
+const _selectFunctionsV1 = "SELECT * FROM system.schema_functions WHERE keyspace_name = '%s' AND function_name = '%s'";
+const _selectFunctionsV2 = "SELECT * FROM system_schema.functions WHERE keyspace_name = '%s' AND function_name = '%s'";
+const _selectAggregatesV1 = "SELECT * FROM system.schema_aggregates WHERE keyspace_name = '%s' AND aggregate_name = '%s'";
+const _selectAggregatesV2 = "SELECT * FROM system_schema.aggregates WHERE keyspace_name = '%s' AND aggregate_name = '%s'";
+const _selectMaterializedViewV2 = "SELECT * FROM system_schema.views WHERE keyspace_name = '%s' AND view_name = '%s'";
 
 /**
  * @abstract
@@ -56,7 +56,7 @@ function SchemaParser(cc) {
  * @protected
  */
 SchemaParser.prototype._createKeyspace = function (name, durableWrites, strategy, strategyOptions) {
-  var ksInfo = {
+  const ksInfo = {
     name: name,
     durableWrites: durableWrites,
     strategy: strategy,
@@ -95,7 +95,7 @@ SchemaParser.prototype.getKeyspaces = function (waitReconnect, callback) {
  * @param {Function} callback
  */
 SchemaParser.prototype.getTable = function (keyspaceName, name, cache, callback) {
-  var tableInfo = cache && cache[name];
+  let tableInfo = cache && cache[name];
   if (!tableInfo) {
     tableInfo = new TableMetadata(name);
     if (cache) {
@@ -112,11 +112,11 @@ SchemaParser.prototype.getTable = function (keyspaceName, name, cache, callback)
   }
   // its not cached and not being retrieved
   tableInfo.loading = true;
-  var tableRow, columnRows, indexRows;
-  var self = this;
+  let tableRow, columnRows, indexRows;
+  const self = this;
   utils.series([
     function getTableRow(next) {
-      var query = util.format(self.selectTable, keyspaceName, name);
+      const query = util.format(self.selectTable, keyspaceName, name);
       self.cc.query(query, function (err, response) {
         if (err) {
           return next(err);
@@ -129,7 +129,7 @@ SchemaParser.prototype.getTable = function (keyspaceName, name, cache, callback)
       if (!tableRow) {
         return next(null, null, null);
       }
-      var query = util.format(self.selectColumns, keyspaceName, name);
+      const query = util.format(self.selectColumns, keyspaceName, name);
       self.cc.query(query, function (err, response) {
         if (err) {
           return next(err);
@@ -143,7 +143,7 @@ SchemaParser.prototype.getTable = function (keyspaceName, name, cache, callback)
         //either the table does not exists or it does not support indexes schema table
         return next();
       }
-      var query = util.format(self.selectIndexes, keyspaceName, name);
+      const query = util.format(self.selectIndexes, keyspaceName, name);
       self.cc.query(query, function (err, response) {
         if (err) {
           return next(err);
@@ -172,7 +172,7 @@ SchemaParser.prototype.getTable = function (keyspaceName, name, cache, callback)
  * @param {Function} callback
  */
 SchemaParser.prototype.getUdt = function (keyspaceName, name, cache, callback) {
-  var udtInfo = cache && cache[name];
+  let udtInfo = cache && cache[name];
   if (!udtInfo) {
     udtInfo = new events.EventEmitter();
     if (cache) {
@@ -193,13 +193,13 @@ SchemaParser.prototype.getUdt = function (keyspaceName, name, cache, callback) {
   }
   udtInfo.loading = true;
   //it is not cached, try to query for it
-  var query = util.format(this.selectUdt, keyspaceName, name);
-  var self = this;
+  const query = util.format(this.selectUdt, keyspaceName, name);
+  const self = this;
   this.cc.query(query, function (err, response) {
     if (err) {
       return udtInfo.emit('load', err);
     }
-    var row = response.rows[0];
+    const row = response.rows[0];
     if (!row) {
       udtInfo.loading = false;
       return udtInfo.emit('load', null, null);
@@ -224,7 +224,6 @@ SchemaParser.prototype.getUdt = function (keyspaceName, name, cache, callback) {
 SchemaParser.prototype._parseUdt = function (udtInfo, row, callback) {
 };
 
-//noinspection JSValidateJSDoc
 /**
  * Builds the metadata based on the table and column rows
  * @abstract
@@ -259,8 +258,8 @@ SchemaParser.prototype.getMaterializedView = function (keyspaceName, name, cache
  */
 SchemaParser.prototype.getFunctions = function (keyspaceName, name, aggregate, cache, callback) {
   /** @type {String} */
-  var query = this.selectFunctions;
-  var parser = this._parseFunction.bind(this);
+  let query = this.selectFunctions;
+  let parser = this._parseFunction.bind(this);
   if (aggregate) {
     query = this.selectAggregates;
     parser = this._parseAggregate.bind(this);
@@ -268,7 +267,7 @@ SchemaParser.prototype.getFunctions = function (keyspaceName, name, aggregate, c
   //if not already loaded
   //get all functions with that name
   //cache it by name and, within name, by signature
-  var functionsInfo = cache && cache[name];
+  let functionsInfo = cache && cache[name];
   if (!functionsInfo) {
     functionsInfo = new events.EventEmitter();
     if (cache) {
@@ -347,15 +346,15 @@ util.inherits(SchemaParserV1, SchemaParser);
 
 /** @override */
 SchemaParserV1.prototype.getKeyspaces = function (waitReconnect, callback) {
-  var self = this;
-  var keyspaces = {};
+  const self = this;
+  const keyspaces = {};
   this.cc.query(_selectAllKeyspacesV1, waitReconnect, function (err, result) {
     if (err) {
       return callback(err);
     }
-    for (var i = 0; i < result.rows.length; i++) {
-      var row = result.rows[i];
-      var ksInfo = self._createKeyspace(
+    for (let i = 0; i < result.rows.length; i++) {
+      const row = result.rows[i];
+      const ksInfo = self._createKeyspace(
         row['keyspace_name'],
         row['durable_writes'],
         row['strategy_class'],
@@ -368,12 +367,12 @@ SchemaParserV1.prototype.getKeyspaces = function (waitReconnect, callback) {
 
 /** @override */
 SchemaParserV1.prototype.getKeyspace = function (name, callback) {
-  var self = this;
+  const self = this;
   this.cc.query(util.format(_selectSingleKeyspaceV1, name), function (err, result) {
     if (err) {
       return callback(err);
     }
-    var row = result.rows[0];
+    const row = result.rows[0];
     if (!row) {
       return callback(null, null);
     }
@@ -385,14 +384,13 @@ SchemaParserV1.prototype.getKeyspace = function (name, callback) {
   });
 };
 
-//noinspection JSUnusedLocalSymbols
 /** @override */
 SchemaParserV1.prototype._parseTableOrView = function (tableInfo, tableRow, columnRows, indexRows, callback) {
-  var i, c, name, types;
-  var encoder = this.cc.getEncoder();
-  var columnsKeyed = {};
-  var partitionKeys = [];
-  var clusteringKeys = [];
+  let i, c, name, types;
+  const encoder = this.cc.getEncoder();
+  const columnsKeyed = {};
+  let partitionKeys = [];
+  let clusteringKeys = [];
   tableInfo.bloomFilterFalsePositiveChance = tableRow['bloom_filter_fp_chance'];
   tableInfo.caching = tableRow['caching'];
   tableInfo.comment = tableRow['comment'];
@@ -426,8 +424,8 @@ SchemaParserV1.prototype._parseTableOrView = function (tableInfo, tableRow, colu
     (function parseColumns() {
       //function context
       for (i = 0; i < columnRows.length; i++) {
-        var row = columnRows[i];
-        var type = encoder.parseFqTypeName(row['validator']);
+        const row = columnRows[i];
+        const type = encoder.parseFqTypeName(row['validator']);
         c = {
           name: row['column_name'],
           type: type
@@ -461,7 +459,7 @@ SchemaParserV1.prototype._parseTableOrView = function (tableInfo, tableRow, colu
       });
     }
     //In C* 1.2, keys are not stored on the schema_columns table
-    var keysStoredInTableRow = (tableInfo.partitionKeys.length === 0);
+    const keysStoredInTableRow = (tableInfo.partitionKeys.length === 0);
     if (keysStoredInTableRow && tableRow['key_aliases']) {
       //In C* 1.2, keys are not stored on the schema_columns table
       partitionKeys = JSON.parse(tableRow['key_aliases']);
@@ -479,7 +477,7 @@ SchemaParserV1.prototype._parseTableOrView = function (tableInfo, tableRow, colu
         tableInfo.partitionKeys.push(c);
       }
     }
-    var comparator = encoder.parseKeyTypes(tableRow['comparator']);
+    const comparator = encoder.parseKeyTypes(tableRow['comparator']);
     if (keysStoredInTableRow && tableRow['column_aliases']) {
       clusteringKeys = JSON.parse(tableRow['column_aliases']);
       for (i = 0; i < clusteringKeys.length; i++) {
@@ -537,8 +535,8 @@ SchemaParserV1.prototype.getMaterializedView = function (keyspaceName, name, cac
 
 /** @override */
 SchemaParserV1.prototype._parseAggregate = function (row, callback) {
-  var encoder = this.cc.getEncoder();
-  var aggregate = new Aggregate();
+  const encoder = this.cc.getEncoder();
+  const aggregate = new Aggregate();
   aggregate.name = row['aggregate_name'];
   aggregate.keyspaceName = row['keyspace_name'];
   aggregate.signature = row['signature'] || utils.emptyArray;
@@ -550,7 +548,7 @@ SchemaParserV1.prototype._parseAggregate = function (row, callback) {
       return encoder.parseFqTypeName(name);
     });
     aggregate.stateType = encoder.parseFqTypeName(row['state_type']);
-    var initConditionValue = encoder.decode(aggregate.initConditionRaw, aggregate.stateType);
+    const initConditionValue = encoder.decode(aggregate.initConditionRaw, aggregate.stateType);
     if (initConditionValue !== null && typeof initConditionValue !== 'undefined') {
       aggregate.initCondition = initConditionValue.toString();
     }
@@ -564,8 +562,8 @@ SchemaParserV1.prototype._parseAggregate = function (row, callback) {
 
 /** @override */
 SchemaParserV1.prototype._parseFunction = function (row, callback) {
-  var encoder = this.cc.getEncoder();
-  var func = new SchemaFunction();
+  const encoder = this.cc.getEncoder();
+  const func = new SchemaFunction();
   func.name = row['function_name'];
   func.keyspaceName = row['keyspace_name'];
   func.signature = row['signature'] || utils.emptyArray;
@@ -587,12 +585,12 @@ SchemaParserV1.prototype._parseFunction = function (row, callback) {
 
 /** @override */
 SchemaParserV1.prototype._parseUdt = function (udtInfo, row, callback) {
-  var encoder = this.cc.getEncoder();
-  var fieldNames = row['field_names'];
-  var fieldTypes = row['field_types'];
-  var fields = new Array(fieldNames.length);
+  const encoder = this.cc.getEncoder();
+  const fieldNames = row['field_names'];
+  const fieldTypes = row['field_types'];
+  const fields = new Array(fieldNames.length);
   try {
-    for (var i = 0; i < fieldNames.length; i++) {
+    for (let i = 0; i < fieldNames.length; i++) {
       fields[i] = {
         name: fieldNames[i],
         type: encoder.parseFqTypeName(fieldTypes[i])
@@ -628,14 +626,14 @@ util.inherits(SchemaParserV2, SchemaParser);
 
 /** @override */
 SchemaParserV2.prototype.getKeyspaces = function (waitReconnect, callback) {
-  var self = this;
-  var keyspaces = {};
+  const self = this;
+  const keyspaces = {};
   this.cc.query(_selectAllKeyspacesV2, waitReconnect, function (err, result) {
     if (err) {
       return callback(err);
     }
-    for (var i = 0; i < result.rows.length; i++) {
-      var ksInfo = self._parseKeyspace(result.rows[i]);
+    for (let i = 0; i < result.rows.length; i++) {
+      const ksInfo = self._parseKeyspace(result.rows[i]);
       keyspaces[ksInfo.name] = ksInfo;
     }
     callback(null, keyspaces);
@@ -644,12 +642,12 @@ SchemaParserV2.prototype.getKeyspaces = function (waitReconnect, callback) {
 
 /** @override */
 SchemaParserV2.prototype.getKeyspace = function (name, callback) {
-  var self = this;
+  const self = this;
   this.cc.query(util.format(_selectSingleKeyspaceV2, name), function (err, result) {
     if (err) {
       return callback(err);
     }
-    var row = result.rows[0];
+    const row = result.rows[0];
     if (!row) {
       return callback(null, null);
     }
@@ -659,7 +657,7 @@ SchemaParserV2.prototype.getKeyspace = function (name, callback) {
 
 /** @override */
 SchemaParserV2.prototype.getMaterializedView = function (keyspaceName, name, cache, callback) {
-  var viewInfo = cache && cache[name];
+  let viewInfo = cache && cache[name];
   if (!viewInfo) {
     viewInfo = new MaterializedView(name);
     if (cache) {
@@ -675,12 +673,12 @@ SchemaParserV2.prototype.getMaterializedView = function (keyspaceName, name, cac
     return;
   }
   viewInfo.loading = true;
-  var tableRow, columnRows;
+  let tableRow, columnRows;
   //it is not cached, try to query for it
-  var self = this;
+  const self = this;
   utils.series([
     function getTableRow(next) {
-      var query = util.format(_selectMaterializedViewV2, keyspaceName, name);
+      const query = util.format(_selectMaterializedViewV2, keyspaceName, name);
       self.cc.query(query, function (err, response) {
         if (err) {
           return next(err);
@@ -693,7 +691,7 @@ SchemaParserV2.prototype.getMaterializedView = function (keyspaceName, name, cac
       if (!tableRow) {
         return next();
       }
-      var query = util.format(self.selectColumns, keyspaceName, name);
+      const query = util.format(self.selectColumns, keyspaceName, name);
       self.cc.query(query, function (err, response) {
         if (err) {
           return next(err);
@@ -717,13 +715,13 @@ SchemaParserV2.prototype.getMaterializedView = function (keyspaceName, name, cac
 };
 
 SchemaParserV2.prototype._parseKeyspace = function (row) {
-  var replication = row['replication'];
-  var strategy;
-  var strategyOptions;
+  const replication = row['replication'];
+  let strategy;
+  let strategyOptions;
   if (replication) {
     strategy = replication['class'];
     strategyOptions = {};
-    for (var key in replication) {
+    for (const key in replication) {
       if (!replication.hasOwnProperty(key) || key === 'class') {
         continue;
       }
@@ -739,19 +737,19 @@ SchemaParserV2.prototype._parseKeyspace = function (row) {
 
 /** @override */
 SchemaParserV2.prototype._parseTableOrView = function (tableInfo, tableRow, columnRows, indexRows, callback) {
-  var encoder = this.cc.getEncoder();
-  var columnsKeyed = {};
-  var partitionKeys = [];
-  var clusteringKeys = [];
-  var isView = tableInfo instanceof MaterializedView;
+  const encoder = this.cc.getEncoder();
+  const columnsKeyed = {};
+  const partitionKeys = [];
+  const clusteringKeys = [];
+  const isView = tableInfo instanceof MaterializedView;
   tableInfo.bloomFilterFalsePositiveChance = tableRow['bloom_filter_fp_chance'];
   tableInfo.caching = JSON.stringify(tableRow['caching']);
   tableInfo.comment = tableRow['comment'];
-  var compaction = tableRow['compaction'];
+  const compaction = tableRow['compaction'];
   if (compaction) {
     tableInfo.compactionOptions = {};
     tableInfo.compactionClass = compaction['class'];
-    for (var key in compaction) {
+    for (const key in compaction) {
       if (!compaction.hasOwnProperty(key) || key === 'class') {
         continue;
       }
@@ -770,18 +768,18 @@ SchemaParserV2.prototype._parseTableOrView = function (tableInfo, tableRow, colu
   tableInfo.minIndexInterval = tableRow['min_index_interval'] || tableInfo.minIndexInterval;
   tableInfo.maxIndexInterval = tableRow['max_index_interval'] || tableInfo.maxIndexInterval;
   if (!isView) {
-    var cdc = tableRow['cdc'];
+    const cdc = tableRow['cdc'];
     if (cdc !== undefined) {
       tableInfo.cdc = cdc;
     }
   }
-  var self = this;
+  const self = this;
   utils.map(columnRows, function (row, next) {
     encoder.parseTypeName(tableRow['keyspace_name'], row['type'], 0, null, self.udtResolver, function (err, type) {
       if (err) {
         return next(err);
       }
-      var c = {
+      const c = {
         name: row['column_name'],
         type: type,
         isStatic: false
@@ -823,13 +821,13 @@ SchemaParserV2.prototype._parseTableOrView = function (tableInfo, tableRow, colu
       return callback();
     }
     tableInfo.indexes = Index.fromRows(indexRows);
-    var flags = tableRow['flags'];
-    var isDense = flags.indexOf('dense') >= 0;
-    var isSuper = flags.indexOf('super') >= 0;
-    var isCompound = flags.indexOf('compound') >= 0;
+    const flags = tableRow['flags'];
+    const isDense = flags.indexOf('dense') >= 0;
+    const isSuper = flags.indexOf('super') >= 0;
+    const isCompound = flags.indexOf('compound') >= 0;
     tableInfo.isCompact = isSuper || isDense || !isCompound;
     //remove the columns related to Thrift
-    var isStaticCompact = !isSuper && !isDense && !isCompound;
+    const isStaticCompact = !isSuper && !isDense && !isCompound;
     if(isStaticCompact) {
       pruneStaticCompactTableColumns(tableInfo);
     }
@@ -842,8 +840,8 @@ SchemaParserV2.prototype._parseTableOrView = function (tableInfo, tableRow, colu
 
 /** @override */
 SchemaParserV2.prototype._parseAggregate = function (row, callback) {
-  var encoder = this.cc.getEncoder();
-  var aggregate = new Aggregate();
+  const encoder = this.cc.getEncoder();
+  const aggregate = new Aggregate();
   aggregate.name = row['aggregate_name'];
   aggregate.keyspaceName = row['keyspace_name'];
   aggregate.signature = row['argument_types'] || utils.emptyArray;
@@ -851,7 +849,7 @@ SchemaParserV2.prototype._parseAggregate = function (row, callback) {
   aggregate.finalFunction = row['final_func'];
   aggregate.initConditionRaw = row['initcond'];
   aggregate.initCondition = aggregate.initConditionRaw;
-  var self = this;
+  const self = this;
   utils.series([
     function parseArguments(next) {
       utils.map(row['argument_types'] || utils.emptyArray, function (name, mapNext) {
@@ -883,8 +881,8 @@ SchemaParserV2.prototype._parseAggregate = function (row, callback) {
 
 /** @override */
 SchemaParserV2.prototype._parseFunction = function (row, callback) {
-  var encoder = this.cc.getEncoder();
-  var func = new SchemaFunction();
+  const encoder = this.cc.getEncoder();
+  const func = new SchemaFunction();
   func.name = row['function_name'];
   func.keyspaceName = row['keyspace_name'];
   func.signature = row['argument_types'] || utils.emptyArray;
@@ -892,7 +890,7 @@ SchemaParserV2.prototype._parseFunction = function (row, callback) {
   func.body = row['body'];
   func.calledOnNullInput = row['called_on_null_input'];
   func.language = row['language'];
-  var self = this;
+  const self = this;
   utils.series([
     function parseArguments(next) {
       utils.map(row['argument_types'] || utils.emptyArray, function (name, mapNext) {
@@ -918,11 +916,11 @@ SchemaParserV2.prototype._parseFunction = function (row, callback) {
 
 /** @override */
 SchemaParserV2.prototype._parseUdt = function (udtInfo, row, callback) {
-  var encoder = this.cc.getEncoder();
-  var fieldTypes = row['field_types'];
-  var keyspace = row['keyspace_name'];
-  var fields = new Array(fieldTypes.length);
-  var self = this;
+  const encoder = this.cc.getEncoder();
+  const fieldTypes = row['field_types'];
+  const keyspace = row['keyspace_name'];
+  const fields = new Array(fieldTypes.length);
+  const self = this;
   utils.forEachOf(row['field_names'], function (name, i, next) {
     encoder.parseTypeName(keyspace, fieldTypes[i], 0, null, self.udtResolver, function (err, type) {
       if (err) {
@@ -943,7 +941,6 @@ SchemaParserV2.prototype._parseUdt = function (udtInfo, row, callback) {
   });
 };
 
-//noinspection JSValidateJSDoc
 /**
  * Upon migration from thrift to CQL, we internally create a pair of surrogate clustering/regular columns
  * for compact static tables. These columns shouldn't be exposed to the user but are currently returned by C*.
@@ -951,12 +948,12 @@ SchemaParserV2.prototype._parseUdt = function (udtInfo, row, callback) {
  * @param {module:metadata~TableMetadata} tableInfo
 */
 function pruneStaticCompactTableColumns(tableInfo) {
-  var i;
-  var c;
+  let i;
+  let c;
   //remove "column1 text" clustering column
   for (i = 0; i < tableInfo.clusteringKeys.length; i++) {
     c = tableInfo.clusteringKeys[i];
-    var index = tableInfo.columns.indexOf(c);
+    const index = tableInfo.columns.indexOf(c);
     tableInfo.columns.splice(index, 1);
     delete tableInfo.columnsByName[c.name];
   }
@@ -976,16 +973,15 @@ function pruneStaticCompactTableColumns(tableInfo) {
   }
 }
 
-//noinspection JSValidateJSDoc
 /**
  * Upon migration from thrift to CQL, we internally create a surrogate column "value" of type custom.
  * This column shouldn't be exposed to the user but is currently returned by C*.
  * @param {module:metadata~TableMetadata} tableInfo
  */
 function pruneDenseTableColumns(tableInfo) {
-  var i = tableInfo.columns.length;
+  let i = tableInfo.columns.length;
   while (i--) {
-    var c = tableInfo.columns[i];
+    const c = tableInfo.columns[i];
     if (!c.isStatic && c.type.code === types.dataTypes.custom && c.type.info === 'empty') {
       // remove "value blob" regular column
       tableInfo.columns.splice(i, 1);
@@ -998,19 +994,18 @@ function pruneDenseTableColumns(tableInfo) {
 
 function getTokenToReplicaMapper(strategy, strategyOptions) {
   if (/SimpleStrategy$/.test(strategy)) {
-    var rf = parseInt(strategyOptions['replication_factor'], 10);
+    const rf = parseInt(strategyOptions['replication_factor'], 10);
     if (rf > 1) {
       return getTokenToReplicaSimpleMapper(rf);
     }
   }
   if (/NetworkTopologyStrategy$/.test(strategy)) {
-    //noinspection JSUnresolvedVariable
     return getTokenToReplicaNetworkMapper(strategyOptions);
   }
   //default, wrap in an Array
   return (function noStrategy(tokenizer, ring, primaryReplicas) {
-    var replicas = {};
-    for (var key in primaryReplicas) {
+    const replicas = {};
+    for (const key in primaryReplicas) {
       if (!primaryReplicas.hasOwnProperty(key)) {
         continue;
       }
@@ -1026,19 +1021,19 @@ function getTokenToReplicaMapper(strategy, strategyOptions) {
  */
 function getTokenToReplicaSimpleMapper(replicationFactor) {
   return (function tokenSimpleStrategy(tokenizer, ringTokensAsStrings, primaryReplicas) {
-    var ringLength = ringTokensAsStrings.length;
-    var rf = Math.min(replicationFactor, ringLength);
-    var replicas = {};
-    for (var i = 0; i < ringLength; i++) {
-      var key = ringTokensAsStrings[i];
-      var tokenReplicas = [primaryReplicas[key]];
-      for (var j = 1; j < rf; j++) {
-        var nextReplicaIndex = i + j;
+    const ringLength = ringTokensAsStrings.length;
+    const rf = Math.min(replicationFactor, ringLength);
+    const replicas = {};
+    for (let i = 0; i < ringLength; i++) {
+      const key = ringTokensAsStrings[i];
+      const tokenReplicas = [primaryReplicas[key]];
+      for (let j = 1; j < rf; j++) {
+        let nextReplicaIndex = i + j;
         if (nextReplicaIndex >= ringLength) {
           //circle back
           nextReplicaIndex = nextReplicaIndex % ringLength;
         }
-        var nextReplica = primaryReplicas[ringTokensAsStrings[nextReplicaIndex]];
+        const nextReplica = primaryReplicas[ringTokensAsStrings[nextReplicaIndex]];
         tokenReplicas.push(nextReplica);
       }
       replicas[key] = tokenReplicas;
@@ -1063,35 +1058,35 @@ function getTokenToReplicaNetworkMapper(replicationFactors) {
   //
   //                E(DC1)
   return (function tokenNetworkStrategy(tokenizer, ringTokensAsStrings, primaryReplicas, datacenters) {
-    var replicas = {};
-    var ringLength = ringTokensAsStrings.length;
+    const replicas = {};
+    const ringLength = ringTokensAsStrings.length;
 
-    for (var i = 0; i < ringLength; i++) {
-      var key = ringTokensAsStrings[i];
-      var tokenReplicas = [];
-      var replicasByDc = {};
-      var racksPlaced = {};
-      var skippedHosts = [];
-      for (var j = 0; j < ringLength; j++) {
-        var nextReplicaIndex = i + j;
+    for (let i = 0; i < ringLength; i++) {
+      const key = ringTokensAsStrings[i];
+      const tokenReplicas = [];
+      const replicasByDc = {};
+      const racksPlaced = {};
+      const skippedHosts = [];
+      for (let j = 0; j < ringLength; j++) {
+        let nextReplicaIndex = i + j;
         if (nextReplicaIndex >= ringLength) {
           //circle back
           nextReplicaIndex = nextReplicaIndex % ringLength;
         }
-        var h = primaryReplicas[ringTokensAsStrings[nextReplicaIndex]];
-        var dc = h.datacenter;
+        const h = primaryReplicas[ringTokensAsStrings[nextReplicaIndex]];
+        const dc = h.datacenter;
         //Check if the next replica belongs to one of the targeted dcs
-        var dcRf = parseInt(replicationFactors[dc], 10);
+        let dcRf = parseInt(replicationFactors[dc], 10);
         if (!dcRf) {
           continue;
         }
         dcRf = Math.min(dcRf, datacenters[dc].hostLength);
-        var dcReplicas = replicasByDc[dc] || 0;
+        let dcReplicas = replicasByDc[dc] || 0;
         //Amount of replicas per dc is greater than rf or the amount of host in the datacenter
         if (dcReplicas >= dcRf) {
           continue;
         }
-        var racksPlacedInDc = racksPlaced[dc];
+        let racksPlacedInDc = racksPlaced[dc];
         if (!racksPlacedInDc) {
           racksPlacedInDc = racksPlaced[dc] = new utils.HashSet();
         }
@@ -1126,7 +1121,7 @@ function getTokenToReplicaNetworkMapper(replicationFactors) {
  * @returns {Number} The number of skipped hosts added.
  */
 function addSkippedHosts(dcRf, dcReplicas, tokenReplicas, skippedHosts) {
-  var i;
+  let i;
   for (i = 0; i < dcRf - dcReplicas && i < skippedHosts.length; i++) {
     tokenReplicas.push(skippedHosts[i]);
   }
@@ -1134,15 +1129,15 @@ function addSkippedHosts(dcRf, dcReplicas, tokenReplicas, skippedHosts) {
 }
 
 function isDoneForToken(replicationFactors, datacenters, replicasByDc) {
-  var keys = Object.keys(replicationFactors);
-  for (var i = 0; i < keys.length; i++) {
-    var dcName = keys[i];
-    var dc = datacenters[dcName];
+  const keys = Object.keys(replicationFactors);
+  for (let i = 0; i < keys.length; i++) {
+    const dcName = keys[i];
+    const dc = datacenters[dcName];
     if (!dc) {
       // A DC is included in the RF but the DC does not exist in the topology
       continue;
     }
-    var rf = Math.min(parseInt(replicationFactors[dcName], 10), dc.hostLength);
+    const rf = Math.min(parseInt(replicationFactors[dcName], 10), dc.hostLength);
     if (rf > 0 && (!replicasByDc[dcName] || replicasByDc[dcName] < rf)) {
       return false;
     }
@@ -1159,7 +1154,7 @@ function isDoneForToken(replicationFactors, datacenters, replicasByDc) {
  * @returns {SchemaParser}
  */
 function getByVersion(cc, udtResolver, version, currentInstance) {
-  var parserConstructor = SchemaParserV1;
+  let parserConstructor = SchemaParserV1;
   if (version && version[0] >= 3) {
     parserConstructor = SchemaParserV2;
   }

--- a/lib/metadata/table-metadata.js
+++ b/lib/metadata/table-metadata.js
@@ -1,7 +1,8 @@
 "use strict";
-var util = require('util');
-var DataCollection = require('./data-collection');
-//noinspection JSValidateJSDoc
+
+const util = require('util');
+const DataCollection = require('./data-collection');
+
 /**
  * Creates a new instance of TableMetadata
  * @classdesc Describes a table
@@ -55,7 +56,6 @@ function TableMetadata(name) {
   this.cdc = null;
 }
 
-//noinspection JSCheckFunctionSignatures
 util.inherits(TableMetadata, DataCollection);
 
 module.exports = TableMetadata;

--- a/lib/operation-state.js
+++ b/lib/operation-state.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var util = require('util');
-var utils = require('./utils');
-var errors = require('./errors');
-var requests = require('./requests');
-var ExecuteRequest = requests.ExecuteRequest;
-var QueryRequest = requests.QueryRequest;
+const util = require('util');
+const utils = require('./utils');
+const errors = require('./errors');
+const requests = require('./requests');
+const ExecuteRequest = requests.ExecuteRequest;
+const QueryRequest = requests.QueryRequest;
 
-var state = {
+const state = {
   init: 0,
   completed: 1,
   timedOut: 2,
@@ -69,16 +69,16 @@ OperationState.prototype.setRequestTimeout = function (defaultReadTimeout, addre
     // No need to set the timeout
     return;
   }
-  var millis = (this._options && this._options.readTimeout !== undefined) ?
+  const millis = (this._options && this._options.readTimeout !== undefined) ?
     this._options.readTimeout : defaultReadTimeout;
   if (!(millis > 0)) {
     // Read timeout disabled
     return;
   }
-  var self = this;
+  const self = this;
   this._timeout = setTimeout(function requestTimedOut() {
     onTimeout();
-    var message = util.format('The host %s did not reply before timeout %d ms', address, millis);
+    const message = util.format('The host %s did not reply before timeout %d ms', address, millis);
     self._markAsTimedOut(new errors.OperationTimedOutError(message), onResponse);
   }, millis);
 };
@@ -129,7 +129,7 @@ OperationState.prototype.setResult = function (err, result) {
 };
 
 OperationState.prototype._swapCallbackAndInvoke = function (err, result, newCallback) {
-  var callback = this._callback;
+  const callback = this._callback;
   this._callback = newCallback || utils.noop;
   callback(err, result);
 };

--- a/lib/policies/address-resolution.js
+++ b/lib/policies/address-resolution.js
@@ -1,7 +1,7 @@
 "use strict";
-var dns = require('dns');
-var util = require('util');
-var utils = require('../utils');
+const dns = require('dns');
+const util = require('util');
+const utils = require('../utils');
 /** @module policies/addressResolution */
 /**
  * @class
@@ -74,9 +74,9 @@ util.inherits(EC2MultiRegionTranslator, AddressTranslator);
  * different EC2 regions (than the client) are unchanged
  */
 EC2MultiRegionTranslator.prototype.translate = function (address, port, callback) {
-  var newAddress = address;
-  var self = this;
-  var name;
+  let newAddress = address;
+  const self = this;
+  let name;
   utils.series([
     function resolve(next) {
       dns.reverse(address, function (err, hostNames) {

--- a/lib/policies/index.js
+++ b/lib/policies/index.js
@@ -8,12 +8,12 @@
  *  [speculative execution]{@link module:policies/speculativeExecution}.
  * @module policies
  */
-var addressResolution = exports.addressResolution = require('./address-resolution');
-var loadBalancing = exports.loadBalancing = require('./load-balancing');
-var reconnection = exports.reconnection = require('./reconnection');
-var retry = exports.retry = require('./retry');
-var speculativeExecution = exports.speculativeExecution = require('./speculative-execution');
-var timestampGeneration = exports.timestampGeneration = require('./timestamp-generation');
+const addressResolution = exports.addressResolution = require('./address-resolution');
+const loadBalancing = exports.loadBalancing = require('./load-balancing');
+const reconnection = exports.reconnection = require('./reconnection');
+const retry = exports.retry = require('./retry');
+const speculativeExecution = exports.speculativeExecution = require('./speculative-execution');
+const timestampGeneration = exports.timestampGeneration = require('./timestamp-generation');
 
 /**
  * Returns a new instance of the default address translator policy used by the driver.

--- a/lib/policies/load-balancing.js
+++ b/lib/policies/load-balancing.js
@@ -1,11 +1,11 @@
 "use strict";
 
-var util = require('util');
-var types = require('../types');
-var utils = require('../utils.js');
-var errors = require('../errors.js');
+const util = require('util');
+const types = require('../types');
+const utils = require('../utils.js');
+const errors = require('../errors.js');
 
-var doneIteratorObject = Object.freeze({ done: true });
+const doneIteratorObject = Object.freeze({ done: true });
 
 /** @module policies/loadBalancing */
 /**
@@ -28,7 +28,6 @@ LoadBalancingPolicy.prototype.init = function (client, hosts, callback) {
   callback();
 };
 
-//noinspection JSUnusedLocalSymbols
 /**
  * Returns the distance assigned by this policy to the provided host.
  * @param {Host} host
@@ -72,11 +71,11 @@ RoundRobinPolicy.prototype.newQueryPlan = function (keyspace, queryOptions, call
   if (!this.hosts) {
     return callback(new Error('Load balancing policy not initialized'));
   }
-  var hosts = this.hosts.values();
-  var self = this;
-  var counter = 0;
+  const hosts = this.hosts.values();
+  const self = this;
+  let counter = 0;
 
-  var planIndex = self.index % hosts.length;
+  let planIndex = self.index % hosts.length;
   self.index += 1;
   if (self.index >= utils.maxInt) {
     self.index = 0;
@@ -131,10 +130,10 @@ DCAwareRoundRobinPolicy.prototype.init = function (client, hosts, callback) {
   hosts.on('remove', this._cleanHostCache.bind(this));
   if (!this.localDc) {
     //get the first alive local, it should be local on top
-    var hostsArray = hosts.values();
+    const hostsArray = hosts.values();
     var dcHost;
-    for (var i = 0; i < hostsArray.length; i++) {
-      var h = hostsArray[i];
+    for (let i = 0; i < hostsArray.length; i++) {
+      const h = hostsArray[i];
       if (h.datacenter) {
         this.localDc = h.datacenter;
         dcHost = h;
@@ -145,7 +144,7 @@ DCAwareRoundRobinPolicy.prototype.init = function (client, hosts, callback) {
     if (!this.localDc) {
       return callback(new errors.DriverInternalError('Local datacenter could not be determined'));
     }
-    client.log('warning', 'No local Data Center was provided with DCAwareRoundRobinPolicy' + 
+    client.log('warning', 'No local Data Center was provided with DCAwareRoundRobinPolicy' +
       '.  Using discovered DC \'' + this.localDc + '\' from host ' + dcHost.address +
       '.  Future releases will require local DC to be specified.');
   }
@@ -172,13 +171,13 @@ DCAwareRoundRobinPolicy.prototype._cleanHostCache = function () {
 };
 
 DCAwareRoundRobinPolicy.prototype._sliceNodesByDc = function() {
-  var hosts = this.hosts.values();
+  const hosts = this.hosts.values();
   if (this.remoteHostsArray) {
     //there were already calculated
     return;
   }
   //do a full lookup to cache the remote hosts by dc
-  var remoteHostsByDc = {};
+  const remoteHostsByDc = {};
   this.localHostsArray = [];
   this.remoteHostsArray = [];
   hosts.forEach(function (h) {
@@ -193,7 +192,7 @@ DCAwareRoundRobinPolicy.prototype._sliceNodesByDc = function() {
     if (this.usedHostsPerRemoteDc === 0) {
       return;
     }
-    var hostPerDc = remoteHostsByDc[h.datacenter];
+    let hostPerDc = remoteHostsByDc[h.datacenter];
     if (!hostPerDc) {
       remoteHostsByDc[h.datacenter] = hostPerDc = [];
     }
@@ -222,15 +221,15 @@ DCAwareRoundRobinPolicy.prototype.newQueryPlan = function (keyspace, queryOption
   }
   this._sliceNodesByDc();
   // Use a local reference of hosts
-  var localHostsArray = this.localHostsArray;
-  var remoteHostsArray = this.remoteHostsArray;
-  var planLocalIndex = this.index;
-  var planRemoteIndex = this.index;
-  var counter = 0;
-  var remoteCounter = 0;
+  const localHostsArray = this.localHostsArray;
+  const remoteHostsArray = this.remoteHostsArray;
+  let planLocalIndex = this.index;
+  let planRemoteIndex = this.index;
+  let counter = 0;
+  let remoteCounter = 0;
   callback(null, {
     next: function () {
-      var host;
+      let host;
       if (counter++ < localHostsArray.length) {
         host = localHostsArray[planLocalIndex++ % localHostsArray.length];
         return { value: host, done: false };
@@ -279,21 +278,21 @@ TokenAwarePolicy.prototype.getDistance = function (host) {
  * second parameter.
  */
 TokenAwarePolicy.prototype.newQueryPlan = function (keyspace, queryOptions, callback) {
-  var routingKey;
+  let routingKey;
   if (queryOptions) {
     routingKey = queryOptions.routingKey;
     if (queryOptions.keyspace) {
       keyspace = queryOptions.keyspace;
     }
   }
-  var replicas;
+  let replicas;
   if (routingKey) {
     replicas = this.client.getReplicas(keyspace, routingKey);
   }
   if (!routingKey || !replicas) {
     return this.childPolicy.newQueryPlan(keyspace, queryOptions, callback);
   }
-  var iterator = new TokenAwareIterator(keyspace, queryOptions, replicas, this.childPolicy);
+  const iterator = new TokenAwareIterator(keyspace, queryOptions, replicas, this.childPolicy);
   iterator.iterate(callback);
 };
 
@@ -317,8 +316,8 @@ function TokenAwareIterator(keyspace, queryOptions, replicas, childPolicy) {
   // Memoize the local replicas
   // The amount of local replicas should be defined before start iterating, in order to select an
   // appropriate (pseudo random) startIndex
-  for (var i = 0; i < replicas.length; i++) {
-    var host = replicas[i];
+  for (let i = 0; i < replicas.length; i++) {
+    const host = replicas[i];
     if (this.childPolicy.getDistance(host) !== types.distance.local) {
       continue;
     }
@@ -333,7 +332,7 @@ function TokenAwareIterator(keyspace, queryOptions, replicas, childPolicy) {
 
 TokenAwareIterator.prototype.iterate = function (callback) {
   //Load the child policy hosts
-  var self = this;
+  const self = this;
   this.childPolicy.newQueryPlan(this.keyspace, this.queryOptions, function (err, iterator) {
     if (err) {
       return callback(err);
@@ -347,13 +346,13 @@ TokenAwareIterator.prototype.iterate = function (callback) {
 };
 
 TokenAwareIterator.prototype.computeNext = function () {
-  var host;
+  let host;
   if (this.replicaIndex < this.localReplicas.length) {
     host = this.localReplicas[(this.startIndex + (this.replicaIndex++)) % this.localReplicas.length];
     return { value: host, done: false };
   }
   // Return hosts from child policy
-  var item;
+  let item;
   while ((item = this.childIterator.next()) && !item.done) {
     if (this.replicaMap[item.value.address]) {
       // Avoid yielding local replicas from the child load balancing policy query plan
@@ -400,7 +399,7 @@ function WhiteListPolicy (childPolicy, whiteList) {
     throw new Error("You must provide the white list of host addresses");
   }
   this.childPolicy = childPolicy;
-  var map = {};
+  const map = {};
   whiteList.forEach(function (address) {
     map[address] = true;
   });
@@ -438,7 +437,7 @@ WhiteListPolicy.prototype._contains = function (host) {
  * Returns the hosts to use for a new query filtered by the white list.
  */
 WhiteListPolicy.prototype.newQueryPlan = function (keyspace, queryOptions, callback) {
-  var self = this;
+  const self = this;
   this.childPolicy.newQueryPlan(keyspace, queryOptions, function (err, iterator) {
     if (err) {
       return callback(err);
@@ -448,10 +447,10 @@ WhiteListPolicy.prototype.newQueryPlan = function (keyspace, queryOptions, callb
 };
 
 WhiteListPolicy.prototype._filter = function (childIterator) {
-  var self = this;
+  const self = this;
   return {
     next: function () {
-      var item = childIterator.next();
+      const item = childIterator.next();
       if (!item.done && !self._contains(item.value)) {
         return this.next();
       }

--- a/lib/policies/load-balancing.js
+++ b/lib/policies/load-balancing.js
@@ -131,7 +131,7 @@ DCAwareRoundRobinPolicy.prototype.init = function (client, hosts, callback) {
   if (!this.localDc) {
     //get the first alive local, it should be local on top
     const hostsArray = hosts.values();
-    var dcHost;
+    let dcHost;
     for (let i = 0; i < hostsArray.length; i++) {
       const h = hostsArray[i];
       if (h.datacenter) {

--- a/lib/policies/reconnection.js
+++ b/lib/policies/reconnection.js
@@ -1,5 +1,5 @@
 'use strict';
-var util = require('util');
+const util = require('util');
 
 /** @module policies/reconnection */
 /**
@@ -34,7 +34,7 @@ util.inherits(ConstantReconnectionPolicy, ReconnectionPolicy);
  * @returns {{next: next}} An infinite iterator
  */
 ConstantReconnectionPolicy.prototype.newSchedule = function () {
-  var self = this;
+  const self = this;
   return {
     next: function () {
       return {value: self.delay, done: false};
@@ -63,12 +63,12 @@ util.inherits(ExponentialReconnectionPolicy, ReconnectionPolicy);
  * @returns {{next: next}} An infinite iterator
  */
 ExponentialReconnectionPolicy.prototype.newSchedule = function () {
-  var self = this;
-  var index = this.startWithNoDelay ? -1 : 0;
+  const self = this;
+  let index = this.startWithNoDelay ? -1 : 0;
   return {
     next: function () {
       index++;
-      var delay = 0;
+      let delay = 0;
       if (index > 64) {
         delay = self.maxDelay;
       }

--- a/lib/policies/retry.js
+++ b/lib/policies/retry.js
@@ -1,7 +1,7 @@
 "use strict";
-var util = require('util');
+const util = require('util');
 
-var errors = require('../errors');
+const errors = require('../errors');
 
 /** @module policies/retry */
 /**
@@ -13,7 +13,6 @@ function RetryPolicy() {
 
 }
 
-//noinspection JSUnusedLocalSymbols
 /**
  * Determines what to do when the driver gets an UnavailableException response from a Cassandra node.
  * @param {OperationInfo} info

--- a/lib/policies/speculative-execution.js
+++ b/lib/policies/speculative-execution.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var util = require('util');
-var errors = require('../errors');
+const util = require('util');
+const errors = require('../errors');
 
 /** @module policies/speculativeExecution */
 
@@ -94,8 +94,8 @@ function ConstantSpeculativeExecutionPolicy(delay, maxSpeculativeExecutions) {
 util.inherits(ConstantSpeculativeExecutionPolicy, SpeculativeExecutionPolicy);
 
 ConstantSpeculativeExecutionPolicy.prototype.newPlan = function () {
-  var executions = 0;
-  var self = this;
+  let executions = 0;
+  const self = this;
   return {
     nextExecution: function () {
       if (executions++ < self._maxSpeculativeExecutions) {

--- a/lib/policies/timestamp-generation.js
+++ b/lib/policies/timestamp-generation.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var util = require('util');
-var Long = require('../types').Long;
-var errors = require('../errors');
+const util = require('util');
+const Long = require('../types').Long;
+const errors = require('../errors');
 
 /** @module policies/timestampGeneration */
 
@@ -11,14 +11,14 @@ var errors = require('../errors');
  * @const
  * @private
  */
-var _maxSafeNumberDate = 9007199254740;
+const _maxSafeNumberDate = 9007199254740;
 
 /**
  * A long representing the value 1000
  * @const
  * @private
  */
-var _longOneThousand = Long.fromInt(1000);
+const _longOneThousand = Long.fromInt(1000);
 
 /**
  * Creates a new instance of {@link TimestampGenerator}.
@@ -95,8 +95,8 @@ MonotonicTimestampGenerator.prototype.getDate = function () {
 };
 
 MonotonicTimestampGenerator.prototype.next = function (client) {
-  var date = this.getDate();
-  var drifted = 0;
+  let date = this.getDate();
+  let drifted = 0;
   if (date > this._lastDate) {
     this._micros = 0;
     this._lastDate = date;
@@ -115,15 +115,15 @@ MonotonicTimestampGenerator.prototype.next = function (client) {
       drifted++;
     }
   }
-  var lastDate = this._lastDate;
+  const lastDate = this._lastDate;
   this._lastDate = date;
-  var result = this._generateMicroseconds();
+  const result = this._generateMicroseconds();
   if (drifted >= this._warningThreshold) {
     // Avoid logging an unbounded amount of times within a clock-skew event or during an interval when more than 1
     // query is being issued by microsecond
-    var currentLogDate = Date.now();
+    const currentLogDate = Date.now();
     if (this._minLogInterval > 0 && this._lastLogDate + this._minLogInterval <= currentLogDate){
-      var message = util.format(
+      const message = util.format(
         'Timestamp generated using current date was %d milliseconds behind the last generated timestamp (which ' +
         'millisecond portion was %d), the returned value (%s) is being artificially incremented to guarantee ' +
         'monotonicity.',

--- a/lib/prepare-handler.js
+++ b/lib/prepare-handler.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var util = require('util');
-var errors = require('./errors');
-var utils = require('./utils');
-var RequestHandler = require('./request-handler');
+const util = require('util');
+const errors = require('./errors');
+const utils = require('./utils');
+const RequestHandler = require('./request-handler');
 
 /**
  * Encapsulates the logic for dealing with the different prepare request and response flows, including failover when
@@ -27,7 +27,7 @@ function PrepareHandler(client, loadBalancing) {
  * @static
  */
 PrepareHandler.getPrepared = function (client, loadBalancing, query, keyspace, callback) {
-  var info = client.metadata.getPreparedInfo(keyspace, query);
+  const info = client.metadata.getPreparedInfo(keyspace, query);
   if (info.queryId) {
     return callback(null, info.queryId, info.meta);
   }
@@ -36,7 +36,7 @@ PrepareHandler.getPrepared = function (client, loadBalancing, query, keyspace, c
     // It's already being prepared
     return;
   }
-  var instance = new PrepareHandler(client, loadBalancing);
+  const instance = new PrepareHandler(client, loadBalancing);
   instance._prepare(info, query, keyspace);
 };
 
@@ -49,9 +49,9 @@ PrepareHandler.getPrepared = function (client, loadBalancing, query, keyspace, c
  * @static
  */
 PrepareHandler.getPreparedMultiple = function (client, loadBalancing, queries, keyspace, callback) {
-  var result = new Array(queries.length);
+  const result = new Array(queries.length);
   utils.forEachOf(queries, function eachQuery(item, index, next) {
-    var query;
+    let query;
     if (item) {
       query = typeof item === 'string' ? item : item.query;
     }
@@ -84,7 +84,7 @@ PrepareHandler.getPreparedMultiple = function (client, loadBalancing, queries, k
  */
 PrepareHandler.prototype._prepare = function (info, query, keyspace) {
   info.preparing = true;
-  var self = this;
+  const self = this;
   this._loadBalancing.newQueryPlan(keyspace, null, function (err, iterator) {
     if (err) {
       info.preparing = false;
@@ -104,7 +104,7 @@ PrepareHandler.prototype._prepare = function (info, query, keyspace) {
  */
 PrepareHandler.prototype._prepareWithQueryPlan = function (info, iterator, triedHosts, query, keyspace) {
   triedHosts = triedHosts || {};
-  var self = this;
+  const self = this;
   RequestHandler.borrowNextConnection(iterator, triedHosts, this._client.profileManager, keyspace,
     function borrowCallback(err, connection, host) {
       if (err) {
@@ -132,7 +132,7 @@ PrepareHandler.prototype._onPrepareSuccess = function (info, response) {
 
 PrepareHandler.prototype._onPrepareError = function (err, host, triedHosts, info, iterator, query, keyspace) {
   if (err.isSocketError || err instanceof errors.OperationTimedOutError) {
-    var self = this;
+    const self = this;
     triedHosts[host.address] = err;
     return self._prepareWithQueryPlan(info, iterator, triedHosts, query, keyspace);
   }
@@ -148,10 +148,10 @@ PrepareHandler.prototype._onPrepareError = function (err, host, triedHosts, info
  * @param {Function} callback
  */
 PrepareHandler.prepareAllQueries = function (host, allPrepared, callback) {
-  var anyKeyspaceQueries = [];
-  var queriesByKeyspace = {};
+  const anyKeyspaceQueries = [];
+  const queriesByKeyspace = {};
   allPrepared.forEach(function (info) {
-    var arr = anyKeyspaceQueries;
+    let arr = anyKeyspaceQueries;
     if (info.keyspace) {
       arr = queriesByKeyspace[info.keyspace] = (queriesByKeyspace[info.keyspace] || []);
     }
@@ -202,7 +202,7 @@ PrepareHandler.prototype.log = utils.log;
  * @private
  */
 PrepareHandler.prototype._prepareOnAllHosts = function (info, response, hostToAvoid, iterator, query, keyspace) {
-  var self = this;
+  const self = this;
   utils.each(utils.iteratorToArray(iterator), function (host, next) {
     if (host.address === hostToAvoid.address) {
       return next();

--- a/lib/readers.js
+++ b/lib/readers.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var util = require('util');
-var utils = require('./utils');
-var types = require('./types');
-var errors = require('./errors');
+const util = require('util');
+const utils = require('./utils');
+const types = require('./types');
+const errors = require('./errors');
 
 /**
  * Information on the formatting of the returned rows
  */
-var resultFlag = {
+const resultFlag = {
   globalTablesSpec:   0x0001,
   hasMorePages:       0x0002,
   noMetadata:         0x0004
@@ -65,11 +65,11 @@ FrameReader.prototype.unshift = function (bytes) {
  * @returns {Buffer}
  */
 FrameReader.prototype.read = function (length) {
-  var end = this.buf.length;
+  let end = this.buf.length;
   if (typeof length !== 'undefined' && this.offset + length < this.buf.length) {
     end = this.offset + length;
   }
-  var bytes = this.slice(this.offset, end);
+  const bytes = this.slice(this.offset, end);
   this.offset = end;
   return bytes;
 };
@@ -86,28 +86,28 @@ FrameReader.prototype.toEnd = function () {
  * @returns {Number}
  */
 FrameReader.prototype.readInt = function() {
-  var result = this.buf.readInt32BE(this.offset);
+  const result = this.buf.readInt32BE(this.offset);
   this.offset += 4;
   return result;
 };
 
 /** @returns {Number} */
 FrameReader.prototype.readShort = function () {
-  var result = this.buf.readUInt16BE(this.offset);
+  const result = this.buf.readUInt16BE(this.offset);
   this.offset += 2;
   return result;
 };
 
 FrameReader.prototype.readByte = function () {
-  var result = this.buf.readUInt8(this.offset);
+  const result = this.buf.readUInt8(this.offset);
   this.offset += 1;
   return result;
 };
 
 FrameReader.prototype.readString = function () {
-  var length = this.readShort();
+  const length = this.readShort();
   this.checkOffset(length);
-  var result = this.buf.toString('utf8', this.offset, this.offset+length);
+  const result = this.buf.toString('utf8', this.offset, this.offset+length);
   this.offset += length;
   return result;
 };
@@ -118,7 +118,7 @@ FrameReader.prototype.readString = function () {
  */
 FrameReader.prototype.checkOffset = function (newLength) {
   if (this.offset + newLength > this.buf.length) {
-    var err = new RangeError('Trying to access beyond buffer length');
+    const err = new RangeError('Trying to access beyond buffer length');
     err.expectedLength = newLength;
     throw err;
   }
@@ -129,9 +129,9 @@ FrameReader.prototype.checkOffset = function (newLength) {
  * @returns {Array}
  */
 FrameReader.prototype.readStringList = function () {
-  var length = this.readShort();
-  var list = new Array(length);
-  for (var i = 0; i < length; i++) {
+  const length = this.readShort();
+  const list = new Array(length);
+  for (let i = 0; i < length; i++) {
     list[i] = this.readString();
   }
   return list;
@@ -142,7 +142,7 @@ FrameReader.prototype.readStringList = function () {
  * @returns {Buffer}
  */
 FrameReader.prototype.readBytes = function () {
-  var length = this.readInt();
+  const length = this.readInt();
   if (length < 0) {
     return null;
   }
@@ -151,7 +151,7 @@ FrameReader.prototype.readBytes = function () {
 };
 
 FrameReader.prototype.readShortBytes = function () {
-  var length = this.readShort();
+  const length = this.readShort();
   if (length < 0) {
     return null;
   }
@@ -166,12 +166,12 @@ FrameReader.prototype.readShortBytes = function () {
 FrameReader.prototype.readBytesMap = function () {
   //A [short] n, followed by n pair <k><v> where <k> is a
   //[string] and <v> is a [bytes].
-  var length = this.readShort();
+  const length = this.readShort();
   if (length < 0) {
     return null;
   }
-  var map = {};
-  for (var i = 0; i < length; i++) {
+  const map = {};
+  for (let i = 0; i < length; i++) {
     map[this.readString()] = this.readBytes();
   }
   return map;
@@ -182,8 +182,8 @@ FrameReader.prototype.readBytesMap = function () {
  * @returns {{code: Number, info: Object|null}} An array of 2 elements
  */
 FrameReader.prototype.readType = function () {
-  var i;
-  var type = {
+  let i;
+  const type = {
     code: this.readShort(),
     type: null
   };
@@ -226,8 +226,8 @@ FrameReader.prototype.readType = function () {
  * @returns {{address: exports.InetAddress, port: Number}}
  */
 FrameReader.prototype.readInet = function () {
-  var length = this.readByte();
-  var address = this.read(length);
+  const length = this.readByte();
+  const address = this.read(length);
   return {address: new types.InetAddress(address), port: this.readInt()};
 };
 
@@ -240,7 +240,7 @@ FrameReader.prototype.readFlagsInfo = function () {
   if (this.header.flags === 0) {
     return utils.emptyObject;
   }
-  var result = {};
+  const result = {};
   if (this.header.flags & types.frameFlags.tracing) {
     this.checkOffset(16);
     result.traceId = new types.Uuid(utils.copyBuffer(this.read(16)));
@@ -261,14 +261,14 @@ FrameReader.prototype.readFlagsInfo = function () {
  * @throws {RangeError}
  */
 FrameReader.prototype.readMetadata = function (kind) {
-  var i;
+  let i;
   //Determines if its a prepared metadata
-  var isPrepared = (kind === types.resultKind.prepared);
-  var meta = {};
+  const isPrepared = (kind === types.resultKind.prepared);
+  const meta = {};
   //as used in Rows and Prepared responses
-  var flags = this.readInt();
+  const flags = this.readInt();
 
-  var columnLength = this.readInt();
+  const columnLength = this.readInt();
   if (types.protocolVersion.supportsPreparedPartitionKey(this.header.version) && isPrepared) {
     //read the pk columns
     meta.partitionKeys = new Array(this.readInt());
@@ -291,7 +291,7 @@ FrameReader.prototype.readMetadata = function (kind) {
     meta.columnsByName = {};
   }
   for (i = 0; i < columnLength; i++) {
-    var col = {};
+    const col = {};
     if(!meta.global_tables_spec) {
       col.ksname = this.readString();
       col.tablename = this.readString();
@@ -399,7 +399,7 @@ FrameReader.prototype.readError = function () {
  * @returns {{eventType: String, inet: {address: Buffer, port: Number}}, *}
  */
 FrameReader.prototype.readEvent = function () {
-  var eventType = this.readString();
+  const eventType = this.readString();
   switch (eventType) {
     case types.protocolEvents.topologyChange:
       return {
@@ -419,7 +419,7 @@ FrameReader.prototype.readEvent = function () {
 };
 
 FrameReader.prototype.parseSchemaChange = function () {
-  var result;
+  let result;
   if (!types.protocolVersion.supportsSchemaChangeFullMetadata(this.header.version)) {
     //v1/v2: 3 strings, the table value can be empty
     result = {

--- a/lib/readers.js
+++ b/lib/readers.js
@@ -318,7 +318,7 @@ const _readFailureMessage = 'Server failure during read query at consistency %s 
 /**
  * Reads the error from the frame
  * @throws {RangeError}
- * @returns {exports.ResponseError}
+ * @returns {ResponseError}
  */
 FrameReader.prototype.readError = function () {
   const code = this.readInt();
@@ -342,7 +342,7 @@ FrameReader.prototype.readError = function () {
       }
       err.isDataPresent = this.readByte();
       if (code === types.responseErrorCodes.readTimeout) {
-        var details;
+        let details;
         if (err.received < err.blockFor) {
           details = util.format('%d replica(s) responded over %d required', err.received, err.blockFor);
         } else if (!err.isDataPresent) {
@@ -367,7 +367,7 @@ FrameReader.prototype.readError = function () {
       err.writeType = this.readString();
 
       if (code === types.responseErrorCodes.writeTimeout) {
-        var template = err.writeType === 'BATCH_LOG' ? _writeTimeoutBatchLogMessage : _writeTimeoutQueryMessage;
+        const template = err.writeType === 'BATCH_LOG' ? _writeTimeoutBatchLogMessage : _writeTimeoutQueryMessage;
         err.message = util.format(template, types.consistencyToString[err.consistencies], err.received, err.blockFor);
       } else {
         err.message = util.format(_writeFailureMessage, types.consistencyToString[err.consistencies],

--- a/lib/request-execution.js
+++ b/lib/request-execution.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var util = require('util');
-var errors = require('./errors');
-var requests = require('./requests');
-var retry = require('./policies/retry');
-var types = require('./types');
-var utils = require('./utils');
+const util = require('util');
+const errors = require('./errors');
+const requests = require('./requests');
+const retry = require('./policies/retry');
+const types = require('./types');
+const utils = require('./utils');
 
-var retryOnNextHostDecision = Object.freeze({
+const retryOnNextHostDecision = Object.freeze({
   decision: retry.RetryPolicy.retryDecision.retry,
   useCurrentHost: false,
   consistency: undefined
@@ -36,7 +36,7 @@ function RequestExecution(parent) {
  * @param {Function} [getHostCallback] Callback to be invoked when a connection to a host was successfully acquired.
  */
 RequestExecution.prototype.start = function (getHostCallback) {
-  var self = this;
+  const self = this;
   getHostCallback = getHostCallback || utils.noop;
   this._parent.getNextConnection(function nextConnectionCallback(err, connection, host) {
     if (self._cancelled) {
@@ -57,7 +57,7 @@ RequestExecution.prototype.start = function (getHostCallback) {
 };
 
 RequestExecution.prototype._sendOnConnection = function () {
-  var self = this;
+  const self = this;
   this._operation =
     this._connection.sendStream(this._request, this._parent.requestOptions, function responseCb(err, response) {
       if (self._cancelled) {
@@ -67,7 +67,7 @@ RequestExecution.prototype._sendOnConnection = function () {
       if (err) {
         return self._handleError(err);
       }
-      var result = self._getResultSet(response);
+      const result = self._getResultSet(response);
       if (response.schemaChange) {
         return self._parent.client.handleSchemaAgreementAndRefresh(
           self._connection, response.schemaChange, function schemaCb(){
@@ -115,7 +115,7 @@ RequestExecution.prototype._handleError = function (err) {
   if (err.code === types.responseErrorCodes.unprepared && (err instanceof errors.ResponseError)) {
     return this._prepareAndRetry(err.queryId);
   }
-  var decisionInfo = this._getDecision(err);
+  const decisionInfo = this._getDecision(err);
   if (err.isSocketError) {
     this._host.removeFromPool(this._connection);
   }
@@ -138,7 +138,7 @@ RequestExecution.prototype._handleError = function (err) {
  * @returns {{decision, useCurrentHost, consistency}}
  */
 RequestExecution.prototype._getDecision = function (err) {
-  var operationInfo = {
+  const operationInfo = {
     query: this._request && this._request.query,
     options: this._parent.requestOptions,
     nbRetry: this._retryCount,
@@ -147,7 +147,7 @@ RequestExecution.prototype._getDecision = function (err) {
     request: this._request,
     retryOnTimeout: false
   };
-  var self = this;
+  const self = this;
   function onRequestError() {
     return self._parent.retryPolicy.onRequestError(operationInfo, self._request.consistency, err);
   }
@@ -218,7 +218,7 @@ RequestExecution.prototype._retry = function (consistency, useCurrentHost) {
 RequestExecution.prototype._prepareAndRetry = function (queryId) {
   this._parent.log('info', util.format('Query 0x%s not prepared on host %s, preparing and retrying',
     queryId.toString('hex'), this._host.address));
-  var info = this._parent.client.metadata.getPreparedById(queryId);
+  const info = this._parent.client.metadata.getPreparedById(queryId);
   if (!info) {
     return this._parent.setCompleted(
       new errors.DriverInternalError(util.format('Unprepared response invalid, id: %s', queryId.toString('hex'))));
@@ -228,7 +228,7 @@ RequestExecution.prototype._prepareAndRetry = function (queryId) {
       new Error(util.format('Query was prepared on keyspace %s, can\'t execute it on %s (%s)',
         info.keyspace, this._connection.keyspace, info.query)));
   }
-  var self = this;
+  const self = this;
   this._connection.prepareOnce(info.query, function (err) {
     if (err) {
       if (!err.isSocketError && err instanceof errors.OperationTimedOutError) {

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -1,10 +1,10 @@
 'use strict';
-var util = require('util');
+const util = require('util');
 
-var errors = require('./errors');
-var types = require('./types');
-var utils = require('./utils');
-var RequestExecution = require('./request-execution');
+const errors = require('./errors');
+const types = require('./types');
+const utils = require('./utils');
+const RequestExecution = require('./request-execution');
 
 /**
  * Handles a request to Cassandra, dealing with host fail-over and retries on error
@@ -45,7 +45,7 @@ function RequestHandler(request, options, client) {
  */
 RequestHandler.borrowNextConnection = function(iterator, triedHosts, profileManager, keyspace, callback) {
   triedHosts = triedHosts || {};
-  var host = getNextHost(iterator, profileManager, triedHosts);
+  const host = getNextHost(iterator, profileManager, triedHosts);
   if (host === null) {
     return callback(new errors.NoHostAvailableError(triedHosts));
   }
@@ -97,16 +97,16 @@ RequestHandler.borrowFromHost = function (host, keyspace, callback) {
  * @private
  */
 function getNextHost(iterator, profileManager, triedHosts) {
-  var host;
+  let host;
   // Get a host that is UP in a sync loop
   while (true) {
-    var item = iterator.next();
+    const item = iterator.next();
     if (item.done) {
       return null;
     }
     host = item.value;
     // set the distance relative to the client first
-    var distance = profileManager.getDistance(host);
+    const distance = profileManager.getDistance(host);
     if (distance === types.distance.ignored) {
       //If its marked as ignore by the load balancing policy, move on.
       continue;
@@ -138,7 +138,7 @@ RequestHandler.prototype.send = function (callback) {
   if (this.requestOptions.captureStackTrace) {
     Error.captureStackTrace(this.stackContainer = {});
   }
-  var self = this;
+  const self = this;
   this.loadBalancingPolicy.newQueryPlan(this.client.keyspace, this.requestOptions, function newPlanCb(err, iterator) {
     if (err) {
       return callback(err);
@@ -150,16 +150,16 @@ RequestHandler.prototype.send = function (callback) {
 };
 
 RequestHandler.prototype._startNewExecution = function () {
-  var execution = new RequestExecution(this);
+  const execution = new RequestExecution(this);
   this._executions.push(execution);
-  var self = this;
+  const self = this;
   execution.start(function hostAcquired(host) {
     // This function is called when a connection to a host was successfully acquired and
     // the execution was not yet cancelled
     if (!self.requestOptions.isIdempotent) {
       return;
     }
-    var delay = self._speculativeExecutionPlan.nextExecution(host);
+    const delay = self._speculativeExecutionPlan.nextExecution(host);
     if (typeof delay !== 'number' || delay < 0) {
       return;
     }
@@ -186,10 +186,10 @@ RequestHandler.prototype._startNewExecution = function () {
  * @param {Function} callback
  */
 RequestHandler.setKeyspace = function (client, callback) {
-  var connection;
-  var hosts = client.hosts.values();
-  for (var i = 0; i < hosts.length; i++) {
-    var host = hosts[i];
+  let connection;
+  const hosts = client.hosts.values();
+  for (let i = 0; i < hosts.length; i++) {
+    const host = hosts[i];
     connection = host.getActiveConnection();
     if (connection) {
       break;
@@ -210,7 +210,7 @@ RequestHandler.prototype.setCompleted = function (err, result) {
     clearTimeout(this._newExecutionTimeout);
   }
   // Mark all executions as cancelled
-  for (var i = 0; i < this._executions.length; i++) {
+  for (let i = 0; i < this._executions.length; i++) {
     this._executions[i].cancel();
   }
   if (err) {
@@ -239,7 +239,7 @@ RequestHandler.prototype.setCompleted = function (err, result) {
  */
 RequestHandler.prototype.handleNoHostAvailable = function (err, sender) {
   // Remove the execution
-  var index = this._executions.indexOf(sender);
+  const index = this._executions.indexOf(sender);
   this._executions.splice(index, 1);
   if (this._executions.length === 0) {
     // There aren't any other executions, we should report back to the user that there isn't

--- a/lib/requests.js
+++ b/lib/requests.js
@@ -1,15 +1,15 @@
 'use strict';
-var util = require('util');
+const util = require('util');
 
-var FrameWriter = require('./writers').FrameWriter;
-var types = require('./types');
-var utils = require('./utils');
+const FrameWriter = require('./writers').FrameWriter;
+const types = require('./types');
+const utils = require('./utils');
 
 /**
  * Options for the execution of the query / prepared statement
  * @private
  */
-var queryFlag = {
+const queryFlag = {
   values:                 0x01,
   skipMetadata:           0x02,
   pageSize:               0x04,
@@ -23,7 +23,7 @@ var queryFlag = {
  * Options for the executing of a batch request from protocol v3 and above
  * @private
  */
-var batchFlag = {
+const batchFlag = {
   withSerialConsistency:  0x10,
   withDefaultTimestamp:   0x20,
   withNameForValues:      0x40
@@ -53,10 +53,10 @@ Request.prototype.write = function (encoder, streamId) {
  * @return {Request}
  */
 Request.prototype.clone = function () {
-  var newRequest = new (this.constructor)();
-  var keysArray = Object.keys(this);
-  for (var i = 0; i < keysArray.length; i++) {
-    var key = keysArray[i];
+  const newRequest = new (this.constructor)();
+  const keysArray = Object.keys(this);
+  for (let i = 0; i < keysArray.length; i++) {
+    const key = keysArray[i];
     newRequest[key] = this[key];
   }
   return newRequest;
@@ -85,8 +85,8 @@ ExecuteRequest.prototype.write = function (encoder, streamId) {
   //      <consistency><flags>[<n><value_1>...<value_n>][<result_page_size>][<paging_state>][<serial_consistency>]
   //v3: <queryId>
   //      <consistency><flags>[<n>[name_1]<value_1>...[name_n]<value_n>][<result_page_size>][<paging_state>][<serial_consistency>][<timestamp>]
-  var frameWriter = new FrameWriter(types.opcodes.execute);
-  var headerFlags = this.options.traceQuery ? types.frameFlags.tracing : 0;
+  const frameWriter = new FrameWriter(types.opcodes.execute);
+  let headerFlags = this.options.traceQuery ? types.frameFlags.tracing : 0;
   if (this.options.customPayload) {
     //The body may contain the custom payload
     headerFlags |= types.frameFlags.customPayload;
@@ -106,7 +106,7 @@ ExecuteRequest.prototype.writeQueryParameters = function (frameWriter, encoder) 
   //v1: <n><value_1>....<value_n><consistency>
   //v2: <consistency><flags>[<n><value_1>...<value_n>][<result_page_size>][<paging_state>][<serial_consistency>]
   //v3: <consistency><flags>[<n>[name_1]<value_1>...[name_n]<value_n>][<result_page_size>][<paging_state>][<serial_consistency>][<timestamp>]
-  var flags = 0;
+  let flags = 0;
   if (types.protocolVersion.supportsPaging(encoder.protocolVersion)) {
     flags |= (this.params && this.params.length) ? queryFlag.values : 0;
     flags |= (this.options.fetchSize > 0) ? queryFlag.pageSize : 0;
@@ -119,8 +119,8 @@ ExecuteRequest.prototype.writeQueryParameters = function (frameWriter, encoder) 
   }
   if (this.params && this.params.length) {
     frameWriter.writeShort(this.params.length);
-    for (var i = 0; i < this.params.length; i++) {
-      var paramValue = this.params[i];
+    for (let i = 0; i < this.params.length; i++) {
+      let paramValue = this.params[i];
       if (flags & queryFlag.withNameForValues) {
         //parameter is composed by name / value
         frameWriter.writeString(paramValue.name);
@@ -147,7 +147,7 @@ ExecuteRequest.prototype.writeQueryParameters = function (frameWriter, encoder) 
     frameWriter.writeShort(this.options.serialConsistency);
   }
   if (flags & queryFlag.withDefaultTimestamp) {
-    var timestamp = this.options.timestamp;
+    let timestamp = this.options.timestamp;
     if (typeof timestamp === 'number') {
       timestamp = types.Long.fromNumber(timestamp);
     }
@@ -175,8 +175,8 @@ QueryRequest.prototype.write = function (encoder, streamId) {
   //      <consistency><flags>[<n><value_1>...<value_n>][<result_page_size>][<paging_state>][<serial_consistency>]
   //v3: <query>
   //      <consistency><flags>[<n>[name_1]<value_1>...[name_n]<value_n>][<result_page_size>][<paging_state>][<serial_consistency>][<timestamp>]
-  var frameWriter = new FrameWriter(types.opcodes.query);
-  var headerFlags = this.options.traceQuery ? types.frameFlags.tracing : 0;
+  const frameWriter = new FrameWriter(types.opcodes.query);
+  let headerFlags = this.options.traceQuery ? types.frameFlags.tracing : 0;
   if (this.options.customPayload) {
     //The body may contain the custom payload
     headerFlags |= types.frameFlags.customPayload;
@@ -200,7 +200,7 @@ function PrepareRequest(query) {
 util.inherits(PrepareRequest, Request);
 
 PrepareRequest.prototype.write = function (encoder, streamId) {
-  var frameWriter = new FrameWriter(types.opcodes.prepare);
+  const frameWriter = new FrameWriter(types.opcodes.prepare);
   frameWriter.writeLString(this.query);
   return frameWriter.write(encoder.protocolVersion, streamId);
 };
@@ -212,7 +212,7 @@ function StartupRequest(cqlVersion) {
 util.inherits(StartupRequest, Request);
 
 StartupRequest.prototype.write = function (encoder, streamId) {
-  var frameWriter = new FrameWriter(types.opcodes.startup);
+  const frameWriter = new FrameWriter(types.opcodes.startup);
   frameWriter.writeStringMap({
     CQL_VERSION: this.cqlVersion
   });
@@ -226,7 +226,7 @@ function RegisterRequest(events) {
 util.inherits(RegisterRequest, Request);
 
 RegisterRequest.prototype.write = function (encoder, streamId) {
-  var frameWriter = new FrameWriter(types.opcodes.register);
+  const frameWriter = new FrameWriter(types.opcodes.register);
   frameWriter.writeStringList(this.events);
   return frameWriter.write(encoder.protocolVersion, streamId);
 };
@@ -243,7 +243,7 @@ function AuthResponseRequest(token) {
 util.inherits(AuthResponseRequest, Request);
 
 AuthResponseRequest.prototype.write = function (encoder, streamId) {
-  var frameWriter = new FrameWriter(types.opcodes.authResponse);
+  const frameWriter = new FrameWriter(types.opcodes.authResponse);
   frameWriter.writeBytes(this.token);
   return frameWriter.write(encoder.protocolVersion, streamId);
 };
@@ -260,7 +260,7 @@ function CredentialsRequest(username, password) {
 util.inherits(CredentialsRequest, Request);
 
 CredentialsRequest.prototype.write = function (encoder, streamId) {
-  var frameWriter = new FrameWriter(types.opcodes.credentials);
+  const frameWriter = new FrameWriter(types.opcodes.credentials);
   frameWriter.writeStringMap({ username:this.username, password:this.password });
   return frameWriter.write(encoder.protocolVersion, streamId);
 };
@@ -288,8 +288,8 @@ BatchRequest.prototype.write = function (encoder, streamId) {
   if (!this.queries || !(this.queries.length > 0)) {
     throw new TypeError(util.format('Invalid queries provided %s', this.queries));
   }
-  var frameWriter = new FrameWriter(types.opcodes.batch);
-  var headerFlags = this.options.traceQuery ? types.frameFlags.tracing : 0;
+  const frameWriter = new FrameWriter(types.opcodes.batch);
+  let headerFlags = this.options.traceQuery ? types.frameFlags.tracing : 0;
   if (this.options.customPayload) {
     //The body may contain the custom payload
     headerFlags |= types.frameFlags.customPayload;
@@ -297,16 +297,16 @@ BatchRequest.prototype.write = function (encoder, streamId) {
   }
   frameWriter.writeByte(this.type);
   frameWriter.writeShort(this.queries.length);
-  var self = this;
+  const self = this;
   this.queries.forEach(function eachQuery(item, i) {
-    var hints = self.hints[i];
-    var params = item.params || utils.emptyArray;
+    let hints = self.hints[i];
+    let params = item.params || utils.emptyArray;
     if (item.queryId) {
       // Contains prepared queries
       frameWriter.writeByte(1);
       frameWriter.writeShortBytes(item.queryId);
       hints = item.meta.columns.map(function (c) { return c.type; });
-      var paramsInfo = utils.adaptNamedParamsPrepared(params, item.meta.columns);
+      const paramsInfo = utils.adaptNamedParamsPrepared(params, item.meta.columns);
       params = paramsInfo.params;
     }
     else {
@@ -322,14 +322,14 @@ BatchRequest.prototype.write = function (encoder, streamId) {
   frameWriter.writeShort(this.options.consistency);
   if (types.protocolVersion.supportsTimestamp(encoder.protocolVersion)) {
     //Batch flags
-    var flags = this.options.serialConsistency ? batchFlag.withSerialConsistency : 0;
+    let flags = this.options.serialConsistency ? batchFlag.withSerialConsistency : 0;
     flags |= this.options.timestamp ? batchFlag.withDefaultTimestamp : 0;
     frameWriter.writeByte(flags);
     if (this.options.serialConsistency) {
       frameWriter.writeShort(this.options.serialConsistency);
     }
     if (this.options.timestamp) {
-      var timestamp = this.options.timestamp;
+      let timestamp = this.options.timestamp;
       if (typeof timestamp === 'number') {
         timestamp = types.Long.fromNumber(timestamp);
       }

--- a/lib/stream-id-stack.js
+++ b/lib/stream-id-stack.js
@@ -1,37 +1,39 @@
 "use strict";
 
-var types = require('./types');
+const types = require('./types');
 
 /**
  * Group size
  * @type {number}
  */
-var groupSize = 128;
+const groupSize = 128;
 /**
  * Number used to right shift ids to allocate them into groups
  * @const
  * @type {number}
  */
-var shiftToGroup = 7;
+const shiftToGroup = 7;
+
 /**
  * Amount of groups that can be released per time
  * If it grows larger than 4 groups (128 * 4), groups can be released
  * @const
  * @type {number}
  */
-var releasableSize = 4;
+const releasableSize = 4;
 /**
  * 32K possible stream ids depending for protocol v3 and above
  * @const
  * @type {number}
  */
-var maxGroupsFor2Bytes = 256;
+const maxGroupsFor2Bytes = 256;
 /**
  * Delay used to check if groups can be released
  * @const
  * @type {number}
  */
-var releaseDelay = 5000;
+// eslint-disable-next-line prefer-const
+let releaseDelay = 5000;
 /**
  * Represents a queue of ids from 0 to maximum stream id supported by the protocol version.
  * Clients can dequeue a stream id using {@link StreamIdStack#shift()} and enqueue (release) using {@link StreamIdStack#push()}
@@ -68,7 +70,7 @@ StreamIdStack.prototype.setVersion = function (version) {
  * @returns {Number} Returns an id or null
  */
 StreamIdStack.prototype.pop = function () {
-  var id = this.currentGroup.pop();
+  let id = this.currentGroup.pop();
   if (typeof id !== 'undefined') {
     this.inUse++;
     return id;
@@ -93,8 +95,8 @@ StreamIdStack.prototype.pop = function () {
  */
 StreamIdStack.prototype.push = function (id) {
   this.inUse--;
-  var groupIndex = id >> shiftToGroup;
-  var group = this.groups[groupIndex];
+  const groupIndex = id >> shiftToGroup;
+  const group = this.groups[groupIndex];
   group.push(id);
   if (groupIndex < this.groupIndex) {
     //Set the lower group to be used to dequeue from
@@ -138,15 +140,15 @@ StreamIdStack.prototype._tryIssueRelease = function () {
     //Nothing to release or a release delay has been issued
     return;
   }
-  var self = this;
+  const self = this;
   this.releaseTimeout = setTimeout(function () {
     self._releaseGroups();
   }, releaseDelay);
 };
 
 StreamIdStack.prototype._releaseGroups = function () {
-  var counter = 0;
-  var index = this.groups.length - 1;
+  let counter = 0;
+  let index = this.groups.length - 1;
   //only release up to n groups (n = releasable size)
   //shrink back up to n groups not all the way up to 1
   while (counter++ < releasableSize && this.groups.length > releasableSize && index > this.groupIndex) {
@@ -163,9 +165,9 @@ StreamIdStack.prototype._releaseGroups = function () {
 };
 
 function generateGroup(initialValue) {
-  var arr = new Array(groupSize);
-  var upperBound = initialValue + groupSize - 1;
-  for (var i = 0; i < groupSize; i++) {
+  const arr = new Array(groupSize);
+  const upperBound = initialValue + groupSize - 1;
+  for (let i = 0; i < groupSize; i++) {
     arr[i] = upperBound - i;
   }
   return arr;

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -1,14 +1,14 @@
 'use strict';
-var util = require('util');
-var stream = require('stream');
-var Transform = stream.Transform;
-var Writable = stream.Writable;
+const util = require('util');
+const stream = require('stream');
+const Transform = stream.Transform;
+const Writable = stream.Writable;
 
-var types = require('./types');
-var utils = require('./utils');
-var errors = require('./errors');
-var FrameHeader = types.FrameHeader;
-var FrameReader = require('./readers').FrameReader;
+const types = require('./types');
+const utils = require('./utils');
+const errors = require('./errors');
+const FrameHeader = types.FrameHeader;
+const FrameReader = require('./readers').FrameReader;
 
 /**
  * Transforms chunks, emits data objects {header, chunk}
@@ -27,7 +27,7 @@ function Protocol (options) {
 util.inherits(Protocol, Transform);
 
 Protocol.prototype._transform = function (chunk, encoding, callback) {
-  var error = null;
+  let error = null;
   try {
     this.readItems(chunk);
   }
@@ -53,8 +53,8 @@ Protocol.prototype.readItems = function (chunk) {
     this.version = FrameHeader.getProtocolVersion(chunk);
     this.headerSize = FrameHeader.size(this.version);
   }
-  var offset = 0;
-  var currentHeader = this.header;
+  let offset = 0;
+  let currentHeader = this.header;
   this.header = null;
   if (this.headerChunks.byteLength !== 0) {
     //incomplete header was buffered try to read the header from the buffered chunks
@@ -67,7 +67,7 @@ Protocol.prototype.readItems = function (chunk) {
     offset = this.headerSize - this.headerChunks.byteLength;
     this.clearHeaderChunks();
   }
-  var items = [];
+  const items = [];
   while (true) {
     if (!currentHeader) {
       if (this.headerSize > chunk.length - offset) {
@@ -75,7 +75,7 @@ Protocol.prototype.readItems = function (chunk) {
           break;
         }
         //the header is incomplete, buffer it until the next chunk
-        var headerPart = chunk.slice(offset, chunk.length);
+        const headerPart = chunk.slice(offset, chunk.length);
         this.headerChunks.parts.push(headerPart);
         this.headerChunks.byteLength = headerPart.length;
         break;
@@ -85,7 +85,7 @@ Protocol.prototype.readItems = function (chunk) {
       offset += this.headerSize;
     }
     //parse body
-    var remaining = chunk.length - offset;
+    const remaining = chunk.length - offset;
     if (currentHeader.bodyLength <= remaining + this.bodyLength) {
       items.push({ header: currentHeader, chunk: chunk, offset: offset, frameEnded: true });
       offset += currentHeader.bodyLength - this.bodyLength;
@@ -105,7 +105,7 @@ Protocol.prototype.readItems = function (chunk) {
     }
     currentHeader = null;
   }
-  for (var i = 0; i < items.length; i++) {
+  for (let i = 0; i < items.length; i++) {
     this.push(items[i]);
   }
 };
@@ -130,9 +130,9 @@ function Parser (streamOptions, encoder) {
 util.inherits(Parser, Transform);
 
 Parser.prototype._transform = function (item, encoding, callback) {
-  var frameInfo = this.frameState(item);
+  const frameInfo = this.frameState(item);
 
-  var error = null;
+  let error = null;
   try {
     this.parseBody(frameInfo, item);
   }
@@ -166,10 +166,10 @@ Parser.prototype.parseBody = function (frameInfo, item) {
     // Frame isn't complete and we are not streaming the frame
     return;
   }
-  var reader = new FrameReader(item.header, item.chunk, item.offset);
+  const reader = new FrameReader(item.header, item.chunk, item.offset);
   // Check that flags have not been parsed yet for this frame
   if (frameInfo.flagsInfo === undefined) {
-    var originalOffset = reader.offset;
+    const originalOffset = reader.offset;
     try {
       frameInfo.flagsInfo = reader.readFlagsInfo();
     }
@@ -210,7 +210,7 @@ Parser.prototype.parseBody = function (frameInfo, item) {
 Parser.prototype.handleFrameBuffers = function (frameInfo, item) {
   if (!frameInfo.isStreaming) {
     // Handle buffering for complete frame bodies
-    var currentLength = (frameInfo.bufferLength || 0) + item.chunk.length - item.offset;
+    const currentLength = (frameInfo.bufferLength || 0) + item.chunk.length - item.offset;
     if (currentLength < item.header.bodyLength) {
       //buffer until the frame is completed
       this.addFrameBuffer(frameInfo, item);
@@ -274,7 +274,7 @@ Parser.prototype.addFrameBuffer = function (frameInfo, item) {
  */
 Parser.prototype.getFrameBuffer = function (frameInfo, item) {
   frameInfo.buffers.push(item.chunk);
-  var result = Buffer.concat(frameInfo.buffers, frameInfo.bodyLength);
+  const result = Buffer.concat(frameInfo.buffers, frameInfo.bodyLength);
   frameInfo.buffers = null;
   return result;
 };
@@ -285,11 +285,11 @@ Parser.prototype.getFrameBuffer = function (frameInfo, item) {
  * @param {FrameReader} reader
  */
 Parser.prototype.parseResult = function (frameInfo, reader) {
-  var result;
+  let result;
   // As we might be streaming and the frame buffer might not be complete,
   // read the metadata and different types of result values in a try-catch.
   // Store the reader position
-  var originalOffset = reader.offset;
+  const originalOffset = reader.offset;
   try {
     if (!frameInfo.meta) {
       frameInfo.kind = reader.readInt();
@@ -306,15 +306,16 @@ Parser.prototype.parseResult = function (frameInfo, reader) {
           result = { header: frameInfo.header, keyspaceSet: reader.readString(), flags: frameInfo.flagsInfo };
           break;
         case types.resultKind.prepared:
-          var preparedId = utils.copyBuffer(reader.readShortBytes());
+        {
+          const preparedId = utils.copyBuffer(reader.readShortBytes());
           frameInfo.meta = reader.readMetadata(frameInfo.kind);
           result = { header: frameInfo.header, id: preparedId, meta: frameInfo.meta, flags: frameInfo.flagsInfo };
           break;
+        }
         case types.resultKind.schemaChange:
           result = { header: frameInfo.header, schemaChange: reader.parseSchemaChange(), flags: frameInfo.flagsInfo };
           break;
         default:
-          //noinspection ExceptionCaughtLocallyJS
           throw errors.DriverInternalError('Unexpected result kind: ' + frameInfo.kind);
       }
     }
@@ -359,14 +360,14 @@ Parser.prototype.parseRows = function (frameInfo, reader) {
       result: { rows: utils.emptyArray, meta: frameInfo.meta, flags: frameInfo.flagsInfo }
     });
   }
-  var meta = frameInfo.meta;
+  const meta = frameInfo.meta;
   frameInfo.rowIndex = frameInfo.rowIndex || 0;
-  for (var i = frameInfo.rowIndex; i < frameInfo.rowLength; i++) {
-    var rowOffset = reader.offset;
-    var row = new types.Row(meta.columns);
-    var cellBuffer;
-    for (var j = 0; j < meta.columns.length; j++ ) {
-      var c = meta.columns[j];
+  for (let i = frameInfo.rowIndex; i < frameInfo.rowLength; i++) {
+    const rowOffset = reader.offset;
+    const row = new types.Row(meta.columns);
+    let cellBuffer;
+    for (let j = 0; j < meta.columns.length; j++ ) {
+      const c = meta.columns[j];
       try {
         cellBuffer = reader.readBytes();
       }
@@ -410,7 +411,7 @@ Parser.prototype.setOptions = function (id, options) {
  * In case the frame ended
  */
 Parser.prototype.frameState = function (item) {
-  var frameInfo = this.frames[item.header.streamId];
+  let frameInfo = this.frames[item.header.streamId];
   if (!frameInfo) {
     frameInfo = {};
     if (!item.frameEnded) {
@@ -457,7 +458,7 @@ Parser.prototype.bufferResultCell = function (frameInfo, reader, originalOffset,
     originalOffset = reader.offset;
   }
   frameInfo.rowIndex = rowIndex;
-  var buffer = reader.slice(originalOffset);
+  const buffer = reader.slice(originalOffset);
   frameInfo.cellBuffer = {
     parts: [ buffer ],
     byteLength: buffer.length,
@@ -479,7 +480,7 @@ function ResultEmitter(options) {
 util.inherits(ResultEmitter, Writable);
 
 ResultEmitter.prototype._write = function (item, encoding, callback) {
-  var error = null;
+  let error = null;
   try {
     this.each(item);
   }
@@ -523,7 +524,7 @@ ResultEmitter.prototype.each = function (item) {
  * Buffers the rows until the result set is completed and emits the result event.
  */
 ResultEmitter.prototype.bufferAndEmit = function (item) {
-  var rows = this.rowBuffer[item.header.streamId];
+  let rows = this.rowBuffer[item.header.streamId];
   if (!rows) {
     rows = this.rowBuffer[item.header.streamId] = [];
   }

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -1,23 +1,23 @@
 'use strict';
 
-var util = require('util');
-var types = require('./types');
-var utils = require('./utils');
-var MutableLong = require('./types/mutable-long');
-var Integer = types.Integer;
+const util = require('util');
+const types = require('./types');
+const utils = require('./utils');
+const MutableLong = require('./types/mutable-long');
+const Integer = types.Integer;
 
 // Murmur3 constants
 //-0x783C846EEEBDAC2B
-var mconst1 = new MutableLong(0x53d5, 0x1142, 0x7b91, 0x87c3);
+const mconst1 = new MutableLong(0x53d5, 0x1142, 0x7b91, 0x87c3);
 //0x4cf5ad432745937f
-var mconst2 = new MutableLong(0x937f, 0x2745, 0xad43, 0x4cf5);
-var mlongFive = MutableLong.fromNumber(5);
+const mconst2 = new MutableLong(0x937f, 0x2745, 0xad43, 0x4cf5);
+const mlongFive = MutableLong.fromNumber(5);
 //0xff51afd7ed558ccd
-var mconst3 = new MutableLong(0x8ccd, 0xed55, 0xafd7, 0xff51);
+const mconst3 = new MutableLong(0x8ccd, 0xed55, 0xafd7, 0xff51);
 //0xc4ceb9fe1a85ec53
-var mconst4 = new MutableLong(0xec53, 0x1a85, 0xb9fe, 0xc4ce);
-var mconst5 = MutableLong.fromNumber(0x52dce729);
-var mconst6 = MutableLong.fromNumber(0x38495ab5);
+const mconst4 = new MutableLong(0xec53, 0x1a85, 0xb9fe, 0xc4ce);
+const mconst5 = MutableLong.fromNumber(0x52dce729);
+const mconst6 = MutableLong.fromNumber(0x38495ab5);
 
 /**
  * Represents a set of methods that are able to generate and parse tokens for the C* partitioner
@@ -27,7 +27,6 @@ function Tokenizer() {
 
 }
 
-//noinspection JSUnusedLocalSymbols
 /**
  * Creates a token based on the Buffer value provided
  * @param {Buffer|Array} value
@@ -36,7 +35,6 @@ Tokenizer.prototype.hash = function (value) {
   throw new Error('You must implement a hash function for the tokenizer');
 };
 
-//noinspection JSUnusedLocalSymbols
 /**
  * Parses a token string and returns a representation of the token
  * @param {String} value
@@ -80,18 +78,18 @@ Murmur3Tokenizer.prototype.hash = function hash(value) {
   // for M3P. Compared to that methods, there's a few inlining of arguments and we
   // only return the first 64-bits of the result since that's all M3 partitioner uses.
 
-  var data = value;
-  var offset = 0;
-  var length = data.length;
+  const data = value;
+  let offset = 0;
+  const length = data.length;
 
-  var nblocks = length >> 4; // Process as 128-bit blocks.
+  const nblocks = length >> 4; // Process as 128-bit blocks.
 
-  var h1 = new MutableLong();
-  var h2 = new MutableLong();
-  var k1 = new MutableLong();
-  var k2 = new MutableLong();
+  const h1 = new MutableLong();
+  const h2 = new MutableLong();
+  let k1 = new MutableLong();
+  let k2 = new MutableLong();
 
-  for (var i = 0; i < nblocks; i++) {
+  for (let i = 0; i < nblocks; i++) {
     k1 = this.getBlock(data, offset, i * 2);
     k2 = this.getBlock(data, offset, i * 2 + 1);
 
@@ -198,8 +196,8 @@ function fromSignedByte(value) {
  * @return {MutableLong}
  */
 Murmur3Tokenizer.prototype.getBlock = function (key, offset, index) {
-  var i8 = index << 3;
-  var blockOffset = offset + i8;
+  const i8 = index << 3;
+  const blockOffset = offset + i8;
   return new MutableLong(
     (key[blockOffset]) | (key[blockOffset + 1] << 8),
     (key[blockOffset + 2]) | (key[blockOffset + 3] << 8),
@@ -213,7 +211,7 @@ Murmur3Tokenizer.prototype.getBlock = function (key, offset, index) {
  * @param {Number} n
  */
 Murmur3Tokenizer.prototype.rotl64 = function (v, n) {
-  var left = v.clone().shiftLeft(n);
+  const left = v.clone().shiftLeft(n);
   v.shiftRightUnsigned(64 - n).or(left);
 };
 
@@ -221,7 +219,7 @@ Murmur3Tokenizer.prototype.rotl64 = function (v, n) {
 Murmur3Tokenizer.prototype.fmix = function (k) {
   k.xor(new MutableLong(k.getUint16(2) >>> 1 | ((k.getUint16(3) << 15) & 0xffff), k.getUint16(3) >>> 1, 0, 0));
   k.multiply(mconst3);
-  var other = new MutableLong(
+  const other = new MutableLong(
     (k.getUint16(2) >>> 1) | ((k.getUint16(3) << 15) & 0xffff),
     k.getUint16(3) >>> 1,
     0,
@@ -279,7 +277,7 @@ RandomTokenizer.prototype.hash = function (value) {
   if (util.isArray(value)) {
     value = utils.allocBufferFromArray(value);
   }
-  var hashedValue = this._crypto.createHash('md5').update(value).digest();
+  const hashedValue = this._crypto.createHash('md5').update(value).digest();
   return Integer.fromBuffer(hashedValue).abs();
 };
 

--- a/lib/types/big-decimal.js
+++ b/lib/types/big-decimal.js
@@ -1,6 +1,6 @@
 'use strict';
-var Integer = require('./integer');
-var utils = require('../utils');
+const Integer = require('./integer');
+const utils = require('../utils');
 
 /** @module types */
 /**
@@ -43,8 +43,8 @@ function BigDecimal(unscaledValue, scale) {
  * @returns {BigDecimal}
  */
 BigDecimal.fromBuffer = function (buf) {
-  var scale = buf.readInt32BE(0);
-  var unscaledValue = Integer.fromBuffer(buf.slice(4));
+  const scale = buf.readInt32BE(0);
+  const unscaledValue = Integer.fromBuffer(buf.slice(4));
   return new BigDecimal(unscaledValue, scale);
 };
 
@@ -54,8 +54,8 @@ BigDecimal.fromBuffer = function (buf) {
  * @returns {Buffer}
  */
 BigDecimal.toBuffer = function (value) {
-  var unscaledValueBuffer = Integer.toBuffer(value._intVal);
-  var scaleBuffer = utils.allocBufferUnsafe(4);
+  const unscaledValueBuffer = Integer.toBuffer(value._intVal);
+  const scaleBuffer = utils.allocBufferUnsafe(4);
   scaleBuffer.writeInt32BE(value._scale, 0);
   return Buffer.concat([scaleBuffer, unscaledValueBuffer], scaleBuffer.length + unscaledValueBuffer.length);
 };
@@ -70,8 +70,8 @@ BigDecimal.fromString = function (value) {
     throw new TypeError('Invalid null or undefined value');
   }
   value = value.trim();
-  var scaleIndex = value.indexOf('.');
-  var scale = 0;
+  const scaleIndex = value.indexOf('.');
+  let scale = 0;
   if (scaleIndex >= 0) {
     scale = value.length - 1 - scaleIndex;
     value = value.substr(0, scaleIndex) + value.substr(scaleIndex + 1);
@@ -88,7 +88,7 @@ BigDecimal.fromNumber = function (value) {
   if (isNaN(value)) {
     return new BigDecimal(Integer.ZERO, 0);
   }
-  var textValue = value.toString();
+  let textValue = value.toString();
   if (textValue.indexOf('e') >= 0) {
     //get until scale 20
     textValue = value.toFixed(20);
@@ -124,7 +124,7 @@ BigDecimal.prototype.notEquals = function (other) {
  *     if the given one is greater.
  */
 BigDecimal.prototype.compare = function (other) {
-  var diff = this.subtract(other);
+  const diff = this.subtract(other);
   if (diff.isNegative()) {
     return -1;
   }
@@ -140,12 +140,12 @@ BigDecimal.prototype.compare = function (other) {
  * @return {!BigDecimal} The BigDecimal result.
  */
 BigDecimal.prototype.subtract = function (other) {
-  var first = this;
+  const first = this;
   if (first._scale === other._scale) {
     return new BigDecimal(first._intVal.subtract(other._intVal), first._scale);
   }
-  var diffScale;
-  var unscaledValue;
+  let diffScale;
+  let unscaledValue;
   if (first._scale < other._scale) {
     //The scale of this is lower
     diffScale = other._scale - first._scale;
@@ -170,12 +170,12 @@ BigDecimal.prototype.subtract = function (other) {
  * @return {!BigDecimal} The BigDecimal result.
  */
 BigDecimal.prototype.add = function (other) {
-  var first = this;
+  const first = this;
   if (first._scale === other._scale) {
     return new BigDecimal(first._intVal.add(other._intVal), first._scale);
   }
-  var diffScale;
-  var unscaledValue;
+  let diffScale;
+  let unscaledValue;
   if (first._scale < other._scale) {
     //The scale of this is lower
     diffScale = other._scale - first._scale;
@@ -218,16 +218,16 @@ BigDecimal.prototype.isZero = function () {
  * @returns {string}
  */
 BigDecimal.prototype.toString = function () {
-  var intString = this._intVal.toString();
+  let intString = this._intVal.toString();
   if (this._scale === 0) {
     return intString;
   }
-  var signSymbol = '';
+  let signSymbol = '';
   if (intString.charAt(0) === '-') {
     signSymbol = '-';
     intString = intString.substr(1);
   }
-  var separatorIndex = intString.length - this._scale;
+  let separatorIndex = intString.length - this._scale;
   if (separatorIndex <= 0) {
     //add zeros at the beginning, plus an additional zero
     intString = utils.stringRepeat('0', (-separatorIndex) + 1) + intString;

--- a/lib/types/duration.js
+++ b/lib/types/duration.js
@@ -1,30 +1,30 @@
 'use strict';
-var Long = require('long');
-var util = require('util');
-var utils = require('../utils');
+const Long = require('long');
+const util = require('util');
+const utils = require('../utils');
 
 /** @module types */
 
 // Reuse the same buffers that should perform slightly better than built-in buffer pool
-var reusableBuffers = {
+const reusableBuffers = {
   months: utils.allocBuffer(9),
   days: utils.allocBuffer(9),
   nanoseconds: utils.allocBuffer(9)
 };
 
-var maxInt32 = 0x7FFFFFFF;
-var longOneThousand = Long.fromInt(1000);
-var nanosPerMicro = longOneThousand;
-var nanosPerMilli = longOneThousand.multiply(nanosPerMicro);
-var nanosPerSecond = longOneThousand.multiply(nanosPerMilli);
-var nanosPerMinute = Long.fromInt(60).multiply(nanosPerSecond);
-var nanosPerHour = Long.fromInt(60).multiply(nanosPerMinute);
-var daysPerWeek = 7;
-var monthsPerYear = 12;
-var standardRegex = /(\d+)(y|mo|w|d|h|s|ms|us|µs|ns|m)/gi;
-var iso8601Regex = /P((\d+)Y)?((\d+)M)?((\d+)D)?(T((\d+)H)?((\d+)M)?((\d+)S)?)?/;
-var iso8601WeekRegex = /P(\d+)W/;
-var iso8601AlternateRegex = /P(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/;
+const maxInt32 = 0x7FFFFFFF;
+const longOneThousand = Long.fromInt(1000);
+const nanosPerMicro = longOneThousand;
+const nanosPerMilli = longOneThousand.multiply(nanosPerMicro);
+const nanosPerSecond = longOneThousand.multiply(nanosPerMilli);
+const nanosPerMinute = Long.fromInt(60).multiply(nanosPerSecond);
+const nanosPerHour = Long.fromInt(60).multiply(nanosPerMinute);
+const daysPerWeek = 7;
+const monthsPerYear = 12;
+const standardRegex = /(\d+)(y|mo|w|d|h|s|ms|us|µs|ns|m)/gi;
+const iso8601Regex = /P((\d+)Y)?((\d+)M)?((\d+)D)?(T((\d+)H)?((\d+)M)?((\d+)S)?)?/;
+const iso8601WeekRegex = /P(\d+)W/;
+const iso8601AlternateRegex = /P(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/;
 
 /**
  * Creates a new instance of {@link Duration}.
@@ -68,12 +68,12 @@ Duration.prototype.equals = function (other) {
  * @returns {Buffer}
  */
 Duration.prototype.toBuffer = function () {
-  var lengthMonths = VIntCoding.writeVInt(Long.fromNumber(this.months), reusableBuffers.months);
-  var lengthDays = VIntCoding.writeVInt(Long.fromNumber(this.days), reusableBuffers.days);
-  var lengthNanoseconds = VIntCoding.writeVInt(this.nanoseconds, reusableBuffers.nanoseconds);
-  var buffer = utils.allocBufferUnsafe(lengthMonths + lengthDays + lengthNanoseconds);
+  const lengthMonths = VIntCoding.writeVInt(Long.fromNumber(this.months), reusableBuffers.months);
+  const lengthDays = VIntCoding.writeVInt(Long.fromNumber(this.days), reusableBuffers.days);
+  const lengthNanoseconds = VIntCoding.writeVInt(this.nanoseconds, reusableBuffers.nanoseconds);
+  const buffer = utils.allocBufferUnsafe(lengthMonths + lengthDays + lengthNanoseconds);
   reusableBuffers.months.copy(buffer, 0, 0, lengthMonths);
-  var offset = lengthMonths;
+  let offset = lengthMonths;
   reusableBuffers.days.copy(buffer, offset, 0, lengthDays);
   offset += lengthDays;
   reusableBuffers.nanoseconds.copy(buffer, offset, 0, lengthNanoseconds);
@@ -85,7 +85,7 @@ Duration.prototype.toBuffer = function () {
  * @return {string}
  */
 Duration.prototype.toString = function () {
-  var value = '';
+  let value = '';
   function append(dividend, divisor, unit) {
     if (dividend === 0 || dividend < divisor) {
       return dividend;
@@ -105,12 +105,12 @@ Duration.prototype.toString = function () {
   if (this.months < 0 || this.days < 0 || this.nanoseconds.isNegative()) {
     value = '-';
   }
-  var remainder = append(Math.abs(this.months), monthsPerYear, "y");
+  let remainder = append(Math.abs(this.months), monthsPerYear, "y");
   append(remainder, 1, "mo");
   append(Math.abs(this.days), 1, "d");
 
   if (!this.nanoseconds.equals(Long.ZERO)) {
-    var nanos = this.nanoseconds.isNegative() ? this.nanoseconds.negate() : this.nanoseconds;
+    const nanos = this.nanoseconds.isNegative() ? this.nanoseconds.negate() : this.nanoseconds;
     remainder = append64(nanos, nanosPerHour, "h");
     remainder = append64(remainder, nanosPerMinute, "m");
     remainder = append64(remainder, nanosPerSecond, "s");
@@ -127,10 +127,10 @@ Duration.prototype.toString = function () {
  * @returns {Duration}
  */
 Duration.fromBuffer = function (buffer) {
-  var offset = { value: 0 };
-  var months = VIntCoding.readVInt(buffer, offset).toNumber();
-  var days = VIntCoding.readVInt(buffer, offset).toNumber();
-  var nanoseconds = VIntCoding.readVInt(buffer, offset);
+  const offset = { value: 0 };
+  const months = VIntCoding.readVInt(buffer, offset).toNumber();
+  const days = VIntCoding.readVInt(buffer, offset).toNumber();
+  const nanoseconds = VIntCoding.readVInt(buffer, offset);
   return new Duration(months, days, nanoseconds);
 };
 
@@ -161,8 +161,8 @@ Duration.fromBuffer = function (buffer) {
  * @returns {Duration}
  */
 Duration.fromString = function (input) {
-  var isNegative = input.charAt(0) === '-';
-  var source = isNegative ? input.substr(1) : input;
+  const isNegative = input.charAt(0) === '-';
+  const source = isNegative ? input.substr(1) : input;
   if (source.charAt(0) === 'P') {
     if (source.charAt(source.length - 1) === 'W') {
       return parseIso8601WeekFormat(isNegative, source);
@@ -182,9 +182,9 @@ Duration.fromString = function (input) {
  * @private
  */
 function parseStandardFormat(isNegative, source) {
-  var builder = new Builder(isNegative);
+  const builder = new Builder(isNegative);
   standardRegex.lastIndex = 0;
-  var matches;
+  let matches;
   while ((matches = standardRegex.exec(source)) && matches.length <= 3) {
     builder.add(matches[1], matches[2]);
   }
@@ -198,11 +198,11 @@ function parseStandardFormat(isNegative, source) {
  * @private
  */
 function parseIso8601Format(isNegative, source) {
-  var matches = iso8601Regex.exec(source);
+  const matches = iso8601Regex.exec(source);
   if (!matches || matches[0] !== source) {
     throw new TypeError(util.format("Unable to convert '%s' to a duration", source));
   }
-  var builder = new Builder(isNegative);
+  const builder = new Builder(isNegative);
   if (matches[1]) {
     builder.addYears(matches[2]);
   }
@@ -233,7 +233,7 @@ function parseIso8601Format(isNegative, source) {
  * @private
  */
 function parseIso8601WeekFormat(isNegative, source) {
-  var matches = iso8601WeekRegex.exec(source);
+  const matches = iso8601WeekRegex.exec(source);
   if (!matches || matches[0] !== source) {
     throw new TypeError(util.format("Unable to convert '%s' to a duration", source));
   }
@@ -249,7 +249,7 @@ function parseIso8601WeekFormat(isNegative, source) {
  * @private
  */
 function parseIso8601AlternativeFormat(isNegative, source) {
-  var matches = iso8601AlternateRegex.exec(source);
+  const matches = iso8601AlternateRegex.exec(source);
   if (!matches || matches[0] !== source) {
     throw new TypeError(util.format("Unable to convert '%s' to a duration", source));
   }
@@ -357,7 +357,7 @@ Builder.prototype._validate64 = function(units, limit, unitName) {
 };
 
 Builder.prototype._getUnitName = function(unitIndex) {
-  var name = this._unitByIndex[+unitIndex];
+  const name = this._unitByIndex[+unitIndex];
   if (!name) {
     throw new Error('unknown unit index: ' + unitIndex);
   }
@@ -365,7 +365,7 @@ Builder.prototype._getUnitName = function(unitIndex) {
 };
 
 Builder.prototype.add = function (textValue, symbol) {
-  var addMethod = this._addMethods[symbol.toLowerCase()];
+  const addMethod = this._addMethods[symbol.toLowerCase()];
   if (!addMethod) {
     throw new TypeError(util.format("Unknown duration symbol '%s'", symbol));
   }
@@ -377,7 +377,7 @@ Builder.prototype.add = function (textValue, symbol) {
  * @return {Builder}
  */
 Builder.prototype.addYears = function (years) {
-  var value = +years;
+  const value = +years;
   this._validateOrder(1);
   this._validateMonths(value, monthsPerYear);
   this._months += value * monthsPerYear;
@@ -389,7 +389,7 @@ Builder.prototype.addYears = function (years) {
  * @return {Builder}
  */
 Builder.prototype.addMonths = function(months) {
-  var value = +months;
+  const value = +months;
   this._validateOrder(2);
   this._validateMonths(value, 1);
   this._months += value;
@@ -401,7 +401,7 @@ Builder.prototype.addMonths = function(months) {
  * @return {Builder}
  */
 Builder.prototype.addWeeks = function(weeks) {
-  var value = +weeks;
+  const value = +weeks;
   this._validateOrder(3);
   this._validateDays(value, daysPerWeek);
   this._days += value * daysPerWeek;
@@ -413,7 +413,7 @@ Builder.prototype.addWeeks = function(weeks) {
  * @return {Builder}
  */
 Builder.prototype.addDays = function(days) {
-  var value = +days;
+  const value = +days;
   this._validateOrder(4);
   this._validateDays(value, 1);
   this._days += value;
@@ -425,7 +425,7 @@ Builder.prototype.addDays = function(days) {
  * @return {Builder}
  */
 Builder.prototype.addHours = function(hours) {
-  var value = typeof hours === 'string' ? Long.fromString(hours) : hours;
+  const value = typeof hours === 'string' ? Long.fromString(hours) : hours;
   this._validateOrder(5);
   this._validateNanos(value, nanosPerHour);
   this._nanoseconds = this._nanoseconds.add(value.multiply(nanosPerHour));
@@ -437,7 +437,7 @@ Builder.prototype.addHours = function(hours) {
  * @return {Builder}
  */
 Builder.prototype.addMinutes = function(minutes) {
-  var value = typeof minutes === 'string' ? Long.fromString(minutes) : minutes;
+  const value = typeof minutes === 'string' ? Long.fromString(minutes) : minutes;
   this._validateOrder(6);
   this._validateNanos(value, nanosPerMinute);
   this._nanoseconds = this._nanoseconds.add(value.multiply(nanosPerMinute));
@@ -449,7 +449,7 @@ Builder.prototype.addMinutes = function(minutes) {
  * @return {Builder}
  */
 Builder.prototype.addSeconds = function(seconds) {
-  var value = typeof seconds === 'string' ? Long.fromString(seconds) : seconds;
+  const value = typeof seconds === 'string' ? Long.fromString(seconds) : seconds;
   this._validateOrder(7);
   this._validateNanos(value, nanosPerSecond);
   this._nanoseconds = this._nanoseconds.add(value.multiply(nanosPerSecond));
@@ -461,7 +461,7 @@ Builder.prototype.addSeconds = function(seconds) {
  * @return {Builder}
  */
 Builder.prototype.addMillis = function(millis) {
-  var value = typeof millis === 'string' ? Long.fromString(millis) : millis;
+  const value = typeof millis === 'string' ? Long.fromString(millis) : millis;
   this._validateOrder(8);
   this._validateNanos(value, nanosPerMilli);
   this._nanoseconds = this._nanoseconds.add(value.multiply(nanosPerMilli));
@@ -473,7 +473,7 @@ Builder.prototype.addMillis = function(millis) {
  * @return {Builder}
  */
 Builder.prototype.addMicros = function(micros) {
-  var value = typeof micros === 'string' ? Long.fromString(micros) : micros;
+  const value = typeof micros === 'string' ? Long.fromString(micros) : micros;
   this._validateOrder(9);
   this._validateNanos(value, nanosPerMicro);
   this._nanoseconds = this._nanoseconds.add(value.multiply(nanosPerMicro));
@@ -485,7 +485,7 @@ Builder.prototype.addMicros = function(micros) {
  * @return {Builder}
  */
 Builder.prototype.addNanos = function(nanos) {
-  var value = typeof nanos === 'string' ? Long.fromString(nanos) : nanos;
+  const value = typeof nanos === 'string' ? Long.fromString(nanos) : nanos;
   this._validateOrder(10);
   this._validateNanos(value, Long.ONE);
   this._nanoseconds = this._nanoseconds.add(value);
@@ -504,7 +504,7 @@ Builder.prototype.build = function () {
  * Exposes only 2 internal methods, the rest are hidden.
  * @private
  */
-var VIntCoding = (function () {
+const VIntCoding = (function () {
   /** @param {Long} n */
   function encodeZigZag64(n) {
     //     (n << 1) ^ (n >> 63);
@@ -532,7 +532,7 @@ var VIntCoding = (function () {
    * @returns {number}
    */
   function writeUnsignedVInt(value, buffer) {
-    var size = computeUnsignedVIntSize(value);
+    const size = computeUnsignedVIntSize(value);
     if (size === 1) {
       buffer[0] = value.getLowBits();
       return 1;
@@ -546,7 +546,7 @@ var VIntCoding = (function () {
    * @returns {number}
    */
   function computeUnsignedVIntSize(value) {
-    var magnitude = numberOfLeadingZeros(value.or(Long.ONE));
+    const magnitude = numberOfLeadingZeros(value.or(Long.ONE));
     return (639 - magnitude * 9) >> 6;
   }
 
@@ -556,10 +556,10 @@ var VIntCoding = (function () {
    * @param {Buffer} buffer
    */
   function encodeVInt(value, size, buffer) {
-    var extraBytes = size - 1;
-    var intValue = value.getLowBits();
-    var i;
-    var intBytes = 4;
+    const extraBytes = size - 1;
+    let intValue = value.getLowBits();
+    let i;
+    let intBytes = 4;
     for (i = extraBytes; i >= 0 && (intBytes--) > 0; i--) {
       buffer[i] = 0xFF & intValue;
       intValue >>= 8;
@@ -580,8 +580,8 @@ var VIntCoding = (function () {
     if (value.equals(Long.ZERO)) {
       return 64;
     }
-    var n = 1;
-    var x = value.getHighBits();
+    let n = 1;
+    let x = value.getHighBits();
     if (x === 0) {
       n += 32;
       x = value.getLowBits();
@@ -626,15 +626,15 @@ var VIntCoding = (function () {
    * @returns {Long}
    */
   function readUnsignedVInt(input, offset) {
-    var firstByte = input[offset.value++];
+    const firstByte = input[offset.value++];
     if ((firstByte & 0x80) === 0) {
       return Long.fromInt(firstByte);
     }
-    var sByteInt = fromSignedByteToInt(firstByte);
-    var size = numberOfExtraBytesToRead(sByteInt);
-    var result = Long.fromInt(sByteInt & firstByteValueMask(size));
-    for (var ii = 0; ii < size; ii++) {
-      var b = Long.fromInt(input[offset.value++]);
+    const sByteInt = fromSignedByteToInt(firstByte);
+    const size = numberOfExtraBytesToRead(sByteInt);
+    let result = Long.fromInt(sByteInt & firstByteValueMask(size));
+    for (let ii = 0; ii < size; ii++) {
+      const b = Long.fromInt(input[offset.value++]);
       //       (result << 8) | b
       result = result.shiftLeft(8).or(b);
     }
@@ -652,7 +652,7 @@ var VIntCoding = (function () {
     if (i === 0) {
       return 32;
     }
-    var n = 1;
+    let n = 1;
     if (i >>> 16 === 0) {
       n += 16;
       i <<= 16;

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -1,18 +1,18 @@
 'use strict';
-var util = require('util');
+const util = require('util');
 
-var errors = require('../errors');
-var TimeUuid = require('./time-uuid');
-var Uuid = require('./uuid');
-var protocolVersion = require('./protocol-version');
-var utils = require('../utils');
+const errors = require('../errors');
+const TimeUuid = require('./time-uuid');
+const Uuid = require('./uuid');
+const protocolVersion = require('./protocol-version');
+const utils = require('../utils');
 
 /** @module types */
 /**
  * Long constructor, wrapper of the internal library used: {@link https://github.com/dcodeIO/long.js Long.js}.
  * @constructor
  */
-var Long = require('long');
+const Long = require('long');
 
 
 /**
@@ -30,7 +30,7 @@ var Long = require('long');
  * @property {Number} localSerial Same as serial but confined to the data center. A write must be written conditionally to the commit log and memtable on a quorum of replica nodes in the same data center.
  * @property {Number} localOne Similar to One but only within the DC the coordinator is in.
  */
-var consistencies = {
+const consistencies = {
   any:          0x00,
   one:          0x01,
   two:          0x02,
@@ -91,7 +91,7 @@ consistencyToString[consistencies.localOne] = 'LOCAL_ONE';
  * @property {Number} udt User-defined type.
  * @property {Number} tuple A sequence of values.
  */
-var dataTypes = {
+const dataTypes = {
   custom:     0x0000,
   ascii:      0x0001,
   bigint:     0x0002,
@@ -126,20 +126,20 @@ var dataTypes = {
   getByName:  function(name) {
     name = name.toLowerCase();
     if (name.indexOf('<') > 0) {
-      var listMatches = /^(list|set)<(.+)>$/.exec(name);
+      const listMatches = /^(list|set)<(.+)>$/.exec(name);
       if (listMatches) {
         return { code: this[listMatches[1]], info: this.getByName(listMatches[2])};
       }
-      var mapMatches = /^(map)< *(.+) *, *(.+)>$/.exec(name);
+      const mapMatches = /^(map)< *(.+) *, *(.+)>$/.exec(name);
       if (mapMatches) {
         return { code: this[mapMatches[1]], info: [this.getByName(mapMatches[2]), this.getByName(mapMatches[3])]};
       }
-      var udtMatches = /^(udt)<(.+)>$/.exec(name);
+      const udtMatches = /^(udt)<(.+)>$/.exec(name);
       if (udtMatches) {
         //udt name as raw string
         return { code: this[udtMatches[1]], info: udtMatches[2]};
       }
-      var tupleMatches = /^(tuple)<(.+)>$/.exec(name);
+      const tupleMatches = /^(tuple)<(.+)>$/.exec(name);
       if (tupleMatches) {
         //tuple info as an array of types
         return { code: this[tupleMatches[1]], info: tupleMatches[2].split(',').map(function (x) {
@@ -147,7 +147,7 @@ var dataTypes = {
         }, this)};
       }
     }
-    var typeInfo = { code: this[name], info: null};
+    const typeInfo = { code: this[name], info: null};
     if (typeof typeInfo.code !== 'number') {
       throw new TypeError('Data type with name ' + name + ' not valid');
     }
@@ -160,13 +160,13 @@ var dataTypes = {
  * @internal
  * @private
  */
-var _dataTypesByCode = (function () {
-  var result = {};
-  for (var key in dataTypes) {
+const _dataTypesByCode = (function () {
+  const result = {};
+  for (const key in dataTypes) {
     if (!dataTypes.hasOwnProperty(key)) {
       continue;
     }
-    var val = dataTypes[key];
+    const val = dataTypes[key];
     if (typeof val !== 'number') {
       continue;
     }
@@ -182,7 +182,7 @@ var _dataTypesByCode = (function () {
  * @property {Number} remote A remote node.
  * @property {Number} ignored A node that is meant to be ignored.
  */
-var distance = {
+const distance = {
   local:    0,
   remote:   1,
   ignored:  2
@@ -193,7 +193,7 @@ var distance = {
  * @internal
  * @ignore
  */
-var opcodes = {
+const opcodes = {
   error:          0x00,
   startup:        0x01,
   ready:          0x02,
@@ -226,7 +226,7 @@ var opcodes = {
  * @internal
  * @ignore
  */
-var protocolEvents = {
+const protocolEvents = {
   topologyChange: 'TOPOLOGY_CHANGE',
   statusChange: 'STATUS_CHANGE',
   schemaChange: 'SCHEMA_CHANGE'
@@ -235,7 +235,7 @@ var protocolEvents = {
 /**
  * Server error codes returned by Cassandra
  */
-var responseErrorCodes = {
+const responseErrorCodes = {
   serverError:            0x0000,
   protocolError:          0x000A,
   badCredentials:         0x0100,
@@ -261,7 +261,7 @@ var responseErrorCodes = {
  * @internal
  * @ignore
  */
-var resultKind = {
+const resultKind = {
   voidResult:      0x0001,
   rows:            0x0002,
   setKeyspace:     0x0003,
@@ -274,7 +274,7 @@ var resultKind = {
  * @internal
  * @ignore
  */
-var frameFlags = {
+const frameFlags = {
   compression:    0x01,
   tracing:        0x02,
   customPayload:  0x04,
@@ -287,20 +287,20 @@ var frameFlags = {
  *   Use this field if you want to set a parameter to <code>unset</code>. Valid for Cassandra 2.2 and above.
  * </p>
  */
-var unset = Object.freeze({'unset': true});
+const unset = Object.freeze({'unset': true});
 
 /**
  * A long representing the value 1000
  * @const
  * @private
  */
-var _longOneThousand = Long.fromInt(1000);
+const _longOneThousand = Long.fromInt(1000);
 
 /**
  * Counter used to generate up to 1000 different timestamp values with the same Date
  * @private
  */
-var _timestampTicks = 0;
+let _timestampTicks = 0;
 
 /**
  * <p><strong>Backward compatibility only, use [TimeUuid]{@link module:types~TimeUuid} instead</strong>.</p>
@@ -311,10 +311,10 @@ var _timestampTicks = 0;
  * @deprecated Use [TimeUuid]{@link module:types~TimeUuid} instead
  */
 function timeuuid(options, buffer, offset) {
-  var date;
-  var ticks;
-  var nodeId;
-  var clockId;
+  let date;
+  let ticks;
+  let nodeId;
+  let clockId;
   if (options) {
     if (typeof options.msecs === 'number') {
       date = new Date(options.msecs);
@@ -333,7 +333,7 @@ function timeuuid(options, buffer, offset) {
       ticks = options.nsecs;
     }
   }
-  var uuid = new TimeUuid(date, ticks, nodeId, clockId);
+  const uuid = new TimeUuid(date, ticks, nodeId, clockId);
   if (buffer instanceof Buffer) {
     //copy the values into the buffer
     uuid.getBuffer().copy(buffer, offset || 0);
@@ -348,7 +348,7 @@ function timeuuid(options, buffer, offset) {
  * @deprecated Use [Uuid]{@link module:types~Uuid} class instead
  */
 function uuid(options, buffer, offset) {
-  var uuid;
+  let uuid;
   if (options) {
     if (util.isArray(options.random)) {
       uuid = new Uuid(utils.allocBufferFromArray(options.random));
@@ -375,7 +375,7 @@ function getDataTypeNameByCode(item) {
   if (!item || typeof item.code !== 'number') {
     throw new errors.ArgumentError('Invalid signature type definition');
   }
-  var typeName = _dataTypesByCode[item.code];
+  const typeName = _dataTypesByCode[item.code];
   if (!typeName) {
     throw new errors.ArgumentError(util.format('Type with code %d not found', item.code));
   }
@@ -442,12 +442,12 @@ FrameHeader.getProtocolVersion = function (buffer) {
  * @returns {FrameHeader}
  */
 FrameHeader.fromBuffer = function (buf, offset) {
-  var streamId = 0;
+  let streamId = 0;
   if (!offset) {
     offset = 0;
   }
-  var version = buf[offset++] & 0x7F;
-  var flags = buf.readUInt8(offset++);
+  const version = buf[offset++] & 0x7F;
+  const flags = buf.readUInt8(offset++);
   if (!protocolVersion.uses2BytesStreamIds(version)) {
     streamId = buf.readInt8(offset++);
   }
@@ -460,10 +460,10 @@ FrameHeader.fromBuffer = function (buf, offset) {
 
 /** @returns {Buffer} */
 FrameHeader.prototype.toBuffer = function () {
-  var buf = utils.allocBufferUnsafe(FrameHeader.size(this.version));
+  const buf = utils.allocBufferUnsafe(FrameHeader.size(this.version));
   buf.writeUInt8(this.version, 0);
   buf.writeUInt8(this.flags, 1);
-  var offset = 3;
+  let offset = 3;
   if (!protocolVersion.uses2BytesStreamIds(this.version)) {
     buf.writeInt8(this.streamId, 2);
   }
@@ -494,13 +494,12 @@ Long.toBuffer = function (value) {
   if (!(value instanceof Long)) {
     throw new TypeError('Expected Long, obtained ' + util.inspect(value));
   }
-  var buffer = utils.allocBufferUnsafe(8);
+  const buffer = utils.allocBufferUnsafe(8);
   buffer.writeUInt32BE(value.getHighBitsUnsigned(), 0);
   buffer.writeUInt32BE(value.getLowBitsUnsigned(), 4);
   return buffer;
 };
 
-//noinspection JSUnresolvedVariable
 /**
  * Provide the name of the constructor and the string representation
  * @returns {string}
@@ -509,7 +508,6 @@ Long.prototype.inspect = function () {
   return 'Long: ' + this.toString();
 };
 
-//noinspection JSUnresolvedVariable
 /**
  * Returns the string representation.
  * Method used by the native JSON.stringify() to serialize this instance
@@ -528,8 +526,7 @@ function generateTimestamp(date, microseconds) {
   if (!date) {
     date = new Date();
   }
-  //noinspection JSUnresolvedVariable
-  var longMicro = Long.ZERO;
+  let longMicro = Long.ZERO;
   if (typeof microseconds === 'number' && microseconds >= 0 && microseconds < 1000) {
     longMicro = Long.fromInt(microseconds);
   }

--- a/lib/types/inet-address.js
+++ b/lib/types/inet-address.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var utils = require('../utils');
+const utils = require('../utils');
 
 /** @module types */
 /**
@@ -39,9 +39,9 @@ InetAddress.fromString = function (value) {
   if (!value) {
     return new InetAddress(utils.allocBufferFromArray([0, 0, 0, 0]));
   }
-  var ipv4Pattern = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
-  var ipv6Pattern = /^[\da-f:.]+$/i;
-  var parts;
+  const ipv4Pattern = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
+  const ipv6Pattern = /^[\da-f:.]+$/i;
+  let parts;
   if (ipv4Pattern.test(value)) {
     parts = value.split('.');
     return new InetAddress(utils.allocBufferFromArray(parts));
@@ -53,11 +53,11 @@ InetAddress.fromString = function (value) {
   if (parts.length < 3) {
     throw new TypeError('Value could not be parsed as InetAddress: ' + value);
   }
-  var buffer = utils.allocBufferUnsafe(16);
-  var filling = 8 - parts.length + 1;
-  var applied = false;
-  var offset = 0;
-  var embeddedIp4 = ipv4Pattern.test(parts[parts.length - 1]);
+  const buffer = utils.allocBufferUnsafe(16);
+  let filling = 8 - parts.length + 1;
+  let applied = false;
+  let offset = 0;
+  const embeddedIp4 = ipv4Pattern.test(parts[parts.length - 1]);
   if (embeddedIp4) {
     // Its IPv6 address with an embedded IPv4 address:
     // subtract 1 from the potential empty filling as ip4 contains 4 bytes instead of 2 of a ipv6 section
@@ -66,8 +66,8 @@ InetAddress.fromString = function (value) {
   function writeItem(uIntValue) {
     buffer.writeUInt8(+uIntValue, offset++);
   }
-  for (var i = 0; i < parts.length; i++) {
-    var item = parts[i];
+  for (let i = 0; i < parts.length; i++) {
+    const item = parts[i];
     if (item) {
       if (embeddedIp4 && i === parts.length - 1) {
         item.split('.').forEach(writeItem);
@@ -83,7 +83,7 @@ InetAddress.fromString = function (value) {
       filling = 1;
     }
     applied = true;
-    for (var j = 0; j < filling; j++) {
+    for (let j = 0; j < filling; j++) {
       buffer[offset++] = 0;
       buffer[offset++] = 0;
     }
@@ -148,12 +148,12 @@ InetAddress.prototype.toString = function (encoding) {
       this.buffer[3]
     );
   }
-  var start = -1;
-  var longest = { length: 0, start: -1};
+  let start = -1;
+  const longest = { length: 0, start: -1};
   function checkLongest (i) {
     if (start >= 0) {
       //close the group
-      var length = i - start;
+      const length = i - start;
       if (length > longest.length) {
         longest.length = length;
         longest.start = start;
@@ -162,7 +162,7 @@ InetAddress.prototype.toString = function (encoding) {
     }
   }
   //get the longest 16-bit group of zeros
-  for (var i = 0; i < this.buffer.length; i = i + 2) {
+  for (let i = 0; i < this.buffer.length; i = i + 2) {
     if (this.buffer[i] === 0 && this.buffer[i + 1] === 0) {
       //its a group of zeros
       if (start < 0) {
@@ -179,8 +179,8 @@ InetAddress.prototype.toString = function (encoding) {
     checkLongest(i);
   }
 
-  var address = '';
-  for (var h = 0; h < this.buffer.length; h = h + 2) {
+  let address = '';
+  for (let h = 0; h < this.buffer.length; h = h + 2) {
     if (h === longest.start) {
       address += ':';
       continue;
@@ -219,7 +219,7 @@ function isValidIPv4Mapped(buffer) {
   // +----------------+----+-------------
   // |0000........0000|FFFF| IPv4 address
 
-  for (var i = 0; i < buffer.length - 6; i++) {
+  for (let i = 0; i < buffer.length - 6; i++) {
     if (buffer[i] !== 0) {
       return false;
     }

--- a/lib/types/local-date.js
+++ b/lib/types/local-date.js
@@ -1,18 +1,18 @@
 "use strict";
-var util = require('util');
+const util = require('util');
 
-var utils = require('../utils');
+const utils = require('../utils');
 /** @module types */
 
 /**
  * @private
  * @const
  */
-var millisecondsPerDay = 86400000;
+const millisecondsPerDay = 86400000;
 /**
  * @private
  */
-var dateCenter = Math.pow(2,31);
+const dateCenter = Math.pow(2,31);
 /**
  *
  * Creates a new instance of LocalDate.
@@ -40,9 +40,8 @@ var dateCenter = Math.pow(2,31);
 function LocalDate(year, month, day) {
   //implementation detail: internally uses a UTC based date
   if (typeof year === 'number' && typeof month === 'number' && typeof day === 'number') {
-    //Use setUTCFullYear as if there is a 2 digit year, Date.UTC() assumes
-    //that is the 20th century.  Thanks ECMAScript!
-    //noinspection JSValidateTypes
+    // Use setUTCFullYear as if there is a 2 digit year, Date.UTC() assumes
+    // that is the 20th century.
     this.date = new Date();
     this.date.setUTCHours(0, 0, 0, 0);
     this.date.setUTCFullYear(year, month-1, day);
@@ -57,7 +56,6 @@ function LocalDate(year, month, day) {
       if(year < -2147483648 || year > 2147483647) {
         throw new Error('You must provide a valid value for days since epoch (-2147483648 <= value <= 2147483647).');
       }
-      //noinspection JSValidateTypes
       this.date = new Date(year * millisecondsPerDay);
     }
   }
@@ -68,10 +66,10 @@ function LocalDate(year, month, day) {
 
   //If date cannot be represented yet given a valid days since epoch, track
   //it internally.
-  var value = isNaN(this.date.getTime()) ? year : null;
+  const value = isNaN(this.date.getTime()) ? year : null;
   Object.defineProperty(this, '_value', { enumerable: false, value: value });
 
-  var self = this;
+  const self = this;
 
   /**
    * A number representing the year.  May return NaN if cannot be represented as
@@ -111,7 +109,6 @@ function LocalDate(year, month, day) {
  * Creates a new instance of LocalDate using the current year, month and day from the system clock in the default time-zone.
  */
 LocalDate.now = function () {
-  //noinspection JSCheckFunctionSignatures
   return LocalDate.fromDate(new Date());
 };
 
@@ -119,7 +116,6 @@ LocalDate.now = function () {
  * Creates a new instance of LocalDate using the current date from the system clock at UTC.
  */
 LocalDate.utcNow = function () {
-  //noinspection JSCheckFunctionSignatures
   return new LocalDate(Date.now());
 };
 
@@ -141,14 +137,14 @@ LocalDate.fromDate = function (date) {
  * @param {String} value
  */
 LocalDate.fromString = function (value) {
-  var dashCount = (value.match(/-/g) || []).length;
+  const dashCount = (value.match(/-/g) || []).length;
   if(dashCount >= 2) {
-    var multiplier = 1;
+    let multiplier = 1;
     if (value[0] === '-') {
       value = value.substring(1);
       multiplier = -1;
     }
-    var parts = value.split('-');
+    const parts = value.split('-');
     return new LocalDate(multiplier * parseInt(parts[0], 10), parseInt(parts[1], 10), parseInt(parts[2], 10));
   }
   if(value.match(/^-?\d+$/)) {
@@ -164,7 +160,6 @@ LocalDate.fromString = function (value) {
  */
 LocalDate.fromBuffer = function (buffer) {
   //move to unix epoch: 0.
-  //noinspection JSCheckFunctionSignatures
   return new LocalDate((buffer.readUInt32BE(0) - dateCenter));
 };
 
@@ -175,9 +170,9 @@ LocalDate.fromBuffer = function (buffer) {
  * if the given one is greater.
  */
 LocalDate.prototype.compare = function (other) {
-  var thisValue = isNaN(this.date.getTime()) ? this._value * millisecondsPerDay : this.date.getTime();
-  var otherValue = isNaN(other.date.getTime()) ? other._value * millisecondsPerDay : other.date.getTime();
-  var diff = thisValue - otherValue;
+  const thisValue = isNaN(this.date.getTime()) ? this._value * millisecondsPerDay : this.date.getTime();
+  const otherValue = isNaN(other.date.getTime()) ? other._value * millisecondsPerDay : other.date.getTime();
+  const diff = thisValue - otherValue;
   if (diff < 0) {
     return -1;
   }
@@ -206,9 +201,9 @@ LocalDate.prototype.inspect = function () {
  */
 LocalDate.prototype.toBuffer = function () {
   //days since unix epoch
-  var daysSinceEpoch = isNaN(this.date.getTime()) ? this._value : Math.floor(this.date.getTime() / millisecondsPerDay);
-  var value = daysSinceEpoch + dateCenter;
-  var buf = utils.allocBufferUnsafe(4);
+  const daysSinceEpoch = isNaN(this.date.getTime()) ? this._value : Math.floor(this.date.getTime() / millisecondsPerDay);
+  const value = daysSinceEpoch + dateCenter;
+  const buf = utils.allocBufferUnsafe(4);
   buf.writeUInt32BE(value, 0);
   return buf;
 };
@@ -219,14 +214,14 @@ LocalDate.prototype.toBuffer = function () {
  * @returns {String}
  */
 LocalDate.prototype.toString = function () {
-  var result;
+  let result;
   //if cannot be parsed as date, return days since epoch representation.
   if (isNaN(this.date.getTime())) {
     return this._value.toString();
   }
-  var year = this.date.getUTCFullYear();
-  var month = this.date.getUTCMonth() + 1;
-  var day = this.date.getUTCDate();
+  const year = this.date.getUTCFullYear();
+  const month = this.date.getUTCMonth() + 1;
+  const day = this.date.getUTCDate();
   if (year < 0) {
     result = '-' + fillZeros((year * -1).toString(), 4);
   }

--- a/lib/types/local-time.js
+++ b/lib/types/local-time.js
@@ -1,32 +1,32 @@
 "use strict";
-var Long = require('long');
-var util = require('util');
-var utils = require('../utils');
+const Long = require('long');
+const util = require('util');
+const utils = require('../utils');
 /** @module types */
 
 /**
  * @const
  * @private
  * */
-var maxNanos = Long.fromString('86399999999999');
+const maxNanos = Long.fromString('86399999999999');
 /**
  * Nanoseconds in a second
  * @const
  * @private
  * */
-var nanoSecInSec = Long.fromNumber(1000000000);
+const nanoSecInSec = Long.fromNumber(1000000000);
 /**
  * Nanoseconds in a millisecond
  * @const
  * @private
  * */
-var nanoSecInMillis = Long.fromNumber(1000000);
+const nanoSecInMillis = Long.fromNumber(1000000);
 /**
  * Milliseconds in day
  * @const
  * @private
  * */
-var millisInDay = 86400000;
+const millisInDay = 86400000;
 /**
  *
  * Creates a new instance of LocalTime.
@@ -46,7 +46,7 @@ function LocalTime(totalNanoseconds) {
     throw new Error('Total nanoseconds out of range');
   }
   this.value = totalNanoseconds;
-  var self = this;
+  const self = this;
   /**
    * Gets the hour component of the time represented by the current instance, a number from 0 to 23.
    * @name hour
@@ -96,11 +96,11 @@ LocalTime.fromString = function (value) {
   if (typeof value !== 'string') {
     throw new Error('Argument type invalid: ' + util.inspect(value));
   }
-  var parts = value.split(':');
-  var millis = parseInt(parts[0], 10) * 3600000 + parseInt(parts[1], 10) * 60000;
-  var nanos;
+  const parts = value.split(':');
+  let millis = parseInt(parts[0], 10) * 3600000 + parseInt(parts[1], 10) * 60000;
+  let nanos;
   if (parts.length === 3) {
-    var secParts = parts[2].split('.');
+    const secParts = parts[2].split('.');
     millis += parseInt(secParts[0], 10) * 1000;
     if (secParts.length === 2) {
       nanos = secParts[1];
@@ -130,10 +130,8 @@ LocalTime.fromDate = function (date, nanoseconds) {
   if (!util.isDate(date)) {
     throw new Error('Not a valid date');
   }
-  //Use the local representation
-  var millis = date.getTime() + date.getTimezoneOffset() * -60000;
-  //Only the milliseconds part
-  millis = millis % millisInDay;
+  //Use the local representation, only the milliseconds portion
+  const millis = (date.getTime() + date.getTimezoneOffset() * -60000) % millisInDay;
   return LocalTime.fromMilliseconds(millis, nanoseconds);
 };
 
@@ -201,7 +199,7 @@ LocalTime.prototype.inspect = function () {
  * @returns {Buffer}
  */
 LocalTime.prototype.toBuffer = function () {
-  var buffer = utils.allocBufferUnsafe(8);
+  const buffer = utils.allocBufferUnsafe(8);
   buffer.writeUInt32BE(this.value.getHighBitsUnsigned(), 0);
   buffer.writeUInt32BE(this.value.getLowBitsUnsigned(), 4);
   return buffer;
@@ -230,8 +228,8 @@ LocalTime.prototype.toJSON = function () {
 LocalTime.prototype._getParts = function () {
   if (!this._partsCache) {
     //hours, minutes, seconds and nanos
-    var parts = [0, 0, 0, 0];
-    var secs = this.value.div(nanoSecInSec);
+    const parts = [0, 0, 0, 0];
+    const secs = this.value.div(nanoSecInSec);
     //faster modulo
     //total nanos
     parts[3] = this.value.subtract(secs.multiply(nanoSecInSec)).toNumber();
@@ -257,7 +255,7 @@ LocalTime.prototype._getParts = function () {
  * @private
  */
 function formatTime(values) {
-  var result;
+  let result;
   if (values[0] < 10) {
     result = '0' + values[0] + ':';
   }
@@ -277,13 +275,13 @@ function formatTime(values) {
     result += values[2];
   }
   if (values[3] > 0) {
-    var nanos = values[3].toString();
+    let nanos = values[3].toString();
     //nine digits
     if (nanos.length < 9) {
       nanos = utils.stringRepeat('0', 9 - nanos.length) + nanos;
     }
-    var lastPosition;
-    for (var i = nanos.length - 1; i > 0; i--) {
+    let lastPosition;
+    for (let i = nanos.length - 1; i > 0; i--) {
       if (nanos[i] !== '0') {
         break;
       }

--- a/lib/types/mutable-long.js
+++ b/lib/types/mutable-long.js
@@ -1,10 +1,10 @@
 "use strict";
 
-var Long = require('long');
+const Long = require('long');
 
-var TWO_PWR_16_DBL = 1 << 16;
-var TWO_PWR_32_DBL = TWO_PWR_16_DBL * TWO_PWR_16_DBL;
-var one = new MutableLong(1, 0, 0, 0);
+const TWO_PWR_16_DBL = 1 << 16;
+const TWO_PWR_32_DBL = TWO_PWR_16_DBL * TWO_PWR_16_DBL;
+const one = new MutableLong(1, 0, 0, 0);
 
 /**
  * Constructs a signed int64 representation.
@@ -23,8 +23,8 @@ MutableLong.fromNumber = function fromNumber(value) {
   if (value < 0) {
     return MutableLong.fromNumber(-value).negate();
   }
-  var low32Bits = value % TWO_PWR_32_DBL;
-  var high32Bits = value / TWO_PWR_32_DBL;
+  const low32Bits = value % TWO_PWR_32_DBL;
+  const high32Bits = value / TWO_PWR_32_DBL;
   return MutableLong.fromBits(low32Bits, high32Bits);
 };
 
@@ -53,7 +53,7 @@ MutableLong.fromString = function fromString(str, radix) {
     throw Error('radix out of range: ' + radix);
   }
 
-  var p;
+  let p;
   if ((p = str.indexOf('-')) > 0) {
     throw Error('number format error: interior "-" character: ' + str);
   }
@@ -62,14 +62,14 @@ MutableLong.fromString = function fromString(str, radix) {
   }
 
   // Do several (8) digits each time through the loop
-  var radixToPower = MutableLong.fromNumber(Math.pow(radix, 8));
+  const radixToPower = MutableLong.fromNumber(Math.pow(radix, 8));
 
-  var result = new MutableLong();
-  for (var i = 0; i < str.length; i += 8) {
-    var size = Math.min(8, str.length - i);
-    var value = parseInt(str.substring(i, i + size), radix);
+  const result = new MutableLong();
+  for (let i = 0; i < str.length; i += 8) {
+    const size = Math.min(8, str.length - i);
+    const value = parseInt(str.substring(i, i + size), radix);
     if (size < 8) {
-      var power = MutableLong.fromNumber(Math.pow(radix, size));
+      const power = MutableLong.fromNumber(Math.pow(radix, size));
       result.multiply(power).add(MutableLong.fromNumber(value));
       break;
     }
@@ -85,8 +85,8 @@ MutableLong.fromString = function fromString(str, radix) {
  * @return {number}
  */
 MutableLong.prototype.compare = function (other) {
-  var thisNeg = this.isNegative();
-  var otherNeg = other.isNegative();
+  const thisNeg = this.isNegative();
+  const otherNeg = other.isNegative();
   if (thisNeg && !otherNeg) {
     return -1;
   }
@@ -98,7 +98,7 @@ MutableLong.prototype.compare = function (other) {
 };
 
 MutableLong.prototype._compareBits = function(other) {
-  for (var i = 3; i >= 0; i--) {
+  for (let i = 3; i >= 0; i--) {
     if (this._arr[i] > other._arr[i]) {
       return 1;
     }
@@ -138,7 +138,7 @@ MutableLong.prototype.not = function () {
 };
 
 MutableLong.prototype.add = function (addend) {
-  var c48 = 0, c32 = 0, c16 = 0, c00 = 0;
+  let c48 = 0, c32 = 0, c16 = 0, c00 = 0;
   c00 += this._arr[0] + addend._arr[0];
   this._arr[0] = c00 & 0xffff;
 
@@ -163,8 +163,8 @@ MutableLong.prototype.shiftLeft = function (numBits) {
   if (numBits >= 64) {
     return this.toZero();
   }
-  var remainingBits = numBits % 16;
-  var pos = Math.floor(numBits / 16);
+  const remainingBits = numBits % 16;
+  const pos = Math.floor(numBits / 16);
   if (pos > 0) {
     this._arr[3] = this._arr[3 - pos];
     this._arr[2] = pos > 2 ? 0 : this._arr[2 - pos];
@@ -188,8 +188,8 @@ MutableLong.prototype.shiftRightUnsigned = function (numBits) {
   if (numBits >= 64) {
     return this.toZero();
   }
-  var remainingBits = numBits % 16;
-  var pos = Math.floor(numBits / 16);
+  const remainingBits = numBits % 16;
+  const pos = Math.floor(numBits / 16);
   if (pos > 0) {
     this._arr[0] = this._arr[pos];
     this._arr[1] = pos > 2 ? 0 : this._arr[1 + pos];
@@ -249,7 +249,7 @@ MutableLong.prototype.multiply = function multiply(multiplier) {
     return this.multiply(multiplier.clone().negate()).negate();
   }
   // We can skip products that would overflow.
-  var c48 = 0, c32 = 0, c16 = 0, c00 = 0;
+  let c48 = 0, c32 = 0, c16 = 0, c00 = 0;
   c00 += this._arr[0] * multiplier._arr[0];
   c16 += c00 >>> 16;
 

--- a/lib/types/protocol-version.js
+++ b/lib/types/protocol-version.js
@@ -15,7 +15,7 @@
  * is supported.
  * @alias module:types~protocolVersion
  */
-var protocolVersion = {
+const protocolVersion = {
   // Strict equality operators to compare versions are allowed, other comparison operators are discouraged. Instead,
   // use a function that checks if a functionality is present on a certain version, for maintainability purposes.
   v1: 0x01,

--- a/lib/types/result-set.js
+++ b/lib/types/result-set.js
@@ -1,5 +1,5 @@
 "use strict";
-var utils = require('../utils');
+const utils = require('../utils');
 
 /** @module types */
 
@@ -10,6 +10,7 @@ var utils = require('../utils');
  * @param {Object} response
  * @param {String} host
  * @param {Object} triedHosts
+ * @param {Number} speculativeExecutions
  * @param {Number} consistency
  * @constructor
  */
@@ -75,7 +76,7 @@ function ResultSet(response, host, triedHosts, speculativeExecutions, consistenc
    */
   this.nextPage = undefined;
 
-  var meta = response.meta;
+  const meta = response.meta;
   if (meta) {
     this.columns = meta.columns;
     if (meta.pageState) {
@@ -128,34 +129,32 @@ ResultSet.prototype.wasApplied = function () {
   if (!this.rows || this.rows.length === 0) {
     return true;
   }
-  var firstRow = this.rows[0];
-  var applied = firstRow['[applied]'];
+  const firstRow = this.rows[0];
+  const applied = firstRow['[applied]'];
   return typeof applied === 'boolean' ? applied : true;
 };
 
-if (typeof Symbol !== 'undefined' && typeof Symbol.iterator === 'symbol') {
-  /**
-   * Gets the iterator function.
-   * <p>
-   *   Retrieves the iterator of the underlying fetched rows and will not cause the driver to fetch the following
-   *   result pages. For more information on result paging,
-   *   [visit the documentation]{@link http://docs.datastax.com/en/developer/nodejs-driver/latest/features/paging/}.
-   * </p>
-   * @alias module:types~ResultSet#@@iterator
-   * @example <caption>Using for...of statement</caption>
-   * const query = 'SELECT name, email, address FROM users WHERE id = ?';
-   * const result = await client.execute(query, [ id ], { prepare: true });
-   * for (let row of result) {
-   *   console.log(row['email']);
-   * }
-   * @returns {Iterator.<Row>}
-   */
-  ResultSet.prototype[Symbol.iterator] = function getIterator() {
-    if (!this.rows) {
-      return utils.emptyArray[Symbol.iterator]();
-    }
-    return this.rows[Symbol.iterator]();
-  };
-}
+/**
+ * Gets the iterator function.
+ * <p>
+ *   Retrieves the iterator of the underlying fetched rows and will not cause the driver to fetch the following
+ *   result pages. For more information on result paging,
+ *   [visit the documentation]{@link http://docs.datastax.com/en/developer/nodejs-driver/latest/features/paging/}.
+ * </p>
+ * @alias module:types~ResultSet#@@iterator
+ * @example <caption>Using for...of statement</caption>
+ * const query = 'SELECT name, email, address FROM users WHERE id = ?';
+ * const result = await client.execute(query, [ id ], { prepare: true });
+ * for (let row of result) {
+ *   console.log(row['email']);
+ * }
+ * @returns {Iterator.<Row>}
+ */
+ResultSet.prototype[Symbol.iterator] = function getIterator() {
+  if (!this.rows) {
+    return utils.emptyArray[Symbol.iterator]();
+  }
+  return this.rows[Symbol.iterator]();
+};
 
 module.exports = ResultSet;

--- a/lib/types/result-stream.js
+++ b/lib/types/result-stream.js
@@ -1,6 +1,6 @@
 'use strict';
-var util = require('util');
-var stream = require('stream');
+const util = require('util');
+const stream = require('stream');
 
 /** @module types */
 /**

--- a/lib/types/row.js
+++ b/lib/types/row.js
@@ -30,7 +30,7 @@ Row.prototype.get = function (columnName) {
  * @returns {Array}
  */
 Row.prototype.values = function () {
-  var valuesArray = [];
+  const valuesArray = [];
   this.forEach(function (val) {
     valuesArray.push(val);
   });
@@ -42,7 +42,7 @@ Row.prototype.values = function () {
  * @returns {Array}
  */
 Row.prototype.keys = function () {
-  var keysArray = [];
+  const keysArray = [];
   this.forEach(function (val, key) {
     keysArray.push(key);
   });
@@ -54,7 +54,7 @@ Row.prototype.keys = function () {
  * @param {Function} callback
  */
 Row.prototype.forEach = function (callback) {
-  for (var columnName in this) {
+  for (const columnName in this) {
     if (!this.hasOwnProperty(columnName)) {
       continue;
     }

--- a/lib/types/time-uuid.js
+++ b/lib/types/time-uuid.js
@@ -1,10 +1,10 @@
 'use strict';
-var util = require('util');
-var crypto = require('crypto');
-var Long = require('long');
+const util = require('util');
+const crypto = require('crypto');
+const Long = require('long');
 
-var Uuid = require('./uuid');
-var utils = require('../utils');
+const Uuid = require('./uuid');
+const utils = require('../utils');
 
 /** @module types */
 /**
@@ -12,31 +12,31 @@ var utils = require('../utils');
  * @const
  * @private
  */
-var _unixToGregorian = 12219292800000;
+const _unixToGregorian = 12219292800000;
 /**
  * 10,000 ticks in a millisecond
  * @const
  * @private
  */
-var _ticksInMs = 10000;
+const _ticksInMs = 10000;
 /**
  * Counter used to generate up to 10000 different timeuuid values with the same Date
  * @private
  * @type {number}
  */
-var _ticks = 0;
+let _ticks = 0;
 /**
  * Counter used to generate ticks for the current time
  * @private
  * @type {number}
  */
-var _ticksForCurrentTime = 0;
+let _ticksForCurrentTime = 0;
 /**
  * Remember the last time when a ticks for the current time so that it can be reset
  * @private
  * @type {number}
  */
-var _lastTimestamp = 0;
+let _lastTimestamp = 0;
 /**
  * Creates a new instance of Uuid based on the parameters provided according to rfc4122.
  * If any of the arguments is not provided, it will be randomly generated, except for the date that will use the current date.
@@ -52,7 +52,7 @@ var _lastTimestamp = 0;
  * @constructor
  */
 function TimeUuid(value, ticks, nodeId, clockId) {
-  var buffer;
+  let buffer;
   if (value instanceof Buffer) {
     if (value.length !== 16) {
       throw new Error('Buffer for v1 uuid not valid');
@@ -123,18 +123,18 @@ TimeUuid.now = function (nodeId, clockId) {
  * @returns {{date: Date, ticks: Number}}
  */
 TimeUuid.prototype.getDatePrecision = function () {
-  var timeLow = this.buffer.readUInt32BE(0);
+  const timeLow = this.buffer.readUInt32BE(0);
 
-  var timeHigh = 0;
+  let timeHigh = 0;
   timeHigh |= ( this.buffer[4] & 0xff ) << 8;
   timeHigh |= this.buffer[5] & 0xff;
   timeHigh |= ( this.buffer[6] & 0x0f ) << 24;
   timeHigh |= ( this.buffer[7] & 0xff ) << 16;
 
-  var val = Long.fromBits(timeLow, timeHigh);
-  var ticksInMsLong = Long.fromNumber(_ticksInMs);
-  var ticks = val.modulo(ticksInMsLong);
-  var time = val
+  const val = Long.fromBits(timeLow, timeHigh);
+  const ticksInMsLong = Long.fromNumber(_ticksInMs);
+  const ticks = val.modulo(ticksInMsLong);
+  const time = val
     .div(ticksInMsLong)
     .subtract(Long.fromNumber(_unixToGregorian));
   return { date: new Date(time.toNumber()), ticks: ticks.toNumber()};
@@ -166,11 +166,11 @@ TimeUuid.prototype.getNodeIdString = function () {
 
 function writeTime(buffer, time, ticks) {
   //value time expressed in ticks precision
-  var val = Long
+  const val = Long
     .fromNumber(time + _unixToGregorian)
     .multiply(Long.fromNumber(10000))
     .add(Long.fromNumber(ticks));
-  var timeHigh = val.getHighBitsUnsigned();
+  const timeHigh = val.getHighBitsUnsigned();
   buffer.writeUInt32BE(val.getLowBitsUnsigned(), 0, true);
   buffer.writeUInt16BE(timeHigh & 0xffff, 4, true);
   buffer.writeUInt16BE(timeHigh >>> 16 & 0xffff, 6, true);
@@ -183,7 +183,7 @@ function writeTime(buffer, time, ticks) {
  * @private
  */
 function getClockId(clockId) {
-  var buffer = clockId;
+  let buffer = clockId;
   if (typeof clockId === 'string') {
     buffer = utils.allocBufferFromString(clockId, 'ascii');
   }
@@ -204,7 +204,7 @@ function getClockId(clockId) {
  * @private
  */
 function getNodeId(nodeId) {
-  var buffer = nodeId;
+  let buffer = nodeId;
   if (typeof nodeId === 'string') {
     buffer = utils.allocBufferFromString(nodeId, 'ascii');
   }
@@ -245,7 +245,7 @@ function getTimeWithTicks(date, ticks) {
   if (!(date instanceof Date) || isNaN(date.getTime())) {
     // time with ticks for the current time
     date = new Date();
-    var time = date.getTime();
+    const time = date.getTime();
     _ticksForCurrentTime++;
     if(_ticksForCurrentTime > _ticksInMs || time > _lastTimestamp) {
       _ticksForCurrentTime = 0;
@@ -273,10 +273,10 @@ function getRandomBytes(length) {
  * @returns {Buffer}
  */
 function generateBuffer(date, ticks, nodeId, clockId) {
-  var timeWithTicks = getTimeWithTicks(date, ticks);
+  const timeWithTicks = getTimeWithTicks(date, ticks);
   nodeId = getNodeId(nodeId);
   clockId = getClockId(clockId);
-  var buffer = utils.allocBufferUnsafe(16);
+  const buffer = utils.allocBufferUnsafe(16);
   //Positions 0-7 Timestamp
   writeTime(buffer, timeWithTicks.time, timeWithTicks.ticks);
   //Position 8-9 Clock

--- a/lib/types/tuple.js
+++ b/lib/types/tuple.js
@@ -1,5 +1,5 @@
 "use strict";
-var util = require('util');
+const util = require('util');
 /** @module types */
 /**
  * Creates a new sequence of immutable objects with the parameters provided.
@@ -14,7 +14,7 @@ var util = require('util');
  * @constructor
  */
 function Tuple() {
-  var elements = Array.prototype.slice.call(arguments);
+  let elements = Array.prototype.slice.call(arguments);
   if (elements.length === 0) {
     throw new TypeError('Tuple must contain at least one value');
   }

--- a/lib/types/uuid.js
+++ b/lib/types/uuid.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var crypto = require('crypto');
-var utils = require('../utils');
+const crypto = require('crypto');
+const utils = require('../utils');
 
 /** @module types */
 
@@ -47,7 +47,7 @@ Uuid.random = function (callback) {
       return callback(null, createUuidFromBuffer(buffer));
     });
   } else {
-    var buffer = getRandomBytes();
+    const buffer = getRandomBytes();
     return createUuidFromBuffer(buffer);
   }
 };
@@ -75,7 +75,7 @@ Uuid.prototype.equals = function (other) {
  */
 Uuid.prototype.toString = function () {
   //32 hex representation of the Buffer
-  var hexValue = getHex(this);
+  const hexValue = getHex(this);
   return (
     hexValue.substr(0, 8) + '-' +
     hexValue.substr(8, 4) + '-' +

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,15 +1,15 @@
 "use strict";
-var util = require('util');
-var errors = require('./errors');
+const util = require('util');
+const errors = require('./errors');
 
 /**
  * Max int that can be accurately represented with 64-bit Number (2^53)
  * @type {number}
  * @const
  */
-var maxInt = 9007199254740992;
+const maxInt = 9007199254740992;
 
-var emptyObject = Object.freeze({});
+const emptyObject = Object.freeze({});
 
 function noop() {}
 
@@ -17,25 +17,25 @@ function noop() {}
  * Forward-compatible allocation of buffer, filled with zeros.
  * @type {Function}
  */
-var allocBuffer = Buffer.alloc || allocBufferFillDeprecated;
+const allocBuffer = Buffer.alloc || allocBufferFillDeprecated;
 
 /**
  * Forward-compatible unsafe allocation of buffer.
  * @type {Function}
  */
-var allocBufferUnsafe = Buffer.allocUnsafe || allocBufferDeprecated;
+const allocBufferUnsafe = Buffer.allocUnsafe || allocBufferDeprecated;
 
 /**
  * Forward-compatible allocation of buffer to contain a string.
  * @type {Function}
  */
-var allocBufferFromString = Buffer.from || allocBufferFromStringDeprecated;
+const allocBufferFromString = Buffer.from || allocBufferFromStringDeprecated;
 
 /**
  * Forward-compatible allocation of buffer from an array of bytes
  * @type {Function}
  */
-var allocBufferFromArray = Buffer.from || allocBufferFromArrayDeprecated;
+const allocBufferFromArray = Buffer.from || allocBufferFromArrayDeprecated;
 
 function allocBufferDeprecated(size) {
   // eslint-disable-next-line
@@ -43,7 +43,7 @@ function allocBufferDeprecated(size) {
 }
 
 function allocBufferFillDeprecated(size) {
-  var b = allocBufferDeprecated(size);
+  const b = allocBufferDeprecated(size);
   b.fill(0);
   return b;
 }
@@ -68,7 +68,7 @@ function allocBufferFromArrayDeprecated(arr) {
  * Creates a copy of a buffer
  */
 function copyBuffer(buf) {
-  var targetBuffer = allocBufferUnsafe(buf.length);
+  const targetBuffer = allocBufferUnsafe(buf.length);
   buf.copy(targetBuffer);
   return targetBuffer;
 }
@@ -91,11 +91,9 @@ function fixStack(stackTrace, error) {
  */
 function log(type, info, furtherInfo) {
   if (!this.logEmitter) {
-    //noinspection JSUnresolvedVariable
     if (!this.options || !this.options.logEmitter) {
       throw new Error('Log emitter not defined');
     }
-    //noinspection JSUnresolvedVariable
     this.logEmitter = this.options.logEmitter;
   }
   this.logEmitter('log', type, this.constructor.name, info, furtherInfo || '');
@@ -108,9 +106,9 @@ function totalLength (arr) {
   if (arr.length === 1) {
     return arr[0].length;
   }
-  var total = 0;
+  let total = 0;
   arr.forEach(function (item) {
-    var length = item.length;
+    let length = item.length;
     length = length ? length : 0;
     total += length;
   });
@@ -121,15 +119,15 @@ function totalLength (arr) {
  * Merge the contents of two or more objects together into the first object. Similar to jQuery.extend
  */
 function extend(target) {
-  var sources = Array.prototype.slice.call(arguments, 1);
+  const sources = Array.prototype.slice.call(arguments, 1);
   sources.forEach(function (source) {
     if (!source) {
       return;
     }
-    var keys = Object.keys(source);
-    for (var i = 0; i < keys.length; i++) {
-      var key = keys[i];
-      var value = source[key];
+    const keys = Object.keys(source);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      const value = source[key];
       if (value === undefined) {
         continue;
       }
@@ -140,9 +138,9 @@ function extend(target) {
 }
 
 function lowerCaseExtend(target) {
-  var sources = Array.prototype.slice.call(arguments, 1);
+  const sources = Array.prototype.slice.call(arguments, 1);
   sources.forEach(function (source) {
-    for (var prop in source) {
+    for (const prop in source) {
       if (source.hasOwnProperty(prop)) {
         target[prop.toLowerCase()] = source[prop];
       }
@@ -157,14 +155,14 @@ function lowerCaseExtend(target) {
  * @returns {Object}
  */
 function deepExtend(target) {
-  var sources = Array.prototype.slice.call(arguments, 1);
+  const sources = Array.prototype.slice.call(arguments, 1);
   sources.forEach(function (source) {
-    for (var prop in source) {
+    for (const prop in source) {
       if (!source.hasOwnProperty(prop)) {
         continue;
       }
-      var targetProp = target[prop];
-      var targetType = (typeof targetProp);
+      const targetProp = target[prop];
+      const targetType = (typeof targetProp);
       //target prop is
       // a native single type
       // or not existent
@@ -203,8 +201,8 @@ function funcCompare(name, argArray) {
     if (typeof a[name] === 'undefined') {
       return 0;
     }
-    var valA = a[name].apply(a, argArray);
-    var valB = b[name].apply(b, argArray);
+    const valA = a[name].apply(a, argArray);
+    const valB = b[name].apply(b, argArray);
     if (valA > valB) {
       return 1;
     }
@@ -220,7 +218,7 @@ function funcCompare(name, argArray) {
  * @returns {{next: function}}
  */
 function arrayIterator (arr) {
-  var index = 0;
+  let index = 0;
   return { next : function () {
     if (index >= arr.length) {
       return {done: true};
@@ -235,8 +233,8 @@ function arrayIterator (arr) {
  * @returns {Array}
  */
 function iteratorToArray(iterator) {
-  var values = [];
-  var item = iterator.next();
+  const values = [];
+  let item = iterator.next();
   while (!item.done) {
     values.push(item.value);
     item = iterator.next();
@@ -254,13 +252,13 @@ function iteratorToArray(iterator) {
  * If it is not found, it returns a negative number which is the bitwise complement of the index of the first element that is larger than key.
  */
 function binarySearch(arr, key, compareFunc) {
-  var low = 0;
-  var high = arr.length-1;
+  let low = 0;
+  let high = arr.length-1;
 
   while (low <= high) {
-    var mid = (low + high) >>> 1;
-    var midVal = arr[mid];
-    var cmp = compareFunc(midVal, key);
+    const mid = (low + high) >>> 1;
+    const midVal = arr[mid];
+    const cmp = compareFunc(midVal, key);
     if (cmp < 0) {
       low = mid + 1;
     }
@@ -287,7 +285,7 @@ function insertSorted(arr, item, compareFunc) {
   if (arr.length === 0) {
     return arr.push(item);
   }
-  var position = binarySearch(arr, item, compareFunc);
+  let position = binarySearch(arr, item, compareFunc);
   if (position < 0) {
     position = ~position;
   }
@@ -321,11 +319,11 @@ function adaptNamedParamsPrepared(params, columns) {
     //The parameters is an Array or there isn't parameter
     return { params: params, keys: null};
   }
-  var paramsArray = new Array(columns.length);
+  const paramsArray = new Array(columns.length);
   params = lowerCaseExtend({}, params);
-  var keys = {};
-  for (var i = 0; i < columns.length; i++) {
-    var name = columns[i].name;
+  const keys = {};
+  for (let i = 0; i < columns.length; i++) {
+    const name = columns[i].name;
     if (!params.hasOwnProperty(name)) {
       throw new errors.ArgumentError(util.format('Parameter "%s" not defined', name));
     }
@@ -348,12 +346,12 @@ function adaptNamedParamsWithHints(params, options) {
     return { params: params, keys: null};
   }
   options.namedParameters = true;
-  var keys = Object.keys(params);
-  var paramsArray = new Array(keys.length);
-  var hints = new Array(keys.length);
-  var userHints = options.hints || emptyObject;
-  for (var i = 0; i < keys.length; i++) {
-    var key = keys[i];
+  const keys = Object.keys(params);
+  const paramsArray = new Array(keys.length);
+  const hints = new Array(keys.length);
+  const userHints = options.hints || emptyObject;
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
     //As lower cased identifiers
     paramsArray[i] = { name: key.toLowerCase(), value: params[key]};
     hints[i] = userHints[key];
@@ -388,9 +386,9 @@ function objectValues(obj) {
   if (!obj) {
     return exports.emptyArray;
   }
-  var keys = Object.keys(obj);
-  var values = new Array(keys.length);
-  for (var i = 0; i < keys.length; i++) {
+  const keys = Object.keys(obj);
+  const values = new Array(keys.length);
+  for (let i = 0; i < keys.length; i++) {
     values[i] = obj[keys[i]];
   }
   return values;
@@ -409,8 +407,8 @@ function promiseWrapper(options, originalCallback, handler) {
     handler.call(this, originalCallback);
     return undefined;
   }
-  var factory = options.promiseFactory || defaultPromiseFactory;
-  var self = this;
+  const factory = options.promiseFactory || defaultPromiseFactory;
+  const self = this;
   return factory(function handlerWrapper(callback) {
     handler.call(self, callback);
   });
@@ -481,17 +479,17 @@ function each(arr, fn, callback) {
     throw new TypeError('First parameter is not an Array');
   }
   callback = callback || noop;
-  var length = arr.length;
+  const length = arr.length;
   if (length === 0) {
     return callback();
   }
-  var completed = 0;
-  for (var i = 0; i < length; i++) {
+  let completed = 0;
+  for (let i = 0; i < length; i++) {
     fn(arr[i], next);
   }
   function next(err) {
     if (err) {
-      var cb = callback;
+      const cb = callback;
       callback = noop;
       cb(err);
       return;
@@ -513,12 +511,12 @@ function eachSeries(arr, fn, callback) {
     throw new TypeError('First parameter is not an Array');
   }
   callback = callback || noop;
-  var length = arr.length;
+  const length = arr.length;
   if (length === 0) {
     return callback();
   }
-  var sync;
-  var index = 1;
+  let sync;
+  let index = 1;
   fn(arr[0], next);
   if (sync === undefined) {
     sync = false;
@@ -566,14 +564,14 @@ function mapEach(arr, fn, useIndex, callback) {
     throw new TypeError('First parameter must be an Array');
   }
   callback = callback || noop;
-  var length = arr.length;
+  const length = arr.length;
   if (length === 0) {
     return callback(null, []);
   }
-  var result = new Array(length);
-  var completed = 0;
-  var invoke = useIndex ? invokeWithIndex : invokeWithoutIndex;
-  for (var i = 0; i < length; i++) {
+  const result = new Array(length);
+  let completed = 0;
+  const invoke = useIndex ? invokeWithIndex : invokeWithoutIndex;
+  for (let i = 0; i < length; i++) {
     invoke(i);
   }
 
@@ -593,7 +591,7 @@ function mapEach(arr, fn, useIndex, callback) {
 
   function next(err) {
     if (err) {
-      var cb = callback;
+      const cb = callback;
       callback = noop;
       cb(err);
       return;
@@ -615,13 +613,13 @@ function mapSeries(arr, fn, callback) {
     throw new TypeError('First parameter must be an Array');
   }
   callback = callback || noop;
-  var length = arr.length;
+  const length = arr.length;
   if (length === 0) {
     return callback(null, []);
   }
-  var result = new Array(length);
-  var index = 0;
-  var sync;
+  const result = new Array(length);
+  let index = 0;
+  let sync;
   invoke(0);
   if (sync === undefined) {
     sync = false;
@@ -644,7 +642,7 @@ function mapSeries(arr, fn, callback) {
     if (sync === undefined) {
       sync = true;
     }
-    var i = index;
+    const i = index;
     if (sync) {
       return process.nextTick(function () {
         invoke(i);
@@ -663,14 +661,14 @@ function parallel(arr, callback) {
     throw new TypeError('First parameter must be an Array');
   }
   callback = callback || noop;
-  var length = arr.length;
-  var completed = 0;
-  for (var i = 0; i < length; i++) {
+  const length = arr.length;
+  let completed = 0;
+  for (let i = 0; i < length; i++) {
     arr[i](next);
   }
   function next(err) {
     if (err) {
-      var cb = callback;
+      const cb = callback;
       callback = noop;
       return cb(err);
     }
@@ -692,8 +690,8 @@ function series(arr, callback) {
     throw new TypeError('First parameter must be an Array');
   }
   callback = callback || noop;
-  var index = 0;
-  var sync;
+  let index = 0;
+  let sync;
   next();
   function next(err, result) {
     if (err) {
@@ -704,7 +702,6 @@ function series(arr, callback) {
     }
     if (sync) {
       return process.nextTick(function () {
-        //noinspection JSUnusedAssignment
         sync = true;
         arr[index++](next);
         sync = false;
@@ -727,13 +724,13 @@ function times(count, iteratorFunc, callback) {
   if (isNaN(count) || count === 0) {
     return callback();
   }
-  var completed = 0;
-  for (var i = 0; i < count; i++) {
+  let completed = 0;
+  for (let i = 0; i < count; i++) {
     iteratorFunc(i, next);
   }
   function next(err) {
     if (err) {
-      var cb = callback;
+      const cb = callback;
       callback = noop;
       return cb(err);
     }
@@ -751,19 +748,19 @@ function times(count, iteratorFunc, callback) {
  * @param {Function} [callback]
  */
 function timesLimit(count, limit, iteratorFunc, callback) {
+  let sync = undefined;
   callback = callback || noop;
   limit = Math.min(limit, count);
-  var index = limit - 1;
-  var i;
-  var completed = 0;
+  let index = limit - 1;
+  let i;
+  let completed = 0;
   for (i = 0; i < limit; i++) {
     iteratorFunc(i, next);
   }
   i = -1;
-  var sync = undefined;
   function next(err) {
     if (err) {
-      var cb = callback;
+      const cb = callback;
       callback = noop;
       cb(err);
       return;
@@ -779,7 +776,7 @@ function timesLimit(count, limit, iteratorFunc, callback) {
       sync = (i >= 0);
     }
     if (sync) {
-      var captureIndex = index;
+      const captureIndex = index;
       return process.nextTick(function () {
         iteratorFunc(captureIndex, next);
       });
@@ -798,8 +795,8 @@ function timesSeries(count, iteratorFunction, callback) {
   if (isNaN(count) || count < 1) {
     return callback();
   }
-  var index = 1;
-  var sync;
+  let index = 1;
+  let sync;
   iteratorFunction(0, next);
   if (sync === undefined) {
     sync = false;
@@ -814,7 +811,7 @@ function timesSeries(count, iteratorFunction, callback) {
     if (sync === undefined) {
       sync = true;
     }
-    var i = index++;
+    const i = index++;
     if (sync) {
       //Prevent "Maximum call stack size exceeded"
       return process.nextTick(function () {
@@ -832,7 +829,7 @@ function timesSeries(count, iteratorFunction, callback) {
  * @param {Function} callback
  */
 function whilst(condition, fn, callback) {
-  var sync = 0;
+  let sync = 0;
   next();
   function next(err) {
     if (err) {

--- a/lib/writers.js
+++ b/lib/writers.js
@@ -1,10 +1,10 @@
 'use strict';
-var events = require('events');
-var util = require('util');
+const events = require('events');
+const util = require('util');
 
-var types = require('./types');
-var utils = require('./utils.js');
-var FrameHeader = types.FrameHeader;
+const types = require('./types');
+const utils = require('./utils.js');
+const FrameHeader = types.FrameHeader;
 
 /**
  * Contains the logic to write all the different types to the frame.
@@ -26,13 +26,13 @@ FrameWriter.prototype.add = function(buf) {
 };
 
 FrameWriter.prototype.writeShort = function(num) {
-  var buf = utils.allocBufferUnsafe(2);
+  const buf = utils.allocBufferUnsafe(2);
   buf.writeUInt16BE(num, 0);
   this.add(buf);
 };
 
 FrameWriter.prototype.writeInt = function(num) {
-  var buf = utils.allocBufferUnsafe(4);
+  const buf = utils.allocBufferUnsafe(4);
   buf.writeInt32BE(num, 0);
   this.add(buf);
 };
@@ -90,16 +90,16 @@ FrameWriter.prototype.writeString = function(str) {
   if (typeof str === "undefined") {
     throw new Error("can not write undefined");
   }
-  var len = Buffer.byteLength(str, 'utf8');
-  var buf = utils.allocBufferUnsafe(2 + len);
+  const len = Buffer.byteLength(str, 'utf8');
+  const buf = utils.allocBufferUnsafe(2 + len);
   buf.writeUInt16BE(len, 0);
   buf.write(str, 2, buf.length-2, 'utf8');
   this.add(buf);
 };
 
 FrameWriter.prototype.writeLString = function(str) {
-  var len = Buffer.byteLength(str, 'utf8');
-  var buf = utils.allocBufferUnsafe(4 + len);
+  const len = Buffer.byteLength(str, 'utf8');
+  const buf = utils.allocBufferUnsafe(4 + len);
   buf.writeInt32BE(len, 0);
   buf.write(str, 4, buf.length-4, 'utf8');
   this.add(buf);
@@ -111,7 +111,7 @@ FrameWriter.prototype.writeStringList = function (values) {
 };
 
 FrameWriter.prototype.writeCustomPayload = function (payload) {
-  var keys = Object.keys(payload);
+  const keys = Object.keys(payload);
   this.writeShort(keys.length);
   keys.forEach(function (k) {
     this.writeString(k);
@@ -120,8 +120,8 @@ FrameWriter.prototype.writeCustomPayload = function (payload) {
 };
 
 FrameWriter.prototype.writeStringMap = function (map) {
-  var keys = [];
-  for (var k in map) {
+  const keys = [];
+  for (const k in map) {
     if (map.hasOwnProperty(k)) {
       keys.push(k);
     }
@@ -129,8 +129,8 @@ FrameWriter.prototype.writeStringMap = function (map) {
 
   this.writeShort(keys.length);
 
-  for(var i = 0; i < keys.length; i++) {
-    var key = keys[i];
+  for(let i = 0; i < keys.length; i++) {
+    const key = keys[i];
     this.writeString(key);
     this.writeString(map[key]);
   }
@@ -144,8 +144,8 @@ FrameWriter.prototype.writeStringMap = function (map) {
  * @throws {TypeError}
  */
 FrameWriter.prototype.write = function (version, streamId, flags) {
-  var header = new FrameHeader(version, flags || 0, streamId, this.opcode, this.bodyLength);
-  var headerBuffer = header.toBuffer();
+  const header = new FrameHeader(version, flags || 0, streamId, this.opcode, this.bodyLength);
+  const headerBuffer = header.toBuffer();
   this.buffers.unshift(headerBuffer);
   return Buffer.concat(this.buffers, headerBuffer.length + this.bodyLength);
 };
@@ -175,7 +175,7 @@ util.inherits(WriteQueue, events.EventEmitter);
  * @param {Function} callback The write callback.
  */
 WriteQueue.prototype.push = function (operation, callback) {
-  var self = this;
+  const self = this;
   if (this.error) {
     // There was a write error, there is no point in further trying to write to the socket.
     return process.nextTick(function writePushError() {
@@ -193,20 +193,20 @@ WriteQueue.prototype.run = function () {
 };
 
 WriteQueue.prototype.process = function () {
-  var self = this;
+  const self = this;
   utils.whilst(
     function condition() {
       return self.queue.length > 0;
     },
     function whileProcess(next) {
       self.isRunning = true;
-      var buffers = [];
-      var callbacks = [];
-      var totalLength = 0;
+      const buffers = [];
+      const callbacks = [];
+      let totalLength = 0;
       while (totalLength < self.coalescingThreshold && self.queue.length > 0) {
-        var writeItem = self.queue.shift();
+        const writeItem = self.queue.shift();
         try {
-          var data = writeItem.operation.request.write(self.encoder, writeItem.operation.streamId);
+          const data = writeItem.operation.request.write(self.encoder, writeItem.operation.streamId);
           totalLength += data.length;
           buffers.push(data);
           callbacks.push(writeItem.callback);
@@ -222,7 +222,7 @@ WriteQueue.prototype.process = function () {
         return next();
       }
       // Before invoking socket.write(), mark that the request has been written to avoid race conditions.
-      for (var i = 0; i < callbacks.length; i++) {
+      for (let i = 0; i < callbacks.length; i++) {
         callbacks[i]();
       }
       self.netClient.write(Buffer.concat(buffers, totalLength), function socketWriteCallback(err) {
@@ -251,11 +251,11 @@ WriteQueue.prototype.setWriteError = function (err) {
   // Use an special flag for items that haven't been written
   this.error.requestNotWritten = true;
   this.error.innerError = err;
-  var q = this.queue;
+  const q = this.queue;
   // Not more items can be added to the queue.
   this.queue = utils.emptyArray;
-  for (var i = 0; i < q.length; i++) {
-    var item = q[i];
+  for (let i = 0; i < q.length; i++) {
+    const item = q[i];
     // Use the error marking that it was not written
     item.callback(this.error);
   }

--- a/test/integration/long/client-metadata-tests.js
+++ b/test/integration/long/client-metadata-tests.js
@@ -1,17 +1,17 @@
 "use strict";
-var assert = require('assert');
-var util = require('util');
+const assert = require('assert');
+const util = require('util');
 
-var helper = require('../../test-helper');
-var Client = require('../../../lib/client');
-var utils = require('../../../lib/utils');
-var tokenizer = require('../../../lib/tokenizer');
+const helper = require('../../test-helper');
+const Client = require('../../../lib/client');
+const utils = require('../../../lib/utils');
+const tokenizer = require('../../../lib/tokenizer');
 
 describe('Client', function () {
   this.timeout(240000);
   describe('#getReplicas() with MurmurPartitioner', function () {
     before(function (done) {
-      var client = newInstance();
+      const client = newInstance();
       var createQuery = "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1' : %d, 'dc2' : %d}";
       utils.series([
         helper.ccmHelper.start('4:4', {sleep: 1000}),
@@ -25,7 +25,7 @@ describe('Client', function () {
     });
     after(helper.ccmHelper.remove);
     it('should get the local and remote replicas for a given keyspace', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       client.connect(function (err) {
         assert.ifError(err);
         validateMurmurReplicas(client);
@@ -33,7 +33,7 @@ describe('Client', function () {
       });
     });
     it('should get the local and remote replicas for a given keyspace if isMetadataSyncEnabled is false but keyspace metadata is present', function (done) {
-      var client = newInstance({ isMetadataSyncEnabled: false });
+      const client = newInstance({ isMetadataSyncEnabled: false });
       client.connect(function (err) {
         assert.ifError(err);
         client.metadata.refreshKeyspace('sampleks1', function(err, keyspace) {
@@ -45,7 +45,7 @@ describe('Client', function () {
       });
     });
     it('should return null if keyspace metadata is not present', function (done) {
-      var client = newInstance({ isMetadataSyncEnabled: false });
+      const client = newInstance({ isMetadataSyncEnabled: false });
       client.connect(function (err) {
         assert.ifError(err);
         var replicas = client.getReplicas('sampleks1', utils.allocBufferFromArray([0, 0, 0, 1]));
@@ -54,7 +54,7 @@ describe('Client', function () {
       });
     });
     it('should get the closest replica if no keyspace specified', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       client.connect(function (err) {
         assert.ifError(err);
         var replicas = client.getReplicas(null, utils.allocBufferFromArray([0, 0, 0, 1]));
@@ -68,7 +68,7 @@ describe('Client', function () {
     });
   });
   describe('#getReplicas() with ByteOrderPartitioner', function () {
-    var ccmOptions = {
+    const ccmOptions = {
       vnodes: true,
       yaml: ['partitioner:org.apache.cassandra.dht.ByteOrderedPartitioner']
     };
@@ -83,10 +83,10 @@ describe('Client', function () {
         //pre-calculated based on Byte ordered partitioner
         assert.strictEqual(replicas[0].address, expectedReplica.address);
       }
-      var client = newInstance();
+      const client = newInstance();
       client.connect(function (err) {
         assert.ifError(err);
-        for (var i = 0; i < client.metadata.ring.length; i++) {
+        for (let i = 0; i < client.metadata.ring.length; i++) {
           var token = client.metadata.ring[i];
           var replica = client.metadata.primaryReplicas[client.metadata.tokenizer.stringify(token)];
           compareReplicas(token, replica);
@@ -96,18 +96,18 @@ describe('Client', function () {
     });
   });
   describe('#getReplicas() with RandomPartitioner', function () {
-    var ccmOptions = {
+    const ccmOptions = {
       vnodes: true,
       yaml: ['partitioner:org.apache.cassandra.dht.RandomPartitioner']
     };
     before(helper.ccmHelper.start('2', ccmOptions));
     after(helper.ccmHelper.remove);
     it('should get the replica', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       client.connect(function (err) {
         helper.assertInstanceOf(client.metadata.tokenizer, tokenizer.RandomTokenizer);
         assert.ifError(err);
-        for (var i = 0; i < client.metadata.ring.length; i++) {
+        for (let i = 0; i < client.metadata.ring.length; i++) {
           var token = client.metadata.ring[i];
           var position = utils.binarySearch(client.metadata.ring, token, client.metadata.tokenizer.compare);
           assert.ok(position >= 0);

--- a/test/integration/long/client-metadata-tests.js
+++ b/test/integration/long/client-metadata-tests.js
@@ -12,7 +12,7 @@ describe('Client', function () {
   describe('#getReplicas() with MurmurPartitioner', function () {
     before(function (done) {
       const client = newInstance();
-      var createQuery = "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1' : %d, 'dc2' : %d}";
+      const createQuery = "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1' : %d, 'dc2' : %d}";
       utils.series([
         helper.ccmHelper.start('4:4', {sleep: 1000}),
         function (next) {
@@ -48,7 +48,7 @@ describe('Client', function () {
       const client = newInstance({ isMetadataSyncEnabled: false });
       client.connect(function (err) {
         assert.ifError(err);
-        var replicas = client.getReplicas('sampleks1', utils.allocBufferFromArray([0, 0, 0, 1]));
+        const replicas = client.getReplicas('sampleks1', utils.allocBufferFromArray([0, 0, 0, 1]));
         assert.strictEqual(null, replicas);
         done();
       });
@@ -57,11 +57,11 @@ describe('Client', function () {
       const client = newInstance();
       client.connect(function (err) {
         assert.ifError(err);
-        var replicas = client.getReplicas(null, utils.allocBufferFromArray([0, 0, 0, 1]));
+        const replicas = client.getReplicas(null, utils.allocBufferFromArray([0, 0, 0, 1]));
         assert.ok(replicas);
         assert.strictEqual(replicas.length, 1);
         //pre-calculated based on murmur3
-        var lastOctets = replicas.map(helper.lastOctetOf);
+        const lastOctets = replicas.map(helper.lastOctetOf);
         assert.strictEqual(lastOctets[0], '3');
         done();
       });
@@ -76,7 +76,7 @@ describe('Client', function () {
     after(helper.ccmHelper.remove);
     it('should get the replica', function (done) {
       function compareReplicas(val, expectedReplica) {
-        var replicas = client.getReplicas(null, val);
+        const replicas = client.getReplicas(null, val);
         assert.ok(replicas);
         //2 replicas per each dc
         assert.strictEqual(replicas.length, 1);
@@ -87,8 +87,8 @@ describe('Client', function () {
       client.connect(function (err) {
         assert.ifError(err);
         for (let i = 0; i < client.metadata.ring.length; i++) {
-          var token = client.metadata.ring[i];
-          var replica = client.metadata.primaryReplicas[client.metadata.tokenizer.stringify(token)];
+          const token = client.metadata.ring[i];
+          const replica = client.metadata.primaryReplicas[client.metadata.tokenizer.stringify(token)];
           compareReplicas(token, replica);
         }
         done();
@@ -108,8 +108,8 @@ describe('Client', function () {
         helper.assertInstanceOf(client.metadata.tokenizer, tokenizer.RandomTokenizer);
         assert.ifError(err);
         for (let i = 0; i < client.metadata.ring.length; i++) {
-          var token = client.metadata.ring[i];
-          var position = utils.binarySearch(client.metadata.ring, token, client.metadata.tokenizer.compare);
+          const token = client.metadata.ring[i];
+          const position = utils.binarySearch(client.metadata.ring, token, client.metadata.tokenizer.compare);
           assert.ok(position >= 0);
         }
         client.execute('select key from system.local', [], { routingKey: utils.allocBufferUnsafe(2)}, function (err) {
@@ -122,14 +122,14 @@ describe('Client', function () {
 });
 
 function validateMurmurReplicas(client) {
-  var replicas = client.getReplicas('sampleks1', utils.allocBufferFromArray([0, 0, 0, 1]));
+  let replicas = client.getReplicas('sampleks1', utils.allocBufferFromArray([0, 0, 0, 1]));
   assert.ok(replicas);
   //2 replicas per each dc
   assert.strictEqual(replicas.length, 4);
   assert.strictEqual(replicas.reduce(function (val, h) { return val + (h.datacenter === 'dc1' ? 1 : 0);}, 0), 2);
 
   //pre-calculated based on murmur3
-  var lastOctets = replicas.map(helper.lastOctetOf);
+  let lastOctets = replicas.map(helper.lastOctetOf);
   assert.strictEqual(lastOctets[0], '3');
   assert.strictEqual(lastOctets[1], '7');
   assert.strictEqual(lastOctets[2], '4');

--- a/test/integration/long/event-tests.js
+++ b/test/integration/long/event-tests.js
@@ -1,23 +1,22 @@
 'use strict';
-var assert = require('assert');
+const assert = require('assert');
 
-var helper = require('../../test-helper');
-var Host = require('../../../lib/host').Host;
-var utils = require('../../../lib/utils');
+const helper = require('../../test-helper');
+const Host = require('../../../lib/host').Host;
+const utils = require('../../../lib/utils');
 
-var Client = require('../../../lib/client');
+const Client = require('../../../lib/client');
 
 describe('Client', function () {
   describe('events', function () {
-    //noinspection JSPotentiallyInvalidUsageOfThis
     this.timeout(600000);
-    var is1x = helper.getCassandraVersion().charAt(0) === '1';
+    const is1x = helper.getCassandraVersion().charAt(0) === '1';
     beforeEach(helper.ccmHelper.start(2));
     afterEach(helper.ccmHelper.remove);
     it('should emit hostUp hostDown', function (done) {
-      var client = newInstance();
-      var hostsWentUp = [];
-      var hostsWentDown = [];
+      const client = newInstance();
+      const hostsWentUp = [];
+      const hostsWentDown = [];
       utils.series([
         client.connect.bind(client),
         function addListeners(next) {
@@ -41,7 +40,7 @@ describe('Client', function () {
             // Set a timeout of 10 seconds to call next at which point
             // things will likely fail if the hostUp event has not been
             // surfaced yet.
-            var timeout = setTimeout(next, 10000);
+            const timeout = setTimeout(next, 10000);
             client.on('hostUp', function() {
               // Call next on a timeout since this callback may be invoked
               // before the one that adds to hostsWentUp.
@@ -70,9 +69,9 @@ describe('Client', function () {
       ], done);
     });
     it('should emit hostAdd hostRemove', function (done) {
-      var client = newInstance();
-      var hostsAdded = [];
-      var hostsRemoved = [];
+      const client = newInstance();
+      const hostsAdded = [];
+      const hostsRemoved = [];
       function trace(message) {
         return (function (next) {
           helper.trace(message);

--- a/test/integration/long/load-balancing-tests.js
+++ b/test/integration/long/load-balancing-tests.js
@@ -1,24 +1,24 @@
 "use strict";
-var assert = require('assert');
-var util = require('util');
+const assert = require('assert');
+const util = require('util');
 
-var helper = require('../../test-helper.js');
-var Client = require('../../../lib/client.js');
-var utils = require('../../../lib/utils.js');
-var loadBalancing = require('../../../lib/policies/load-balancing.js');
+const helper = require('../../test-helper.js');
+const Client = require('../../../lib/client.js');
+const utils = require('../../../lib/utils.js');
+const loadBalancing = require('../../../lib/policies/load-balancing.js');
 var DCAwareRoundRobinPolicy = loadBalancing.DCAwareRoundRobinPolicy;
 var TokenAwarePolicy = loadBalancing.TokenAwarePolicy;
 
 describe('DCAwareRoundRobinPolicy', function () {
   this.timeout(180000);
   it('should never hit remote dc if not set', function (done) {
-    var countByHost = {};
+    const countByHost = {};
     utils.series([
       //1 cluster with 3 dcs with 2 nodes each
       helper.ccmHelper.start('2:2:2') ,
       function testCase(next) {
-        var options = utils.deepExtend({}, helper.baseOptions, {policies: {loadBalancing: new DCAwareRoundRobinPolicy()}});
-        var client = new Client(options);
+        const options = utils.deepExtend({}, helper.baseOptions, {policies: {loadBalancing: new DCAwareRoundRobinPolicy()}});
+        const client = new Client(options);
         utils.times(120, function (n, timesNext) {
           client.execute(helper.queries.basic, function (err, result) {
             assert.ifError(err);
@@ -48,7 +48,7 @@ describe('TokenAwarePolicy', function () {
   describe('with a 3:3 node topology', function() {
     var keyspace = 'ks1';
     var table = 'table1';
-    var client = new Client({
+    const client = new Client({
       policies: { loadBalancing: new TokenAwarePolicy(new DCAwareRoundRobinPolicy())},
       keyspace: keyspace,
       contactPoints: helper.baseOptions.contactPoints
@@ -64,7 +64,7 @@ describe('TokenAwarePolicy', function () {
           localClient.execute(util.format(createQuery, keyspace, 1, 1), helper.waitSchema(localClient, next));
         },
         function createTable(next) {
-          var query = util.format('CREATE TABLE %s.%s (id int primary key, name int)', keyspace, table);
+          const query = util.format('CREATE TABLE %s.%s (id int primary key, name int)', keyspace, table);
           localClient.execute(query, helper.waitSchema(localClient, next));
         },
         localClient.shutdown.bind(localClient)
@@ -93,7 +93,7 @@ describe('TokenAwarePolicy', function () {
       };
       utils.times(100, function (n, timesNext) {
         var id = (n % 10) + 1;
-        var query = util.format('INSERT INTO %s (id, name) VALUES (%s, %s)', table, id, id);
+        const query = util.format('INSERT INTO %s (id, name) VALUES (%s, %s)', table, id, id);
         client.execute(query, null, {routingKey: utils.allocBufferFromArray([0, 0, 0, id])}, function (err, result) {
           assert.ifError(err);
           //for murmur id = 1, it go to replica 2
@@ -149,7 +149,7 @@ describe('TokenAwarePolicy', function () {
       utils.times(20, function (n, timesNext) {
         //keyspace 1
         policy_dc2.newQueryPlan(keyspace1, {routingKey: routingKey}, function (err, iterator) {
-          var hosts = helper.iteratorToArray(iterator);
+          const hosts = helper.iteratorToArray(iterator);
           // 2 local replicas first, 2 remaining local nodes.
           assert.ok(hosts.length, 4);
           hosts.forEach(function(host) {
@@ -166,7 +166,7 @@ describe('TokenAwarePolicy', function () {
       utils.times(20, function (n, timesNext) {
         //keyspace 2
         policy_dc2.newQueryPlan(keyspace2, {routingKey: routingKey}, function (err, iterator) {
-          var hosts = helper.iteratorToArray(iterator);
+          const hosts = helper.iteratorToArray(iterator);
           // 1 local replica, 3 remaining local nodes.
           assert.ok(hosts.length, 4);
           hosts.forEach(function(host) {
@@ -183,7 +183,7 @@ describe('TokenAwarePolicy', function () {
       utils.times(20, function (n, timesNext) {
         //no keyspace
         policy_dc1.newQueryPlan(null, {routingKey: routingKey}, function (err, iterator) {
-          var hosts = helper.iteratorToArray(iterator);
+          const hosts = helper.iteratorToArray(iterator);
           //1 (closest) replica irrespective of keyspace topology, plus 3 additional local nodes
           assert.ok(hosts.length, 4);
           hosts.forEach(function(host) {
@@ -200,7 +200,7 @@ describe('TokenAwarePolicy', function () {
       utils.times(20, function (n, timesNext) {
         //no keyspace
         policy_dc2.newQueryPlan(null, {routingKey: routingKey}, function (err, iterator) {
-          var hosts = helper.iteratorToArray(iterator);
+          const hosts = helper.iteratorToArray(iterator);
           // Should simply get all local nodes, since no keyspace was provided and the closest
           // replica is in dc1, no token aware ordering is provided.
           assert.ok(hosts.length, 4);

--- a/test/integration/long/reconnection-tests.js
+++ b/test/integration/long/reconnection-tests.js
@@ -13,11 +13,11 @@ describe('reconnection', function () {
   this.timeout(120000);
   describe('when a node is back UP', function () {
     it('should re-prepare on demand', function (done) {
-      var dummyClient = new Client(helper.baseOptions);
+      const dummyClient = new Client(helper.baseOptions);
       const keyspace = helper.getRandomName('ks');
       const table = helper.getRandomName('tbl');
-      var insertQuery1 = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
-      var insertQuery2 = util.format('INSERT INTO %s (id, int_sample) VALUES (?, ?)', table);
+      const insertQuery1 = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
+      const insertQuery2 = util.format('INSERT INTO %s (id, int_sample) VALUES (?, ?)', table);
       const client = new Client(utils.extend({
         keyspace: keyspace,
         contactPoints: helper.baseOptions.contactPoints,
@@ -74,10 +74,10 @@ describe('reconnection', function () {
       ], done);
     });
     it('should reconnect and re-prepare once there is an available host', function (done) {
-      var dummyClient = new Client(helper.baseOptions);
+      const dummyClient = new Client(helper.baseOptions);
       const keyspace = helper.getRandomName('ks');
       const table = helper.getRandomName('tbl');
-      var insertQuery1 = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
+      const insertQuery1 = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
       const client = new Client({
         keyspace: keyspace,
         contactPoints: helper.baseOptions.contactPoints,
@@ -143,11 +143,11 @@ describe('reconnection', function () {
       ], done);
     });
     it('should re-prepare and execute batches of prepared queries', function (done) {
-      var dummyClient = new Client(helper.baseOptions);
+      const dummyClient = new Client(helper.baseOptions);
       const keyspace = helper.getRandomName('ks');
       const table = helper.getRandomName('tbl');
-      var insertQuery1 = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
-      var insertQuery2 = util.format('INSERT INTO %s (id, int_sample) VALUES (?, ?)', table);
+      const insertQuery1 = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
+      const insertQuery2 = util.format('INSERT INTO %s (id, int_sample) VALUES (?, ?)', table);
       const queriedHosts = {};
       const client = new Client(utils.extend({
         keyspace: keyspace,
@@ -175,7 +175,7 @@ describe('reconnection', function () {
         },
         function insert1(next) {
           utils.times(10, function (n, timesNext) {
-            var queries = [
+            const queries = [
               { query: insertQuery1, params: [types.Uuid.random(), n.toString()]},
               { query: insertQuery2, params: [types.Uuid.random(), n]}
             ];
@@ -186,7 +186,7 @@ describe('reconnection', function () {
         helper.toTask(helper.ccmHelper.exec, null, ['node2', 'start']),
         function insertAfterRestart(next) {
           utils.times(15, function (n, timesNext) {
-            var queries = [
+            const queries = [
               { query: insertQuery1, params: [types.Uuid.random(), n.toString()]},
               { query: insertQuery2, params: [types.Uuid.random(), n]}
             ];
@@ -266,7 +266,7 @@ describe('reconnection', function () {
         },
         function isUp(next) {
           // Ensure all hosts are up.
-          var hosts = client.hosts.values();
+          const hosts = client.hosts.values();
           assert.strictEqual(hosts.length, 2);
           hosts.forEach(function(host) {
             assert.ok(host.isUp());

--- a/test/integration/long/reconnection-tests.js
+++ b/test/integration/long/reconnection-tests.js
@@ -1,24 +1,24 @@
 "use strict";
-var assert = require('assert');
-var util = require('util');
+const assert = require('assert');
+const util = require('util');
 
-var helper = require('../../test-helper.js');
-var Client = require('../../../lib/client.js');
-var types = require('../../../lib/types');
-var utils = require('../../../lib/utils');
-var errors = require('../../../lib/errors');
-var reconnection = require('../../../lib/policies/reconnection');
+const helper = require('../../test-helper.js');
+const Client = require('../../../lib/client.js');
+const types = require('../../../lib/types');
+const utils = require('../../../lib/utils');
+const errors = require('../../../lib/errors');
+const reconnection = require('../../../lib/policies/reconnection');
 
 describe('reconnection', function () {
   this.timeout(120000);
   describe('when a node is back UP', function () {
     it('should re-prepare on demand', function (done) {
       var dummyClient = new Client(helper.baseOptions);
-      var keyspace = helper.getRandomName('ks');
-      var table = helper.getRandomName('tbl');
+      const keyspace = helper.getRandomName('ks');
+      const table = helper.getRandomName('tbl');
       var insertQuery1 = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
       var insertQuery2 = util.format('INSERT INTO %s (id, int_sample) VALUES (?, ?)', table);
-      var client = new Client(utils.extend({
+      const client = new Client(utils.extend({
         keyspace: keyspace,
         contactPoints: helper.baseOptions.contactPoints,
         policies: { reconnection: new reconnection.ConstantReconnectionPolicy(100)}
@@ -75,10 +75,10 @@ describe('reconnection', function () {
     });
     it('should reconnect and re-prepare once there is an available host', function (done) {
       var dummyClient = new Client(helper.baseOptions);
-      var keyspace = helper.getRandomName('ks');
-      var table = helper.getRandomName('tbl');
+      const keyspace = helper.getRandomName('ks');
+      const table = helper.getRandomName('tbl');
       var insertQuery1 = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
-      var client = new Client({
+      const client = new Client({
         keyspace: keyspace,
         contactPoints: helper.baseOptions.contactPoints,
         policies: { reconnection: new reconnection.ConstantReconnectionPolicy(100)}
@@ -144,12 +144,12 @@ describe('reconnection', function () {
     });
     it('should re-prepare and execute batches of prepared queries', function (done) {
       var dummyClient = new Client(helper.baseOptions);
-      var keyspace = helper.getRandomName('ks');
-      var table = helper.getRandomName('tbl');
+      const keyspace = helper.getRandomName('ks');
+      const table = helper.getRandomName('tbl');
       var insertQuery1 = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
       var insertQuery2 = util.format('INSERT INTO %s (id, int_sample) VALUES (?, ?)', table);
-      var queriedHosts = {};
-      var client = new Client(utils.extend({
+      const queriedHosts = {};
+      const client = new Client(utils.extend({
         keyspace: keyspace,
         contactPoints: helper.baseOptions.contactPoints,
         policies: { reconnection: new reconnection.ConstantReconnectionPolicy(100)},
@@ -203,7 +203,7 @@ describe('reconnection', function () {
   describe('when connections are silently dropped', function () {
     it('should callback in err the next request', function (done) {
       //never reconnect
-      var client = new Client(utils.extend({}, helper.baseOptions, {policies: {reconnection: new reconnection.ConstantReconnectionPolicy(Number.MAX_VALUE)}}));
+      const client = new Client(utils.extend({}, helper.baseOptions, {policies: {reconnection: new reconnection.ConstantReconnectionPolicy(Number.MAX_VALUE)}}));
       utils.series([
         helper.ccmHelper.start(1),
         client.connect.bind(client),
@@ -233,7 +233,7 @@ describe('reconnection', function () {
   });
   describe('when a node is killed during connection initialization', function() {
     it('should properly abort the connection and retry', function(done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         helper.ccmHelper.start(2),
         function pauseNode2(next) {

--- a/test/integration/long/stress-tests.js
+++ b/test/integration/long/stress-tests.js
@@ -1,21 +1,21 @@
 "use strict";
-var assert = require('assert');
-var util = require('util');
+const assert = require('assert');
+const util = require('util');
 
-var helper = require('../../test-helper.js');
-var Client = require('../../../lib/client.js');
-var types = require('../../../lib/types');
-var utils = require('../../../lib/utils.js');
+const helper = require('../../test-helper.js');
+const Client = require('../../../lib/client.js');
+const types = require('../../../lib/types');
+const utils = require('../../../lib/utils.js');
 
 describe('Client', function () {
   this.timeout(180000);
   afterEach(helper.ccmHelper.remove);
   it('should handle parallel insert and select', function (done) {
-    var client = newInstance({encoding: { copyBuffer: false}});
-    //var client = newInstance();
-    var keyspace = helper.getRandomName('ks');
+    const client = newInstance({encoding: { copyBuffer: false}});
+    //const client = newInstance();
+    const keyspace = helper.getRandomName('ks');
     var table = keyspace + '.' + helper.getRandomName('tbl');
-    var selectQuery = 'SELECT * FROM ' + table;
+    const selectQuery = 'SELECT * FROM ' + table;
     var insertQuery = util.format('INSERT INTO %s (id, text_sample, timestamp_sample) VALUES (?, ?, ?)', table);
     var times = 2000;
     utils.series([
@@ -32,16 +32,16 @@ describe('Client', function () {
     ], done);
     function insert(callback) {
       utils.timesLimit(times, 500, function (i, next) {
-        var options = {
+        const options = {
           prepare: 1,
           consistency: types.consistencies.quorum};
         client.execute(insertQuery, [types.uuid(), 'text' + i, new Date()], options, next);
       }, callback);
     }
     function select(callback) {
-      var resultCount = 0;
+      let resultCount = 0;
       utils.timesLimit(Math.floor(times / 5), 200, function (i, next) {
-        var options = {
+        const options = {
           prepare: 1,
           consistency: types.consistencies.one};
         client.execute(selectQuery, [], options, function (err, result) {
@@ -58,10 +58,10 @@ describe('Client', function () {
     }
   });
   it('should handle parallel insert and select with nodes failing', function (done) {
-    var client = newInstance();
-    var keyspace = helper.getRandomName('ks');
+    const client = newInstance();
+    const keyspace = helper.getRandomName('ks');
     var table = keyspace + '.' + helper.getRandomName('tbl');
-    var selectQuery = 'SELECT * FROM ' + table;
+    const selectQuery = 'SELECT * FROM ' + table;
     var insertQuery = util.format('INSERT INTO %s (id, text_sample, timestamp_sample) VALUES (?, ?, ?)', table);
     var times = 2000;
     utils.series([
@@ -78,16 +78,16 @@ describe('Client', function () {
     ], done);
     function insert(callback) {
       utils.timesLimit(times, 500, function (i, next) {
-        var options = {
+        const options = {
           prepare: 1,
           consistency: types.consistencies.quorum};
         client.execute(insertQuery, [types.uuid(), 'text' + i, new Date()], options, next);
       }, callback);
     }
     function select(callback) {
-      var resultCount = 0;
+      let resultCount = 0;
       utils.timesLimit(Math.floor(times / 5), 100, function (i, next) {
-        var options = {
+        const options = {
           prepare: 1,
           consistency: types.consistencies.one};
         client.execute(selectQuery, [], options, function (err, result) {
@@ -109,12 +109,12 @@ describe('Client', function () {
     }
   });
   it('should handle parallel insert and select of large blobs', function (done) {
-    var client = newInstance();
-    var keyspace = helper.getRandomName('ks');
-    var table = helper.getRandomName('tbl');
+    const client = newInstance();
+    const keyspace = helper.getRandomName('ks');
+    const table = helper.getRandomName('tbl');
     var clientInsert = newInstance({keyspace: keyspace});
     var clientSelect = newInstance({keyspace: keyspace});
-    var selectQuery = 'SELECT * FROM ' + table + ' LIMIT 10';
+    const selectQuery = 'SELECT * FROM ' + table + ' LIMIT 10';
     var insertQuery = util.format('INSERT INTO %s (id, double_sample, blob_sample) VALUES (?, ?, ?)', table);
     var times = 500;
     utils.series([
@@ -130,10 +130,10 @@ describe('Client', function () {
       }
     ], done);
     function insert(callback) {
-      var n = 0;
+      let n = 0;
       utils.timesLimit(times, 100, function (i, next) {
         i = ++n;
-        var options = {
+        const options = {
           prepare: 1,
           consistency: types.consistencies.quorum};
         var buf = utils.allocBuffer(i * 1024);
@@ -142,9 +142,9 @@ describe('Client', function () {
       }, callback);
     }
     function select(callback) {
-      var resultCount = 0;
+      let resultCount = 0;
       utils.timesLimit(times*10, 2, function (i, next) {
-        var options = {
+        const options = {
           prepare: 1,
           consistency: types.consistencies.one,
           autoPage: true};

--- a/test/integration/long/stress-tests.js
+++ b/test/integration/long/stress-tests.js
@@ -14,10 +14,10 @@ describe('Client', function () {
     const client = newInstance({encoding: { copyBuffer: false}});
     //const client = newInstance();
     const keyspace = helper.getRandomName('ks');
-    var table = keyspace + '.' + helper.getRandomName('tbl');
+    const table = keyspace + '.' + helper.getRandomName('tbl');
     const selectQuery = 'SELECT * FROM ' + table;
-    var insertQuery = util.format('INSERT INTO %s (id, text_sample, timestamp_sample) VALUES (?, ?, ?)', table);
-    var times = 2000;
+    const insertQuery = util.format('INSERT INTO %s (id, text_sample, timestamp_sample) VALUES (?, ?, ?)', table);
+    const times = 2000;
     utils.series([
       helper.ccmHelper.start(3),
       function createKs(next) {
@@ -60,10 +60,10 @@ describe('Client', function () {
   it('should handle parallel insert and select with nodes failing', function (done) {
     const client = newInstance();
     const keyspace = helper.getRandomName('ks');
-    var table = keyspace + '.' + helper.getRandomName('tbl');
+    const table = keyspace + '.' + helper.getRandomName('tbl');
     const selectQuery = 'SELECT * FROM ' + table;
-    var insertQuery = util.format('INSERT INTO %s (id, text_sample, timestamp_sample) VALUES (?, ?, ?)', table);
-    var times = 2000;
+    const insertQuery = util.format('INSERT INTO %s (id, text_sample, timestamp_sample) VALUES (?, ?, ?)', table);
+    const times = 2000;
     utils.series([
       helper.ccmHelper.start(3),
       function createKs(next) {
@@ -112,11 +112,11 @@ describe('Client', function () {
     const client = newInstance();
     const keyspace = helper.getRandomName('ks');
     const table = helper.getRandomName('tbl');
-    var clientInsert = newInstance({keyspace: keyspace});
-    var clientSelect = newInstance({keyspace: keyspace});
+    const clientInsert = newInstance({keyspace: keyspace});
+    const clientSelect = newInstance({keyspace: keyspace});
     const selectQuery = 'SELECT * FROM ' + table + ' LIMIT 10';
-    var insertQuery = util.format('INSERT INTO %s (id, double_sample, blob_sample) VALUES (?, ?, ?)', table);
-    var times = 500;
+    const insertQuery = util.format('INSERT INTO %s (id, double_sample, blob_sample) VALUES (?, ?, ?)', table);
+    const times = 500;
     utils.series([
       helper.ccmHelper.start(3),
       function createKs(next) {
@@ -136,7 +136,7 @@ describe('Client', function () {
         const options = {
           prepare: 1,
           consistency: types.consistencies.quorum};
-        var buf = utils.allocBuffer(i * 1024);
+        const buf = utils.allocBuffer(i * 1024);
         buf.write(i + ' dummy values ' + (new Array(100)).join(i.toString()));
         clientInsert.execute(insertQuery, [types.uuid(), buf.length, buf], options, next);
       }, callback);

--- a/test/integration/short/client-batch-tests.js
+++ b/test/integration/short/client-batch-tests.js
@@ -1,22 +1,22 @@
 'use strict';
-var assert = require('assert');
-var util = require('util');
+const assert = require('assert');
+const util = require('util');
 
-var helper = require('../../test-helper.js');
-var Client = require('../../../lib/client.js');
-var types = require('../../../lib/types');
-var utils = require('../../../lib/utils.js');
-var errors = require('../../../lib/errors.js');
-var vit = helper.vit;
+const helper = require('../../test-helper.js');
+const Client = require('../../../lib/client.js');
+const types = require('../../../lib/types');
+const utils = require('../../../lib/utils.js');
+const errors = require('../../../lib/errors.js');
+const vit = helper.vit;
 
 describe('Client', function () {
   this.timeout(120000);
   describe('#batch(queries, {prepare: 0}, callback)', function () {
-    var keyspace = helper.getRandomName('ks');
+    const keyspace = helper.getRandomName('ks');
     var table1 = keyspace + '.' + helper.getRandomName('tblA');
     var table2 = keyspace + '.' + helper.getRandomName('tblB');
     before(function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         helper.ccmHelper.start(1),
         helper.toTask(client.execute, client, helper.createKeyspaceCql(keyspace, 1)),
@@ -27,10 +27,10 @@ describe('Client', function () {
     after(helper.ccmHelper.remove);
     vit('2.0', 'should execute a batch of queries with no params', function (done) {
       var insertQuery = 'INSERT INTO %s (id, text_sample) VALUES (%s, \'%s\')';
-      var selectQuery = 'SELECT * FROM %s WHERE id = %s';
-      var id1 = types.Uuid.random();
-      var id2 = types.Uuid.random();
-      var client = newInstance();
+      const selectQuery = 'SELECT * FROM %s WHERE id = %s';
+      const id1 = types.Uuid.random();
+      const id2 = types.Uuid.random();
+      const client = newInstance();
       var queries = [
         util.format(insertQuery, table1, id1, 'one'),
         util.format(insertQuery, table2, id2, 'two')
@@ -61,10 +61,10 @@ describe('Client', function () {
     });
     vit('2.0', 'should execute a batch of queries with params', function (done) {
       var insertQuery = 'INSERT INTO %s (id, double_sample) VALUES (?, ?)';
-      var selectQuery = 'SELECT * FROM %s WHERE id = %s';
-      var id1 = types.Uuid.random();
-      var id2 = types.Uuid.random();
-      var client = newInstance();
+      const selectQuery = 'SELECT * FROM %s WHERE id = %s';
+      const id1 = types.Uuid.random();
+      const id2 = types.Uuid.random();
+      const client = newInstance();
       var queries = [
         {query: util.format(insertQuery, table1), params: [id1, 1000]},
         {query: util.format(insertQuery, table2), params: [id2, 2000.2]}
@@ -95,7 +95,7 @@ describe('Client', function () {
       ], done);
     });
     vit('2.0', 'should callback with error when there is a ResponseError', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       client.batch(['INSERT WILL FAIL'], function (err) {
         assert.ok(err);
         assert.ok(err instanceof errors.ResponseError);
@@ -104,7 +104,7 @@ describe('Client', function () {
       });
     });
     vit('2.0', 'should fail if non-existent profile provided', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       client.batch(['INSERT WILL FAIL'], {executionProfile: 'none'}, function (err) {
         assert.ok(err);
         assert.ok(err instanceof errors.ArgumentError);
@@ -112,7 +112,7 @@ describe('Client', function () {
       });
     });
     vit('2.0', 'should validate that arguments are valid', function () {
-      var client = newInstance();
+      const client = newInstance();
       var badArgumentCalls = [
         function () {
           return client.batch();
@@ -141,8 +141,8 @@ describe('Client', function () {
       return Promise.all(promises);
     });
     vit('2.0', 'should allow parameters without hints', function (done) {
-      var client = newInstance();
-      var query = util.format('INSERT INTO %s (id, int_sample) VALUES (?, ?)', table1);
+      const client = newInstance();
+      const query = util.format('INSERT INTO %s (id, int_sample) VALUES (?, ?)', table1);
       utils.series([
         client.connect.bind(client),
         function (next) {
@@ -158,9 +158,9 @@ describe('Client', function () {
       ], done);
     });
     vit('2.0', 'should use hints when provided', function (done) {
-      var client = newInstance();
-      var id1 = types.Uuid.random();
-      var id2 = types.Uuid.random();
+      const client = newInstance();
+      const id1 = types.Uuid.random();
+      const id2 = types.Uuid.random();
       var queries = [
         { query: util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table1),
           params: [id1, 'sample1']
@@ -175,7 +175,7 @@ describe('Client', function () {
       ];
       client.batch(queries, {hints: hints, consistency: types.consistencies.quorum}, function (err) {
         assert.ifError(err);
-        var query = util.format('SELECT * FROM %s where id IN (%s, %s)', table1, id1, id2);
+        const query = util.format('SELECT * FROM %s where id IN (%s, %s)', table1, id1, id2);
         client.execute(query, [], {consistency: types.consistencies.quorum}, function (err, result) {
           assert.ifError(err);
           assert.ok(result && result.rows);
@@ -186,7 +186,7 @@ describe('Client', function () {
       });
     });
     vit('2.0', 'should callback in err when wrong hints are provided', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       var queries = [{
         query: util.format('INSERT INTO %s (id, text_sample, double_sample) VALUES (?, ?, ?)', table1),
         params: [types.Uuid.random(), 'what', 1]
@@ -226,11 +226,11 @@ describe('Client', function () {
     });
     vit('2.1', 'should support protocol level timestamp', function (done) {
       var insertQuery = 'INSERT INTO %s (id, text_sample) VALUES (?, ?)';
-      var selectQuery = 'SELECT id, text_sample, writetime(text_sample) FROM %s WHERE id = %s';
-      var id1 = types.Uuid.random();
-      var id2 = types.Uuid.random();
-      var client = newInstance();
-      var timestamp = types.Long.fromString('1428311323417123');
+      const selectQuery = 'SELECT id, text_sample, writetime(text_sample) FROM %s WHERE id = %s';
+      const id1 = types.Uuid.random();
+      const id2 = types.Uuid.random();
+      const client = newInstance();
+      const timestamp = types.Long.fromString('1428311323417123');
       var queries = [
         {query: util.format(insertQuery, table1), params: [id1, 'value 1 with timestamp']},
         {query: util.format(insertQuery, table2), params: [id2, 'value 2 with timestamp']}
@@ -264,9 +264,9 @@ describe('Client', function () {
     });
     vit('2.1', 'should support serial consistency', function (done) {
       var insertQuery = 'INSERT INTO %s (id, text_sample) VALUES (?, ?)';
-      var selectQuery = 'SELECT id, text_sample, writetime(text_sample) FROM %s WHERE id = %s';
-      var id1 = types.Uuid.random();
-      var client = newInstance();
+      const selectQuery = 'SELECT id, text_sample, writetime(text_sample) FROM %s WHERE id = %s';
+      const id1 = types.Uuid.random();
+      const client = newInstance();
       var queries = [
         {query: util.format(insertQuery, table1), params: [id1, 'value with serial']}
       ];
@@ -290,10 +290,10 @@ describe('Client', function () {
     describe('with no callback specified', function () {
       vit('2.0', 'should return a promise when batch completes', function () {
         var insertQuery = 'INSERT INTO %s (id, text_sample) VALUES (%s, \'%s\')';
-        var selectQuery = 'SELECT * FROM %s WHERE id = %s';
-        var id1 = types.Uuid.random();
-        var id2 = types.Uuid.random();
-        var client = newInstance();
+        const selectQuery = 'SELECT * FROM %s WHERE id = %s';
+        const id1 = types.Uuid.random();
+        const id2 = types.Uuid.random();
+        const client = newInstance();
         var queries = [
           util.format(insertQuery, table1, id1, 'one'),
           util.format(insertQuery, table2, id2, 'two')
@@ -319,11 +319,11 @@ describe('Client', function () {
     });
   });
   describe('#batch(queries, {prepare: 1}, callback)', function () {
-    var keyspace = helper.getRandomName('ks');
+    const keyspace = helper.getRandomName('ks');
     var table1 = keyspace + '.' + helper.getRandomName('tblA');
     var table2 = keyspace + '.' + helper.getRandomName('tblB');
     before(function (done) {
-      var client = newInstance();
+      const client = newInstance();
       var createTableCql = 'CREATE TABLE %s (' +
         ' id uuid,' +
         ' time timeuuid,' +
@@ -345,10 +345,10 @@ describe('Client', function () {
     });
     after(helper.ccmHelper.remove);
     vit('2.0', 'should prepare and send the request', function (done) {
-      var client = newInstance();
-      var id1 = types.Uuid.random();
-      var id2 = types.Uuid.random();
-      var consistency = types.consistencies.quorum;
+      const client = newInstance();
+      const id1 = types.Uuid.random();
+      const id2 = types.Uuid.random();
+      const consistency = types.consistencies.quorum;
       var queries = [{
         query: util.format('INSERT INTO %s (id, time, text_sample) VALUES (?, ?, ?)', table1),
         params: [id1, types.timeuuid(), 'sample1']
@@ -358,7 +358,7 @@ describe('Client', function () {
       }];
       client.batch(queries, {prepare: true, consistency: consistency}, function (err) {
         assert.ifError(err);
-        var query = 'SELECT * FROM %s where id = %s';
+        const query = 'SELECT * FROM %s where id = %s';
         utils.series([
           function (next) {
             client.execute(util.format(query, table1, id1), [], {consistency: consistency}, function (err, result) {
@@ -381,7 +381,7 @@ describe('Client', function () {
       });
     });
     vit('2.0', 'should callback in error when the one of the queries contains syntax error', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       var queries1 = [{
         query: util.format('INSERT INTO %s (id, time, text_sample) VALUES (?, ?, ?)', table2),
         params: [types.Uuid.random(), types.timeuuid(), 'sample1']
@@ -400,7 +400,7 @@ describe('Client', function () {
       }, done);
     });
     vit('2.0', 'should callback in error when the type does not match', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       var queries = [{
         query: util.format('INSERT INTO %s (id, time, int_sample) VALUES (?, ?, ?)', table1),
         params: [types.Uuid.random(), types.timeuuid(), {notValid: true}]
@@ -413,17 +413,17 @@ describe('Client', function () {
       }, done);
     });
     vit('2.0', 'should handle multiple prepares in parallel', function (done) {
-      var consistency = types.consistencies.quorum;
-      var id1Tbl1 = types.Uuid.random();
-      var id1Tbl2 = types.Uuid.random();
-      var id2Tbl1 = types.Uuid.random();
-      var id2Tbl2 = types.Uuid.random();
+      const consistency = types.consistencies.quorum;
+      const id1Tbl1 = types.Uuid.random();
+      const id1Tbl2 = types.Uuid.random();
+      const id2Tbl1 = types.Uuid.random();
+      const id2Tbl2 = types.Uuid.random();
       //Avoid using the same queries from test to test, include hardcoded values
       var query1Table1 = util.format('INSERT INTO %s (id, time, decimal_sample, int_sample) VALUES (?, ?, ?, 201)', table1);
       var query1Table2 = util.format('INSERT INTO %s (id, time, timestamp_sample, int_sample) VALUES (?, ?, ?, 202)', table2);
       var query2Table1 = util.format('INSERT INTO %s (id, time, decimal_sample, int_sample) VALUES (?, ?, ?, 301)', table1);
       var query2Table2 = util.format('INSERT INTO %s (id, time, float_sample, int_sample) VALUES (?, ?, ?, 302)', table2);
-      var client = newInstance();
+      const client = newInstance();
       utils.parallel([
         function (next) {
           utils.timesLimit(120, 100, function (n, eachNext) {
@@ -454,10 +454,10 @@ describe('Client', function () {
           return done(err);
         }
         //verify results in both tables
-        var q = 'SELECT * FROM %s where id IN (%s, %s)';
+        const q = 'SELECT * FROM %s where id IN (%s, %s)';
         utils.series([
           function (next) {
-            var query = util.format(q, table1, id1Tbl1, id2Tbl1);
+            const query = util.format(q, table1, id1Tbl1, id2Tbl1);
             client.execute(query, [], { consistency: consistency }, function (err, result) {
               assert.ifError(err);
               var rows1 = result.rows;
@@ -466,7 +466,7 @@ describe('Client', function () {
             });
           },
           function (next) {
-            var query = util.format(q, table2, id1Tbl2, id2Tbl2);
+            const query = util.format(q, table2, id1Tbl2, id2Tbl2);
             client.execute(query, [], { consistency: consistency }, function (err, result) {
               assert.ifError(err);
               var rows2 = result.rows;
@@ -478,10 +478,10 @@ describe('Client', function () {
       });
     });
     vit('2.0', 'should allow named parameters', function (done) {
-      var client = newInstance();
-      var id1 = types.Uuid.random();
-      var id2 = types.Uuid.random();
-      var consistency = types.consistencies.quorum;
+      const client = newInstance();
+      const id1 = types.Uuid.random();
+      const id2 = types.Uuid.random();
+      const consistency = types.consistencies.quorum;
       var queries = [{
         query: util.format('INSERT INTO %s (id, time, text_sample) VALUES (:paramId, :time, :text_sample)', table1),
         params: { text_SAMPLE: 'named params', paramID: id1, time: types.TimeUuid.now()}
@@ -491,7 +491,7 @@ describe('Client', function () {
       }];
       client.batch(queries, {prepare: true, consistency: consistency}, function (err) {
         assert.ifError(err);
-        var query = 'SELECT * FROM %s where id = %s';
+        const query = 'SELECT * FROM %s where id = %s';
         utils.series([
           function (next) {
             client.execute(util.format(query, table1, id1), [], {consistency: consistency}, function (err, result) {
@@ -514,11 +514,11 @@ describe('Client', function () {
       });
     });
     vit('2.0', 'should execute batch containing the same query multiple times', function (done) {
-      var client = newInstance({
+      const client = newInstance({
         queryOptions: { consistency: types.consistencies.quorum }
       });
-      var id = types.Uuid.random();
-      var query = util.format('INSERT INTO %s (id, time, int_sample) VALUES (?, ?, ?)', table1);
+      const id = types.Uuid.random();
+      const query = util.format('INSERT INTO %s (id, time, int_sample) VALUES (?, ?, ?)', table1);
       var queries = [
         { query: query, params: [id, types.TimeUuid.now(), 1000]},
         { query: query, params: [id, types.TimeUuid.now(), 2000]}

--- a/test/integration/short/client-batch-tests.js
+++ b/test/integration/short/client-batch-tests.js
@@ -13,8 +13,8 @@ describe('Client', function () {
   this.timeout(120000);
   describe('#batch(queries, {prepare: 0}, callback)', function () {
     const keyspace = helper.getRandomName('ks');
-    var table1 = keyspace + '.' + helper.getRandomName('tblA');
-    var table2 = keyspace + '.' + helper.getRandomName('tblB');
+    const table1 = keyspace + '.' + helper.getRandomName('tblA');
+    const table2 = keyspace + '.' + helper.getRandomName('tblB');
     before(function (done) {
       const client = newInstance();
       utils.series([
@@ -26,12 +26,12 @@ describe('Client', function () {
     });
     after(helper.ccmHelper.remove);
     vit('2.0', 'should execute a batch of queries with no params', function (done) {
-      var insertQuery = 'INSERT INTO %s (id, text_sample) VALUES (%s, \'%s\')';
+      const insertQuery = 'INSERT INTO %s (id, text_sample) VALUES (%s, \'%s\')';
       const selectQuery = 'SELECT * FROM %s WHERE id = %s';
       const id1 = types.Uuid.random();
       const id2 = types.Uuid.random();
       const client = newInstance();
-      var queries = [
+      const queries = [
         util.format(insertQuery, table1, id1, 'one'),
         util.format(insertQuery, table2, id2, 'two')
       ];
@@ -60,12 +60,12 @@ describe('Client', function () {
       ], done);
     });
     vit('2.0', 'should execute a batch of queries with params', function (done) {
-      var insertQuery = 'INSERT INTO %s (id, double_sample) VALUES (?, ?)';
+      const insertQuery = 'INSERT INTO %s (id, double_sample) VALUES (?, ?)';
       const selectQuery = 'SELECT * FROM %s WHERE id = %s';
       const id1 = types.Uuid.random();
       const id2 = types.Uuid.random();
       const client = newInstance();
-      var queries = [
+      const queries = [
         {query: util.format(insertQuery, table1), params: [id1, 1000]},
         {query: util.format(insertQuery, table2), params: [id2, 2000.2]}
       ];
@@ -113,7 +113,7 @@ describe('Client', function () {
     });
     vit('2.0', 'should validate that arguments are valid', function () {
       const client = newInstance();
-      var badArgumentCalls = [
+      const badArgumentCalls = [
         function () {
           return client.batch();
         },
@@ -125,7 +125,7 @@ describe('Client', function () {
         }
       ];
 
-      var promises = badArgumentCalls.map(function (method) {
+      const promises = badArgumentCalls.map(function (method) {
         return method()
           .then(function () {
             throw new Error('Expected rejected promise for method ' + method.toString());
@@ -161,7 +161,7 @@ describe('Client', function () {
       const client = newInstance();
       const id1 = types.Uuid.random();
       const id2 = types.Uuid.random();
-      var queries = [
+      const queries = [
         { query: util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table1),
           params: [id1, 'sample1']
         },
@@ -169,7 +169,7 @@ describe('Client', function () {
           params: [id2, -1, -1]
         }
       ];
-      var hints = [
+      const hints = [
         null,
         [null, 'int', 'bigint']
       ];
@@ -187,7 +187,7 @@ describe('Client', function () {
     });
     vit('2.0', 'should callback in err when wrong hints are provided', function (done) {
       const client = newInstance();
-      var queries = [{
+      const queries = [{
         query: util.format('INSERT INTO %s (id, text_sample, double_sample) VALUES (?, ?, ?)', table1),
         params: [types.Uuid.random(), 'what', 1]
       }];
@@ -225,13 +225,13 @@ describe('Client', function () {
       ], done);
     });
     vit('2.1', 'should support protocol level timestamp', function (done) {
-      var insertQuery = 'INSERT INTO %s (id, text_sample) VALUES (?, ?)';
+      const insertQuery = 'INSERT INTO %s (id, text_sample) VALUES (?, ?)';
       const selectQuery = 'SELECT id, text_sample, writetime(text_sample) FROM %s WHERE id = %s';
       const id1 = types.Uuid.random();
       const id2 = types.Uuid.random();
       const client = newInstance();
       const timestamp = types.Long.fromString('1428311323417123');
-      var queries = [
+      const queries = [
         {query: util.format(insertQuery, table1), params: [id1, 'value 1 with timestamp']},
         {query: util.format(insertQuery, table2), params: [id2, 'value 2 with timestamp']}
       ];
@@ -263,11 +263,11 @@ describe('Client', function () {
       ], done);
     });
     vit('2.1', 'should support serial consistency', function (done) {
-      var insertQuery = 'INSERT INTO %s (id, text_sample) VALUES (?, ?)';
+      const insertQuery = 'INSERT INTO %s (id, text_sample) VALUES (?, ?)';
       const selectQuery = 'SELECT id, text_sample, writetime(text_sample) FROM %s WHERE id = %s';
       const id1 = types.Uuid.random();
       const client = newInstance();
-      var queries = [
+      const queries = [
         {query: util.format(insertQuery, table1), params: [id1, 'value with serial']}
       ];
       utils.series([
@@ -289,12 +289,12 @@ describe('Client', function () {
     });
     describe('with no callback specified', function () {
       vit('2.0', 'should return a promise when batch completes', function () {
-        var insertQuery = 'INSERT INTO %s (id, text_sample) VALUES (%s, \'%s\')';
+        const insertQuery = 'INSERT INTO %s (id, text_sample) VALUES (%s, \'%s\')';
         const selectQuery = 'SELECT * FROM %s WHERE id = %s';
         const id1 = types.Uuid.random();
         const id2 = types.Uuid.random();
         const client = newInstance();
-        var queries = [
+        const queries = [
           util.format(insertQuery, table1, id1, 'one'),
           util.format(insertQuery, table2, id2, 'two')
         ];
@@ -320,11 +320,11 @@ describe('Client', function () {
   });
   describe('#batch(queries, {prepare: 1}, callback)', function () {
     const keyspace = helper.getRandomName('ks');
-    var table1 = keyspace + '.' + helper.getRandomName('tblA');
-    var table2 = keyspace + '.' + helper.getRandomName('tblB');
+    const table1 = keyspace + '.' + helper.getRandomName('tblA');
+    const table2 = keyspace + '.' + helper.getRandomName('tblB');
     before(function (done) {
       const client = newInstance();
-      var createTableCql = 'CREATE TABLE %s (' +
+      const createTableCql = 'CREATE TABLE %s (' +
         ' id uuid,' +
         ' time timeuuid,' +
         ' text_sample text,' +
@@ -349,7 +349,7 @@ describe('Client', function () {
       const id1 = types.Uuid.random();
       const id2 = types.Uuid.random();
       const consistency = types.consistencies.quorum;
-      var queries = [{
+      const queries = [{
         query: util.format('INSERT INTO %s (id, time, text_sample) VALUES (?, ?, ?)', table1),
         params: [id1, types.timeuuid(), 'sample1']
       },{
@@ -363,7 +363,7 @@ describe('Client', function () {
           function (next) {
             client.execute(util.format(query, table1, id1), [], {consistency: consistency}, function (err, result) {
               assert.ifError(err);
-              var row1 = result.first();
+              const row1 = result.first();
               assert.strictEqual(row1['text_sample'], 'sample1');
               next();
             });
@@ -371,7 +371,7 @@ describe('Client', function () {
           function (next) {
             client.execute(util.format(query, table2, id2), [], {consistency: consistency}, function (err, result) {
               assert.ifError(err);
-              var row2 = result.first();
+              const row2 = result.first();
               assert.strictEqual(row2['int_sample'], -101);
               assert.strictEqual(row2['varint_sample'].toString(), '151');
               next();
@@ -382,16 +382,16 @@ describe('Client', function () {
     });
     vit('2.0', 'should callback in error when the one of the queries contains syntax error', function (done) {
       const client = newInstance();
-      var queries1 = [{
+      const queries1 = [{
         query: util.format('INSERT INTO %s (id, time, text_sample) VALUES (?, ?, ?)', table2),
         params: [types.Uuid.random(), types.timeuuid(), 'sample1']
       },{
         query: util.format('INSERT WILL FAIL'),
         params: [types.Uuid.random(), types.timeuuid(), -101, -1]
       }];
-      var queries2 = [queries1[1], queries1[1]];
+      const queries2 = [queries1[1], queries1[1]];
       utils.times(10, function (n, next) {
-        var queries = (n % 2 === 0) ? queries1 : queries2;
+        const queries = (n % 2 === 0) ? queries1 : queries2;
         client.batch(queries, {prepare: true}, function (err) {
           helper.assertInstanceOf(err, errors.ResponseError);
           assert.strictEqual(err.code, types.responseErrorCodes.syntaxError);
@@ -401,7 +401,7 @@ describe('Client', function () {
     });
     vit('2.0', 'should callback in error when the type does not match', function (done) {
       const client = newInstance();
-      var queries = [{
+      const queries = [{
         query: util.format('INSERT INTO %s (id, time, int_sample) VALUES (?, ?, ?)', table1),
         params: [types.Uuid.random(), types.timeuuid(), {notValid: true}]
       }];
@@ -419,15 +419,15 @@ describe('Client', function () {
       const id2Tbl1 = types.Uuid.random();
       const id2Tbl2 = types.Uuid.random();
       //Avoid using the same queries from test to test, include hardcoded values
-      var query1Table1 = util.format('INSERT INTO %s (id, time, decimal_sample, int_sample) VALUES (?, ?, ?, 201)', table1);
-      var query1Table2 = util.format('INSERT INTO %s (id, time, timestamp_sample, int_sample) VALUES (?, ?, ?, 202)', table2);
-      var query2Table1 = util.format('INSERT INTO %s (id, time, decimal_sample, int_sample) VALUES (?, ?, ?, 301)', table1);
-      var query2Table2 = util.format('INSERT INTO %s (id, time, float_sample, int_sample) VALUES (?, ?, ?, 302)', table2);
+      const query1Table1 = util.format('INSERT INTO %s (id, time, decimal_sample, int_sample) VALUES (?, ?, ?, 201)', table1);
+      const query1Table2 = util.format('INSERT INTO %s (id, time, timestamp_sample, int_sample) VALUES (?, ?, ?, 202)', table2);
+      const query2Table1 = util.format('INSERT INTO %s (id, time, decimal_sample, int_sample) VALUES (?, ?, ?, 301)', table1);
+      const query2Table2 = util.format('INSERT INTO %s (id, time, float_sample, int_sample) VALUES (?, ?, ?, 302)', table2);
       const client = newInstance();
       utils.parallel([
         function (next) {
           utils.timesLimit(120, 100, function (n, eachNext) {
-            var queries = [{
+            const queries = [{
               query: query1Table1,
               params: [id1Tbl1, types.timeuuid(), types.BigDecimal.fromNumber(new Date().getTime())]
             }, {
@@ -439,7 +439,7 @@ describe('Client', function () {
         },
         function (next) {
           utils.timesLimit(120, 100, function (n, eachNext) {
-            var queries = [{
+            const queries = [{
               query: query2Table1,
               params: [id2Tbl1, types.timeuuid(), types.BigDecimal.fromNumber(new Date().getTime())]
             }, {
@@ -460,7 +460,7 @@ describe('Client', function () {
             const query = util.format(q, table1, id1Tbl1, id2Tbl1);
             client.execute(query, [], { consistency: consistency }, function (err, result) {
               assert.ifError(err);
-              var rows1 = result.rows;
+              const rows1 = result.rows;
               assert.strictEqual(rows1.length, 240);
               next();
             });
@@ -469,7 +469,7 @@ describe('Client', function () {
             const query = util.format(q, table2, id1Tbl2, id2Tbl2);
             client.execute(query, [], { consistency: consistency }, function (err, result) {
               assert.ifError(err);
-              var rows2 = result.rows;
+              const rows2 = result.rows;
               assert.strictEqual(rows2.length, 240);
               next();
             });
@@ -482,7 +482,7 @@ describe('Client', function () {
       const id1 = types.Uuid.random();
       const id2 = types.Uuid.random();
       const consistency = types.consistencies.quorum;
-      var queries = [{
+      const queries = [{
         query: util.format('INSERT INTO %s (id, time, text_sample) VALUES (:paramId, :time, :text_sample)', table1),
         params: { text_SAMPLE: 'named params', paramID: id1, time: types.TimeUuid.now()}
       },{
@@ -496,7 +496,7 @@ describe('Client', function () {
           function (next) {
             client.execute(util.format(query, table1, id1), [], {consistency: consistency}, function (err, result) {
               assert.ifError(err);
-              var row1 = result.first();
+              const row1 = result.first();
               assert.strictEqual(row1['text_sample'], 'named params');
               next();
             });
@@ -504,7 +504,7 @@ describe('Client', function () {
           function (next) {
             client.execute(util.format(query, table2, id2), [], {consistency: consistency}, function (err, result) {
               assert.ifError(err);
-              var row2 = result.first();
+              const row2 = result.first();
               assert.strictEqual(row2['int_sample'], 501);
               assert.strictEqual(row2['varint_sample'].toString(), '2010');
               next();
@@ -519,14 +519,14 @@ describe('Client', function () {
       });
       const id = types.Uuid.random();
       const query = util.format('INSERT INTO %s (id, time, int_sample) VALUES (?, ?, ?)', table1);
-      var queries = [
+      const queries = [
         { query: query, params: [id, types.TimeUuid.now(), 1000]},
         { query: query, params: [id, types.TimeUuid.now(), 2000]}
       ];
       client.batch(queries, { prepare: true }, function (err) {
         assert.ifError(err);
         //Check values inserted
-        var selectQuery = util.format('SELECT int_sample FROM %s WHERE id = ?', table1);
+        const selectQuery = util.format('SELECT int_sample FROM %s WHERE id = ?', table1);
         client.execute(selectQuery, [id], function (err, result) {
           assert.ifError(err);
           assert.strictEqual(result.rows.length, 2);

--- a/test/integration/short/client-each-row-tests.js
+++ b/test/integration/short/client-each-row-tests.js
@@ -65,8 +65,8 @@ describe('Client', function () {
     it('should call rowCallback per each row', function (done) {
       const client = setupInfo.client;
       const table = helper.getRandomName('table');
-      var length = 300;
-      var noop = function () {};
+      const length = 300;
+      const noop = function () {};
       let counter = 0;
       utils.series([
         function createTable(next) {
@@ -110,7 +110,7 @@ describe('Client', function () {
     vit('2.0', 'should autoPage', function (done) {
       const table = helper.getRandomName('table');
       const client = setupInfo.client;
-      var noop = function () {};
+      const noop = function () {};
       utils.series([
         function createTable(next) {
           client.eachRow(helper.createTableCql(table), [], noop, helper.waitSchema(client, next));
@@ -175,8 +175,8 @@ describe('Client', function () {
     it('should call rowCallback per each row', function (done) {
       const client = setupInfo.client;
       const table = helper.getRandomName('table');
-      var length = 500;
-      var noop = function () {};
+      const length = 500;
+      const noop = function () {};
       let counter = 0;
       utils.series([
         function createTable(next) {
@@ -201,7 +201,7 @@ describe('Client', function () {
     });
     it('should allow maps with float values NaN and infinite values', function (done) {
       const client = setupInfo.client;
-      var values = [
+      const values = [
         [ 'finite', { val: 1 }],
         [ 'NaN', { val: NaN }],
         [ 'Infinite', { val: Number.POSITIVE_INFINITY }],
@@ -240,10 +240,10 @@ describe('Client', function () {
     });
     vit('2.0', 'should autoPage on parallel different tables', function (done) {
       const keyspace = helper.getRandomName('ks');
-      var table1 = keyspace + '.' + helper.getRandomName('table');
-      var table2 = keyspace + '.' + helper.getRandomName('table');
+      const table1 = keyspace + '.' + helper.getRandomName('table');
+      const table2 = keyspace + '.' + helper.getRandomName('table');
       const client = newInstance({ queryOptions: { consistency: types.consistencies.quorum }});
-      var noop = function () {};
+      const noop = function () {};
       utils.series([
         function createKs(next) {
           client.eachRow(helper.createKeyspaceCql(keyspace, 3), [], noop, helper.waitSchema(client, next));
@@ -408,7 +408,7 @@ describe('Client', function () {
         queryOptions: { consistency: types.consistencies.quorum }
       });
       let counter = 0;
-      var rowLength = 10;
+      const rowLength = 10;
       utils.series([
         client.connect.bind(client),
         helper.toTask(insertTestData, null, client, table, rowLength),
@@ -494,7 +494,7 @@ describe('Client', function () {
         table,
         table
       );
-      var params = { id1: types.Uuid.random(), id2: types.Uuid.random(), sample: utils.stringRepeat('c', 2562) };
+      const params = { id1: types.Uuid.random(), id2: types.Uuid.random(), sample: utils.stringRepeat('c', 2562) };
       client.eachRow(query, params, { prepare: true }, utils.noop, function (err, result) {
         assert.ifError(err);
         assert.ok(result.info.warnings);
@@ -532,7 +532,7 @@ function insertTestData(client, table, length, callback) {
     },
     function insertData(seriesNext) {
       const query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
-      var value = utils.stringRepeat('abcdefghij', 10);
+      const value = utils.stringRepeat('abcdefghij', 10);
       utils.timesLimit(length, 100, function (n, next) {
         client.eachRow(query, [types.Uuid.random(), value], {prepare: 1}, helper.noop, next);
       }, seriesNext);

--- a/test/integration/short/client-each-row-tests.js
+++ b/test/integration/short/client-each-row-tests.js
@@ -1,22 +1,22 @@
 "use strict";
-var assert = require('assert');
-var util = require('util');
+const assert = require('assert');
+const util = require('util');
 
-var helper = require('../../test-helper.js');
-var Client = require('../../../lib/client.js');
-var types = require('../../../lib/types');
-var utils = require('../../../lib/utils.js');
-var errors = require('../../../lib/errors.js');
-var vit = helper.vit;
+const helper = require('../../test-helper.js');
+const Client = require('../../../lib/client.js');
+const types = require('../../../lib/types');
+const utils = require('../../../lib/utils.js');
+const errors = require('../../../lib/errors.js');
+const vit = helper.vit;
 
 describe('Client', function () {
   this.timeout(120000);
   describe('#eachRow(query, params, {prepare: 0})', function () {
-    var setupInfo = helper.setup(1);
+    const setupInfo = helper.setup(1);
     it('should callback per row and the end callback', function (done) {
-      var client = newInstance();
-      var query = helper.queries.basic;
-      var counter = 0;
+      const client = newInstance();
+      const query = helper.queries.basic;
+      let counter = 0;
       client.eachRow(query, [], {prepare: false}, function (n, row) {
         assert.strictEqual(n, 0);
         assert.ok(row instanceof types.Row, null);
@@ -29,8 +29,8 @@ describe('Client', function () {
       });
     });
     it('should allow calls without end callback', function (done) {
-      var client = setupInfo.client;
-      var query = helper.queries.basic;
+      const client = setupInfo.client;
+      const query = helper.queries.basic;
       client.eachRow(query, [], {}, function (n, row) {
         assert.strictEqual(n, 0);
         assert.ok(row instanceof types.Row, null);
@@ -38,9 +38,9 @@ describe('Client', function () {
       });
     });
     it('should end callback when no rows', function (done) {
-      var client = setupInfo.client;
-      var query = helper.queries.basicNoResults;
-      var counter = 0;
+      const client = setupInfo.client;
+      const query = helper.queries.basicNoResults;
+      let counter = 0;
       client.eachRow(query, [], {}, function () {
         counter++;
       }, function (err) {
@@ -50,10 +50,10 @@ describe('Client', function () {
       });
     });
     it('should end callback when VOID result', function (done) {
-      var client = setupInfo.client;
-      var keyspace = helper.getRandomName('ks');
-      var query = helper.createKeyspaceCql(keyspace, 1);
-      var counter = 0;
+      const client = setupInfo.client;
+      const keyspace = helper.getRandomName('ks');
+      const query = helper.createKeyspaceCql(keyspace, 1);
+      let counter = 0;
       client.eachRow(query, [], {}, function () {
         counter++;
       }, function (err) {
@@ -63,17 +63,17 @@ describe('Client', function () {
       });
     });
     it('should call rowCallback per each row', function (done) {
-      var client = setupInfo.client;
-      var table = helper.getRandomName('table');
+      const client = setupInfo.client;
+      const table = helper.getRandomName('table');
       var length = 300;
       var noop = function () {};
-      var counter = 0;
+      let counter = 0;
       utils.series([
         function createTable(next) {
           client.eachRow(helper.createTableCql(table), [], noop, helper.waitSchema(client, next));
         },
         function insert(next) {
-          var query = 'INSERT INTO %s (id, text_sample) VALUES (%s, \'text%s\')';
+          const query = 'INSERT INTO %s (id, text_sample) VALUES (%s, \'text%s\')';
           utils.timesSeries(length, function (n, timesNext) {
             client.eachRow(util.format(query, table, types.Uuid.random(), n), [], noop, timesNext);
           }, next);
@@ -92,10 +92,10 @@ describe('Client', function () {
         }], done);
     });
     it('should fail if non-existent profile provided', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       utils.series([
         function queryWithBadProfile(next) {
-          var counter = 0;
+          let counter = 0;
           client.eachRow(helper.queries.basicNoResults, [], {executionProfile: 'none'}, function() {
             counter++;
           }, function (err) {
@@ -108,23 +108,23 @@ describe('Client', function () {
       ], done);
     });
     vit('2.0', 'should autoPage', function (done) {
-      var table = helper.getRandomName('table');
-      var client = setupInfo.client;
+      const table = helper.getRandomName('table');
+      const client = setupInfo.client;
       var noop = function () {};
       utils.series([
         function createTable(next) {
           client.eachRow(helper.createTableCql(table), [], noop, helper.waitSchema(client, next));
         },
         function insertData(seriesNext) {
-          var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
+          const query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
           utils.times(100, function (n, next) {
             client.eachRow(query, [types.Uuid.random(), n.toString()], noop, next);
           }, seriesNext);
         },
         function selectDataMultiplePages(seriesNext) {
           //It should fetch 3 times, a total of 100 rows (45+45+10)
-          var query = util.format('SELECT * FROM %s', table);
-          var rowCount = 0;
+          const query = util.format('SELECT * FROM %s', table);
+          let rowCount = 0;
           client.eachRow(query, [], {fetchSize: 45, autoPage: true}, function () {
             rowCount++;
           }, function (err, result) {
@@ -136,8 +136,8 @@ describe('Client', function () {
         },
         function selectDataOnePage(seriesNext) {
           //It should fetch 1 time, a total of 100 rows (even if asked more)
-          var query = util.format('SELECT * FROM %s', table);
-          var rowCount = 0;
+          const query = util.format('SELECT * FROM %s', table);
+          let rowCount = 0;
           client.eachRow(query, [], {fetchSize: 2000, autoPage: true}, function () {
             rowCount++;
           }, function (err, result) {
@@ -151,17 +151,17 @@ describe('Client', function () {
     });
   });
   describe('#eachRow(query, params, {prepare: 1})', function () {
-    var table = helper.getRandomName('table');
-    var setupInfo = helper.setup(3, {
+    const table = helper.getRandomName('table');
+    const setupInfo = helper.setup(3, {
       ccmOptions: { jvmArgs: ['-Dcassandra.wait_for_tracing_events_timeout_secs=-1'] },
       replicationFactor: 3,
       queries: [ helper.createTableCql(table) ]
     });
-    var queryOptions = { prepare: true, consistency: types.consistencies.quorum };
+    const queryOptions = { prepare: true, consistency: types.consistencies.quorum };
     it('should callback per row and the end callback', function (done) {
-      var client = setupInfo.client;
-      var query = helper.queries.basic;
-      var counter = 0;
+      const client = setupInfo.client;
+      const query = helper.queries.basic;
+      let counter = 0;
       client.eachRow(query, [], {prepare: true}, function (n, row) {
         assert.strictEqual(n, 0);
         assert.ok(row instanceof types.Row, null);
@@ -173,17 +173,17 @@ describe('Client', function () {
       });
     });
     it('should call rowCallback per each row', function (done) {
-      var client = setupInfo.client;
-      var table = helper.getRandomName('table');
+      const client = setupInfo.client;
+      const table = helper.getRandomName('table');
       var length = 500;
       var noop = function () {};
-      var counter = 0;
+      let counter = 0;
       utils.series([
         function createTable(next) {
           client.eachRow(helper.createTableCql(table), [], noop, helper.waitSchema(client, next));
         },
         function insert(next) {
-          var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
+          const query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
           utils.timesSeries(length, function (n, timesNext) {
             client.eachRow(query, [ types.Uuid.random(), 'text-' + n ], queryOptions, noop, timesNext);
           }, next);
@@ -200,21 +200,21 @@ describe('Client', function () {
         }], done);
     });
     it('should allow maps with float values NaN and infinite values', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       var values = [
         [ 'finite', { val: 1 }],
         [ 'NaN', { val: NaN }],
         [ 'Infinite', { val: Number.POSITIVE_INFINITY }],
         [ 'Negative Infinite', { val: Number.NEGATIVE_INFINITY }]
       ];
-      var expectedValues = {};
+      const expectedValues = {};
       utils.series([
         function createTable(next) {
-          var query = 'CREATE TABLE tbl_map_floats (id text PRIMARY KEY, data map<text, float>)';
+          const query = 'CREATE TABLE tbl_map_floats (id text PRIMARY KEY, data map<text, float>)';
           client.execute(query, next);
         },
         function insertData(next) {
-          var query = 'INSERT INTO tbl_map_floats (id, data) VALUES (?, ?)';
+          const query = 'INSERT INTO tbl_map_floats (id, data) VALUES (?, ?)';
           utils.eachSeries(values, function (params, eachNext) {
             expectedValues[params[0]] = params[1].val;
             client.execute(query, params, queryOptions, eachNext);
@@ -222,7 +222,7 @@ describe('Client', function () {
         },
         function retrieveData(next) {
           client.eachRow('SELECT * FROM tbl_map_floats', [], queryOptions, function (n, row) {
-            var expected = expectedValues[row['id']];
+            const expected = expectedValues[row['id']];
             if (isNaN(expected)) {
               assert.ok(isNaN(row['data'].val));
             }
@@ -239,10 +239,10 @@ describe('Client', function () {
       ], done);
     });
     vit('2.0', 'should autoPage on parallel different tables', function (done) {
-      var keyspace = helper.getRandomName('ks');
+      const keyspace = helper.getRandomName('ks');
       var table1 = keyspace + '.' + helper.getRandomName('table');
       var table2 = keyspace + '.' + helper.getRandomName('table');
-      var client = newInstance({ queryOptions: { consistency: types.consistencies.quorum }});
+      const client = newInstance({ queryOptions: { consistency: types.consistencies.quorum }});
       var noop = function () {};
       utils.series([
         function createKs(next) {
@@ -255,13 +255,13 @@ describe('Client', function () {
           client.eachRow(helper.createTableCql(table2), [], noop, helper.waitSchema(client, next));
         },
         function insertData(seriesNext) {
-          var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table1);
+          const query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table1);
           utils.timesLimit(200, 25, function (n, next) {
             client.eachRow(query, [types.Uuid.random(), n.toString()], {prepare: 1}, noop, next);
           }, seriesNext);
         },
         function insertData(seriesNext) {
-          var query = util.format('INSERT INTO %s (id, int_sample) VALUES (?, ?)', table2);
+          const query = util.format('INSERT INTO %s (id, int_sample) VALUES (?, ?)', table2);
           utils.timesLimit(135, 25, function (n, next) {
             client.eachRow(query, [types.Uuid.random(), n+1], {prepare: 1}, noop, next);
           }, seriesNext);
@@ -269,8 +269,8 @@ describe('Client', function () {
         function selectDataMultiplePages(seriesNext) {
           utils.parallel([
             function (parallelNext) {
-              var query = util.format('SELECT * FROM %s', table1);
-              var rowCount = 0;
+              const query = util.format('SELECT * FROM %s', table1);
+              let rowCount = 0;
               client.eachRow(query, [], {fetchSize: 39, autoPage: true, prepare: true}, function (n, row) {
                 assert.ok(row['text_sample']);
                 rowCount++;
@@ -280,8 +280,8 @@ describe('Client', function () {
               });
             },
             function (parallelNext) {
-              var query = util.format('SELECT * FROM %s', table2);
-              var rowCount = 0;
+              const query = util.format('SELECT * FROM %s', table2);
+              let rowCount = 0;
               client.eachRow(query, [], { fetchSize: 23, autoPage: true, prepare: true }, function (n, row) {
                 rowCount++;
                 assert.ok(row['int_sample']);
@@ -300,17 +300,17 @@ describe('Client', function () {
       }
     });
     vit('2.0', 'should use pageState and fetchSize', function (done) {
-      var client = newInstance({
+      const client = newInstance({
         keyspace: setupInfo.keyspace,
         queryOptions: { consistency: types.consistencies.quorum }
       });
-      var metaPageState;
-      var pageState;
+      let metaPageState;
+      let pageState;
       utils.series([
         helper.toTask(insertTestData, null, client, table, 131),
         function selectData(seriesNext) {
           //Only fetch 70
-          var counter = 0;
+          let counter = 0;
           client.eachRow(util.format('SELECT * FROM %s', table), [], {prepare: 1, fetchSize: 70}, function () {
             counter++;
           }, function (err, result) {
@@ -324,7 +324,7 @@ describe('Client', function () {
         },
         function selectDataRemaining(seriesNext) {
           //The remaining
-          var counter = 0;
+          let counter = 0;
           client.eachRow(util.format('SELECT * FROM %s', table), [], {prepare: 1, fetchSize: 70, pageState: pageState}, function (n, row) {
             assert.ok(row);
             counter++;
@@ -337,7 +337,7 @@ describe('Client', function () {
         },
         function selectDataRemainingWithMetaPageState(seriesNext) {
           //The remaining
-          var counter = 0;
+          let counter = 0;
           client.eachRow(util.format('SELECT * FROM %s', table), [], {prepare: 1, fetchSize: 70, pageState: metaPageState}, function (n, row) {
             assert.ok(row);
             counter++;
@@ -351,12 +351,12 @@ describe('Client', function () {
       ], done);
     });
     vit('2.0', 'should expose result.nextPage() method', function (done) {
-      var client = newInstance({
+      const client = newInstance({
         keyspace: setupInfo.keyspace,
         queryOptions: { consistency: types.consistencies.quorum }
       });
-      var pageState;
-      var nextPageRows;
+      let pageState;
+      let nextPageRows;
       utils.series([
         client.connect.bind(client),
         helper.toTask(insertTestData, null, client, table, 110),
@@ -387,7 +387,7 @@ describe('Client', function () {
         },
         function selectDataRemaining(seriesNext) {
           //Select the remaining with pageState and compare the results.
-          var counter = 0;
+          let counter = 0;
           client.eachRow(util.format('SELECT * FROM %s', table), [], {prepare: 1, fetchSize: 100, pageState: pageState}, function (n, row) {
             assert.ok(row);
             counter++;
@@ -403,11 +403,11 @@ describe('Client', function () {
       ], done);
     });
     vit('2.0', 'should not expose result.nextPage() method when no more rows', function (done) {
-      var client = newInstance({
+      const client = newInstance({
         keyspace: setupInfo.keyspace,
         queryOptions: { consistency: types.consistencies.quorum }
       });
-      var counter = 0;
+      let counter = 0;
       var rowLength = 10;
       utils.series([
         client.connect.bind(client),
@@ -427,16 +427,16 @@ describe('Client', function () {
       ], done);
     });
     it('should retrieve the trace id when queryTrace flag is set', function (done) {
-      var client = newInstance({
+      const client = newInstance({
         keyspace: setupInfo.keyspace,
         queryOptions: { consistency: types.consistencies.quorum }
       });
-      var id = types.Uuid.random();
+      const id = types.Uuid.random();
       utils.series([
         client.connect.bind(client),
         function selectNotExistent(next) {
-          var query = util.format('SELECT * FROM %s WHERE id = ?', table);
-          var called = 0;
+          const query = util.format('SELECT * FROM %s WHERE id = ?', table);
+          let called = 0;
           client.eachRow(query, [types.Uuid.random()], {prepare: true, traceQuery: true}, function () {
             called++;
           }, function (err, result) {
@@ -448,8 +448,8 @@ describe('Client', function () {
           });
         },
         function insertQuery(next) {
-          var query = util.format('INSERT INTO %s (id) VALUES (?)', table);
-          var called = 0;
+          const query = util.format('INSERT INTO %s (id) VALUES (?)', table);
+          let called = 0;
           client.eachRow(query, [id], { prepare: true, traceQuery: true}, function () {
             called++;
           }, function (err, result) {
@@ -461,8 +461,8 @@ describe('Client', function () {
           });
         },
         function selectSingleRow(next) {
-          var query = util.format('SELECT * FROM %s WHERE id = ?', table);
-          var called = 0;
+          const query = util.format('SELECT * FROM %s WHERE id = ?', table);
+          let called = 0;
           client.eachRow(query, [id], { prepare: true, traceQuery: true}, function () {
             called++;
           }, function (err, result) {
@@ -477,8 +477,8 @@ describe('Client', function () {
       ], done);
     });
     helper.vit('2.2', 'should include the warning in the ResultSet', function (done) {
-      var client = newInstance({ keyspace: setupInfo.client.keyspace });
-      var loggedMessage = false;
+      const client = newInstance({ keyspace: setupInfo.client.keyspace });
+      let loggedMessage = false;
       client.on('log', function (level, className, message) {
         if (loggedMessage || level !== 'warning') {
           return;
@@ -488,7 +488,7 @@ describe('Client', function () {
           loggedMessage = true;
         }
       });
-      var query = util.format(
+      const query = util.format(
         "BEGIN UNLOGGED BATCH INSERT INTO %s (id, text_sample) VALUES (:id1, :sample)\n" +
         "INSERT INTO %s (id, text_sample) VALUES (:id2, :sample) APPLY BATCH",
         table,
@@ -531,7 +531,7 @@ function insertTestData(client, table, length, callback) {
       client.eachRow('TRUNCATE ' + table, [], helper.noop, seriesNext);
     },
     function insertData(seriesNext) {
-      var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
+      const query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
       var value = utils.stringRepeat('abcdefghij', 10);
       utils.timesLimit(length, 100, function (n, next) {
         client.eachRow(query, [types.Uuid.random(), value], {prepare: 1}, helper.noop, next);
@@ -541,7 +541,7 @@ function insertTestData(client, table, length, callback) {
 }
 
 function insertSelectTest(table, rowLength, times, selectLimit, selectOptions, done) {
-  var client = newInstance({
+  const client = newInstance({
     queryOptions: {
       consistency: types.consistencies.quorum,
       fetchSize: rowLength
@@ -551,13 +551,13 @@ function insertSelectTest(table, rowLength, times, selectLimit, selectOptions, d
     }
   });
   client.on('log', helper.log(['warning', 'error']));
-  var query = util.format('SELECT * FROM %s LIMIT %d', table, selectLimit);
+  const query = util.format('SELECT * FROM %s LIMIT %d', table, selectLimit);
   utils.series([
     client.connect.bind(client),
     helper.toTask(insertTestData, null, client, table, rowLength),
     function selectData(seriesNext) {
       utils.timesLimit(times, 5, function (n, timesNext) {
-        var counter = 0;
+        let counter = 0;
         client.eachRow(query, [], selectOptions, function (n, row) {
           assert.ok(row);
           counter++;

--- a/test/integration/short/client-execute-prepared-tests.js
+++ b/test/integration/short/client-execute-prepared-tests.js
@@ -16,8 +16,8 @@ const commonKs = helper.getRandomName('ks');
 describe('Client', function () {
   this.timeout(120000);
   describe('#execute(query, params, {prepare: 1}, callback)', function () {
-    var commonTable = commonKs + '.' + helper.getRandomName('table');
-    var commonTable2 = commonKs + '.' + helper.getRandomName('table');
+    const commonTable = commonKs + '.' + helper.getRandomName('table');
+    const commonTable2 = commonKs + '.' + helper.getRandomName('table');
     const setupInfo = helper.setup(3, {
       keyspace: commonKs,
       queries: [ helper.createTableWithClusteringKeyCql(commonTable), helper.createTableCql(commonTable2) ]
@@ -56,20 +56,20 @@ describe('Client', function () {
     });
     it('should prepare and execute a queries in parallel', function (done) {
       const client = setupInfo.client;
-      var queries = [
+      const queries = [
         helper.queries.basic,
         helper.queries.basicNoResults,
         util.format('SELECT * FROM %s WHERE id1 = ?', commonTable),
         util.format('SELECT * FROM %s WHERE id1 IN (?, ?)', commonTable)
       ];
-      var params = [
+      const params = [
         null,
         null,
         [types.Uuid.random()],
         [types.Uuid.random(), types.Uuid.random()]
       ];
       utils.times(100, function (n, next) {
-        var index = n % 4;
+        const index = n % 4;
         client.execute(queries[index], params[index], {prepare: 1}, function (err, result) {
           assert.ifError(err);
           assert.ok(result);
@@ -124,20 +124,20 @@ describe('Client', function () {
       });
     });
     it('should serialize all guessed types', function (done) {
-      var values = [types.Uuid.random(), 'as', '111', null, new types.Long(0x1001, 0x0109AA), 1, utils.allocBufferFromArray([1, 240]),
+      const values = [types.Uuid.random(), 'as', '111', null, new types.Long(0x1001, 0x0109AA), 1, utils.allocBufferFromArray([1, 240]),
         true, new Date(1221111111), types.InetAddress.fromString('10.12.0.1'), null, null, null];
-      var columnNames = 'id, ascii_sample, text_sample, int_sample, bigint_sample, double_sample, blob_sample, ' +
+      const columnNames = 'id, ascii_sample, text_sample, int_sample, bigint_sample, double_sample, blob_sample, ' +
         'boolean_sample, timestamp_sample, inet_sample, timeuuid_sample, list_sample, set_sample';
       serializationTest(setupInfo.client, values, columnNames, done);
     });
     it('should serialize all null values', function (done) {
-      var values = [types.Uuid.random(), null, null, null, null, null, null, null, null, null, null, null, null];
-      var columnNames = 'id, ascii_sample, text_sample, int_sample, bigint_sample, double_sample, blob_sample, boolean_sample, timestamp_sample, inet_sample, timeuuid_sample, list_sample, set_sample';
+      const values = [types.Uuid.random(), null, null, null, null, null, null, null, null, null, null, null, null];
+      const columnNames = 'id, ascii_sample, text_sample, int_sample, bigint_sample, double_sample, blob_sample, boolean_sample, timestamp_sample, inet_sample, timeuuid_sample, list_sample, set_sample';
       serializationTest(setupInfo.client, values, columnNames, done);
     });
     it('should use prepared metadata to determine the type of params in query', function (done) {
-      var values = [types.Uuid.random(), types.TimeUuid.now(), [1, 1000, 0], {k: '1'}, 1, -100019, ['arr'], types.InetAddress.fromString('192.168.1.1')];
-      var columnNames = 'id, timeuuid_sample, list_sample2, map_sample, int_sample, float_sample, set_sample, inet_sample';
+      const values = [types.Uuid.random(), types.TimeUuid.now(), [1, 1000, 0], {k: '1'}, 1, -100019, ['arr'], types.InetAddress.fromString('192.168.1.1')];
+      const columnNames = 'id, timeuuid_sample, list_sample2, map_sample, int_sample, float_sample, set_sample, inet_sample';
       serializationTest(setupInfo.client, values, columnNames, done);
     });
     vit('2.0', 'should support IN clause with 1 marker', function (done) {
@@ -196,7 +196,7 @@ describe('Client', function () {
     });
     it('should encode and decode varint values', function (done) {
       const client = setupInfo.client;
-      var table = commonKs + '.' + helper.getRandomName('table');
+      const table = commonKs + '.' + helper.getRandomName('table');
       const expectedRows = {};
       utils.series([
         helper.toTask(client.execute, client, util.format('CREATE TABLE %s (id uuid primary key, val varint)', table)),
@@ -204,7 +204,7 @@ describe('Client', function () {
           const query = util.format('INSERT INTO %s (id, val) VALUES (?, ?)', table);
           utils.timesLimit(150, 100, function (n, next) {
             const id = types.uuid();
-            const value = types.Integer.fromNumber(n * 999);
+            let value = types.Integer.fromNumber(n * 999);
             value = value.multiply(types.Integer.fromString('9999901443'));
             if (n % 2 === 0) {
               //as a string also
@@ -219,7 +219,7 @@ describe('Client', function () {
             assert.ifError(err);
             result.rows.forEach(function (row) {
               helper.assertInstanceOf(row['val'], types.Integer);
-              var expectedValue = expectedRows[row['id']];
+              const expectedValue = expectedRows[row['id']];
               assert.ok(expectedValue);
               assert.strictEqual(row['val'].toString(), expectedValue.toString());
             });
@@ -230,7 +230,7 @@ describe('Client', function () {
     });
     it('should encode and decode decimal values', function (done) {
       const client = setupInfo.client;
-      var table = commonKs + '.' + helper.getRandomName('table');
+      const table = commonKs + '.' + helper.getRandomName('table');
       const expectedRows = {};
       utils.series([
         helper.toTask(client.execute, client, util.format('CREATE TABLE %s (id uuid primary key, val decimal)', table)),
@@ -238,7 +238,7 @@ describe('Client', function () {
           const query = util.format('INSERT INTO %s (id, val) VALUES (?, ?)', table);
           utils.timesLimit(150, 100, function (n, next) {
             const id = types.Uuid.random();
-            var value = (n * 999).toString() + '.' + (100 + n * 7).toString();
+            let value = (n * 999).toString() + '.' + (100 + n * 7).toString();
             if (n % 10 === 0) {
               value = '-' + value;
             }
@@ -255,7 +255,7 @@ describe('Client', function () {
             assert.ifError(err);
             result.rows.forEach(function (row) {
               helper.assertInstanceOf(row['val'], types.BigDecimal);
-              var expectedValue = expectedRows[row['id']];
+              const expectedValue = expectedRows[row['id']];
               assert.ok(expectedValue);
               assert.strictEqual(row['val'].toString(), expectedValue.toString());
             });
@@ -304,9 +304,9 @@ describe('Client', function () {
     });
     it('should encode and decode maps using Map polyfills', function (done) {
       const client = newInstance({ encoding: { map: helper.Map}});
-      var table = commonKs + '.' + helper.getRandomName('table');
+      const table = commonKs + '.' + helper.getRandomName('table');
       const MapPF = helper.Map;
-      var values = [
+      const values = [
         [
           //map1 to n with array of length 2 as values
           Uuid.random(),
@@ -317,7 +317,7 @@ describe('Client', function () {
           new MapPF([[types.timeuuid(), types.BigDecimal.fromString('1.20008')], [types.timeuuid(), types.BigDecimal.fromString('-9.26')]])
         ]
       ];
-      var createTableCql = util.format('CREATE TABLE %s ' +
+      const createTableCql = util.format('CREATE TABLE %s ' +
       '(id uuid primary key, ' +
       'map_text_text map<text,text>, ' +
       'map_int_date map<int,timestamp>, ' +
@@ -335,7 +335,7 @@ describe('Client', function () {
         },
         function selectData(seriesNext) {
           //Make ? markers C*1.2-compatible
-          var markers = values.map(function () { return '?'; }).join(',');
+          const markers = values.map(function () { return '?'; }).join(',');
           const query = util.format('SELECT * FROM %s WHERE id IN (' + markers + ')', table);
           client.execute(query, values.map(function (x) { return x[0]; }), {prepare: true}, function (err, result) {
             assert.ifError(err);
@@ -356,9 +356,9 @@ describe('Client', function () {
     });
     it('should encode and decode sets using Set polyfills', function (done) {
       const client = newInstance({ encoding: { set: helper.Set}});
-      var table = commonKs + '.' + helper.getRandomName('table');
+      const table = commonKs + '.' + helper.getRandomName('table');
       const SetPF = helper.Set;
-      var values = [
+      const values = [
         [
           Uuid.random(),
           new SetPF(['k3', 'v33333122', 'z1', 'z2']),
@@ -376,7 +376,7 @@ describe('Client', function () {
           null
         ]
       ];
-      var createTableCql = util.format('CREATE TABLE %s ' +
+      const createTableCql = util.format('CREATE TABLE %s ' +
       '(id uuid primary key, ' +
       'set_text set<text>, ' +
       'set_timestamp set<timestamp>, ' +
@@ -394,7 +394,7 @@ describe('Client', function () {
         },
         function selectData(seriesNext) {
           //Make ? markers C*1.2-compatible
-          var markers = values.map(function () { return '?'; }).join(',');
+          const markers = values.map(function () { return '?'; }).join(',');
           const query = util.format('SELECT * FROM %s WHERE id IN (' + markers + ')', table);
           client.execute(query, values.map(function (x) { return x[0]; }), {prepare: true}, function (err, result) {
             assert.ifError(err);
@@ -420,12 +420,12 @@ describe('Client', function () {
     });
     vit('2.1', 'should support protocol level timestamp', function (done) {
       const client = setupInfo.client;
-      var id = Uuid.random();
+      const id = Uuid.random();
       const timestamp = types.generateTimestamp(new Date(), 456);
       utils.series([
         function insert(next) {
           const query = util.format('INSERT INTO %s (id1, id2, text_sample) VALUES (?, ?, ?)', commonTable);
-          var params = [id, types.TimeUuid.now(), 'hello sample timestamp'];
+          const params = [id, types.TimeUuid.now(), 'hello sample timestamp'];
           client.execute(query, params, { timestamp: timestamp, prepare: 1}, next);
         },
         function select(next) {
@@ -444,16 +444,16 @@ describe('Client', function () {
       const client = newInstance({ keyspace: commonKs,
         queryOptions: { consistency: types.consistencies.quorum,
           prepare: true}});
-      var createTableCql = 'CREATE TABLE tbl_nested (' +
+      const createTableCql = 'CREATE TABLE tbl_nested (' +
         'id uuid PRIMARY KEY, ' +
         'map1 map<text, frozen<set<timeuuid>>>, ' +
         'list1 list<frozen<set<timeuuid>>>)';
-      var id = Uuid.random();
-      var map = {
+      const id = Uuid.random();
+      const map = {
         'key1': [types.TimeUuid.now(), types.TimeUuid.now()],
         'key2': [types.TimeUuid.now()]
       };
-      var list = [
+      const list = [
         [types.TimeUuid.now()],
         [types.TimeUuid.now(), types.TimeUuid.now()]
       ];
@@ -507,7 +507,7 @@ describe('Client', function () {
         commonTable,
         commonTable
       );
-      var params = { id0: types.Uuid.random(), id1: types.Uuid.random(), id2: types.TimeUuid.now(), sample: utils.stringRepeat('c', 2562) };
+      const params = { id0: types.Uuid.random(), id1: types.Uuid.random(), id2: types.TimeUuid.now(), sample: utils.stringRepeat('c', 2562) };
       client.execute(query, params, {prepare: true}, function (err, result) {
         assert.ifError(err);
         assert.ok(result.info.warnings);
@@ -520,7 +520,7 @@ describe('Client', function () {
     it('should support hardcoded parameters that are part of the routing key', function (done) {
       const client = setupInfo.client;
       const table = helper.getRandomName('tbl');
-      var createQuery = util.format('CREATE TABLE %s (a int, b int, c int, d int, ' +
+      const createQuery = util.format('CREATE TABLE %s (a int, b int, c int, d int, ' +
         'PRIMARY KEY ((a, b, c)))', table);
       utils.series([
         helper.toTask(client.execute, client, createQuery),
@@ -535,8 +535,8 @@ describe('Client', function () {
     });
     it('should allow undefined value as a null or unset depending on the protocol version', function (done) {
       const client1 = newInstance();
-      var client2 = newInstance({ encoding: { useUndefinedAsUnset: true}});
-      var id = Uuid.random();
+      const client2 = newInstance({ encoding: { useUndefinedAsUnset: true}});
+      const id = Uuid.random();
       utils.series([
         client1.connect.bind(client1),
         client2.connect.bind(client2),
@@ -619,7 +619,7 @@ describe('Client', function () {
       // empty strings are an interesting case in collections as they have 0 length.
       const client = setupInfo.client;
       const tid = types.TimeUuid.now();
-      var id = Uuid.random();
+      const id = Uuid.random();
       const map = {};
       map[tid] = '';
       utils.series([
@@ -643,7 +643,7 @@ describe('Client', function () {
     });
     describe('with a different keyspace', function () {
       it('should fill in the keyspace in the query options passed to the lbp', function (done) {
-        var lbp = new loadBalancing.RoundRobinPolicy();
+        const lbp = new loadBalancing.RoundRobinPolicy();
         lbp.newQueryPlanOriginal = lbp.newQueryPlan;
         const queryOptionsArray = [];
         lbp.newQueryPlan = function (query, queryOptions, callback) {
@@ -658,7 +658,7 @@ describe('Client', function () {
           },
           client.shutdown.bind(client),
           function assertResults(next) {
-            var queryOptions = queryOptionsArray[queryOptionsArray.length - 1];
+            const queryOptions = queryOptionsArray[queryOptionsArray.length - 1];
             assert.strictEqual(queryOptions.keyspace, 'system');
             next();
           }
@@ -676,12 +676,12 @@ describe('Client', function () {
         ], done);
       });
       vit('2.1', 'should encode objects into udt', function (done) {
-        var insertQuery = 'INSERT INTO tbl_udts (id, phone_col, address_col) VALUES (?, ?, ?)';
+        const insertQuery = 'INSERT INTO tbl_udts (id, phone_col, address_col) VALUES (?, ?, ?)';
         const selectQuery = 'SELECT id, phone_col, address_col FROM tbl_udts WHERE id = ?';
         const client = newInstance({ keyspace: commonKs, queryOptions: { prepare: true }});
-        var id = Uuid.random();
-        var phone = { alias: 'work2', number: '555 9012', country_code: 54};
-        var address = { street: 'DayMan', ZIP: 28111, phones: [ { alias: 'personal'} ]};
+        const id = Uuid.random();
+        const phone = { alias: 'work2', number: '555 9012', country_code: 54};
+        const address = { street: 'DayMan', ZIP: 28111, phones: [ { alias: 'personal'} ]};
         utils.series([
           function insert(next) {
             client.execute(insertQuery, [id, phone, address], next);
@@ -690,12 +690,12 @@ describe('Client', function () {
             client.execute(selectQuery, [id], function (err, result) {
               assert.ifError(err);
               const row = result.first();
-              var phoneResult = row['phone_col'];
+              const phoneResult = row['phone_col'];
               assert.strictEqual(phoneResult.alias, phone.alias);
               assert.strictEqual(phoneResult.number, phone.number);
               assert.strictEqual(phoneResult.country_code, phone.country_code);
               assert.equal(phoneResult.other, phone.other);
-              var addressResult = row['address_col'];
+              const addressResult = row['address_col'];
               assert.strictEqual(addressResult.street, address.street);
               assert.strictEqual(addressResult.ZIP, address.ZIP);
               assert.strictEqual(addressResult.phones.length, 1);
@@ -708,12 +708,12 @@ describe('Client', function () {
         ], done);
       });
       vit('2.1', 'should encode and decode tuples', function (done) {
-        var insertQuery = 'INSERT INTO tbl_tuples (id, tuple_col1, tuple_col2) VALUES (?, ?, ?)';
+        const insertQuery = 'INSERT INTO tbl_tuples (id, tuple_col1, tuple_col2) VALUES (?, ?, ?)';
         const selectQuery = 'SELECT * FROM tbl_tuples WHERE id = ?';
         const client = newInstance({ keyspace: commonKs, queryOptions: { prepare: true}});
-        var id1 = Uuid.random();
-        var tuple1 = new types.Tuple('val1', 1);
-        var tuple2 = new types.Tuple(Uuid.random(), types.Long.fromInt(12), true);
+        const id1 = Uuid.random();
+        const tuple1 = new types.Tuple('val1', 1);
+        const tuple2 = new types.Tuple(Uuid.random(), types.Long.fromInt(12), true);
         utils.series([
           function insert1(next) {
             client.execute(insertQuery, [id1, tuple1, tuple2], next);
@@ -728,8 +728,8 @@ describe('Client', function () {
             client.execute(selectQuery, [id1], function (err, result) {
               assert.ifError(err);
               const row = result.first();
-              var tuple1Result = row['tuple_col1'];
-              var tuple2Result = row['tuple_col2'];
+              const tuple1Result = row['tuple_col1'];
+              const tuple2Result = row['tuple_col2'];
               assert.strictEqual(tuple1Result.length, 2);
               assert.strictEqual(tuple1Result.get(0), 'val1');
               assert.strictEqual(tuple1Result.get(0), tuple1.get(0));
@@ -745,7 +745,7 @@ describe('Client', function () {
       });
     });
     describe('with smallint and tinyint types', function () {
-      var insertQuery = 'INSERT INTO tbl_smallints (id, smallint_sample, tinyint_sample) VALUES (?, ?, ?)';
+      const insertQuery = 'INSERT INTO tbl_smallints (id, smallint_sample, tinyint_sample) VALUES (?, ?, ?)';
       const selectQuery = 'SELECT id, smallint_sample, tinyint_sample FROM tbl_smallints WHERE id = ?';
       before(function (done) {
         const query = 'CREATE TABLE tbl_smallints ' +
@@ -753,7 +753,7 @@ describe('Client', function () {
         setupInfo.client.execute(query, done);
       });
       vit('2.2', 'should encode and decode smallint and tinyint values as Number', function (done) {
-        var values = [
+        const values = [
           [Uuid.random(), 1, 1],
           [Uuid.random(), 0, 0],
           [Uuid.random(), -1, -2],
@@ -781,7 +781,7 @@ describe('Client', function () {
     describe('with date and time types', function () {
       const LocalDate = types.LocalDate;
       const LocalTime = types.LocalTime;
-      var insertQuery = 'INSERT INTO tbl_datetimes (id, date_sample, time_sample) VALUES (?, ?, ?)';
+      const insertQuery = 'INSERT INTO tbl_datetimes (id, date_sample, time_sample) VALUES (?, ?, ?)';
       const selectQuery = 'SELECT id, date_sample, time_sample FROM tbl_datetimes WHERE id = ?';
       before(function (done) {
         const query = 'CREATE TABLE tbl_datetimes ' +
@@ -789,7 +789,7 @@ describe('Client', function () {
         setupInfo.client.execute(query, done);
       });
       vit('2.2', 'should encode and decode date and time values as LocalDate and LocalTime', function (done) {
-        var values = [
+        const values = [
           [Uuid.random(), new LocalDate(1969, 10, 13), new LocalTime(types.Long.fromString('0'))],
           [Uuid.random(), new LocalDate(2010, 4, 29), LocalTime.fromString('15:01:02.1234')],
           [Uuid.random(), new LocalDate(2005, 8, 5), LocalTime.fromString('01:56:03.000501')],
@@ -820,9 +820,9 @@ describe('Client', function () {
     describe('with unset', function () {
       vit('2.2', 'should allow unset as a valid value', function (done) {
         const client1 = newInstance();
-        var client2 = newInstance({ encoding: { useUndefinedAsUnset: true}});
-        var id1 = Uuid.random();
-        var id2 = Uuid.random();
+        const client2 = newInstance({ encoding: { useUndefinedAsUnset: true}});
+        const id1 = Uuid.random();
+        const id2 = Uuid.random();
         utils.series([
           client1.connect.bind(client1),
           client2.connect.bind(client2),
@@ -883,7 +883,7 @@ describe('Client', function () {
               assert.ifError(err);
               assert.strictEqual(result.rowLength, 10);
               // each key should be a multiple of 10.
-              var keys = result.rows.map(function(row) {
+              const keys = result.rows.map(function(row) {
                 assert.strictEqual(row['v'], 0);
                 return row['k'];
               }).sort();
@@ -910,7 +910,7 @@ describe('Client', function () {
             client.execute(query, [[20,19,18]], {prepare: 1}, function(err, result) {
               assert.ifError(err);
               assert.strictEqual(result.rowLength, 1);
-              var row = result.rows[0];
+              const row = result.rows[0];
               assert.strictEqual(row['k'], 21);
               assert.deepEqual(row['v'], [20,19,18]);
               seriesNext();
@@ -927,7 +927,7 @@ describe('Client', function () {
           function insertData(seriesNext) {
             const query = util.format('INSERT INTO %s (k, v) VALUES (?, ?)', table);
             utils.times(100, function (n, next) {
-              var v = {
+              const v = {
                 'key1' : n + 1,
                 'keyt10' : n * 10
               };
@@ -943,8 +943,8 @@ describe('Client', function () {
               assert.ifError(err);
               assert.strictEqual(result.rowLength, 10);
               // each key should be a multiple of 10.
-              var keys = result.rows.map(function(row) {
-                var k = row['k'];
+              const keys = result.rows.map(function(row) {
+                const k = row['k'];
                 assert.deepEqual(row['v'], {'key1': k + 1, 'keyt10' : k * 10, 'by10' : k / 10});
                 return k;
               }).sort();
@@ -963,7 +963,7 @@ describe('Client', function () {
           function insertData(seriesNext) {
             const query = util.format('INSERT INTO %s (k, v) VALUES (?, ?)', table);
             utils.times(100, function (n, next) {
-              var v = {
+              const v = {
                 'key1' : n + 1,
                 'keyt10' : n * 10
               };
@@ -975,7 +975,7 @@ describe('Client', function () {
             client.execute(query, [100], {prepare: 1}, function(err, result) {
               assert.ifError(err);
               assert.strictEqual(result.rowLength, 2);
-              var rows = result.rows.sort(function(a, b) {
+              const rows = result.rows.sort(function(a, b) {
                 return a['k'] - b['k'];
               });
 
@@ -997,7 +997,7 @@ describe('Client', function () {
           function insertData(seriesNext) {
             const query = util.format('INSERT INTO %s (k, v) VALUES (?, ?)', table);
             utils.times(100, function (n, next) {
-              var v = {
+              const v = {
                 'key1' : n + 1,
                 'keyt10' : n * 10
               };
@@ -1009,7 +1009,7 @@ describe('Client', function () {
             client.execute(query, ['key1', 100], {prepare: 1}, function(err, result) {
               assert.ifError(err);
               assert.strictEqual(result.rowLength, 1);
-              var rows = result.rows;
+              const rows = result.rows;
               assert.strictEqual(rows[0]['k'], 99);
               assert.deepEqual(rows[0]['v'], {'key1' : 100, 'keyt10' : 990});
               seriesNext();
@@ -1019,9 +1019,9 @@ describe('Client', function () {
       });
     });
     vdescribe('3.0', 'with materialized views', function () {
-      var keyspace = 'ks_view_prepared';
+      const keyspace = 'ks_view_prepared';
       before(function createTables(done) {
-        var queries = [
+        const queries = [
           "CREATE KEYSPACE ks_view_prepared WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",
           "CREATE TABLE ks_view_prepared.scores (user TEXT, game TEXT, year INT, month INT, day INT, score INT, PRIMARY KEY (user, game, year, month, day))",
           "CREATE MATERIALIZED VIEW ks_view_prepared.alltimehigh AS SELECT user FROM scores WHERE game IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL PRIMARY KEY (game, score, user, year, month, day) WITH CLUSTERING ORDER BY (score desc)"
@@ -1035,12 +1035,12 @@ describe('Client', function () {
           contactPoints: helper.baseOptions.contactPoints
         });
         utils.timesSeries(10, function (n, timesNext) {
-          var game = n.toString();
+          const game = n.toString();
           const query = 'SELECT * FROM alltimehigh WHERE game = ?';
           client.execute(query, [game], { traceQuery: true, prepare: true}, function (err, result) {
             assert.ifError(err);
-            var coordinator = result.info.queriedHost;
-            var traceId = result.info.traceId;
+            const coordinator = result.info.queriedHost;
+            const traceId = result.info.traceId;
             client.metadata.getTrace(traceId, function (err, trace) {
               assert.ifError(err);
               trace.events.forEach(function (event) {
@@ -1067,13 +1067,13 @@ function newInstance(options) {
 }
 
 function serializationTest(client, values, columns, done) {
-  var table = commonKs + '.' + helper.getRandomName('table');
+  const table = commonKs + '.' + helper.getRandomName('table');
   const queryOptions = { prepare: true, consistency: types.consistencies.localQuorum };
   utils.series([
     helper.toTask(client.execute, client, helper.createTableCql(table)),
     function (next) {
-      var markers = '?';
-      var columnsSplit = columns.split(',');
+      let markers = '?';
+      const columnsSplit = columns.split(',');
       for (let i = 1; i < columnsSplit.length; i++) {
         markers += ', ?';
       }
@@ -1088,7 +1088,7 @@ function serializationTest(client, values, columns, done) {
         assert.ifError(err);
         assert.ok(result);
         assert.ok(result.rows && result.rows.length > 0, 'There should be a row');
-        var row = result.rows[0];
+        const row = result.rows[0];
         assert.strictEqual(row.values().length, values.length);
         for (let i = 0; i < values.length; i++) {
           helper.assertValueEqual(values[i], row.get(i));

--- a/test/integration/short/client-execute-prepared-tests.js
+++ b/test/integration/short/client-execute-prepared-tests.js
@@ -1,30 +1,30 @@
 'use strict';
-var assert = require('assert');
-var util = require('util');
+const assert = require('assert');
+const util = require('util');
 
-var helper = require('../../test-helper');
-var Client = require('../../../lib/client');
-var types = require('../../../lib/types');
-var utils = require('../../../lib/utils');
-var errors = require('../../../lib/errors');
-var loadBalancing = require('../../../lib/policies/load-balancing');
-var vit = helper.vit;
-var vdescribe = helper.vdescribe;
-var Uuid = types.Uuid;
-var commonKs = helper.getRandomName('ks');
+const helper = require('../../test-helper');
+const Client = require('../../../lib/client');
+const types = require('../../../lib/types');
+const utils = require('../../../lib/utils');
+const errors = require('../../../lib/errors');
+const loadBalancing = require('../../../lib/policies/load-balancing');
+const vit = helper.vit;
+const vdescribe = helper.vdescribe;
+const Uuid = types.Uuid;
+const commonKs = helper.getRandomName('ks');
 
 describe('Client', function () {
   this.timeout(120000);
   describe('#execute(query, params, {prepare: 1}, callback)', function () {
     var commonTable = commonKs + '.' + helper.getRandomName('table');
     var commonTable2 = commonKs + '.' + helper.getRandomName('table');
-    var setupInfo = helper.setup(3, {
+    const setupInfo = helper.setup(3, {
       keyspace: commonKs,
       queries: [ helper.createTableWithClusteringKeyCql(commonTable), helper.createTableCql(commonTable2) ]
     });
     it('should execute a prepared query with parameters on all hosts', function (done) {
-      var client = setupInfo.client;
-      var query = util.format('SELECT * FROM %s WHERE id1 = ?', commonTable);
+      const client = setupInfo.client;
+      const query = util.format('SELECT * FROM %s WHERE id1 = ?', commonTable);
       utils.timesSeries(3, function (n, next) {
         client.execute(query, [types.Uuid.random()], {prepare: 1}, function (err, result) {
           assert.ifError(err);
@@ -36,8 +36,8 @@ describe('Client', function () {
       }, done);
     });
     it('should callback with error when query is invalid', function (done) {
-      var client = setupInfo.client;
-      var query = 'SELECT WILL FAIL';
+      const client = setupInfo.client;
+      const query = 'SELECT WILL FAIL';
       client.execute(query, ['system'], {prepare: 1}, function (err) {
         assert.ok(err);
         assert.strictEqual(err.code, types.responseErrorCodes.syntaxError);
@@ -46,7 +46,7 @@ describe('Client', function () {
       });
     });
     it('should prepare and execute a query without parameters', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       client.execute(helper.queries.basic, null, {prepare: 1}, function (err, result) {
         assert.ifError(err);
         assert.ok(result);
@@ -55,7 +55,7 @@ describe('Client', function () {
       });
     });
     it('should prepare and execute a queries in parallel', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       var queries = [
         helper.queries.basic,
         helper.queries.basicNoResults,
@@ -79,7 +79,7 @@ describe('Client', function () {
       }, done);
     });
     it('should fail following times if it fails to prepare', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       utils.series([function (seriesNext) {
         //parallel
         utils.times(10, function (n, next) {
@@ -103,20 +103,20 @@ describe('Client', function () {
     });
     context('when prepareOnAllHosts set to false', function () {
       it('should execute a prepared query on all hosts', function (done) {
-        var client = newInstance({ prepareOnAllHosts: false });
+        const client = newInstance({ prepareOnAllHosts: false });
         utils.timesSeries(6, function (n, next) {
           client.execute(helper.queries.basic, [], { prepare: true }, next);
         }, helper.finish(client, done));
       });
       it('should execute a prepared query on all hosts with the keyspace set', function (done) {
-        var client = newInstance({ prepareOnAllHosts: false, keyspace: 'system' });
+        const client = newInstance({ prepareOnAllHosts: false, keyspace: 'system' });
         utils.timesSeries(6, function (n, next) {
           client.execute('SELECT * FROM local', [], { prepare: true }, next);
         }, helper.finish(client, done));
       });
     });
     it('should fail if the type does not match', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       client.execute(util.format('SELECT * FROM %s WHERE id1 = ?', commonTable), [1000], {prepare: 1}, function (err) {
         helper.assertInstanceOf(err, Error);
         helper.assertInstanceOf(err, TypeError);
@@ -141,7 +141,7 @@ describe('Client', function () {
       serializationTest(setupInfo.client, values, columnNames, done);
     });
     vit('2.0', 'should support IN clause with 1 marker', function (done) {
-      var query = util.format('SELECT * FROM %s WHERE id1 IN ?', commonTable);
+      const query = util.format('SELECT * FROM %s WHERE id1 IN ?', commonTable);
       setupInfo.client.execute(query, [ [ Uuid.random(), Uuid.random() ] ], { prepare: true }, function (err, result) {
         assert.ifError(err);
         assert.ok(result);
@@ -150,17 +150,17 @@ describe('Client', function () {
       });
     });
     vit('2.0', 'should use pageState and fetchSize', function (done) {
-      var client = newInstance({
+      const client = newInstance({
         keyspace: commonKs,
         queryOptions: { consistency: types.consistencies.quorum }
       });
-      var pageState;
-      var metaPageState;
-      var table = helper.getRandomName('table');
+      let pageState;
+      let metaPageState;
+      const table = helper.getRandomName('table');
       utils.series([
         helper.toTask(client.execute, client, helper.createTableCql(table)),
         function insertData(seriesNext) {
-          var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
+          const query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
           utils.times(100, function (n, next) {
             client.execute(query, [types.uuid(), n.toString()], {prepare: 1}, next);
           }, seriesNext);
@@ -195,16 +195,16 @@ describe('Client', function () {
       ], done);
     });
     it('should encode and decode varint values', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       var table = commonKs + '.' + helper.getRandomName('table');
-      var expectedRows = {};
+      const expectedRows = {};
       utils.series([
         helper.toTask(client.execute, client, util.format('CREATE TABLE %s (id uuid primary key, val varint)', table)),
         function insertData(seriesNext) {
-          var query = util.format('INSERT INTO %s (id, val) VALUES (?, ?)', table);
+          const query = util.format('INSERT INTO %s (id, val) VALUES (?, ?)', table);
           utils.timesLimit(150, 100, function (n, next) {
-            var id = types.uuid();
-            var value = types.Integer.fromNumber(n * 999);
+            const id = types.uuid();
+            const value = types.Integer.fromNumber(n * 999);
             value = value.multiply(types.Integer.fromString('9999901443'));
             if (n % 2 === 0) {
               //as a string also
@@ -229,15 +229,15 @@ describe('Client', function () {
       ], done);
     });
     it('should encode and decode decimal values', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       var table = commonKs + '.' + helper.getRandomName('table');
-      var expectedRows = {};
+      const expectedRows = {};
       utils.series([
         helper.toTask(client.execute, client, util.format('CREATE TABLE %s (id uuid primary key, val decimal)', table)),
         function insertData(seriesNext) {
-          var query = util.format('INSERT INTO %s (id, val) VALUES (?, ?)', table);
+          const query = util.format('INSERT INTO %s (id, val) VALUES (?, ?)', table);
           utils.timesLimit(150, 100, function (n, next) {
-            var id = types.Uuid.random();
+            const id = types.Uuid.random();
             var value = (n * 999).toString() + '.' + (100 + n * 7).toString();
             if (n % 10 === 0) {
               value = '-' + value;
@@ -266,7 +266,7 @@ describe('Client', function () {
     });
     describe('with named parameters', function () {
       vit('2.0', 'should allow an array of parameters', function (done) {
-        var query = util.format('SELECT * FROM %s WHERE id1 = :id1', commonTable);
+        const query = util.format('SELECT * FROM %s WHERE id1 = :id1', commonTable);
         setupInfo.client.execute(query, [ Uuid.random() ], { prepare: 1 }, function (err, result) {
           assert.ifError(err);
           assert.ok(result && result.rows);
@@ -275,7 +275,7 @@ describe('Client', function () {
         });
       });
       vit('2.0', 'should allow associative array of parameters', function (done) {
-        var query = util.format('SELECT * FROM %s WHERE id1 = :id1', commonTable);
+        const query = util.format('SELECT * FROM %s WHERE id1 = :id1', commonTable);
         setupInfo.client.execute(query, {'id1': Uuid.random()}, {prepare: 1}, function (err, result) {
           assert.ifError(err);
           assert.ok(result && result.rows);
@@ -284,7 +284,7 @@ describe('Client', function () {
         });
       });
       vit('2.0', 'should be case insensitive', function (done) {
-        var query = util.format('SELECT * FROM %s WHERE id1 = :ID1', commonTable);
+        const query = util.format('SELECT * FROM %s WHERE id1 = :ID1', commonTable);
         setupInfo.client.execute(query, {'iD1': Uuid.random()}, {prepare: 1}, function (err, result) {
           assert.ifError(err);
           assert.ok(result && result.rows);
@@ -293,7 +293,7 @@ describe('Client', function () {
         });
       });
       vit('2.0', 'should allow objects with other props as parameters', function (done) {
-        var query = util.format('SELECT * FROM %s WHERE id1 = :ID1', commonTable);
+        const query = util.format('SELECT * FROM %s WHERE id1 = :ID1', commonTable);
         setupInfo.client.execute(query, {'ID1': Uuid.random(), other: 'value'}, {prepare: 1}, function (err, result) {
           assert.ifError(err);
           assert.ok(result && result.rows);
@@ -303,9 +303,9 @@ describe('Client', function () {
       });
     });
     it('should encode and decode maps using Map polyfills', function (done) {
-      var client = newInstance({ encoding: { map: helper.Map}});
+      const client = newInstance({ encoding: { map: helper.Map}});
       var table = commonKs + '.' + helper.getRandomName('table');
-      var MapPF = helper.Map;
+      const MapPF = helper.Map;
       var values = [
         [
           //map1 to n with array of length 2 as values
@@ -327,7 +327,7 @@ describe('Client', function () {
       utils.series([
         helper.toTask(client.execute, client, createTableCql),
         function insertData(seriesNext) {
-          var query = util.format('INSERT INTO %s (id, map_text_text, map_int_date, map_date_float, map_varint_boolean, map_timeuuid_text) ' +
+          const query = util.format('INSERT INTO %s (id, map_text_text, map_int_date, map_date_float, map_varint_boolean, map_timeuuid_text) ' +
           'VALUES (?, ?, ?, ?, ?, ?)', table);
           utils.each(values, function (params, next) {
             client.execute(query, params, {prepare: true}, next);
@@ -336,12 +336,12 @@ describe('Client', function () {
         function selectData(seriesNext) {
           //Make ? markers C*1.2-compatible
           var markers = values.map(function () { return '?'; }).join(',');
-          var query = util.format('SELECT * FROM %s WHERE id IN (' + markers + ')', table);
+          const query = util.format('SELECT * FROM %s WHERE id IN (' + markers + ')', table);
           client.execute(query, values.map(function (x) { return x[0]; }), {prepare: true}, function (err, result) {
             assert.ifError(err);
             assert.ok(result.rows.length);
             result.rows.forEach(function (row) {
-              var expectedValues = helper.first(values, function (item) { return item[0].equals(row.id); });
+              const expectedValues = helper.first(values, function (item) { return item[0].equals(row.id); });
               helper.assertInstanceOf(row['map_text_text'], MapPF);
               assert.strictEqual(row['map_text_text'].toString(), expectedValues[1].toString());
               assert.strictEqual(row['map_int_date'].toString(), expectedValues[2].toString());
@@ -355,9 +355,9 @@ describe('Client', function () {
       ], done);
     });
     it('should encode and decode sets using Set polyfills', function (done) {
-      var client = newInstance({ encoding: { set: helper.Set}});
+      const client = newInstance({ encoding: { set: helper.Set}});
       var table = commonKs + '.' + helper.getRandomName('table');
-      var SetPF = helper.Set;
+      const SetPF = helper.Set;
       var values = [
         [
           Uuid.random(),
@@ -386,7 +386,7 @@ describe('Client', function () {
       utils.series([
         helper.toTask(client.execute, client, createTableCql),
         function insertData(seriesNext) {
-          var query = util.format('INSERT INTO %s (id, set_text, set_timestamp, set_float, set_bigint, set_timeuuid) ' +
+          const query = util.format('INSERT INTO %s (id, set_text, set_timestamp, set_float, set_bigint, set_timeuuid) ' +
           'VALUES (?, ?, ?, ?, ?, ?)', table);
           utils.each(values, function (params, next) {
             client.execute(query, params, {prepare: true}, next);
@@ -395,12 +395,12 @@ describe('Client', function () {
         function selectData(seriesNext) {
           //Make ? markers C*1.2-compatible
           var markers = values.map(function () { return '?'; }).join(',');
-          var query = util.format('SELECT * FROM %s WHERE id IN (' + markers + ')', table);
+          const query = util.format('SELECT * FROM %s WHERE id IN (' + markers + ')', table);
           client.execute(query, values.map(function (x) { return x[0]; }), {prepare: true}, function (err, result) {
             assert.ifError(err);
             assert.ok(result.rows.length);
             result.rows.forEach(function (row) {
-              var expectedValues = helper.first(values, function (item) { return item[0].equals(row.id); });
+              const expectedValues = helper.first(values, function (item) { return item[0].equals(row.id); });
               helper.assertInstanceOf(row['set_text'], SetPF);
               assert.strictEqual(row['set_text'].toString(), expectedValues[1].toString());
               assert.strictEqual(row['set_timestamp'].toString(), expectedValues[2].toString());
@@ -419,19 +419,19 @@ describe('Client', function () {
       ], done);
     });
     vit('2.1', 'should support protocol level timestamp', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       var id = Uuid.random();
-      var timestamp = types.generateTimestamp(new Date(), 456);
+      const timestamp = types.generateTimestamp(new Date(), 456);
       utils.series([
         function insert(next) {
-          var query = util.format('INSERT INTO %s (id1, id2, text_sample) VALUES (?, ?, ?)', commonTable);
+          const query = util.format('INSERT INTO %s (id1, id2, text_sample) VALUES (?, ?, ?)', commonTable);
           var params = [id, types.TimeUuid.now(), 'hello sample timestamp'];
           client.execute(query, params, { timestamp: timestamp, prepare: 1}, next);
         },
         function select(next) {
-          var query = util.format('SELECT text_sample, writetime(text_sample) from %s WHERE id1 = ?', commonTable);
+          const query = util.format('SELECT text_sample, writetime(text_sample) from %s WHERE id1 = ?', commonTable);
           client.execute(query, [id], { prepare: 1}, function (err, result) {
-            var row = result.first();
+            const row = result.first();
             assert.ok(row);
             assert.strictEqual(row['text_sample'], 'hello sample timestamp');
             assert.strictEqual(row['writetime(text_sample)'].toString(), timestamp.toString());
@@ -441,7 +441,7 @@ describe('Client', function () {
       ], done);
     });
     vit('2.1.3', 'should support nested collections', function (done) {
-      var client = newInstance({ keyspace: commonKs,
+      const client = newInstance({ keyspace: commonKs,
         queryOptions: { consistency: types.consistencies.quorum,
           prepare: true}});
       var createTableCql = 'CREATE TABLE tbl_nested (' +
@@ -461,14 +461,14 @@ describe('Client', function () {
       utils.series([
         helper.toTask(client.execute, client, createTableCql),
         function insert(next) {
-          var query = 'INSERT INTO tbl_nested (id, map1, list1) VALUES (?, ?, ?)';
+          const query = 'INSERT INTO tbl_nested (id, map1, list1) VALUES (?, ?, ?)';
           client.execute(query, [id, map, list], next);
         },
         function select(next) {
-          var query = 'SELECT * FROM tbl_nested WHERE id = ?';
+          const query = 'SELECT * FROM tbl_nested WHERE id = ?';
           client.execute(query, [id], function (err, result) {
             assert.ifError(err);
-            var row = result.first();
+            const row = result.first();
             assert.ok(row['map1']);
             assert.strictEqual(Object.keys(row['map1']).length, 2);
             assert.ok(util.isArray(row['map1']['key1']));
@@ -490,8 +490,8 @@ describe('Client', function () {
       ], done);
     });
     vit('2.2', 'should include the warning in the ResultSet', function (done) {
-      var client = newInstance();
-      var loggedMessage = false;
+      const client = newInstance();
+      let loggedMessage = false;
       client.on('log', function (level, className, message) {
         if (loggedMessage || level !== 'warning') {
           return;
@@ -501,7 +501,7 @@ describe('Client', function () {
           loggedMessage = true;
         }
       });
-      var query = util.format(
+      const query = util.format(
         "BEGIN UNLOGGED BATCH INSERT INTO %s (id1, id2, text_sample) VALUES (:id0, :id2, :sample)\n" +
         "INSERT INTO %s (id1, id2, text_sample) VALUES (:id1, :id2, :sample) APPLY BATCH",
         commonTable,
@@ -518,14 +518,14 @@ describe('Client', function () {
       });
     });
     it('should support hardcoded parameters that are part of the routing key', function (done) {
-      var client = setupInfo.client;
-      var table = helper.getRandomName('tbl');
+      const client = setupInfo.client;
+      const table = helper.getRandomName('tbl');
       var createQuery = util.format('CREATE TABLE %s (a int, b int, c int, d int, ' +
         'PRIMARY KEY ((a, b, c)))', table);
       utils.series([
         helper.toTask(client.execute, client, createQuery),
         function (next) {
-          var query = util.format('SELECT * FROM %s WHERE c = ? AND a = ? AND b = 0', table);
+          const query = util.format('SELECT * FROM %s WHERE c = ? AND a = ? AND b = 0', table);
           client.execute(query, [1, 1], { prepare: true}, function (err) {
             assert.ifError(err);
             next();
@@ -534,7 +534,7 @@ describe('Client', function () {
       ], done);
     });
     it('should allow undefined value as a null or unset depending on the protocol version', function (done) {
-      var client1 = newInstance();
+      const client1 = newInstance();
       var client2 = newInstance({ encoding: { useUndefinedAsUnset: true}});
       var id = Uuid.random();
       utils.series([
@@ -542,15 +542,15 @@ describe('Client', function () {
         client2.connect.bind(client2),
         function insert2(next) {
           //use undefined
-          var query = util.format('INSERT INTO %s (id1, id2, text_sample, map_sample) VALUES (?, ?, ?, ?)', commonTable);
+          const query = util.format('INSERT INTO %s (id1, id2, text_sample, map_sample) VALUES (?, ?, ?, ?)', commonTable);
           client2.execute(query, [id, types.TimeUuid.now(), 'test null or unset', undefined], { prepare: true}, next);
         },
         function select2(next) {
-          var query = util.format('SELECT id1, id2, text_sample, map_sample FROM %s WHERE id1 = ?', commonTable);
+          const query = util.format('SELECT id1, id2, text_sample, map_sample FROM %s WHERE id1 = ?', commonTable);
           client2.execute(query, [id], { prepare: true}, function (err, result) {
             assert.ifError(err);
             assert.strictEqual(result.rowLength, 1);
-            var row = result.first();
+            const row = result.first();
             assert.strictEqual(row['id1'].toString(), id.toString());
             assert.strictEqual(row['text_sample'], 'test null or unset');
             assert.strictEqual(row['map_sample'], null);
@@ -562,52 +562,52 @@ describe('Client', function () {
       ], done);
     });
     it('should not allow collections with null or unset values', function (done) {
-      var client = setupInfo.client;
-      var tid = types.TimeUuid.now();
+      const client = setupInfo.client;
+      const tid = types.TimeUuid.now();
       utils.series([
         function testListWithNull(next) {
-          var query = util.format('INSERT INTO %s (id1, id2, list_sample) VALUES (?, ?, ?)', commonTable);
+          const query = util.format('INSERT INTO %s (id1, id2, list_sample) VALUES (?, ?, ?)', commonTable);
           client.execute(query, [Uuid.random(), tid, [tid, null]], { prepare: true}, function (err) {
             helper.assertInstanceOf(err, TypeError);
             next();
           });
         },
         function testListWithUnset(next) {
-          var query = util.format('INSERT INTO %s (id1, id2, list_sample) VALUES (?, ?, ?)', commonTable);
+          const query = util.format('INSERT INTO %s (id1, id2, list_sample) VALUES (?, ?, ?)', commonTable);
           client.execute(query, [Uuid.random(), tid, [tid, types.unset]], { prepare: true}, function (err) {
             helper.assertInstanceOf(err, TypeError);
             next();
           });
         },
         function testSetWithNull(next) {
-          var query = util.format('INSERT INTO %s (id1, id2, set_sample) VALUES (?, ?, ?)', commonTable);
+          const query = util.format('INSERT INTO %s (id1, id2, set_sample) VALUES (?, ?, ?)', commonTable);
           client.execute(query, [Uuid.random(), tid, [1, null]], { prepare: true}, function (err) {
             helper.assertInstanceOf(err, TypeError);
             next();
           });
         },
         function testSetWithUnset(next) {
-          var query = util.format('INSERT INTO %s (id1, id2, set_sample) VALUES (?, ?, ?)', commonTable);
+          const query = util.format('INSERT INTO %s (id1, id2, set_sample) VALUES (?, ?, ?)', commonTable);
           client.execute(query, [Uuid.random(), tid, [1, types.unset]], { prepare: true}, function (err) {
             helper.assertInstanceOf(err, TypeError);
             next();
           });
         },
         function testMapWithNull(next) {
-          var map = {};
+          const map = {};
           map[tid] = 1;
           map[types.TimeUuid.now()] = null;
-          var query = util.format('INSERT INTO %s (id1, id2, map_sample) VALUES (?, ?, ?)', commonTable);
+          const query = util.format('INSERT INTO %s (id1, id2, map_sample) VALUES (?, ?, ?)', commonTable);
           client.execute(query, [Uuid.random(), tid, map], { prepare: true}, function (err) {
             helper.assertInstanceOf(err, TypeError);
             next();
           });
         },
         function testMapWithUnset(next) {
-          var map = {};
+          const map = {};
           map[tid] = 1;
           map[types.TimeUuid.now()] = types.unset;
-          var query = util.format('INSERT INTO %s (id1, id2, map_sample) VALUES (?, ?, ?)', commonTable);
+          const query = util.format('INSERT INTO %s (id1, id2, map_sample) VALUES (?, ?, ?)', commonTable);
           client.execute(query, [Uuid.random(), tid, map], { prepare: true}, function (err) {
             helper.assertInstanceOf(err, TypeError);
             next();
@@ -617,22 +617,22 @@ describe('Client', function () {
     });
     it('should return empty string values', function (done) {
       // empty strings are an interesting case in collections as they have 0 length.
-      var client = setupInfo.client;
-      var tid = types.TimeUuid.now();
+      const client = setupInfo.client;
+      const tid = types.TimeUuid.now();
       var id = Uuid.random();
-      var map = {};
+      const map = {};
       map[tid] = '';
       utils.series([
         function insertDataWithEmptyStringValues(next) {
-          var query = util.format('INSERT INTO %s (id, map_sample, list_sample, set_sample) VALUES (?, ?, ?, ?)', commonTable2);
+          const query = util.format('INSERT INTO %s (id, map_sample, list_sample, set_sample) VALUES (?, ?, ?, ?)', commonTable2);
           client.execute(query, [id, map, [''], ['']], { prepare: true}, next);
         },
         function retrieveMapWithEmptyStringValue(next) {
-          var query = util.format('SELECT * FROM %s where id = ?', commonTable2);
+          const query = util.format('SELECT * FROM %s where id = ?', commonTable2);
           client.execute(query, [id], { prepare: true }, function (err, result) {
             assert.ifError(err);
             assert.strictEqual(result.rowLength, 1);
-            var row = result.first();
+            const row = result.first();
             assert.deepEqual(row['map_sample'], map);
             assert.deepEqual(row['list_sample'], ['']);
             assert.deepEqual(row['set_sample'], ['']);
@@ -645,12 +645,12 @@ describe('Client', function () {
       it('should fill in the keyspace in the query options passed to the lbp', function (done) {
         var lbp = new loadBalancing.RoundRobinPolicy();
         lbp.newQueryPlanOriginal = lbp.newQueryPlan;
-        var queryOptionsArray = [];
+        const queryOptionsArray = [];
         lbp.newQueryPlan = function (query, queryOptions, callback) {
           queryOptionsArray.push(queryOptions);
           lbp.newQueryPlanOriginal(query, queryOptions, callback);
         };
-        var client = newInstance({ keyspace: commonKs, policies: { loadBalancing: lbp}});
+        const client = newInstance({ keyspace: commonKs, policies: { loadBalancing: lbp}});
         utils.series([
           client.connect.bind(client),
           function query(next) {
@@ -667,7 +667,7 @@ describe('Client', function () {
     });
     describe('with udt and tuple', function () {
       before(function (done) {
-        var client = setupInfo.client;
+        const client = setupInfo.client;
         utils.series([
           helper.toTask(client.execute, client, 'CREATE TYPE phone (alias text, number text, country_code int, other boolean)'),
           helper.toTask(client.execute, client, 'CREATE TYPE address (street text, "ZIP" int, phones set<frozen<phone>>)'),
@@ -677,8 +677,8 @@ describe('Client', function () {
       });
       vit('2.1', 'should encode objects into udt', function (done) {
         var insertQuery = 'INSERT INTO tbl_udts (id, phone_col, address_col) VALUES (?, ?, ?)';
-        var selectQuery = 'SELECT id, phone_col, address_col FROM tbl_udts WHERE id = ?';
-        var client = newInstance({ keyspace: commonKs, queryOptions: { prepare: true }});
+        const selectQuery = 'SELECT id, phone_col, address_col FROM tbl_udts WHERE id = ?';
+        const client = newInstance({ keyspace: commonKs, queryOptions: { prepare: true }});
         var id = Uuid.random();
         var phone = { alias: 'work2', number: '555 9012', country_code: 54};
         var address = { street: 'DayMan', ZIP: 28111, phones: [ { alias: 'personal'} ]};
@@ -689,7 +689,7 @@ describe('Client', function () {
           function select(next) {
             client.execute(selectQuery, [id], function (err, result) {
               assert.ifError(err);
-              var row = result.first();
+              const row = result.first();
               var phoneResult = row['phone_col'];
               assert.strictEqual(phoneResult.alias, phone.alias);
               assert.strictEqual(phoneResult.number, phone.number);
@@ -709,8 +709,8 @@ describe('Client', function () {
       });
       vit('2.1', 'should encode and decode tuples', function (done) {
         var insertQuery = 'INSERT INTO tbl_tuples (id, tuple_col1, tuple_col2) VALUES (?, ?, ?)';
-        var selectQuery = 'SELECT * FROM tbl_tuples WHERE id = ?';
-        var client = newInstance({ keyspace: commonKs, queryOptions: { prepare: true}});
+        const selectQuery = 'SELECT * FROM tbl_tuples WHERE id = ?';
+        const client = newInstance({ keyspace: commonKs, queryOptions: { prepare: true}});
         var id1 = Uuid.random();
         var tuple1 = new types.Tuple('val1', 1);
         var tuple2 = new types.Tuple(Uuid.random(), types.Long.fromInt(12), true);
@@ -727,7 +727,7 @@ describe('Client', function () {
           function select1(next) {
             client.execute(selectQuery, [id1], function (err, result) {
               assert.ifError(err);
-              var row = result.first();
+              const row = result.first();
               var tuple1Result = row['tuple_col1'];
               var tuple2Result = row['tuple_col2'];
               assert.strictEqual(tuple1Result.length, 2);
@@ -746,9 +746,9 @@ describe('Client', function () {
     });
     describe('with smallint and tinyint types', function () {
       var insertQuery = 'INSERT INTO tbl_smallints (id, smallint_sample, tinyint_sample) VALUES (?, ?, ?)';
-      var selectQuery = 'SELECT id, smallint_sample, tinyint_sample FROM tbl_smallints WHERE id = ?';
+      const selectQuery = 'SELECT id, smallint_sample, tinyint_sample FROM tbl_smallints WHERE id = ?';
       before(function (done) {
-        var query = 'CREATE TABLE tbl_smallints ' +
+        const query = 'CREATE TABLE tbl_smallints ' +
           '(id uuid PRIMARY KEY, smallint_sample smallint, tinyint_sample tinyint, text_sample text)';
         setupInfo.client.execute(query, done);
       });
@@ -759,7 +759,7 @@ describe('Client', function () {
           [Uuid.random(), -1, -2],
           [Uuid.random(), -130, -128]
         ];
-        var client = setupInfo.client;
+        const client = setupInfo.client;
         utils.eachSeries(values, function (params, next) {
           client.execute(insertQuery, params, { prepare: true}, function (err) {
             assert.ifError(err);
@@ -767,7 +767,7 @@ describe('Client', function () {
               assert.ifError(err);
               assert.ok(result);
               assert.ok(result.rowLength);
-              var row = result.first();
+              const row = result.first();
               assert.ok(row);
               assert.strictEqual(row['id'].toString(), params[0].toString());
               assert.strictEqual(row['smallint_sample'], params[1]);
@@ -779,12 +779,12 @@ describe('Client', function () {
       });
     });
     describe('with date and time types', function () {
-      var LocalDate = types.LocalDate;
-      var LocalTime = types.LocalTime;
+      const LocalDate = types.LocalDate;
+      const LocalTime = types.LocalTime;
       var insertQuery = 'INSERT INTO tbl_datetimes (id, date_sample, time_sample) VALUES (?, ?, ?)';
-      var selectQuery = 'SELECT id, date_sample, time_sample FROM tbl_datetimes WHERE id = ?';
+      const selectQuery = 'SELECT id, date_sample, time_sample FROM tbl_datetimes WHERE id = ?';
       before(function (done) {
-        var query = 'CREATE TABLE tbl_datetimes ' +
+        const query = 'CREATE TABLE tbl_datetimes ' +
           '(id uuid PRIMARY KEY, date_sample date, time_sample time, text_sample text)';
         setupInfo.client.execute(query, done);
       });
@@ -796,7 +796,7 @@ describe('Client', function () {
           [Uuid.random(), new LocalDate(1983, 2, 24), new LocalTime(types.Long.fromString('86399999999999'))],
           [Uuid.random(), new LocalDate(-2147483648), new LocalTime(types.Long.fromString('6311999549933'))]
         ];
-        var client = setupInfo.client;
+        const client = setupInfo.client;
         utils.eachSeries(values, function (params, next) {
           client.execute(insertQuery, params, { prepare: true}, function (err) {
             assert.ifError(err);
@@ -804,7 +804,7 @@ describe('Client', function () {
               assert.ifError(err);
               assert.ok(result);
               assert.ok(result.rowLength);
-              var row = result.first();
+              const row = result.first();
               assert.ok(row);
               assert.strictEqual(row['id'].toString(), params[0].toString());
               helper.assertInstanceOf(row['date_sample'], LocalDate);
@@ -819,7 +819,7 @@ describe('Client', function () {
     });
     describe('with unset', function () {
       vit('2.2', 'should allow unset as a valid value', function (done) {
-        var client1 = newInstance();
+        const client1 = newInstance();
         var client2 = newInstance({ encoding: { useUndefinedAsUnset: true}});
         var id1 = Uuid.random();
         var id2 = Uuid.random();
@@ -827,15 +827,15 @@ describe('Client', function () {
           client1.connect.bind(client1),
           client2.connect.bind(client2),
           function insert1(next) {
-            var query = util.format('INSERT INTO %s (id1, id2, text_sample, map_sample) VALUES (?, ?, ?, ?)', commonTable);
+            const query = util.format('INSERT INTO %s (id1, id2, text_sample, map_sample) VALUES (?, ?, ?, ?)', commonTable);
             client1.execute(query, [id1, types.TimeUuid.now(), 'test unset', types.unset], { prepare: true}, next);
           },
           function select1(next) {
-            var query = util.format('SELECT id1, id2, text_sample, map_sample FROM %s WHERE id1 = ?', commonTable);
+            const query = util.format('SELECT id1, id2, text_sample, map_sample FROM %s WHERE id1 = ?', commonTable);
             client1.execute(query, [id1], { prepare: true}, function (err, result) {
               assert.ifError(err);
               assert.strictEqual(result.rowLength, 1);
-              var row = result.first();
+              const row = result.first();
               assert.strictEqual(row['id1'].toString(), id1.toString());
               assert.strictEqual(row['text_sample'], 'test unset');
               assert.strictEqual(row['map_sample'], null);
@@ -844,15 +844,15 @@ describe('Client', function () {
           },
           function insert2(next) {
             //use undefined
-            var query = util.format('INSERT INTO %s (id1, id2, text_sample, map_sample) VALUES (?, ?, ?, ?)', commonTable);
+            const query = util.format('INSERT INTO %s (id1, id2, text_sample, map_sample) VALUES (?, ?, ?, ?)', commonTable);
             client2.execute(query, [id2, types.TimeUuid.now(), 'test unset 2', undefined], { prepare: true}, next);
           },
           function select2(next) {
-            var query = util.format('SELECT id1, id2, text_sample, map_sample FROM %s WHERE id1 = ?', commonTable);
+            const query = util.format('SELECT id1, id2, text_sample, map_sample FROM %s WHERE id1 = ?', commonTable);
             client2.execute(query, [id2], { prepare: true}, function (err, result) {
               assert.ifError(err);
               assert.strictEqual(result.rowLength, 1);
-              var row = result.first();
+              const row = result.first();
               assert.strictEqual(row['id1'].toString(), id2.toString());
               assert.strictEqual(row['text_sample'], 'test unset 2');
               assert.strictEqual(row['map_sample'], null);
@@ -866,19 +866,19 @@ describe('Client', function () {
     });
     describe('with secondary indexes', function() {
       it('should be able to retrieve using simple index', function(done) {
-        var client = setupInfo.client;
-        var table = helper.getRandomName('tbl');
+        const client = setupInfo.client;
+        const table = helper.getRandomName('tbl');
         utils.series([
           helper.toTask(client.execute, client, util.format("CREATE TABLE %s (k int PRIMARY KEY, v int)", table)),
           helper.toTask(client.execute, client, util.format("CREATE INDEX simple_index ON %s (v)", table)),
           function insertData(seriesNext) {
-            var query = util.format('INSERT INTO %s (k, v) VALUES (?, ?)', table);
+            const query = util.format('INSERT INTO %s (k, v) VALUES (?, ?)', table);
             utils.times(100, function (n, next) {
               client.execute(query, [n, n % 10], {prepare: 1}, next);
             }, seriesNext);
           },
           function selectData(seriesNext) {
-            var query = util.format('SELECT * FROM %s WHERE v=?', table);
+            const query = util.format('SELECT * FROM %s WHERE v=?', table);
             client.execute(query, [0], {prepare: 1}, function(err, result) {
               assert.ifError(err);
               assert.strictEqual(result.rowLength, 10);
@@ -894,19 +894,19 @@ describe('Client', function () {
         ],done);
       });
       vit('2.1', 'should be able to retrieve using index on frozen list', function(done) {
-        var client = setupInfo.client;
-        var table = helper.getRandomName('tbl');
+        const client = setupInfo.client;
+        const table = helper.getRandomName('tbl');
         utils.series([
           helper.toTask(client.execute, client, util.format("CREATE TABLE %s (k int PRIMARY KEY, v frozen<list<int>>)", table)),
           helper.toTask(client.execute, client, util.format("CREATE INDEX frozen_index ON %s (full(v))", table)),
           function insertData(seriesNext) {
-            var query = util.format('INSERT INTO %s (k, v) VALUES (?, ?)', table);
+            const query = util.format('INSERT INTO %s (k, v) VALUES (?, ?)', table);
             utils.times(100, function (n, next) {
               client.execute(query, [n, [n-1, n-2, n-3]], {prepare: 1}, next);
             }, seriesNext);
           },
           function selectData(seriesNext) {
-            var query = util.format('SELECT * FROM %s WHERE v=?', table);
+            const query = util.format('SELECT * FROM %s WHERE v=?', table);
             client.execute(query, [[20,19,18]], {prepare: 1}, function(err, result) {
               assert.ifError(err);
               assert.strictEqual(result.rowLength, 1);
@@ -919,13 +919,13 @@ describe('Client', function () {
         ],done);
       });
       vit('2.1', 'should be able to retrieve using index on map keys', function(done) {
-        var client = setupInfo.client;
-        var table = helper.getRandomName('tbl');
+        const client = setupInfo.client;
+        const table = helper.getRandomName('tbl');
         utils.series([
           helper.toTask(client.execute, client, util.format("CREATE TABLE %s (k int PRIMARY KEY, v map<text,int>)", table)),
           helper.toTask(client.execute, client, util.format("CREATE INDEX keys_index on %s (keys(v))", table)),
           function insertData(seriesNext) {
-            var query = util.format('INSERT INTO %s (k, v) VALUES (?, ?)', table);
+            const query = util.format('INSERT INTO %s (k, v) VALUES (?, ?)', table);
             utils.times(100, function (n, next) {
               var v = {
                 'key1' : n + 1,
@@ -938,7 +938,7 @@ describe('Client', function () {
             }, seriesNext);
           },
           function selectData(seriesNext) {
-            var query = util.format('SELECT * FROM %s WHERE v CONTAINS KEY ?', table);
+            const query = util.format('SELECT * FROM %s WHERE v CONTAINS KEY ?', table);
             client.execute(query, ['by10'], {prepare: 1}, function(err, result) {
               assert.ifError(err);
               assert.strictEqual(result.rowLength, 10);
@@ -955,13 +955,13 @@ describe('Client', function () {
         ], done);
       });
       vit('2.1', 'should be able to retrieve using index on map values', function(done) {
-        var client = setupInfo.client;
-        var table = helper.getRandomName('tbl');
+        const client = setupInfo.client;
+        const table = helper.getRandomName('tbl');
         utils.series([
           helper.toTask(client.execute, client, util.format("CREATE TABLE %s (k int PRIMARY KEY, v map<text,int>)", table)),
           helper.toTask(client.execute, client, util.format("CREATE INDEX values_index on %s (v)", table)),
           function insertData(seriesNext) {
-            var query = util.format('INSERT INTO %s (k, v) VALUES (?, ?)', table);
+            const query = util.format('INSERT INTO %s (k, v) VALUES (?, ?)', table);
             utils.times(100, function (n, next) {
               var v = {
                 'key1' : n + 1,
@@ -971,7 +971,7 @@ describe('Client', function () {
             }, seriesNext);
           },
           function selectData(seriesNext) {
-            var query = util.format('SELECT * FROM %s WHERE v CONTAINS ?', table);
+            const query = util.format('SELECT * FROM %s WHERE v CONTAINS ?', table);
             client.execute(query, [100], {prepare: 1}, function(err, result) {
               assert.ifError(err);
               assert.strictEqual(result.rowLength, 2);
@@ -989,13 +989,13 @@ describe('Client', function () {
         ], done);
       });
       vit('2.2', 'should be able to retrieve using index on map entries', function(done) {
-        var client = setupInfo.client;
-        var table = helper.getRandomName('tbl');
+        const client = setupInfo.client;
+        const table = helper.getRandomName('tbl');
         utils.series([
           helper.toTask(client.execute, client, util.format("CREATE TABLE %s (k int PRIMARY KEY, v map<text,int>)", table)),
           helper.toTask(client.execute, client, util.format("CREATE INDEX entries_index on %s (entries(v))", table)),
           function insertData(seriesNext) {
-            var query = util.format('INSERT INTO %s (k, v) VALUES (?, ?)', table);
+            const query = util.format('INSERT INTO %s (k, v) VALUES (?, ?)', table);
             utils.times(100, function (n, next) {
               var v = {
                 'key1' : n + 1,
@@ -1005,7 +1005,7 @@ describe('Client', function () {
             }, seriesNext);
           },
           function selectData(seriesNext) {
-            var query = util.format('SELECT * FROM %s WHERE v[?]=?', table);
+            const query = util.format('SELECT * FROM %s WHERE v[?]=?', table);
             client.execute(query, ['key1', 100], {prepare: 1}, function(err, result) {
               assert.ifError(err);
               assert.strictEqual(result.rowLength, 1);
@@ -1029,14 +1029,14 @@ describe('Client', function () {
         utils.eachSeries(queries, setupInfo.client.execute.bind(setupInfo.client), helper.wait(2000, done));
       });
       it('should choose the correct coordinator based on the partition key', function (done) {
-        var client = new Client({
+        const client = new Client({
           policies: { loadBalancing: new loadBalancing.TokenAwarePolicy(new loadBalancing.RoundRobinPolicy())},
           keyspace: keyspace,
           contactPoints: helper.baseOptions.contactPoints
         });
         utils.timesSeries(10, function (n, timesNext) {
           var game = n.toString();
-          var query = 'SELECT * FROM alltimehigh WHERE game = ?';
+          const query = 'SELECT * FROM alltimehigh WHERE game = ?';
           client.execute(query, [game], { traceQuery: true, prepare: true}, function (err, result) {
             assert.ifError(err);
             var coordinator = result.info.queriedHost;
@@ -1068,29 +1068,29 @@ function newInstance(options) {
 
 function serializationTest(client, values, columns, done) {
   var table = commonKs + '.' + helper.getRandomName('table');
-  var queryOptions = { prepare: true, consistency: types.consistencies.localQuorum };
+  const queryOptions = { prepare: true, consistency: types.consistencies.localQuorum };
   utils.series([
     helper.toTask(client.execute, client, helper.createTableCql(table)),
     function (next) {
       var markers = '?';
       var columnsSplit = columns.split(',');
-      for (var i = 1; i < columnsSplit.length; i++) {
+      for (let i = 1; i < columnsSplit.length; i++) {
         markers += ', ?';
       }
-      var query = util.format('INSERT INTO %s ' +
+      const query = util.format('INSERT INTO %s ' +
         '(%s) VALUES ' +
         '(%s)', table, columns, markers);
       client.execute(query, values, queryOptions, next);
     },
     function (next) {
-      var query = util.format('SELECT %s FROM %s WHERE id = ?', columns, table);
+      const query = util.format('SELECT %s FROM %s WHERE id = ?', columns, table);
       client.execute(query, [values[0]], queryOptions, function (err, result) {
         assert.ifError(err);
         assert.ok(result);
         assert.ok(result.rows && result.rows.length > 0, 'There should be a row');
         var row = result.rows[0];
         assert.strictEqual(row.values().length, values.length);
-        for (var i = 0; i < values.length; i++) {
+        for (let i = 0; i < values.length; i++) {
           helper.assertValueEqual(values[i], row.get(i));
         }
         next();

--- a/test/integration/short/client-execute-tests.js
+++ b/test/integration/short/client-execute-tests.js
@@ -1,25 +1,25 @@
 "use strict";
-var assert = require('assert');
-var util = require('util');
+const assert = require('assert');
+const util = require('util');
 
-var helper = require('../../test-helper.js');
-var Client = require('../../../lib/client.js');
-var ExecutionProfile = require('../../../lib/execution-profile.js').ExecutionProfile;
-var types = require('../../../lib/types');
-var utils = require('../../../lib/utils.js');
-var errors = require('../../../lib/errors.js');
-var vit = helper.vit;
-var vdescribe = helper.vdescribe;
+const helper = require('../../test-helper.js');
+const Client = require('../../../lib/client.js');
+const ExecutionProfile = require('../../../lib/execution-profile.js').ExecutionProfile;
+const types = require('../../../lib/types');
+const utils = require('../../../lib/utils.js');
+const errors = require('../../../lib/errors.js');
+const vit = helper.vit;
+const vdescribe = helper.vdescribe;
 
 describe('Client', function () {
   this.timeout(120000);
   describe('#execute(query, params, {prepare: 0}, callback)', function () {
-    var keyspace = helper.getRandomName('ks');
+    const keyspace = helper.getRandomName('ks');
     var table = keyspace + '.' + helper.getRandomName('table');
-    var selectAllQuery = 'SELECT * FROM ' + table;
-    var setupInfo = helper.setup(1, { keyspace: keyspace, queries: [ helper.createTableCql(table) ] });
+    const selectAllQuery = 'SELECT * FROM ' + table;
+    const setupInfo = helper.setup(1, { keyspace: keyspace, queries: [ helper.createTableCql(table) ] });
     it('should execute a basic query', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       client.execute(helper.queries.basic, function (err, result) {
         assert.equal(err, null);
         assert.notEqual(result, null);
@@ -28,10 +28,10 @@ describe('Client', function () {
       });
     });
     it('should callback with syntax error', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       client.connect(function (err) {
         assert.ifError(err);
-        var query = 'SELECT WILL FAIL';
+        const query = 'SELECT WILL FAIL';
         client.execute(query, function (err, result) {
           assert.ok(err);
           assert.strictEqual(err.code, types.responseErrorCodes.syntaxError);
@@ -42,7 +42,7 @@ describe('Client', function () {
       });
     });
     it('should callback with an empty Array instance as rows when not found', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       client.execute(helper.queries.basicNoResults, function (err, result) {
         assert.ifError(err);
         assert.ok(result);
@@ -53,13 +53,13 @@ describe('Client', function () {
       });
     });
     it('should handle 500 parallel queries', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       utils.times(500, function (n, next) {
         client.execute(helper.queries.basic, [], next);
       }, done);
     });
     it('should fail if non-existent profile provided', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         function queryWithBadProfile(next) {
           client.execute(helper.queries.basicNoResults, [], {executionProfile: 'none'}, function(err) {
@@ -72,7 +72,7 @@ describe('Client', function () {
       ], done);
     });
     vit('2.0', 'should guess known types', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       var columns = 'id, timeuuid_sample, text_sample, double_sample, timestamp_sample, blob_sample, list_sample';
       //a precision a float32 can represent
       var values = [types.Uuid.random(), types.TimeUuid.now(), 'text sample 1', 133, new Date(121212211), utils.allocBufferUnsafe(100), ['one', 'two']];
@@ -80,7 +80,7 @@ describe('Client', function () {
       insertSelectTest(client, table, columns, values, null, done);
     });
     vit('2.0', 'should use parameter hints as number for simple types', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       var columns = 'id, text_sample, float_sample, int_sample';
       //a precision a float32 can represent
       var values = [types.Uuid.random(), 'text sample', 1000.0999755859375, -12];
@@ -91,14 +91,14 @@ describe('Client', function () {
       var columns = 'id, text_sample, float_sample, int_sample';
       var values = [types.Uuid.random(), 'text sample', -9, 1];
       var hints = [null, 'text', 'float', 'int'];
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       insertSelectTest(client, table, columns, values, hints, done);
     });
     vit('2.0', 'should use parameter hints as string for complex types partial', function (done) {
       var columns = 'id, map_sample, list_sample, set_sample';
       var values = [types.Uuid.random(), {val1: 'text sample1'}, ['list_text1'], ['set_text1']];
       var hints = [null, 'map', 'list', 'set'];
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       insertSelectTest(client, table, columns, values, hints, done);
     });
     vit('2.0', 'should use parameter hints as string for complex types complete', function (done) {
@@ -106,7 +106,7 @@ describe('Client', function () {
       var values = [types.Uuid.random(), {val1: 'text sample1'}, ['list_text1'], ['set_text1']];
       //complete info
       var hints = [null, 'map<text, text>', 'list<text>', 'set<text>'];
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       insertSelectTest(client, table, columns, values, hints, done);
     });
     vit('2.0', 'should use parameter hints for custom map polyfills', function (done) {
@@ -117,18 +117,18 @@ describe('Client', function () {
       var values = [types.Uuid.random(), map];
       //complete info
       var hints = [null, 'map<text, text>'];
-      var client = newInstance({encoding: { map: helper.Map }});
+      const client = newInstance({encoding: { map: helper.Map }});
       insertSelectTest(client, table, columns, values, hints, done);
     });
     vit('2.0', 'should use pageState and fetchSize', function (done) {
-      var client = setupInfo.client;
-      var pageState = null;
+      const client = setupInfo.client;
+      let pageState = null;
       utils.series([
         function truncate(seriesNext) {
           client.execute('TRUNCATE ' + table, seriesNext);
         },
         function insertData(seriesNext) {
-          var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
+          const query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
           utils.times(100, function (n, next) {
             client.execute(query, [types.Uuid.random(), n.toString()], next);
           }, seriesNext);
@@ -155,13 +155,13 @@ describe('Client', function () {
       ], done);
     });
     vit('2.0', 'should not autoPage', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       utils.series([
         function truncate(seriesNext) {
           client.execute('TRUNCATE ' + table, seriesNext);
         },
         function insertData(seriesNext) {
-          var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
+          const query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
           utils.times(100, function (n, next) {
             client.execute(query, [types.Uuid.random(), n.toString()], next);
           }, seriesNext);
@@ -177,13 +177,13 @@ describe('Client', function () {
       ], done);
     });
     vit('2.0', 'should return ResultSet compatible with @@iterator', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       utils.series([
         function truncate(seriesNext) {
           client.execute('TRUNCATE ' + table, seriesNext);
         },
         function insertData(seriesNext) {
-          var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
+          const query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
           utils.times(100, function (n, next) {
             client.execute(query, [types.Uuid.random(), n.toString()], next);
           }, seriesNext);
@@ -195,9 +195,9 @@ describe('Client', function () {
             assert.strictEqual(result.rowLength, 25);
             // should not page
             var iterator = result[Symbol.iterator]();
-            var count = 0;
-            var uuids = [];
-            var item;
+            let count = 0;
+            const uuids = [];
+            let item;
             for (item = iterator.next(); !item.done; item = iterator.next()) {
               assert.ok(item.value);
               var id = item.value.id;
@@ -218,8 +218,8 @@ describe('Client', function () {
       ], done);
     });
     vit('2.0', 'should callback in err when wrong hints are provided', function (done) {
-      var client = setupInfo.client;
-      var query = util.format('SELECT * FROM %s WHERE id IN (?, ?, ?)', table);
+      const client = setupInfo.client;
+      const query = util.format('SELECT * FROM %s WHERE id IN (?, ?, ?)', table);
       //valid params
       var params = [types.Uuid.random(), types.Uuid.random(), types.Uuid.random()];
       utils.series([
@@ -253,12 +253,12 @@ describe('Client', function () {
       ], done);
     });
     vit('2.1', 'should encode CONTAINS parameter', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       client.execute(util.format('CREATE INDEX list_sample_index ON %s(list_sample)', table), function (err) {
         assert.ifError(err);
         // Allow 1 second for index to build (otherwise an IndexNotAvailableException may be raised while index is building).
         setTimeout(function() {
-          var query = util.format('SELECT * FROM %s WHERE list_sample CONTAINS ? AND list_sample CONTAINS ? ALLOW FILTERING', table);
+          const query = util.format('SELECT * FROM %s WHERE list_sample CONTAINS ? AND list_sample CONTAINS ? ALLOW FILTERING', table);
           //valid params
           var params = ['val1', 'val2'];
           client.execute(query, params, function (err) {
@@ -270,7 +270,7 @@ describe('Client', function () {
       });
     });
     it('should accept localOne and localQuorum consistencies', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       utils.series([
         function (next) {
           client.execute(selectAllQuery, [], {consistency: types.consistencies.localOne}, next);
@@ -281,7 +281,7 @@ describe('Client', function () {
       ], done);
     });
     it('should use consistency level from profile and override profile when provided in query options', function (done) {
-      var client = newInstance({profiles: [new ExecutionProfile('cl', {consistency: types.consistencies.quorum})]});
+      const client = newInstance({profiles: [new ExecutionProfile('cl', {consistency: types.consistencies.quorum})]});
       utils.series([
         function ensureProfileCLUsed (next) {
           client.execute(selectAllQuery, [], {executionProfile: 'cl'}, function(err, result) {
@@ -301,20 +301,20 @@ describe('Client', function () {
       ], done);
     });
     vit('2.2', 'should accept unset as a valid value', function (done) {
-      var client = setupInfo.client;
-      var id = types.Uuid.random();
+      const client = setupInfo.client;
+      const id = types.Uuid.random();
       utils.series([
         client.connect.bind(client),
         function insert(next) {
-          var query = util.format('INSERT INTO %s (id, text_sample, double_sample) VALUES (?, ?, ?)', table);
+          const query = util.format('INSERT INTO %s (id, text_sample, double_sample) VALUES (?, ?, ?)', table);
           client.execute(query, [id, 'sample unset', types.unset], next);
         },
         function select(next) {
-          var query = util.format('SELECT id, text_sample, double_sample FROM %s WHERE id = ?', table);
+          const query = util.format('SELECT id, text_sample, double_sample FROM %s WHERE id = ?', table);
           client.execute(query, [id], function (err, result) {
             assert.ifError(err);
             assert.strictEqual(result.rowLength, 1);
-            var row = result.first();
+            const row = result.first();
             assert.strictEqual(row['text_sample'], 'sample unset');
             assert.strictEqual(row['double_sample'], null);
             next();
@@ -323,7 +323,7 @@ describe('Client', function () {
       ], done);
     });
     it('should handle several concurrent executes while the pool is not ready', function (done) {
-      var client = newInstance({pooling: {
+      const client = newInstance({pooling: {
         coreConnectionsPerHost: {
           //lots of connections per host
           '0': 100,
@@ -347,14 +347,14 @@ describe('Client', function () {
       ], helper.finish(client, done));
     });
     it('should return the column definitions', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       //insert at least 1 row
       var insertQuery = util.format('INSERT INTO %s (id) VALUES (%s)', table, types.Uuid.random());
       utils.series([
         client.connect.bind(client),
         helper.toTask(client.execute, client, insertQuery),
         function verifyColumns(next) {
-          var query = util.format('SELECT text_sample, timestamp_sample, int_sample, timeuuid_sample, list_sample2, map_sample from %s LIMIT 1', table);
+          const query = util.format('SELECT text_sample, timestamp_sample, int_sample, timeuuid_sample, list_sample2, map_sample from %s LIMIT 1', table);
           client.execute(query, function (err, result) {
             assert.ifError(err);
             assert.ok(result.rows.length);
@@ -376,7 +376,7 @@ describe('Client', function () {
           });
         },
         function verifyColumnsInAnEmptyResultSet(next) {
-          var query = util.format('SELECT * from %s WHERE id = 00000000-0000-0000-0000-000000000000', table);
+          const query = util.format('SELECT * from %s WHERE id = 00000000-0000-0000-0000-000000000000', table);
           client.execute(query, function (err, result) {
             assert.ifError(err);
             assert.ok(result.columns);
@@ -387,24 +387,24 @@ describe('Client', function () {
       ], done);
     });
     it('should return rows that are serializable to json', function (done) {
-      var client = setupInfo.client;
-      var id = types.Uuid.random();
-      var timeId = types.TimeUuid.now();
+      const client = setupInfo.client;
+      const id = types.Uuid.random();
+      const timeId = types.TimeUuid.now();
       utils.series([
         function insert(next) {
-          var query = util.format(
+          const query = util.format(
             'INSERT INTO %s (id, timeuuid_sample, inet_sample, bigint_sample, decimal_sample) VALUES (%s, %s, \'%s\', %s, %s)',
             table, id, timeId, '::2233:0:0:bb', -100, "0.1");
           client.execute(query, next);
         },
         function select(next) {
-          var query = util.format(
+          const query = util.format(
             'SELECT id, timeuuid_sample, inet_sample, bigint_sample, decimal_sample from %s WHERE id = %s', table, id);
           client.execute(query, function (err, result) {
             assert.ifError(err);
             assert.strictEqual(result.rows.length, 1);
             var row = result.rows[0];
-            var expected = util.format('{"id":"%s",' +
+            const expected = util.format('{"id":"%s",' +
               '"timeuuid_sample":"%s",' +
               '"inet_sample":"::2233:0:0:bb",' +
               '"bigint_sample":"-100",' +
@@ -418,11 +418,11 @@ describe('Client', function () {
     vit('2.0', 'should use serial consistency level from profile and override profile when provided in query options', function (done) {
       // This is a bit crude, but sets an invalid serial CL (ONE) and ensures an error is thrown when using the
       // profile serial CL.  This establishes a way to differentiate between when the profile cl is used and not.
-      var client = newInstance({profiles: [new ExecutionProfile('cl', {serialConsistency: types.consistencies.one})]});
-      var id = types.Uuid.random();
+      const client = newInstance({profiles: [new ExecutionProfile('cl', {serialConsistency: types.consistencies.one})]});
+      const id = types.Uuid.random();
       utils.series([
         function insertWithProfileSerialCL(next) {
-          var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?) IF NOT EXISTS', table);
+          const query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?) IF NOT EXISTS', table);
           client.execute(query, [id, 'hello serial'], { executionProfile: 'cl'}, function(err) {
             // expect an error as we used an invalid serial CL.
             assert.ok(err);
@@ -431,13 +431,13 @@ describe('Client', function () {
           });
         },
         function insertWithQueryCL(next) {
-          var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?) IF NOT EXISTS', table);
+          const query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?) IF NOT EXISTS', table);
           client.execute(query, [id, 'hello serial'], { executionProfile: 'cl', serialConsistency: types.consistencies.localSerial}, next);
         },
         function select(next) {
-          var query = util.format('SELECT id, text_sample from %s WHERE id = ?', table);
+          const query = util.format('SELECT id, text_sample from %s WHERE id = ?', table);
           client.execute(query, [id], function (err, result) {
-            var row = result.first();
+            const row = result.first();
             assert.ok(row);
             assert.strictEqual(row['text_sample'], 'hello serial');
             next();
@@ -446,18 +446,18 @@ describe('Client', function () {
       ], helper.finish(client, done));
     });
     vit('2.1', 'should support protocol level timestamp', function (done) {
-      var client = setupInfo.client;
-      var id = types.Uuid.random();
-      var timestamp = types.generateTimestamp(new Date(), 777);
+      const client = setupInfo.client;
+      const id = types.Uuid.random();
+      const timestamp = types.generateTimestamp(new Date(), 777);
       utils.series([
         function insert(next) {
-          var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
+          const query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
           client.execute(query, [id, 'hello timestamp'], { timestamp: timestamp}, next);
         },
         function select(next) {
-          var query = util.format('SELECT id, text_sample, writetime(text_sample) from %s WHERE id = ?', table);
+          const query = util.format('SELECT id, text_sample, writetime(text_sample) from %s WHERE id = ?', table);
           client.execute(query, [id], function (err, result) {
-            var row = result.first();
+            const row = result.first();
             assert.ok(row);
             assert.strictEqual(row['text_sample'], 'hello timestamp');
             assert.strictEqual(row['writetime(text_sample)'].toString(), timestamp.toString());
@@ -467,12 +467,12 @@ describe('Client', function () {
       ], done);
     });
     it('should retrieve the trace id when queryTrace flag is set', function (done) {
-      var client = setupInfo.client;
-      var id = types.Uuid.random();
+      const client = setupInfo.client;
+      const id = types.Uuid.random();
       utils.series([
         client.connect.bind(client),
         function selectNotExistent(next) {
-          var query = util.format('SELECT * FROM %s WHERE id = %s', table, types.Uuid.random());
+          const query = util.format('SELECT * FROM %s WHERE id = %s', table, types.Uuid.random());
           client.execute(query, [], { traceQuery: true}, function (err, result) {
             assert.ifError(err);
             assert.ok(result);
@@ -481,7 +481,7 @@ describe('Client', function () {
           });
         },
         function insertQuery(next) {
-          var query = util.format('INSERT INTO %s (id) VALUES (%s)', table, id.toString());
+          const query = util.format('INSERT INTO %s (id) VALUES (%s)', table, id.toString());
           client.execute(query, [], { traceQuery: true}, function (err, result) {
             assert.ifError(err);
             assert.ok(result);
@@ -490,7 +490,7 @@ describe('Client', function () {
           });
         },
         function selectSingleRow(next) {
-          var query = util.format('SELECT * FROM %s WHERE id = %s', table, id.toString());
+          const query = util.format('SELECT * FROM %s WHERE id = %s', table, id.toString());
           client.execute(query, [], { traceQuery: true}, function (err, result) {
             assert.ifError(err);
             assert.ok(result);
@@ -501,7 +501,7 @@ describe('Client', function () {
       ], done);
     });
     it('should not retrieve trace id by default', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       client.execute('SELECT * FROM system.local', function (err, result) {
         assert.ifError(err);
         assert.ok(result.info);
@@ -510,8 +510,8 @@ describe('Client', function () {
       });
     });
     vit('2.2', 'should include the warning in the ResultSet', function (done) {
-      var client = setupInfo.client;
-      var loggedMessage = false;
+      const client = setupInfo.client;
+      let loggedMessage = false;
       client.on('log', function (level, className, message) {
         if (loggedMessage || level !== 'warning') {
           return;
@@ -521,7 +521,7 @@ describe('Client', function () {
           loggedMessage = true;
         }
       });
-      var query = util.format(
+      const query = util.format(
         "BEGIN UNLOGGED BATCH INSERT INTO %s (id, text_sample) VALUES (%s, '%s')\n" +
         "INSERT INTO %s (id, text_sample) VALUES (%s, '%s') APPLY BATCH",
         table,
@@ -542,11 +542,11 @@ describe('Client', function () {
       });
     });
     describe('with udt and tuple', function () {
-      var sampleId = types.Uuid.random();
+      const sampleId = types.Uuid.random();
       var insertQuery = 'INSERT INTO tbl_udts (id, phone_col, address_col) VALUES (%s, %s, %s)';
-      var selectQuery = 'SELECT id, phone_col, address_col FROM tbl_udts WHERE id = %s';
+      const selectQuery = 'SELECT id, phone_col, address_col FROM tbl_udts WHERE id = %s';
       before(function (done) {
-        var client = setupInfo.client;
+        const client = setupInfo.client;
         utils.series([
           client.connect.bind(client),
           helper.toTask(client.execute, client, 'CREATE TYPE phone (alias text, number text, country_code int, other boolean)'),
@@ -561,7 +561,7 @@ describe('Client', function () {
         ], done);
       });
       vit('2.1', 'should retrieve column information', function (done) {
-        var client = setupInfo.client;
+        const client = setupInfo.client;
         client.execute(util.format(selectQuery, sampleId), function (err, result) {
           assert.ifError(err);
           assert.ok(result.columns);
@@ -597,10 +597,10 @@ describe('Client', function () {
         });
       });
       vit('2.1', 'should parse udt row', function (done) {
-        var client = setupInfo.client;
+        const client = setupInfo.client;
         client.execute(util.format(selectQuery, sampleId), function (err, result) {
           assert.ifError(err);
-          var row = result.first();
+          const row = result.first();
           assert.ok(row);
           var phone = row['phone_col'];
           assert.ok(phone);
@@ -624,17 +624,17 @@ describe('Client', function () {
       vit('2.1', 'should allow udt parameter hints and retrieve metadata', function (done) {
         var phone = { alias: 'home2', number: '555 0000', country_code: 34, other: true};
         var address = {street: 'NightMan2', ZIP: 90987, phones: [{ 'alias': 'personal2', 'number': '555 0001'}, {alias: 'work2'}]};
-        var id = types.Uuid.random();
-        var client = setupInfo.client;
+        const id = types.Uuid.random();
+        const client = setupInfo.client;
         utils.series([
           function insert(next) {
-            var query = util.format(insertQuery, '?', '?', '?');
+            const query = util.format(insertQuery, '?', '?', '?');
             client.execute(query, [id, phone, address], { hints: [null, 'udt<phone>', 'udt<address>']}, next);
           },
           function select(next) {
             client.execute(util.format(selectQuery, '?'), [id], function (err, result) {
               assert.ifError(err);
-              var row = result.first();
+              const row = result.first();
               assert.ok(row);
               assert.ok(row['phone_col']);
               assert.strictEqual(row['phone_col']['alias'], phone.alias);
@@ -653,18 +653,18 @@ describe('Client', function () {
         ], done);
       });
       vit('2.1', 'should allow tuple parameter hints', function (done) {
-        var client = setupInfo.client;
-        var id = types.Uuid.random();
+        const client = setupInfo.client;
+        const id = types.Uuid.random();
         var tuple = new types.Tuple('Surf Rider', 110, utils.allocBufferFromString('0f0f', 'hex'));
         utils.series([
           function insert(next) {
-            var query ='INSERT INTO tbl_tuples (id, tuple_col) VALUES (?, ?)';
+            const query ='INSERT INTO tbl_tuples (id, tuple_col) VALUES (?, ?)';
             client.execute(query, [id, tuple], { hints: [null, 'tuple<text, int,blob>']}, next);
           },
           function select(next) {
             client.execute(util.format('SELECT * FROM tbl_tuples WHERE id = ?'), [id], function (err, result) {
               assert.ifError(err);
-              var row = result.first();
+              const row = result.first();
               assert.ok(row);
               assert.ok(row['tuple_col']);
               assert.strictEqual(row['tuple_col'].length, 3);
@@ -677,7 +677,7 @@ describe('Client', function () {
         ], done);
       });
       vit('2.2', 'should allow insertions as json', function (done) {
-        var client = setupInfo.client;
+        const client = setupInfo.client;
         var o = {
           id: types.Uuid.random(),
           address_col: {
@@ -688,14 +688,14 @@ describe('Client', function () {
         };
         utils.series([
           function insert(next) {
-            var query = 'INSERT INTO tbl_udts JSON ?';
+            const query = 'INSERT INTO tbl_udts JSON ?';
             client.execute(query, [JSON.stringify(o)], next);
           },
           function select(next) {
-            var query = 'SELECT * FROM tbl_udts WHERE id = ?';
+            const query = 'SELECT * FROM tbl_udts WHERE id = ?';
             client.execute(query, [o.id], function (err, result) {
               assert.ifError(err);
-              var row = result.first();
+              const row = result.first();
               assert.ok(row);
               assert.ok(row['address_col']);
               assert.strictEqual(row['address_col'].street, o.address_col.street);
@@ -708,27 +708,27 @@ describe('Client', function () {
     });
     describe('with named parameters', function () {
       vit('2.1', 'should allow named parameters', function (done) {
-        var query = util.format('INSERT INTO %s (id, text_sample, bigint_sample) VALUES (:id, :myText, :myBigInt)', table);
+        const query = util.format('INSERT INTO %s (id, text_sample, bigint_sample) VALUES (:id, :myText, :myBigInt)', table);
         var values = { id: types.Uuid.random(), myText: 'hello', myBigInt: types.Long.fromNumber(2)};
-        var client = setupInfo.client;
+        const client = setupInfo.client;
         client.execute(query, values, function (err) {
           assert.ifError(err);
           verifyRow(table, values.id, 'text_sample, bigint_sample', [values.myText, values.myBigInt], done);
         });
       });
       vit('2.1', 'should use parameter hints', function (done) {
-        var query = util.format('INSERT INTO %s (id, int_sample, float_sample) VALUES (:id, :myInt, :myFloat)', table);
+        const query = util.format('INSERT INTO %s (id, int_sample, float_sample) VALUES (:id, :myInt, :myFloat)', table);
         var values = {id: types.Uuid.random(), myInt: 100, myFloat: 2.0999999046325684};
-        var client = setupInfo.client;
+        const client = setupInfo.client;
         client.execute(query, values, { hints: {myFloat: 'float', myInt: {code: types.dataTypes.int}}}, function (err) {
           assert.ifError(err);
           verifyRow(table, values.id, 'int_sample, float_sample', [values.myInt, values.myFloat], done);
         });
       });
       vit('2.1', 'should allow parameters with different casings', function (done) {
-        var query = util.format('INSERT INTO %s (id, text_sample, list_sample2) VALUES (:ID, :MyText, :mylist)', table);
+        const query = util.format('INSERT INTO %s (id, text_sample, list_sample2) VALUES (:ID, :MyText, :mylist)', table);
         var values = { id: types.Uuid.random(), mytext: 'hello', myLIST: [ -1, 0, 500, 3]};
-        var client = setupInfo.client;
+        const client = setupInfo.client;
         client.execute(query, values, { hints: { myLIST: 'list<int>'}}, function (err) {
           assert.ifError(err);
           verifyRow(table, values.id, 'text_sample, list_sample2', [values.mytext, values.myLIST], done);
@@ -736,11 +736,11 @@ describe('Client', function () {
       });
     });
     describe('with smallint and tinyint', function () {
-      var sampleId = types.Uuid.random();
+      const sampleId = types.Uuid.random();
       var insertQuery = 'INSERT INTO tbl_smallints (id, smallint_sample, tinyint_sample, text_sample) VALUES (%s, %s, %s, %s)';
-      var selectQuery = 'SELECT id, smallint_sample, tinyint_sample, text_sample FROM tbl_smallints WHERE id = %s';
+      const selectQuery = 'SELECT id, smallint_sample, tinyint_sample, text_sample FROM tbl_smallints WHERE id = %s';
       before(function (done) {
-        var client = setupInfo.client;
+        const client = setupInfo.client;
         utils.series([
           helper.toTask(client.execute, client, 'CREATE TABLE tbl_smallints (id uuid PRIMARY KEY, smallint_sample smallint, tinyint_sample tinyint, text_sample text)'),
           helper.toTask(client.execute, client, util.format(
@@ -748,13 +748,13 @@ describe('Client', function () {
         ], done);
       });
       vit('2.2', 'should retrieve smallint and tinyint values as Number', function (done) {
-        var query = util.format(selectQuery, sampleId);
-        var client = setupInfo.client;
+        const query = util.format(selectQuery, sampleId);
+        const client = setupInfo.client;
         client.execute(query, function (err, result) {
           assert.ifError(err);
           assert.ok(result);
           assert.ok(result.rowLength);
-          var row = result.first();
+          const row = result.first();
           assert.ok(row);
           assert.strictEqual(row['text_sample'], 'two');
           assert.strictEqual(row['smallint_sample'], 0x0200);
@@ -763,16 +763,16 @@ describe('Client', function () {
         });
       });
       vit('2.2', 'should encode and decode smallint and tinyint values as Number', function (done) {
-        var client = setupInfo.client;
-        var query = util.format(insertQuery, '?', '?', '?', '?');
-        var id = types.Uuid.random();
+        const client = setupInfo.client;
+        const query = util.format(insertQuery, '?', '?', '?', '?');
+        const id = types.Uuid.random();
         client.execute(query, [id, 10, 11, 'another text'], { hints: [null, 'smallint', 'tinyint']}, function (err) {
           assert.ifError(err);
           client.execute(util.format(selectQuery, id), function (err, result) {
             assert.ifError(err);
             assert.ok(result);
             assert.ok(result.rowLength);
-            var row = result.first();
+            const row = result.first();
             assert.ok(row);
             assert.strictEqual(row['text_sample'], 'another text');
             assert.strictEqual(row['smallint_sample'], 10);
@@ -783,12 +783,12 @@ describe('Client', function () {
       });
     });
     describe('with date and time types', function () {
-      var LocalDate = types.LocalDate;
-      var LocalTime = types.LocalTime;
+      const LocalDate = types.LocalDate;
+      const LocalTime = types.LocalTime;
       var insertQuery = 'INSERT INTO tbl_datetimes (id, date_sample, time_sample) VALUES (?, ?, ?)';
-      var selectQuery = 'SELECT id, date_sample, time_sample FROM tbl_datetimes WHERE id = ?';
+      const selectQuery = 'SELECT id, date_sample, time_sample FROM tbl_datetimes WHERE id = ?';
       before(function (done) {
-        var query = 'CREATE TABLE tbl_datetimes ' +
+        const query = 'CREATE TABLE tbl_datetimes ' +
           '(id uuid PRIMARY KEY, date_sample date, time_sample time, text_sample text)';
         setupInfo.client.execute(query, done);
       });
@@ -800,7 +800,7 @@ describe('Client', function () {
           [types.Uuid.random(), new LocalDate(1983, 2, 24), new LocalTime(types.Long.fromString('86399999999999'))],
           [types.Uuid.random(), new LocalDate(-2147483648), new LocalTime(types.Long.fromString('6311999549933'))]
         ];
-        var client = setupInfo.client;
+        const client = setupInfo.client;
         utils.eachSeries(values, function (params, next) {
           client.execute(insertQuery, params, function (err) {
             assert.ifError(err);
@@ -808,7 +808,7 @@ describe('Client', function () {
               assert.ifError(err);
               assert.ok(result);
               assert.ok(result.rowLength);
-              var row = result.first();
+              const row = result.first();
               assert.ok(row);
               assert.strictEqual(row['id'].toString(), params[0].toString());
               helper.assertInstanceOf(row['date_sample'], LocalDate);
@@ -823,8 +823,8 @@ describe('Client', function () {
     });
     describe('with json support', function () {
       before(function (done) {
-        var client = setupInfo.client;
-        var query =
+        const client = setupInfo.client;
+        const query =
           'CREATE TABLE tbl_json (' +
           '  id uuid PRIMARY KEY,' +
           '  tid timeuuid,' +
@@ -838,7 +838,7 @@ describe('Client', function () {
         client.execute(query, done);
       });
       vit('2.2', 'should allow insert of all ECMAScript types as json', function (done) {
-        var client = setupInfo.client;
+        const client = setupInfo.client;
         var o = {
           id: types.Uuid.random(),
           text_sample: 'hello json',
@@ -854,14 +854,14 @@ describe('Client', function () {
         };
         utils.series([
           function insert(next) {
-            var query = util.format('INSERT INTO %s JSON ?', table);
+            const query = util.format('INSERT INTO %s JSON ?', table);
             client.execute(query, [JSON.stringify(o)], next);
           },
           function select(next) {
-            var query = util.format('SELECT * FROM %s WHERE id = ?', table);
+            const query = util.format('SELECT * FROM %s WHERE id = ?', table);
             client.execute(query, [o.id], function (err, result) {
               assert.ifError(err);
-              var row = result.first();
+              const row = result.first();
               assert.ok(row);
               assert.strictEqual(row['text_sample'], o.text_sample);
               assert.strictEqual(row['int_sample'], o.int_sample);
@@ -881,7 +881,7 @@ describe('Client', function () {
         ], done);
       });
       vit('2.2', 'should allow insert of all non - ECMAScript types as json', function (done) {
-        var client = setupInfo.client;
+        const client = setupInfo.client;
         var o = {
           id:   types.Uuid.random(),
           tid:  types.TimeUuid.now(),
@@ -895,14 +895,14 @@ describe('Client', function () {
         };
         utils.series([
           function insert(next) {
-            var query = 'INSERT INTO tbl_json JSON ?';
+            const query = 'INSERT INTO tbl_json JSON ?';
             client.execute(query, [JSON.stringify(o)], next);
           },
           function select(next) {
-            var query = 'SELECT * FROM tbl_json WHERE id = ?';
+            const query = 'SELECT * FROM tbl_json WHERE id = ?';
             client.execute(query, [o.id], function (err, result) {
               assert.ifError(err);
-              var row = result.first();
+              const row = result.first();
               assert.ok(row);
               assert.strictEqual(row['tid'].toString(), o.tid.toString());
               assert.strictEqual(row['dec'].toString(), o.dec.toString());
@@ -922,7 +922,7 @@ describe('Client', function () {
     });
     describe('with no callback specified', function () {
       vit('2.0', 'should return a promise with the result as a value', function () {
-        var client = newInstance();
+        const client = newInstance();
         return client.connect()
           .then(function () {
             // Only the query
@@ -937,7 +937,7 @@ describe('Client', function () {
           .then(function (result) {
             // With parameters and options
             helper.assertInstanceOf(result, types.ResultSet);
-            var options = { consistency: types.consistencies.localOne };
+            const options = { consistency: types.consistencies.localOne };
             return client.execute('select key from system.local WHERE key = ?', [ 'local' ], options);
           })
           .then(function () {
@@ -945,7 +945,7 @@ describe('Client', function () {
           });
       });
       it('should reject the promise when there is a syntax error', function () {
-        var client = setupInfo.client;
+        const client = setupInfo.client;
         return client.connect()
           .then(function () {
             return client.execute('SELECT INVALID QUERY');
@@ -959,10 +959,10 @@ describe('Client', function () {
       });
     });
     vdescribe('2.0', 'with lightweight transactions', function () {
-      var client = setupInfo.client;
-      var id = types.Uuid.random();
+      const client = setupInfo.client;
+      const id = types.Uuid.random();
       before(function (done) {
-        var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
+        const query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
         client.execute(query, [id, 'val' ], done);
       });
       [
@@ -991,16 +991,16 @@ function insertSelectTest(client, table, columns, values, hints, done) {
   utils.series([
     function (next) {
       var markers = '?';
-      for (var i = 1; i < columnsSplit.length; i++) {
+      for (let i = 1; i < columnsSplit.length; i++) {
         markers += ', ?';
       }
-      var query = util.format('INSERT INTO %s ' +
+      const query = util.format('INSERT INTO %s ' +
         '(%s) VALUES ' +
         '(%s)', table, columns, markers);
       client.execute(query, values, {prepare: 0, hints: hints}, next);
     },
     function (next) {
-      var query = util.format('SELECT %s FROM %s WHERE id = %s', columns, table, values[0]);
+      const query = util.format('SELECT %s FROM %s WHERE id = %s', columns, table, values[0]);
       client.execute(query, null, {prepare: 0}, function (err, result) {
         assert.ifError(err);
         assert.ok(result);
@@ -1008,7 +1008,7 @@ function insertSelectTest(client, table, columns, values, hints, done) {
         var row = result.rows[0];
         assert.strictEqual(row.values().length, values.length);
         assert.strictEqual(row.keys().join(', '), columnsSplit.join(','));
-        for (var i = 0; i < values.length; i++) {
+        for (let i = 0; i < values.length; i++) {
           helper.assertValueEqual(values[i], row.get(i));
         }
         next();
@@ -1018,10 +1018,10 @@ function insertSelectTest(client, table, columns, values, hints, done) {
 }
 
 function verifyRow(table, id, fields, values, callback) {
-  var client = newInstance();
+  const client = newInstance();
   client.execute(util.format('SELECT %s FROM %s WHERE id = %s', fields, table, id), function (err, result) {
     assert.ifError(err);
-    var row = result.first();
+    const row = result.first();
     assert.ok(row, 'It should contain a row');
     helper.assertValueEqual(row.values(), values);
     callback();

--- a/test/integration/short/client-execute-tests.js
+++ b/test/integration/short/client-execute-tests.js
@@ -15,7 +15,7 @@ describe('Client', function () {
   this.timeout(120000);
   describe('#execute(query, params, {prepare: 0}, callback)', function () {
     const keyspace = helper.getRandomName('ks');
-    var table = keyspace + '.' + helper.getRandomName('table');
+    const table = keyspace + '.' + helper.getRandomName('table');
     const selectAllQuery = 'SELECT * FROM ' + table;
     const setupInfo = helper.setup(1, { keyspace: keyspace, queries: [ helper.createTableCql(table) ] });
     it('should execute a basic query', function (done) {
@@ -73,50 +73,50 @@ describe('Client', function () {
     });
     vit('2.0', 'should guess known types', function (done) {
       const client = setupInfo.client;
-      var columns = 'id, timeuuid_sample, text_sample, double_sample, timestamp_sample, blob_sample, list_sample';
+      const columns = 'id, timeuuid_sample, text_sample, double_sample, timestamp_sample, blob_sample, list_sample';
       //a precision a float32 can represent
-      var values = [types.Uuid.random(), types.TimeUuid.now(), 'text sample 1', 133, new Date(121212211), utils.allocBufferUnsafe(100), ['one', 'two']];
+      const values = [types.Uuid.random(), types.TimeUuid.now(), 'text sample 1', 133, new Date(121212211), utils.allocBufferUnsafe(100), ['one', 'two']];
       //no hint
       insertSelectTest(client, table, columns, values, null, done);
     });
     vit('2.0', 'should use parameter hints as number for simple types', function (done) {
       const client = setupInfo.client;
-      var columns = 'id, text_sample, float_sample, int_sample';
+      const columns = 'id, text_sample, float_sample, int_sample';
       //a precision a float32 can represent
-      var values = [types.Uuid.random(), 'text sample', 1000.0999755859375, -12];
-      var hints = [types.dataTypes.uuid, types.dataTypes.text, types.dataTypes.float, types.dataTypes.int];
+      const values = [types.Uuid.random(), 'text sample', 1000.0999755859375, -12];
+      const hints = [types.dataTypes.uuid, types.dataTypes.text, types.dataTypes.float, types.dataTypes.int];
       insertSelectTest(client, table, columns, values, hints, done);
     });
     vit('2.0', 'should use parameter hints as string for simple types', function (done) {
-      var columns = 'id, text_sample, float_sample, int_sample';
-      var values = [types.Uuid.random(), 'text sample', -9, 1];
-      var hints = [null, 'text', 'float', 'int'];
+      const columns = 'id, text_sample, float_sample, int_sample';
+      const values = [types.Uuid.random(), 'text sample', -9, 1];
+      const hints = [null, 'text', 'float', 'int'];
       const client = setupInfo.client;
       insertSelectTest(client, table, columns, values, hints, done);
     });
     vit('2.0', 'should use parameter hints as string for complex types partial', function (done) {
-      var columns = 'id, map_sample, list_sample, set_sample';
-      var values = [types.Uuid.random(), {val1: 'text sample1'}, ['list_text1'], ['set_text1']];
-      var hints = [null, 'map', 'list', 'set'];
+      const columns = 'id, map_sample, list_sample, set_sample';
+      const values = [types.Uuid.random(), {val1: 'text sample1'}, ['list_text1'], ['set_text1']];
+      const hints = [null, 'map', 'list', 'set'];
       const client = setupInfo.client;
       insertSelectTest(client, table, columns, values, hints, done);
     });
     vit('2.0', 'should use parameter hints as string for complex types complete', function (done) {
-      var columns = 'id, map_sample, list_sample, set_sample';
-      var values = [types.Uuid.random(), {val1: 'text sample1'}, ['list_text1'], ['set_text1']];
+      const columns = 'id, map_sample, list_sample, set_sample';
+      const values = [types.Uuid.random(), {val1: 'text sample1'}, ['list_text1'], ['set_text1']];
       //complete info
-      var hints = [null, 'map<text, text>', 'list<text>', 'set<text>'];
+      const hints = [null, 'map<text, text>', 'list<text>', 'set<text>'];
       const client = setupInfo.client;
       insertSelectTest(client, table, columns, values, hints, done);
     });
     vit('2.0', 'should use parameter hints for custom map polyfills', function (done) {
-      var columns = 'id, map_sample';
-      var map = new helper.Map();
+      const columns = 'id, map_sample';
+      const map = new helper.Map();
       map.set('k1', 'value 1');
       map.set('k2', 'value 2');
-      var values = [types.Uuid.random(), map];
+      const values = [types.Uuid.random(), map];
       //complete info
-      var hints = [null, 'map<text, text>'];
+      const hints = [null, 'map<text, text>'];
       const client = newInstance({encoding: { map: helper.Map }});
       insertSelectTest(client, table, columns, values, hints, done);
     });
@@ -194,13 +194,13 @@ describe('Client', function () {
             assert.ifError(err);
             assert.strictEqual(result.rowLength, 25);
             // should not page
-            var iterator = result[Symbol.iterator]();
+            const iterator = result[Symbol.iterator]();
             let count = 0;
             const uuids = [];
             let item;
             for (item = iterator.next(); !item.done; item = iterator.next()) {
               assert.ok(item.value);
-              var id = item.value.id;
+              const id = item.value.id;
               // should not encounter same id twice.
               assert.strictEqual(uuids.indexOf(id), -1);
               uuids.push(item.value.id);
@@ -221,7 +221,7 @@ describe('Client', function () {
       const client = setupInfo.client;
       const query = util.format('SELECT * FROM %s WHERE id IN (?, ?, ?)', table);
       //valid params
-      var params = [types.Uuid.random(), types.Uuid.random(), types.Uuid.random()];
+      const params = [types.Uuid.random(), types.Uuid.random(), types.Uuid.random()];
       utils.series([
         client.connect.bind(client),
         function hintsArrayAsObject(next) {
@@ -260,7 +260,7 @@ describe('Client', function () {
         setTimeout(function() {
           const query = util.format('SELECT * FROM %s WHERE list_sample CONTAINS ? AND list_sample CONTAINS ? ALLOW FILTERING', table);
           //valid params
-          var params = ['val1', 'val2'];
+          const params = ['val1', 'val2'];
           client.execute(query, params, function (err) {
             //it should not fail
             assert.ifError(err);
@@ -330,7 +330,7 @@ describe('Client', function () {
           '1': 1,
           '2': 0
         }}});
-      var execute = function (next) {
+      const execute = function (next) {
         client.execute(selectAllQuery, next);
       };
       utils.parallel([
@@ -349,7 +349,7 @@ describe('Client', function () {
     it('should return the column definitions', function (done) {
       const client = setupInfo.client;
       //insert at least 1 row
-      var insertQuery = util.format('INSERT INTO %s (id) VALUES (%s)', table, types.Uuid.random());
+      const insertQuery = util.format('INSERT INTO %s (id) VALUES (%s)', table, types.Uuid.random());
       utils.series([
         client.connect.bind(client),
         helper.toTask(client.execute, client, insertQuery),
@@ -403,7 +403,7 @@ describe('Client', function () {
           client.execute(query, function (err, result) {
             assert.ifError(err);
             assert.strictEqual(result.rows.length, 1);
-            var row = result.rows[0];
+            const row = result.rows[0];
             const expected = util.format('{"id":"%s",' +
               '"timeuuid_sample":"%s",' +
               '"inet_sample":"::2233:0:0:bb",' +
@@ -543,7 +543,7 @@ describe('Client', function () {
     });
     describe('with udt and tuple', function () {
       const sampleId = types.Uuid.random();
-      var insertQuery = 'INSERT INTO tbl_udts (id, phone_col, address_col) VALUES (%s, %s, %s)';
+      const insertQuery = 'INSERT INTO tbl_udts (id, phone_col, address_col) VALUES (%s, %s, %s)';
       const selectQuery = 'SELECT id, phone_col, address_col FROM tbl_udts WHERE id = %s';
       before(function (done) {
         const client = setupInfo.client;
@@ -567,7 +567,7 @@ describe('Client', function () {
           assert.ok(result.columns);
           assert.strictEqual(result.columns.length, 3);
           assert.strictEqual(result.columns[1].type.code, types.dataTypes.udt);
-          var phoneInfo = result.columns[1].type.info;
+          const phoneInfo = result.columns[1].type.info;
           assert.strictEqual(phoneInfo.name, 'phone');
           assert.strictEqual(phoneInfo.fields.length, 4);
           assert.strictEqual(phoneInfo.fields[0].name, 'alias');
@@ -575,7 +575,7 @@ describe('Client', function () {
           assert.strictEqual(phoneInfo.fields[2].name, 'country_code');
           assert.strictEqual(phoneInfo.fields[2].type.code, types.dataTypes.int);
           assert.strictEqual(result.columns[2].type.code, types.dataTypes.udt);
-          var addressInfo = result.columns[2].type.info;
+          const addressInfo = result.columns[2].type.info;
           assert.strictEqual(addressInfo.name, 'address');
           assert.strictEqual(addressInfo.fields.length, 3);
           assert.strictEqual(addressInfo.fields[0].name, 'street');
@@ -584,7 +584,7 @@ describe('Client', function () {
           assert.strictEqual(addressInfo.fields[2].name, 'phones');
           assert.strictEqual(addressInfo.fields[2].type.code, types.dataTypes.set);
           assert.strictEqual(addressInfo.fields[2].type.info.code, types.dataTypes.udt);
-          var subPhone = addressInfo.fields[2].type.info.info;
+          const subPhone = addressInfo.fields[2].type.info.info;
           assert.strictEqual(subPhone.name, 'phone');
           assert.strictEqual(subPhone.fields.length, 4);
           assert.strictEqual(subPhone.fields[0].name, 'alias');
@@ -602,13 +602,13 @@ describe('Client', function () {
           assert.ifError(err);
           const row = result.first();
           assert.ok(row);
-          var phone = row['phone_col'];
+          const phone = row['phone_col'];
           assert.ok(phone);
           assert.strictEqual(phone['alias'], 'home');
           assert.strictEqual(phone['number'], '555 1234');
           assert.strictEqual(phone['country_code'], 54);
           assert.strictEqual(phone['other'], null);
-          var address = row['address_col'];
+          const address = row['address_col'];
           assert.ok(address);
           assert.strictEqual(address['street'], 'NightMan');
           assert.strictEqual(address['ZIP'], 90988);
@@ -622,8 +622,8 @@ describe('Client', function () {
         });
       });
       vit('2.1', 'should allow udt parameter hints and retrieve metadata', function (done) {
-        var phone = { alias: 'home2', number: '555 0000', country_code: 34, other: true};
-        var address = {street: 'NightMan2', ZIP: 90987, phones: [{ 'alias': 'personal2', 'number': '555 0001'}, {alias: 'work2'}]};
+        const phone = { alias: 'home2', number: '555 0000', country_code: 34, other: true};
+        const address = {street: 'NightMan2', ZIP: 90987, phones: [{ 'alias': 'personal2', 'number': '555 0001'}, {alias: 'work2'}]};
         const id = types.Uuid.random();
         const client = setupInfo.client;
         utils.series([
@@ -655,7 +655,7 @@ describe('Client', function () {
       vit('2.1', 'should allow tuple parameter hints', function (done) {
         const client = setupInfo.client;
         const id = types.Uuid.random();
-        var tuple = new types.Tuple('Surf Rider', 110, utils.allocBufferFromString('0f0f', 'hex'));
+        const tuple = new types.Tuple('Surf Rider', 110, utils.allocBufferFromString('0f0f', 'hex'));
         utils.series([
           function insert(next) {
             const query ='INSERT INTO tbl_tuples (id, tuple_col) VALUES (?, ?)';
@@ -678,7 +678,7 @@ describe('Client', function () {
       });
       vit('2.2', 'should allow insertions as json', function (done) {
         const client = setupInfo.client;
-        var o = {
+        const o = {
           id: types.Uuid.random(),
           address_col: {
             street: 'whatever',
@@ -709,7 +709,7 @@ describe('Client', function () {
     describe('with named parameters', function () {
       vit('2.1', 'should allow named parameters', function (done) {
         const query = util.format('INSERT INTO %s (id, text_sample, bigint_sample) VALUES (:id, :myText, :myBigInt)', table);
-        var values = { id: types.Uuid.random(), myText: 'hello', myBigInt: types.Long.fromNumber(2)};
+        const values = { id: types.Uuid.random(), myText: 'hello', myBigInt: types.Long.fromNumber(2)};
         const client = setupInfo.client;
         client.execute(query, values, function (err) {
           assert.ifError(err);
@@ -718,7 +718,7 @@ describe('Client', function () {
       });
       vit('2.1', 'should use parameter hints', function (done) {
         const query = util.format('INSERT INTO %s (id, int_sample, float_sample) VALUES (:id, :myInt, :myFloat)', table);
-        var values = {id: types.Uuid.random(), myInt: 100, myFloat: 2.0999999046325684};
+        const values = {id: types.Uuid.random(), myInt: 100, myFloat: 2.0999999046325684};
         const client = setupInfo.client;
         client.execute(query, values, { hints: {myFloat: 'float', myInt: {code: types.dataTypes.int}}}, function (err) {
           assert.ifError(err);
@@ -727,7 +727,7 @@ describe('Client', function () {
       });
       vit('2.1', 'should allow parameters with different casings', function (done) {
         const query = util.format('INSERT INTO %s (id, text_sample, list_sample2) VALUES (:ID, :MyText, :mylist)', table);
-        var values = { id: types.Uuid.random(), mytext: 'hello', myLIST: [ -1, 0, 500, 3]};
+        const values = { id: types.Uuid.random(), mytext: 'hello', myLIST: [ -1, 0, 500, 3]};
         const client = setupInfo.client;
         client.execute(query, values, { hints: { myLIST: 'list<int>'}}, function (err) {
           assert.ifError(err);
@@ -737,7 +737,7 @@ describe('Client', function () {
     });
     describe('with smallint and tinyint', function () {
       const sampleId = types.Uuid.random();
-      var insertQuery = 'INSERT INTO tbl_smallints (id, smallint_sample, tinyint_sample, text_sample) VALUES (%s, %s, %s, %s)';
+      const insertQuery = 'INSERT INTO tbl_smallints (id, smallint_sample, tinyint_sample, text_sample) VALUES (%s, %s, %s, %s)';
       const selectQuery = 'SELECT id, smallint_sample, tinyint_sample, text_sample FROM tbl_smallints WHERE id = %s';
       before(function (done) {
         const client = setupInfo.client;
@@ -785,7 +785,7 @@ describe('Client', function () {
     describe('with date and time types', function () {
       const LocalDate = types.LocalDate;
       const LocalTime = types.LocalTime;
-      var insertQuery = 'INSERT INTO tbl_datetimes (id, date_sample, time_sample) VALUES (?, ?, ?)';
+      const insertQuery = 'INSERT INTO tbl_datetimes (id, date_sample, time_sample) VALUES (?, ?, ?)';
       const selectQuery = 'SELECT id, date_sample, time_sample FROM tbl_datetimes WHERE id = ?';
       before(function (done) {
         const query = 'CREATE TABLE tbl_datetimes ' +
@@ -793,7 +793,7 @@ describe('Client', function () {
         setupInfo.client.execute(query, done);
       });
       vit('2.2', 'should encode and decode date and time values as LocalDate and LocalTime', function (done) {
-        var values = [
+        const values = [
           [types.Uuid.random(), new LocalDate(1969, 10, 13), new LocalTime(types.Long.fromString('0'))],
           [types.Uuid.random(), new LocalDate(2010, 4, 29), LocalTime.fromString('15:01:02.1234')],
           [types.Uuid.random(), new LocalDate(2005, 8, 5), LocalTime.fromString('01:56:03.000501')],
@@ -839,7 +839,7 @@ describe('Client', function () {
       });
       vit('2.2', 'should allow insert of all ECMAScript types as json', function (done) {
         const client = setupInfo.client;
-        var o = {
+        const o = {
           id: types.Uuid.random(),
           text_sample: 'hello json',
           int_sample: 100,
@@ -882,7 +882,7 @@ describe('Client', function () {
       });
       vit('2.2', 'should allow insert of all non - ECMAScript types as json', function (done) {
         const client = setupInfo.client;
-        var o = {
+        const o = {
           id:   types.Uuid.random(),
           tid:  types.TimeUuid.now(),
           dec:  new types.BigDecimal(113, 2),
@@ -987,10 +987,10 @@ describe('Client', function () {
 });
 
 function insertSelectTest(client, table, columns, values, hints, done) {
-  var columnsSplit = columns.split(',');
+  const columnsSplit = columns.split(',');
   utils.series([
     function (next) {
-      var markers = '?';
+      let markers = '?';
       for (let i = 1; i < columnsSplit.length; i++) {
         markers += ', ?';
       }
@@ -1005,7 +1005,7 @@ function insertSelectTest(client, table, columns, values, hints, done) {
         assert.ifError(err);
         assert.ok(result);
         assert.ok(result.rows && result.rows.length > 0, 'There should be a row');
-        var row = result.rows[0];
+        const row = result.rows[0];
         assert.strictEqual(row.values().length, values.length);
         assert.strictEqual(row.keys().join(', '), columnsSplit.join(','));
         for (let i = 0; i < values.length; i++) {

--- a/test/integration/short/client-pool-tests.js
+++ b/test/integration/short/client-pool-tests.js
@@ -12,7 +12,7 @@ const policies = require('../../../lib/policies');
 const RoundRobinPolicy = require('../../../lib/policies/load-balancing.js').RoundRobinPolicy;
 const Murmur3Tokenizer = require('../../../lib/tokenizer.js').Murmur3Tokenizer;
 const PlainTextAuthProvider = require('../../../lib/auth/plain-text-auth-provider.js');
-var ConstantSpeculativeExecutionPolicy = policies.speculativeExecution.ConstantSpeculativeExecutionPolicy;
+const ConstantSpeculativeExecutionPolicy = policies.speculativeExecution.ConstantSpeculativeExecutionPolicy;
 const OrderedLoadBalancingPolicy = helper.OrderedLoadBalancingPolicy;
 
 describe('Client', function () {
@@ -133,7 +133,7 @@ describe('Client', function () {
         assert.ifError(err);
         //the 3 original hosts
         assert.strictEqual(client.hosts.length, 3);
-        var hosts = client.hosts.keys();
+        const hosts = client.hosts.keys();
         assert.strictEqual(hosts[0], contactPoints[0] + ':9042');
         assert.notEqual(hosts[1], contactPoints[1] + ':9042');
         assert.notEqual(hosts[2], contactPoints[1] + ':9042');
@@ -169,7 +169,7 @@ describe('Client', function () {
       client.connect(function (err) {
         assert.ifError(err);
         assert.ok(client.options.pooling.coreConnectionsPerHost);
-        var defaults = clientOptions.coreConnectionsPerHostV3;
+        let defaults = clientOptions.coreConnectionsPerHostV3;
         if (client.controlConnection.protocolVersion < 3) {
           defaults = clientOptions.coreConnectionsPerHostV2;
         }
@@ -211,7 +211,7 @@ describe('Client', function () {
         client.connect(function (err) {
           assert.ifError(err);
           assert.strictEqual(client.hosts.length, 3);
-          var state = client.getState();
+          const state = client.getState();
           client.hosts.forEach(function (host) {
             assert.strictEqual(host.pool.connections.length, 3, 'For host ' + host.address);
             assert.strictEqual(state.getOpenConnections(host), 3);
@@ -221,7 +221,7 @@ describe('Client', function () {
       }, done);
     });
     it('should only warmup connections for hosts with local distance', function (done) {
-      var lbPolicy = new RoundRobinPolicy();
+      const lbPolicy = new RoundRobinPolicy();
       lbPolicy.getDistance = function (host) {
         const id = helper.lastOctetOf(host.address);
         if(id === '1') {
@@ -255,7 +255,7 @@ describe('Client', function () {
       });
     });
     it('should connect after unsuccessful attempt caused by a non-existent keyspace', function (done) {
-      var keyspace = 'ks_test_after_fail';
+      const keyspace = 'ks_test_after_fail';
       const client = newInstance({ keyspace: keyspace });
       utils.series([
         function tryConnect(next) {
@@ -355,7 +355,7 @@ describe('Client', function () {
         client.connect(function (err) {
           assert.ifError(err);
           assert.strictEqual(client.hosts.length, 1);
-          const expected = contactPoint + ':9042';
+          let expected = contactPoint + ':9042';
           if (contactPoint.indexOf('[') === 0) {
             expected = contactPoint.replace(/[[\]]/g, '');
           }
@@ -382,7 +382,7 @@ describe('Client', function () {
         function (next) {
           client.connect(function (err) {
             assert.ifError(err);
-            var hosts = client.hosts.values();
+            const hosts = client.hosts.values();
             assert.strictEqual(1, hosts.length);
             assert.strictEqual(typeof hosts[0].datacenter, 'string');
             assert.notEqual(hosts[0].datacenter.length, 0);
@@ -409,7 +409,7 @@ describe('Client', function () {
           helper.ccmHelper.start(2),
           client.connect.bind(client),
           function checkInitialState(next) {
-            var hosts = client.hosts.values();
+            const hosts = client.hosts.values();
             assert.ok(hosts[0].isUp());
             assert.ok(hosts[1].isUp());
             next();
@@ -501,7 +501,7 @@ describe('Client', function () {
           return done(err);
         }
         assert.strictEqual(client.hosts.length, 3);
-        var hosts = client.hosts.slice(0);
+        const hosts = client.hosts.slice(0);
         assert.strictEqual(hosts[0].pool.coreConnectionsLength, 3);
         assert.strictEqual(hosts[1].pool.coreConnectionsLength, 3);
         // wait for the pool to be the expected size
@@ -511,7 +511,7 @@ describe('Client', function () {
       });
     });
     it('should wait for schema agreement before calling back', function (done) {
-      var queries = [
+      const queries = [
         "CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3};",
         "CREATE TABLE ks1.tbl1 (id uuid PRIMARY KEY, value text)",
         "SELECT * FROM ks1.tbl1",
@@ -605,13 +605,13 @@ describe('Client', function () {
     });
     function changingDistancesTest(address) {
       return (function doTest(done) {
-        var lbp = new RoundRobinPolicy();
+        const lbp = new RoundRobinPolicy();
         let ignoredHost;
         let cc;
         lbp.getDistance = function (h) {
           return helper.lastOctetOf(h) === ignoredHost ? types.distance.ignored : types.distance.local;
         };
-        var connectionsPerHost = 5;
+        const connectionsPerHost = 5;
         const client = newInstance({
           policies: { loadBalancing: lbp },
           pooling: { coreConnectionsPerHost: { '0': connectionsPerHost } }
@@ -646,14 +646,14 @@ describe('Client', function () {
           }),
           queryAndCheckPool(500, function (coordinators) {
             // The pool for 1st and 3rd host should have the appropriate size by now.
-            var expectedPoolInfo = { '1': connectionsPerHost, '2': connectionsPerHost, '3': connectionsPerHost};
+            const expectedPoolInfo = { '1': connectionsPerHost, '2': connectionsPerHost, '3': connectionsPerHost};
             expectedPoolInfo[ignoredHost] = 0;
             assert.deepEqual(getPoolInfo(client), expectedPoolInfo );
             assert.deepEqual(coordinators, [ '1', '2', '3'].filter(function (x) { return x !== ignoredHost;}));
           }),
           client.shutdown.bind(client),
           function checkPoolState(next) {
-            var expectedState = { '1': 0, '2': 0, '3': 0};
+            const expectedState = { '1': 0, '2': 0, '3': 0};
             assert.deepEqual(getPoolInfo(client), expectedState);
             setTimeout(function checkPoolStateDelayed() {
               assert.deepEqual(getPoolInfo(client), expectedState);
@@ -836,7 +836,7 @@ describe('Client', function () {
       ], done);
     });
     it('should reconnect in the background', function (done) {
-      var reconnectionDelay = 500;
+      const reconnectionDelay = 500;
       const client = newInstance({
         pooling: { heartBeatInterval: 0, warmup: true },
         policies: { reconnection: new policies.reconnection.ConstantReconnectionPolicy(reconnectionDelay) }
@@ -844,7 +844,7 @@ describe('Client', function () {
       utils.series([
         client.connect.bind(client),
         function (next) {
-          var hosts = client.hosts.values();
+          const hosts = client.hosts.values();
           assert.strictEqual('1', helper.lastOctetOf(client.controlConnection.host));
           assert.strictEqual(3, hosts.length);
           hosts.forEach(function (h) {
@@ -896,9 +896,9 @@ describe('Client', function () {
           }, next);
         },
         function shutDown(next) {
-          var hosts = client.hosts.values();
+          const hosts = client.hosts.values();
           assert.strictEqual(hosts.length, 2);
-          var state = client.getState();
+          const state = client.getState();
           // Check the pools before shutting down
           hosts.forEach(function each(host) {
             assert.ok(state.getOpenConnections(host) > 0);
@@ -908,9 +908,9 @@ describe('Client', function () {
           client.shutdown(next);
         },
         function checkPool(next) {
-          var hosts = client.hosts.values();
+          const hosts = client.hosts.values();
           assert.strictEqual(hosts.length, 2);
-          var state = client.getState();
+          const state = client.getState();
           assert.deepEqual(state.getConnectedHosts(), []);
           hosts.forEach(function each(host) {
             assert.strictEqual(host.pool.connections.length, 0);
@@ -930,7 +930,7 @@ describe('Client', function () {
           }, next);
         },
         function shutDown(next) {
-          var hosts = client.hosts.values();
+          const hosts = client.hosts.values();
           assert.strictEqual(hosts.length, 2);
           assert.ok(hosts[0].pool.connections.length > 0);
           assert.ok(!hosts[0].pool.shuttingDown);

--- a/test/integration/short/client-pool-tests.js
+++ b/test/integration/short/client-pool-tests.js
@@ -1,24 +1,24 @@
 "use strict";
-var assert = require('assert');
-var dns = require('dns');
+const assert = require('assert');
+const dns = require('dns');
 
-var helper = require('../../test-helper');
-var Client = require('../../../lib/client');
-var clientOptions = require('../../../lib/client-options');
-var utils = require('../../../lib/utils');
-var errors = require('../../../lib/errors');
-var types = require('../../../lib/types');
-var policies = require('../../../lib/policies');
-var RoundRobinPolicy = require('../../../lib/policies/load-balancing.js').RoundRobinPolicy;
-var Murmur3Tokenizer = require('../../../lib/tokenizer.js').Murmur3Tokenizer;
-var PlainTextAuthProvider = require('../../../lib/auth/plain-text-auth-provider.js');
+const helper = require('../../test-helper');
+const Client = require('../../../lib/client');
+const clientOptions = require('../../../lib/client-options');
+const utils = require('../../../lib/utils');
+const errors = require('../../../lib/errors');
+const types = require('../../../lib/types');
+const policies = require('../../../lib/policies');
+const RoundRobinPolicy = require('../../../lib/policies/load-balancing.js').RoundRobinPolicy;
+const Murmur3Tokenizer = require('../../../lib/tokenizer.js').Murmur3Tokenizer;
+const PlainTextAuthProvider = require('../../../lib/auth/plain-text-auth-provider.js');
 var ConstantSpeculativeExecutionPolicy = policies.speculativeExecution.ConstantSpeculativeExecutionPolicy;
-var OrderedLoadBalancingPolicy = helper.OrderedLoadBalancingPolicy;
+const OrderedLoadBalancingPolicy = helper.OrderedLoadBalancingPolicy;
 
 describe('Client', function () {
   this.timeout(120000);
   describe('#connect()', function () {
-    var useLocalhost;
+    let useLocalhost;
     before(helper.ccmHelper.start(3));
     before(function (done) {
       dns.resolve('localhost', function (err) {
@@ -28,7 +28,7 @@ describe('Client', function () {
     });
     after(helper.ccmHelper.remove);
     it('should discover all hosts in the ring and hosts object can be serializable', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       client.connect(function (err) {
         if (err) {
           return done(err);
@@ -44,7 +44,7 @@ describe('Client', function () {
       });
     });
     it('should retrieve the cassandra version of the hosts', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       client.connect(function (err) {
         if (err) {
           return done(err);
@@ -60,7 +60,7 @@ describe('Client', function () {
       });
     });
     it('should fail if the contact points can not be resolved', function (done) {
-      var client = newInstance({contactPoints: ['not-a-host']});
+      const client = newInstance({contactPoints: ['not-a-host']});
       client.connect(function (err) {
         assert.ok(err);
         helper.assertInstanceOf(err, errors.NoHostAvailableError);
@@ -71,7 +71,7 @@ describe('Client', function () {
       });
     });
     it('should fail if the contact points can not be reached', function (done) {
-      var client = newInstance({contactPoints: ['1.1.1.1']});
+      const client = newInstance({contactPoints: ['1.1.1.1']});
       client.connect(function (err) {
         assert.ok(err);
         helper.assertInstanceOf(err, errors.NoHostAvailableError);
@@ -79,7 +79,7 @@ describe('Client', function () {
       });
     });
     it('should select a tokenizer', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       client.connect(function (err) {
         if (err) {return done(err);}
         helper.assertInstanceOf(client.metadata.tokenizer, Murmur3Tokenizer);
@@ -87,7 +87,7 @@ describe('Client', function () {
       });
     });
     it('should allow multiple parallel calls to connect', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.times(100, function (n, next) {
         client.connect(next);
       }, function (err) {
@@ -99,7 +99,7 @@ describe('Client', function () {
       if (!useLocalhost) {
         return done();
       }
-      var client = new Client(utils.extend({}, helper.baseOptions, {contactPoints: ['localhost']}));
+      const client = new Client(utils.extend({}, helper.baseOptions, {contactPoints: ['localhost']}));
       client.connect(function (err) {
         assert.ifError(err);
         assert.strictEqual(client.hosts.length, 3);
@@ -110,7 +110,7 @@ describe('Client', function () {
       });
     });
     it('should fail if the keyspace does not exists', function (done) {
-      var client = new Client(utils.extend({}, helper.baseOptions, {keyspace: 'not-existent-ks'}));
+      const client = new Client(utils.extend({}, helper.baseOptions, {keyspace: 'not-existent-ks'}));
       utils.times(10, function (n, next) {
         client.connect(function (err) {
           assert.ok(err);
@@ -125,10 +125,10 @@ describe('Client', function () {
       });
     });
     it('should not use contactPoints that are not part of peers', function (done) {
-      var contactPoints = helper.baseOptions.contactPoints.slice(0);
+      const contactPoints = helper.baseOptions.contactPoints.slice(0);
       contactPoints.push('host-not-existent-not-peer');
       contactPoints.push('1.1.1.1');
-      var client = newInstance({contactPoints: contactPoints});
+      const client = newInstance({contactPoints: contactPoints});
       client.connect(function (err) {
         assert.ifError(err);
         //the 3 original hosts
@@ -143,7 +143,7 @@ describe('Client', function () {
       });
     });
     it('should use the default pooling options according to the protocol version', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       client.connect(function (err) {
         assert.ifError(err);
         assert.ok(client.options.pooling.coreConnectionsPerHost);
@@ -163,7 +163,7 @@ describe('Client', function () {
       });
     });
     it('should override default pooling options when specified', function (done) {
-      var client = newInstance({ pooling: {
+      const client = newInstance({ pooling: {
         coreConnectionsPerHost: { '0': 4 }
       }});
       client.connect(function (err) {
@@ -192,7 +192,7 @@ describe('Client', function () {
       });
     });
     it('should not fail when switching keyspace and a contact point is not valid', function (done) {
-      var client = new Client({
+      const client = new Client({
         contactPoints: ['1.1.1.1', helper.baseOptions.contactPoints[0]],
         keyspace: 'system'
       });
@@ -204,10 +204,10 @@ describe('Client', function () {
     it('should open connections to all hosts when warmup is set', function (done) {
       // do it multiple times
       utils.timesSeries(300, function (n, next) {
-        var connectionsPerHost = {};
+        const connectionsPerHost = {};
         connectionsPerHost[types.distance.local] = 3;
         connectionsPerHost[types.distance.remote] = 1;
-        var client = newInstance({pooling: {warmup: true, coreConnectionsPerHost: connectionsPerHost}});
+        const client = newInstance({pooling: {warmup: true, coreConnectionsPerHost: connectionsPerHost}});
         client.connect(function (err) {
           assert.ifError(err);
           assert.strictEqual(client.hosts.length, 3);
@@ -223,7 +223,7 @@ describe('Client', function () {
     it('should only warmup connections for hosts with local distance', function (done) {
       var lbPolicy = new RoundRobinPolicy();
       lbPolicy.getDistance = function (host) {
-        var id = helper.lastOctetOf(host.address);
+        const id = helper.lastOctetOf(host.address);
         if(id === '1') {
           return types.distance.local;
         }
@@ -233,10 +233,10 @@ describe('Client', function () {
         return types.distance.ignored;
       };
 
-      var connectionsPerHost = {};
+      const connectionsPerHost = {};
       connectionsPerHost[types.distance.local] = 3;
       connectionsPerHost[types.distance.remote] = 1;
-      var client = newInstance({
+      const client = newInstance({
         policies: { loadBalancing: lbPolicy },
         pooling: { warmup: true, coreConnectionsPerHost: connectionsPerHost}
       });
@@ -244,7 +244,7 @@ describe('Client', function () {
         assert.ifError(err);
         assert.strictEqual(client.hosts.length, 3);
         client.hosts.forEach(function (host) {
-          var id = helper.lastOctetOf(host);
+          const id = helper.lastOctetOf(host);
           if(id === '1') {
             assert.strictEqual(host.pool.connections.length, 3);
           } else {
@@ -256,7 +256,7 @@ describe('Client', function () {
     });
     it('should connect after unsuccessful attempt caused by a non-existent keyspace', function (done) {
       var keyspace = 'ks_test_after_fail';
-      var client = newInstance({ keyspace: keyspace });
+      const client = newInstance({ keyspace: keyspace });
       utils.series([
         function tryConnect(next) {
           client.connect(function (err) {
@@ -265,7 +265,7 @@ describe('Client', function () {
           });
         },
         function createKeyspace(next) {
-          var tempClient = newInstance();
+          const tempClient = newInstance();
           tempClient.execute(helper.createKeyspaceCql(keyspace), function (err) {
             assert.ifError(err);
             tempClient.shutdown(next);
@@ -291,8 +291,8 @@ describe('Client', function () {
     }));
     after(helper.ccmHelper.remove);
     it('should connect using the plain text authenticator', function (done) {
-      var options = {authProvider: new PlainTextAuthProvider('cassandra', 'cassandra')};
-      var client = newInstance(options);
+      const options = {authProvider: new PlainTextAuthProvider('cassandra', 'cassandra')};
+      const client = newInstance(options);
       utils.times(100, function (n, next) {
         client.connect(next);
       }, function (err) {
@@ -300,8 +300,8 @@ describe('Client', function () {
       });
     });
     it('should connect using the plain text authenticator when calling execute', function (done) {
-      var options = {authProvider: new PlainTextAuthProvider('cassandra', 'cassandra'), keyspace: 'system'};
-      var client = newInstance(options);
+      const options = {authProvider: new PlainTextAuthProvider('cassandra', 'cassandra'), keyspace: 'system'};
+      const client = newInstance(options);
       utils.times(100, function (n, next) {
         client.execute('SELECT * FROM local', next);
       }, function (err) {
@@ -309,8 +309,8 @@ describe('Client', function () {
       });
     });
     it('should return an AuthenticationError', function (done) {
-      var options = {authProvider: new PlainTextAuthProvider('not___EXISTS', 'not___EXISTS'), keyspace: 'system'};
-      var client = newInstance(options);
+      const options = {authProvider: new PlainTextAuthProvider('not___EXISTS', 'not___EXISTS'), keyspace: 'system'};
+      const client = newInstance(options);
       utils.timesSeries(10, function (n, next) {
         client.connect(function (err) {
           assert.ok(err);
@@ -322,8 +322,8 @@ describe('Client', function () {
       }, done);
     });
     it('should return an AuthenticationError when calling execute', function (done) {
-      var options = {authProvider: new PlainTextAuthProvider('not___EXISTS', 'not___EXISTS'), keyspace: 'system'};
-      var client = newInstance(options);
+      const options = {authProvider: new PlainTextAuthProvider('not___EXISTS', 'not___EXISTS'), keyspace: 'system'};
+      const client = newInstance(options);
       utils.times(10, function (n, next) {
         client.execute('SELECT * FROM local', function (err) {
           assert.ok(err);
@@ -351,11 +351,11 @@ describe('Client', function () {
         }
       ], done);
       function testConnect(contactPoint, testDone) {
-        var client = newInstance({ contactPoints: [ contactPoint ] });
+        const client = newInstance({ contactPoints: [ contactPoint ] });
         client.connect(function (err) {
           assert.ifError(err);
           assert.strictEqual(client.hosts.length, 1);
-          var expected = contactPoint + ':9042';
+          const expected = contactPoint + ':9042';
           if (contactPoint.indexOf('[') === 0) {
             expected = contactPoint.replace(/[[\]]/g, '');
           }
@@ -369,7 +369,7 @@ describe('Client', function () {
   });
   describe('#connect() with nodes failing', function () {
     it('should connect after a failed attempt', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         helper.ccmHelper.removeIfAny,
         function (next) {
@@ -396,7 +396,7 @@ describe('Client', function () {
     function getReceiveNotificationTest(nodeNumber) {
       return (function receiveNotificationTest(done) {
         // Should receive notification when a node gracefully closes connections
-        var client = newInstance({
+        const client = newInstance({
           pooling: {
             warmup: true,
             heartBeatInterval: 0,
@@ -437,7 +437,7 @@ describe('Client', function () {
     before(helper.ccmHelper.start(3));
     after(helper.ccmHelper.remove);
     it('should use the keyspace provided', function (done) {
-      var client = new Client(utils.extend({}, helper.baseOptions, {keyspace: 'system'}));
+      const client = new Client(utils.extend({}, helper.baseOptions, {keyspace: 'system'}));
       //on all hosts
       utils.times(10, function (n, next) {
         assert.strictEqual(client.keyspace, 'system');
@@ -451,7 +451,7 @@ describe('Client', function () {
       }, done);
     });
     it('should fail to execute if the keyspace does not exists', function (done) {
-      var client = new Client(utils.extend({}, helper.baseOptions, {keyspace: 'NOT____EXISTS'}));
+      const client = new Client(utils.extend({}, helper.baseOptions, {keyspace: 'NOT____EXISTS'}));
       // Execute on all hosts, some executions in parallel and some serial
       utils.timesLimit(12, 6, function (n, next) {
         //No matter what, the keyspace does not exists
@@ -462,7 +462,7 @@ describe('Client', function () {
       }, done);
     });
     it('should change the active keyspace after USE statement', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       client.execute('USE system', function (err) {
         if (err) {
           return done(err);
@@ -475,7 +475,7 @@ describe('Client', function () {
       });
     });
     it('should return ResponseError when executing USE with a wrong keyspace', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       client.execute('USE ks_not_exist', function (err) {
         assert.ok(err instanceof errors.ResponseError);
         assert.equal(client.keyspace, null);
@@ -483,7 +483,7 @@ describe('Client', function () {
       });
     });
     it('should create the amount of connections determined by the options', function (done) {
-      var options = {
+      const options = {
         pooling: {
           coreConnectionsPerHost: {
             '0': 3,
@@ -492,7 +492,7 @@ describe('Client', function () {
           }
         }
       };
-      var client = new Client(utils.extend({}, helper.baseOptions, options));
+      const client = new Client(utils.extend({}, helper.baseOptions, options));
       //execute a couple of queries
       utils.timesLimit(100, 50, function (n, next) {
         client.execute(helper.queries.basic, next);
@@ -528,7 +528,7 @@ describe('Client', function () {
         "SELECT * FROM ks2.tbl4",
         "SELECT * FROM ks2.tbl4"
       ];
-      var client = newInstance();
+      const client = newInstance();
       //warmup first
       utils.timesSeries(10, function (n, next) {
         client.execute('SELECT key FROM system.local', next);
@@ -553,7 +553,7 @@ describe('Client', function () {
           helper.ccmHelper.resumeNode(2, done);
         });
         it('should wait until is completed on the first node', function (done) {
-          var client = newInstance({
+          const client = newInstance({
             pooling: { warmup: true },
             policies: {
               speculativeExecution: policy,
@@ -579,7 +579,7 @@ describe('Client', function () {
               }, function (err, results) {
                 assert.ifError(err);
                 assert.strictEqual(results.length, 2);
-                var expectedHost;
+                let expectedHost;
                 if (policy instanceof ConstantSpeculativeExecutionPolicy) {
                   // Use the next one in a speculative execution
                   expectedHost = client.hosts.keys()[1];
@@ -606,19 +606,19 @@ describe('Client', function () {
     function changingDistancesTest(address) {
       return (function doTest(done) {
         var lbp = new RoundRobinPolicy();
-        var ignoredHost;
-        var cc;
+        let ignoredHost;
+        let cc;
         lbp.getDistance = function (h) {
           return helper.lastOctetOf(h) === ignoredHost ? types.distance.ignored : types.distance.local;
         };
         var connectionsPerHost = 5;
-        var client = newInstance({
+        const client = newInstance({
           policies: { loadBalancing: lbp },
           pooling: { coreConnectionsPerHost: { '0': connectionsPerHost } }
         });
         function queryAndCheckPool(limit, assertions) {
           return (function executeSomeQueries(next) {
-            var coordinators = {};
+            const coordinators = {};
             utils.timesLimit(limit, 3, function (n, timesNext) {
               client.execute(helper.queries.basic, function (err, result) {
                 if (!err) {
@@ -676,9 +676,9 @@ describe('Client', function () {
     beforeEach(helper.ccmHelper.start(3));
     afterEach(helper.ccmHelper.remove);
     it('should failover after a node goes down', function (done) {
-      var client = newInstance();
-      var hosts = {};
-      var hostsDown = [];
+      const client = newInstance();
+      const hosts = {};
+      const hostsDown = [];
       utils.series([
         client.connect.bind(client),
         function (next) {
@@ -739,7 +739,7 @@ describe('Client', function () {
       ], done);
     });
     it('should failover when a node goes down with some outstanding requests', function (done) {
-      var options = utils.extend({}, helper.baseOptions);
+      const options = utils.extend({}, helper.baseOptions);
       options.pooling = {
         coreConnectionsPerHost: {
           '0': 1,
@@ -747,9 +747,9 @@ describe('Client', function () {
           '2': 0
         }
       };
-      var client = new Client(options);
-      var hosts = {};
-      var query = helper.queries.basic;
+      const client = new Client(options);
+      const hosts = {};
+      const query = helper.queries.basic;
       utils.series([
         function (next) {
           // wait for all initial events to ensure we don't incidentally get an 'UP' event for node 2
@@ -768,7 +768,7 @@ describe('Client', function () {
         function testCase(seriesNext) {
           //3 hosts alive
           assert.strictEqual(Object.keys(hosts).length, 3);
-          var killed = false;
+          let killed = false;
           utils.timesLimit(500, 20, function (n, next) {
             if (n === 10) {
               //kill a node when there are some outstanding requests
@@ -807,8 +807,8 @@ describe('Client', function () {
       utils.series([
         helper.toTask(helper.ccmHelper.exec, null, ['node2', 'stop']),
         function (next) {
-          var warnings = [];
-          var client = newInstance({ pooling: { warmup: true } });
+          const warnings = [];
+          const client = newInstance({ pooling: { warmup: true } });
           client.on('log', function (level, className, message) {
             if (level !== 'warning' || className !== 'Client') {
               return;
@@ -827,7 +827,7 @@ describe('Client', function () {
       utils.series([
         helper.toTask(helper.ccmHelper.exec, null, ['node1', 'stop']),
         function (next) {
-          var client = newInstance({ contactPoints: ['127.0.0.1', '127.0.0.2'], pooling: { warmup: true } });
+          const client = newInstance({ contactPoints: ['127.0.0.1', '127.0.0.2'], pooling: { warmup: true } });
           client.connect(function (err) {
             assert.ifError(err);
             client.shutdown(next);
@@ -837,7 +837,7 @@ describe('Client', function () {
     });
     it('should reconnect in the background', function (done) {
       var reconnectionDelay = 500;
-      var client = newInstance({
+      const client = newInstance({
         pooling: { heartBeatInterval: 0, warmup: true },
         policies: { reconnection: new policies.reconnection.ConstantReconnectionPolicy(reconnectionDelay) }
       });
@@ -886,7 +886,7 @@ describe('Client', function () {
     before(helper.ccmHelper.start(2));
     after(helper.ccmHelper.remove);
     it('should close all connections to all hosts', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         client.connect.bind(client),
         function makeSomeQueries(next) {
@@ -921,7 +921,7 @@ describe('Client', function () {
       ], done);
     });
     it('should not leak any connection when connection pool is still growing', function (done) {
-      var client = newInstance({ pooling: { coreConnectionsPerHost: { '0': 4 }}});
+      const client = newInstance({ pooling: { coreConnectionsPerHost: { '0': 4 }}});
       utils.series([
         client.connect.bind(client),
         function makeSomeQueries(next) {
@@ -951,7 +951,7 @@ describe('Client', function () {
       ], done);
     });
     it('should callback after a NoHostAvailableError', function (done) {
-      var client = newInstance({ contactPoints: [ '::1', '::2'] });
+      const client = newInstance({ contactPoints: [ '::1', '::2'] });
       client.connect(function (err) {
         helper.assertInstanceOf(err, errors.NoHostAvailableError);
         assert.strictEqual(client.hosts.length, 0);
@@ -963,7 +963,7 @@ describe('Client', function () {
       });
     });
     it('should close all connections after connecting with an invalid keyspace', function (done) {
-      var client = newInstance({ keyspace: 'KS_DOES_NOT_EXIST' });
+      const client = newInstance({ keyspace: 'KS_DOES_NOT_EXIST' });
       client.connect(function (err) {
         helper.assertInstanceOf(err, errors.ResponseError);
         assert.strictEqual(client.hosts.length, 0);
@@ -986,7 +986,7 @@ function newInstance(options) {
  * Returns a dictionary containing the last octet of the address as keys and the pool size as values.
  */
 function getPoolInfo(client) {
-  var info = {};
+  const info = {};
   client.hosts.forEach(function (h, address) {
     info[helper.lastOctetOf(address)] = h.pool.connections.length;
   });

--- a/test/integration/short/client-stream-tests.js
+++ b/test/integration/short/client-stream-tests.js
@@ -1,13 +1,13 @@
 "use strict";
-var assert = require('assert');
-var util = require('util');
+const assert = require('assert');
+const util = require('util');
 
-var helper = require('../../test-helper.js');
-var vit = helper.vit;
-var Client = require('../../../lib/client.js');
-var types = require('../../../lib/types');
-var utils = require('../../../lib/utils.js');
-var errors = require('../../../lib/errors.js');
+const helper = require('../../test-helper.js');
+const vit = helper.vit;
+const Client = require('../../../lib/client.js');
+const types = require('../../../lib/types');
+const utils = require('../../../lib/utils.js');
+const errors = require('../../../lib/errors.js');
 
 describe('Client', function () {
   this.timeout(120000);
@@ -15,7 +15,7 @@ describe('Client', function () {
     before(helper.ccmHelper.start(1));
     after(helper.ccmHelper.remove);
     it('should emit end when no rows', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       var stream = client.stream(helper.queries.basicNoResults, [], {prepare: false});
       stream
         .on('end', done)
@@ -28,17 +28,17 @@ describe('Client', function () {
         .on('error', done);
     });
     it('should end when VOID result', function (done) {
-      var client = newInstance();
-      var keyspace = helper.getRandomName('ks');
-      var query = helper.createKeyspaceCql(keyspace, 1);
-      var counter = 0;
+      const client = newInstance();
+      const keyspace = helper.getRandomName('ks');
+      const query = helper.createKeyspaceCql(keyspace, 1);
+      let counter = 0;
       client.stream(query, [], {prepare: false})
         .on('end', function () {
           assert.strictEqual(counter, 0);
           done();
         })
         .on('readable', function () {
-          var row;
+          let row;
           while ((row = this.read())) {
             assert.ok(row);
             counter++;
@@ -47,16 +47,16 @@ describe('Client', function () {
         .on('error', done);
     });
     it('should be readable once when there is one row', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       var stream = client.stream(helper.queries.basic, []);
-      var counter = 0;
+      let counter = 0;
       stream
         .on('end', function () {
           assert.strictEqual(counter, 1);
           done();
         })
         .on('readable', function () {
-          var row;
+          let row;
           while ((row = this.read())) {
             assert.ok(row);
             assert.strictEqual(row.key, 'local');
@@ -66,9 +66,9 @@ describe('Client', function () {
         .on('error', done);
     });
     it('should emit response errors', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       var stream = client.stream('SELECT WILL FAIL', []);
-      var errorCalled = false;
+      let errorCalled = false;
       stream
         .on('end', function () {
           assert.strictEqual(errorCalled, true);
@@ -86,7 +86,7 @@ describe('Client', function () {
         });
     });
     it('should not fail with autoPage when there isn\'t any data', function (done) {
-      var client = newInstance({keyspace: 'system'});
+      const client = newInstance({keyspace: 'system'});
       var stream = client.stream(helper.queries.basicNoResults, [], {autoPage: true});
       stream
         .on('end', function () {
@@ -102,9 +102,9 @@ describe('Client', function () {
         });
     });
     it('should emit error if non-existent profile provided', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       var stream = client.stream(helper.queries.basicNoResults, [], {executionProfile: 'none'});
-      var errorCalled = false;
+      let errorCalled = false;
       stream
         .on('end', function () {
           assert.strictEqual(errorCalled, true);
@@ -123,10 +123,10 @@ describe('Client', function () {
     });
   });
   describe('#stream(query, params, {prepare: 1})', function () {
-    var commonKs = helper.getRandomName('ks');
+    const commonKs = helper.getRandomName('ks');
     var commonTable = commonKs + '.' + helper.getRandomName('table');
     before(function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         helper.ccmHelper.start(3),
         client.connect.bind(client),
@@ -137,7 +137,7 @@ describe('Client', function () {
     });
     after(helper.ccmHelper.remove);
     it('should prepare and emit end when no rows', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       var stream = client.stream(helper.queries.basicNoResults, [], { prepare: true });
       stream
         .on('end', function () {
@@ -153,8 +153,8 @@ describe('Client', function () {
         });
     });
     it('should prepare and emit the exact amount of rows', function (done) {
-      var client = newInstance({queryOptions: {consistency: types.consistencies.quorum}});
-      var keyspace = helper.getRandomName('ks');
+      const client = newInstance({queryOptions: {consistency: types.consistencies.quorum}});
+      const keyspace = helper.getRandomName('ks');
       var table = keyspace + '.' + helper.getRandomName('table');
       var length = 1000;
       utils.series([
@@ -167,21 +167,21 @@ describe('Client', function () {
         },
         function (next) {
           utils.timesLimit(length, 100, function (n, timesNext) {
-            var query = 'INSERT INTO %s (id, int_sample, bigint_sample) VALUES (%s, %d, %s)';
+            const query = 'INSERT INTO %s (id, int_sample, bigint_sample) VALUES (%s, %d, %s)';
             query = util.format(query, table, types.Uuid.random(), n, new types.Long(n, 0x090807).toString());
             client.execute(query, timesNext);
           }, next);
         },
         function (next) {
-          var query = util.format('SELECT * FROM %s LIMIT 10000', table);
-          var counter = 0;
+          const query = util.format('SELECT * FROM %s LIMIT 10000', table);
+          let counter = 0;
           client.stream(query, [], {prepare: 1})
             .on('end', function () {
               assert.strictEqual(counter, length);
               next();
             })
             .on('readable', function () {
-              var row;
+              let row;
               while ((row = this.read())) {
                 assert.ok(row);
                 assert.strictEqual(typeof row.int_sample, 'number');
@@ -195,8 +195,8 @@ describe('Client', function () {
       ], done);
     });
     it('should prepare and fetch paging the exact amount of rows', function (done) {
-      var client = newInstance({queryOptions: {consistency: types.consistencies.quorum}});
-      var keyspace = helper.getRandomName('ks');
+      const client = newInstance({queryOptions: {consistency: types.consistencies.quorum}});
+      const keyspace = helper.getRandomName('ks');
       var table = keyspace + '.' + helper.getRandomName('table');
       var length = 350;
       utils.series([
@@ -209,21 +209,21 @@ describe('Client', function () {
         },
         function (next) {
           utils.timesLimit(length, 100, function (n, timesNext) {
-            var query = 'INSERT INTO %s (id, int_sample, bigint_sample) VALUES (%s, %d, %s)';
+            const query = 'INSERT INTO %s (id, int_sample, bigint_sample) VALUES (%s, %d, %s)';
             query = util.format(query, table, types.Uuid.random(), n + 1, new types.Long(n, 0x090807).toString());
             client.execute(query, timesNext);
           }, next);
         },
         function (next) {
-          var query = util.format('SELECT * FROM %s LIMIT 10000', table);
-          var counter = 0;
+          const query = util.format('SELECT * FROM %s LIMIT 10000', table);
+          let counter = 0;
           client.stream(query, [], {autoPage: true, fetchSize: 100, prepare: 1})
             .on('end', function () {
               assert.strictEqual(counter, length);
               next();
             })
             .on('readable', function () {
-              var row;
+              let row;
               while ((row = this.read())) {
                 assert.ok(row);
                 assert.ok(row.int_sample);
@@ -237,9 +237,9 @@ describe('Client', function () {
       ], done);
     });
     it('should emit argument parsing errors', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       var stream = client.stream(helper.queries.basic + ' WHERE key = ?', [{}], {prepare: 1});
-      var errCalled = false;
+      let errCalled = false;
       stream
         .on('error', function (err) {
           assert.ok(err);
@@ -255,10 +255,10 @@ describe('Client', function () {
         });
     });
     it('should emit other ResponseErrors', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       //Invalid amount of parameters
       var stream = client.stream(helper.queries.basic, ['param1'], {prepare: 1});
-      var errCalled = false;
+      let errCalled = false;
       stream
         .on('readable', function () {
           //Node.js 0.10, never emits readable
@@ -277,8 +277,8 @@ describe('Client', function () {
         });
     });
     it('should wait buffer until read', function (done) {
-      var client = newInstance();
-      var allRead = false;
+      const client = newInstance();
+      let allRead = false;
       var stream = client.stream(helper.queries.basic, null, {prepare: 1});
       stream.
         on('end', function () {
@@ -290,7 +290,7 @@ describe('Client', function () {
           var streamContext = this;
           setTimeout(function () {
             //delay all reading
-            var row;
+            let row;
             while ((row = streamContext.read())) {
               assert.ok(row);
             }
@@ -299,22 +299,22 @@ describe('Client', function () {
         });
     });
     vit('2.0', 'should not buffer more than fetchSize', function (done) {
-      var client = newInstance();
-      var id = types.Uuid.random();
-      var consistency = types.consistencies.quorum;
+      const client = newInstance();
+      const id = types.Uuid.random();
+      const consistency = types.consistencies.quorum;
       var rowsLength = 1000;
       var fetchSize = 100;
       utils.series([
         function insert(next) {
-          var query = util.format('INSERT INTO %s (id1, id2, text_sample) VALUES (?, ?, ?)', commonTable);
+          const query = util.format('INSERT INTO %s (id1, id2, text_sample) VALUES (?, ?, ?)', commonTable);
           utils.timesLimit(rowsLength, 50, function (n, timesNext) {
             client.execute(query, [id, types.TimeUuid.now(), n.toString()], { prepare: true, consistency: consistency}, timesNext);
           }, next);
         },
         function testBuffering(next) {
-          var query = util.format('SELECT id2, text_sample from %s WHERE id1 = ?', commonTable);
+          const query = util.format('SELECT id2, text_sample from %s WHERE id1 = ?', commonTable);
           var stream = client.stream(query, [id], { prepare: true, fetchSize: fetchSize, consistency: consistency});
-          var rowsRead = 0;
+          let rowsRead = 0;
           stream.
             on('end', function () {
               setTimeout(function onEndTimeout() {
@@ -324,8 +324,8 @@ describe('Client', function () {
             })
             .on('error', helper.throwop)
             .on('readable', function () {
-              var row;
-              var self = this;
+              let row;
+              const self = this;
               utils.whilst(function condition() {
                 assert.ok(self.buffer.length <= fetchSize);
                 return (row = self.read());

--- a/test/integration/short/client-stream-tests.js
+++ b/test/integration/short/client-stream-tests.js
@@ -16,13 +16,13 @@ describe('Client', function () {
     after(helper.ccmHelper.remove);
     it('should emit end when no rows', function (done) {
       const client = newInstance();
-      var stream = client.stream(helper.queries.basicNoResults, [], {prepare: false});
+      const stream = client.stream(helper.queries.basicNoResults, [], {prepare: false});
       stream
         .on('end', done)
         .on('readable', function () {
           //Node.js 0.10, readable is never called
           //Node.js 0.12, readable is called with null
-          var chunk = stream.read();
+          const chunk = stream.read();
           assert.strictEqual(chunk, null);
         })
         .on('error', done);
@@ -48,7 +48,7 @@ describe('Client', function () {
     });
     it('should be readable once when there is one row', function (done) {
       const client = newInstance();
-      var stream = client.stream(helper.queries.basic, []);
+      const stream = client.stream(helper.queries.basic, []);
       let counter = 0;
       stream
         .on('end', function () {
@@ -67,7 +67,7 @@ describe('Client', function () {
     });
     it('should emit response errors', function (done) {
       const client = newInstance();
-      var stream = client.stream('SELECT WILL FAIL', []);
+      const stream = client.stream('SELECT WILL FAIL', []);
       let errorCalled = false;
       stream
         .on('end', function () {
@@ -87,7 +87,7 @@ describe('Client', function () {
     });
     it('should not fail with autoPage when there isn\'t any data', function (done) {
       const client = newInstance({keyspace: 'system'});
-      var stream = client.stream(helper.queries.basicNoResults, [], {autoPage: true});
+      const stream = client.stream(helper.queries.basicNoResults, [], {autoPage: true});
       stream
         .on('end', function () {
           done();
@@ -103,7 +103,7 @@ describe('Client', function () {
     });
     it('should emit error if non-existent profile provided', function (done) {
       const client = newInstance();
-      var stream = client.stream(helper.queries.basicNoResults, [], {executionProfile: 'none'});
+      const stream = client.stream(helper.queries.basicNoResults, [], {executionProfile: 'none'});
       let errorCalled = false;
       stream
         .on('end', function () {
@@ -124,7 +124,7 @@ describe('Client', function () {
   });
   describe('#stream(query, params, {prepare: 1})', function () {
     const commonKs = helper.getRandomName('ks');
-    var commonTable = commonKs + '.' + helper.getRandomName('table');
+    const commonTable = commonKs + '.' + helper.getRandomName('table');
     before(function (done) {
       const client = newInstance();
       utils.series([
@@ -138,7 +138,7 @@ describe('Client', function () {
     after(helper.ccmHelper.remove);
     it('should prepare and emit end when no rows', function (done) {
       const client = newInstance();
-      var stream = client.stream(helper.queries.basicNoResults, [], { prepare: true });
+      const stream = client.stream(helper.queries.basicNoResults, [], { prepare: true });
       stream
         .on('end', function () {
           done();
@@ -155,8 +155,8 @@ describe('Client', function () {
     it('should prepare and emit the exact amount of rows', function (done) {
       const client = newInstance({queryOptions: {consistency: types.consistencies.quorum}});
       const keyspace = helper.getRandomName('ks');
-      var table = keyspace + '.' + helper.getRandomName('table');
-      var length = 1000;
+      const table = keyspace + '.' + helper.getRandomName('table');
+      const length = 1000;
       utils.series([
         client.connect.bind(client),
         function (next) {
@@ -167,7 +167,7 @@ describe('Client', function () {
         },
         function (next) {
           utils.timesLimit(length, 100, function (n, timesNext) {
-            const query = 'INSERT INTO %s (id, int_sample, bigint_sample) VALUES (%s, %d, %s)';
+            let query = 'INSERT INTO %s (id, int_sample, bigint_sample) VALUES (%s, %d, %s)';
             query = util.format(query, table, types.Uuid.random(), n, new types.Long(n, 0x090807).toString());
             client.execute(query, timesNext);
           }, next);
@@ -197,8 +197,8 @@ describe('Client', function () {
     it('should prepare and fetch paging the exact amount of rows', function (done) {
       const client = newInstance({queryOptions: {consistency: types.consistencies.quorum}});
       const keyspace = helper.getRandomName('ks');
-      var table = keyspace + '.' + helper.getRandomName('table');
-      var length = 350;
+      const table = keyspace + '.' + helper.getRandomName('table');
+      const length = 350;
       utils.series([
         client.connect.bind(client),
         function (next) {
@@ -209,7 +209,7 @@ describe('Client', function () {
         },
         function (next) {
           utils.timesLimit(length, 100, function (n, timesNext) {
-            const query = 'INSERT INTO %s (id, int_sample, bigint_sample) VALUES (%s, %d, %s)';
+            let query = 'INSERT INTO %s (id, int_sample, bigint_sample) VALUES (%s, %d, %s)';
             query = util.format(query, table, types.Uuid.random(), n + 1, new types.Long(n, 0x090807).toString());
             client.execute(query, timesNext);
           }, next);
@@ -238,7 +238,7 @@ describe('Client', function () {
     });
     it('should emit argument parsing errors', function (done) {
       const client = newInstance();
-      var stream = client.stream(helper.queries.basic + ' WHERE key = ?', [{}], {prepare: 1});
+      const stream = client.stream(helper.queries.basic + ' WHERE key = ?', [{}], {prepare: 1});
       let errCalled = false;
       stream
         .on('error', function (err) {
@@ -257,7 +257,7 @@ describe('Client', function () {
     it('should emit other ResponseErrors', function (done) {
       const client = newInstance();
       //Invalid amount of parameters
-      var stream = client.stream(helper.queries.basic, ['param1'], {prepare: 1});
+      const stream = client.stream(helper.queries.basic, ['param1'], {prepare: 1});
       let errCalled = false;
       stream
         .on('readable', function () {
@@ -279,7 +279,7 @@ describe('Client', function () {
     it('should wait buffer until read', function (done) {
       const client = newInstance();
       let allRead = false;
-      var stream = client.stream(helper.queries.basic, null, {prepare: 1});
+      const stream = client.stream(helper.queries.basic, null, {prepare: 1});
       stream.
         on('end', function () {
           assert.strictEqual(allRead, true);
@@ -287,7 +287,7 @@ describe('Client', function () {
         })
         .on('error', helper.throwop)
         .on('readable', function () {
-          var streamContext = this;
+          const streamContext = this;
           setTimeout(function () {
             //delay all reading
             let row;
@@ -302,8 +302,8 @@ describe('Client', function () {
       const client = newInstance();
       const id = types.Uuid.random();
       const consistency = types.consistencies.quorum;
-      var rowsLength = 1000;
-      var fetchSize = 100;
+      const rowsLength = 1000;
+      const fetchSize = 100;
       utils.series([
         function insert(next) {
           const query = util.format('INSERT INTO %s (id1, id2, text_sample) VALUES (?, ?, ?)', commonTable);
@@ -313,7 +313,7 @@ describe('Client', function () {
         },
         function testBuffering(next) {
           const query = util.format('SELECT id2, text_sample from %s WHERE id1 = ?', commonTable);
-          var stream = client.stream(query, [id], { prepare: true, fetchSize: fetchSize, consistency: consistency});
+          const stream = client.stream(query, [id], { prepare: true, fetchSize: fetchSize, consistency: consistency});
           let rowsRead = 0;
           stream.
             on('end', function () {

--- a/test/integration/short/connection-tests.js
+++ b/test/integration/short/connection-tests.js
@@ -22,7 +22,7 @@ describe('Connection', function () {
       });
     });
     it('should use the max supported protocol version', function (done) {
-      var localCon = newInstance(null, null);
+      const localCon = newInstance(null, null);
       localCon.open(function (err) {
         assert.ifError(err);
         assert.strictEqual(localCon.protocolVersion, getProtocolVersion());
@@ -31,7 +31,7 @@ describe('Connection', function () {
     });
     vit('3.0', 'should callback in error when protocol version is not supported server side', function (done) {
       // Attempting to connect with protocol v2
-      var localCon = newInstance(null, 2);
+      const localCon = newInstance(null, 2);
       localCon.open(function (err) {
         helper.assertInstanceOf(err, Error);
         assert.ok(!localCon.connected);
@@ -42,7 +42,7 @@ describe('Connection', function () {
     vit('2.0', 'should limit the max protocol version based on the protocolOptions', function (done) {
       const options = utils.extend({}, defaultOptions);
       options.protocolOptions.maxVersion = getProtocolVersion() - 1;
-      var localCon = newInstance(null, null, options);
+      const localCon = newInstance(null, null, options);
       localCon.open(function (err) {
         assert.ifError(err);
         assert.strictEqual(localCon.protocolVersion, options.protocolOptions.maxVersion);
@@ -50,15 +50,16 @@ describe('Connection', function () {
       });
     });
     it('should open with all the protocol versions supported', function (done) {
-      var maxProtocolVersionSupported = getProtocolVersion();
-      var minProtocolVersionSupported = getMinProtocolVersion();
+      const maxProtocolVersionSupported = getProtocolVersion();
+      const minProtocolVersionSupported = getMinProtocolVersion();
+      let protocolVersion;
       if(helper.getCassandraVersion()) {
-        var protocolVersion = minProtocolVersionSupported - 1;
+        protocolVersion = minProtocolVersionSupported - 1;
       }
       utils.whilst(function condition() {
         return (++protocolVersion) <= maxProtocolVersionSupported;
       }, function iterator (next) {
-        var localCon = newInstance(null, protocolVersion);
+        const localCon = newInstance(null, protocolVersion);
         localCon.open(function (err) {
           assert.ifError(err);
           assert.ok(localCon.connected, 'Must be status connected');
@@ -67,7 +68,7 @@ describe('Connection', function () {
       }, done);
     });
     it('should fail when the host does not exits', function (done) {
-      var localCon = newInstance('1.1.1.1');
+      const localCon = newInstance('1.1.1.1');
       localCon.open(function (err) {
         assert.ok(err, 'Must return a connection error');
         assert.ok(!localCon.connected);
@@ -75,7 +76,7 @@ describe('Connection', function () {
       });
     });
     it('should fail when the host exists but port closed', function (done) {
-      var localCon = newInstance('127.0.0.1:8090');
+      const localCon = newInstance('127.0.0.1:8090');
       localCon.open(function (err) {
         assert.ok(err, 'Must return a connection error');
         assert.ok(!localCon.connected);
@@ -85,11 +86,11 @@ describe('Connection', function () {
     it('should set the timeout for the heartbeat', function (done) {
       const options = utils.extend({}, defaultOptions);
       options.pooling.heartBeatInterval = 100;
-      var c = newInstance(null, undefined, options);
+      const c = newInstance(null, undefined, options);
       let sendCounter = 0;
       c.open(function (err) {
         assert.ifError(err);
-        var originalSend = c.sendStream;
+        const originalSend = c.sendStream;
         c.sendStream = function() {
           sendCounter++;
           originalSend.apply(c, arguments);
@@ -167,13 +168,13 @@ describe('Connection', function () {
       const options = utils.extend({}, defaultOptions);
       options.socketOptions.readTimeout = 0;
       options.policies.retry = new helper.RetryMultipleTimes(3);
-      var connection = newInstance(null, null, options);
-      var maxRequests = connection.protocolVersion < 3 ? 128 : Math.pow(2, 15);
+      const connection = newInstance(null, null, options);
+      const maxRequests = connection.protocolVersion < 3 ? 128 : Math.pow(2, 15);
       utils.series([
         connection.open.bind(connection),
         function asserting(seriesNext) {
           utils.times(maxRequests + 10, function (n, next) {
-            var request = getRequest(helper.queries.basic);
+            const request = getRequest(helper.queries.basic);
             connection.sendStream(request, null, next);
           }, seriesNext);
         }
@@ -183,8 +184,8 @@ describe('Connection', function () {
       const options = utils.extend({}, defaultOptions);
       options.socketOptions.readTimeout = 0;
       options.policies.retry = new helper.RetryMultipleTimes(3);
-      var connection = newInstance(null, null, options);
-      var maxRequests = connection.protocolVersion < 3 ? 128 : Math.pow(2, 15);
+      const connection = newInstance(null, null, options);
+      const maxRequests = connection.protocolVersion < 3 ? 128 : Math.pow(2, 15);
       let killed = false;
       utils.series([
         connection.open.bind(connection),
@@ -195,7 +196,7 @@ describe('Connection', function () {
               killed = true;
               return next();
             }
-            var request = getRequest('SELECT key FROM system.local');
+            const request = getRequest('SELECT key FROM system.local');
             connection.sendStream(request, null, function (err) {
               if (killed && err) {
                 assert.ok(err.isSocketError);

--- a/test/integration/short/connection-tests.js
+++ b/test/integration/short/connection-tests.js
@@ -1,12 +1,12 @@
 "use strict";
-var assert = require('assert');
+const assert = require('assert');
 
-var Connection = require('../../../lib/connection.js');
-var defaultOptions = require('../../../lib/client-options.js').defaultOptions();
-var utils = require('../../../lib/utils.js');
-var requests = require('../../../lib/requests.js');
-var helper = require('../../test-helper.js');
-var vit = helper.vit;
+const Connection = require('../../../lib/connection.js');
+const defaultOptions = require('../../../lib/client-options.js').defaultOptions();
+const utils = require('../../../lib/utils.js');
+const requests = require('../../../lib/requests.js');
+const helper = require('../../test-helper.js');
+const vit = helper.vit;
 
 describe('Connection', function () {
   this.timeout(120000);
@@ -14,7 +14,7 @@ describe('Connection', function () {
     before(helper.ccmHelper.start(1));
     after(helper.ccmHelper.remove);
     it('should open', function (done) {
-      var localCon = newInstance();
+      const localCon = newInstance();
       localCon.open(function (err) {
         assert.ifError(err);
         assert.ok(localCon.connected, 'Must be status connected');
@@ -40,7 +40,7 @@ describe('Connection', function () {
       });
     });
     vit('2.0', 'should limit the max protocol version based on the protocolOptions', function (done) {
-      var options = utils.extend({}, defaultOptions);
+      const options = utils.extend({}, defaultOptions);
       options.protocolOptions.maxVersion = getProtocolVersion() - 1;
       var localCon = newInstance(null, null, options);
       localCon.open(function (err) {
@@ -83,10 +83,10 @@ describe('Connection', function () {
       });
     });
     it('should set the timeout for the heartbeat', function (done) {
-      var options = utils.extend({}, defaultOptions);
+      const options = utils.extend({}, defaultOptions);
       options.pooling.heartBeatInterval = 100;
       var c = newInstance(null, undefined, options);
-      var sendCounter = 0;
+      let sendCounter = 0;
       c.open(function (err) {
         assert.ifError(err);
         var originalSend = c.sendStream;
@@ -105,7 +105,7 @@ describe('Connection', function () {
     before(helper.ccmHelper.start(1, {ssl: true}));
     after(helper.ccmHelper.remove);
     it('should open to a ssl enabled host', function (done) {
-      var localCon = newInstance();
+      const localCon = newInstance();
       localCon.options.sslOptions = {};
       localCon.open(function (err) {
         assert.ifError(err);
@@ -123,12 +123,12 @@ describe('Connection', function () {
     before(helper.ccmHelper.start(1));
     after(helper.ccmHelper.remove);
     it('should change active keyspace', function (done) {
-      var localCon = newInstance();
-      var keyspace = helper.getRandomName();
+      const localCon = newInstance();
+      const keyspace = helper.getRandomName();
       utils.series([
         localCon.open.bind(localCon),
         function creating(next) {
-          var query = 'CREATE KEYSPACE ' + keyspace + ' WITH replication = {\'class\': \'SimpleStrategy\', \'replication_factor\' : 1};';
+          const query = 'CREATE KEYSPACE ' + keyspace + ' WITH replication = {\'class\': \'SimpleStrategy\', \'replication_factor\' : 1};';
           localCon.sendStream(getRequest(query), {}, next);
         },
         function changing(next) {
@@ -141,13 +141,13 @@ describe('Connection', function () {
       ], done);
     });
     it('should be case sensitive', function (done) {
-      var localCon = newInstance();
-      var keyspace = helper.getRandomName().toUpperCase();
+      const localCon = newInstance();
+      const keyspace = helper.getRandomName().toUpperCase();
       assert.notStrictEqual(keyspace, keyspace.toLowerCase());
       utils.series([
         localCon.open.bind(localCon),
         function creating(next) {
-          var query = 'CREATE KEYSPACE "' + keyspace + '" WITH replication = {\'class\': \'SimpleStrategy\', \'replication_factor\' : 1};';
+          const query = 'CREATE KEYSPACE "' + keyspace + '" WITH replication = {\'class\': \'SimpleStrategy\', \'replication_factor\' : 1};';
           localCon.sendStream(getRequest(query), {}, next);
         },
         function changing(next) {
@@ -164,7 +164,7 @@ describe('Connection', function () {
     before(helper.ccmHelper.start(1));
     after(helper.ccmHelper.remove);
     it('should queue pending if there is not an available stream id', function (done) {
-      var options = utils.extend({}, defaultOptions);
+      const options = utils.extend({}, defaultOptions);
       options.socketOptions.readTimeout = 0;
       options.policies.retry = new helper.RetryMultipleTimes(3);
       var connection = newInstance(null, null, options);
@@ -180,12 +180,12 @@ describe('Connection', function () {
       ], done);
     });
     it('should callback the pending queue if the connection is there is a socket error', function (done) {
-      var options = utils.extend({}, defaultOptions);
+      const options = utils.extend({}, defaultOptions);
       options.socketOptions.readTimeout = 0;
       options.policies.retry = new helper.RetryMultipleTimes(3);
       var connection = newInstance(null, null, options);
       var maxRequests = connection.protocolVersion < 3 ? 128 : Math.pow(2, 15);
-      var killed = false;
+      let killed = false;
       utils.series([
         connection.open.bind(connection),
         function asserting(seriesNext) {

--- a/test/integration/short/control-connection-tests.js
+++ b/test/integration/short/control-connection-tests.js
@@ -44,7 +44,7 @@ describe('ControlConnection', function () {
           }, 200, 10, next);
         },
         function (next) {
-          var keyspaceInfo = cc.metadata.keyspaces['sample_change_1'];
+          const keyspaceInfo = cc.metadata.keyspaces['sample_change_1'];
           assert.ok(keyspaceInfo);
           assert.ok(keyspaceInfo.strategy);
           assert.equal(keyspaceInfo.strategyOptions.replication_factor, 3);
@@ -59,7 +59,7 @@ describe('ControlConnection', function () {
           }, 200, 10, next);
         },
         function (next) {
-          var keyspaceInfo = cc.metadata.keyspaces['sample_change_1'];
+          const keyspaceInfo = cc.metadata.keyspaces['sample_change_1'];
           assert.ok(keyspaceInfo);
           assert.equal(keyspaceInfo.strategyOptions.replication_factor, 2);
           next();
@@ -71,7 +71,7 @@ describe('ControlConnection', function () {
           }, 200, 10, next);
         },
         function (next) {
-          var keyspaceInfo = cc.metadata.keyspaces['sample_change_1'];
+          const keyspaceInfo = cc.metadata.keyspaces['sample_change_1'];
           assert.ok(!keyspaceInfo);
           next();
         },
@@ -100,9 +100,9 @@ describe('ControlConnection', function () {
         helper.toTask(helper.ccmHelper.stopNode, null, 2),
         helper.waitOnHostDown(cc, 2),
         function (next) {
-          var hosts = cc.hosts.slice(0);
+          const hosts = cc.hosts.slice(0);
           assert.strictEqual(hosts.length, 2);
-          var countUp = hosts.reduce(function (value, host) {
+          const countUp = hosts.reduce(function (value, host) {
             value += host.isUp() ? 1 : 0;
             return value;
           }, 0);
@@ -124,8 +124,8 @@ describe('ControlConnection', function () {
         // wait for that to be the case.
         helper.waitOnHostUp(cc, 3),
         function (next) {
-          var hosts = cc.hosts.slice(0);
-          var countUp = hosts.reduce(function (value, host) {
+          const hosts = cc.hosts.slice(0);
+          const countUp = hosts.reduce(function (value, host) {
             value += host.isUp() ? 1 : 0;
             return value;
           }, 0);
@@ -142,7 +142,7 @@ describe('ControlConnection', function () {
         helper.toTask(helper.ccmHelper.decommissionNode, null, 2),
         helper.waitOnHostGone(cc, 2),
         function (next) {
-          var hosts = cc.hosts.slice(0);
+          const hosts = cc.hosts.slice(0);
           assert.strictEqual(hosts.length, 1);
           cc.shutdown();
           next();
@@ -163,7 +163,7 @@ describe('ControlConnection', function () {
           lbp.init({ log: utils.noop }, cc.hosts, next);
         },
         function ensureConnected(next) {
-          var hosts = cc.hosts.values();
+          const hosts = cc.hosts.values();
           hosts.forEach(function (h) {
             h.setDistance(lbp.getDistance(h));
           });
@@ -194,7 +194,7 @@ describe('ControlConnection', function () {
     });
     it('should reconnect when all hosts go down and back up', function (done) {
       const options = clientOptions.extend(utils.extend({ pooling: { coreConnectionsPerHost: {}}}, helper.baseOptions));
-      var reconnectionDelay = 200;
+      const reconnectionDelay = 200;
       options.policies.reconnection = new policies.reconnection.ConstantReconnectionPolicy(reconnectionDelay);
       const cc = newInstance(options, 1, 1);
       utils.series([
@@ -206,7 +206,7 @@ describe('ControlConnection', function () {
         },
         function setHostDistance(next) {
           // the control connection host should be local or remote to trigger DOWN events
-          var distance = options.policies.loadBalancing.getDistance(cc.host);
+          const distance = options.policies.loadBalancing.getDistance(cc.host);
           cc.host.setDistance(distance);
           next();
         },

--- a/test/integration/short/control-connection-tests.js
+++ b/test/integration/short/control-connection-tests.js
@@ -1,15 +1,15 @@
 "use strict";
-var assert = require('assert');
-var util = require('util');
+const assert = require('assert');
+const util = require('util');
 
-var helper = require('../../test-helper');
-var Client = require('../../../lib/client.js');
-var ControlConnection = require('../../../lib/control-connection');
-var utils = require('../../../lib/utils');
-var types = require('../../../lib/types');
-var clientOptions = require('../../../lib/client-options');
-var policies = require('../../../lib/policies');
-var ProfileManager = require('../../../lib/execution-profile').ProfileManager;
+const helper = require('../../test-helper');
+const Client = require('../../../lib/client.js');
+const ControlConnection = require('../../../lib/control-connection');
+const utils = require('../../../lib/utils');
+const types = require('../../../lib/types');
+const clientOptions = require('../../../lib/client-options');
+const policies = require('../../../lib/policies');
+const ProfileManager = require('../../../lib/execution-profile').ProfileManager;
 
 describe('ControlConnection', function () {
   this.timeout(120000);
@@ -17,7 +17,7 @@ describe('ControlConnection', function () {
     beforeEach(helper.ccmHelper.start(2));
     afterEach(helper.ccmHelper.remove);
     it('should retrieve local host and peers', function (done) {
-      var cc = newInstance();
+      const cc = newInstance();
       cc.init(function (err) {
         assert.ifError(err);
         assert.strictEqual(cc.hosts.length, 2);
@@ -32,8 +32,8 @@ describe('ControlConnection', function () {
       });
     });
     it('should subscribe to SCHEMA_CHANGE events and refresh keyspace information', function (done) {
-      var cc = newInstance({ refreshSchemaDelay: 100 });
-      var otherClient = new Client(helper.baseOptions);
+      const cc = newInstance({ refreshSchemaDelay: 100 });
+      const otherClient = new Client(helper.baseOptions);
       utils.series([
         cc.init.bind(cc),
         helper.toTask(otherClient.execute, otherClient, "CREATE KEYSPACE sample_change_1 WITH replication = " +
@@ -90,7 +90,7 @@ describe('ControlConnection', function () {
       TestLoadBalancing.prototype.getDistance = function (h) {
         return (helper.lastOctetOf(h) === '2' ? types.distance.ignored : types.distance.local);
       };
-      var cc = newInstance({ policies: { loadBalancing: new TestLoadBalancing() } });
+      const cc = newInstance({ policies: { loadBalancing: new TestLoadBalancing() } });
       utils.series([
         cc.init.bind(cc),
         helper.delay(2000 + (helper.isWin() ? 13000 : 0)),
@@ -113,9 +113,9 @@ describe('ControlConnection', function () {
       ], done);
     });
     it('should subscribe to TOPOLOGY_CHANGE add events and refresh ring info', function (done) {
-      var options = clientOptions.extend(utils.extend({ pooling: { coreConnectionsPerHost: {}}}, helper.baseOptions));
+      const options = clientOptions.extend(utils.extend({ pooling: { coreConnectionsPerHost: {}}}, helper.baseOptions));
       options.policies.reconnection = new policies.reconnection.ConstantReconnectionPolicy(1000);
-      var cc = newInstance(options, 1, 1);
+      const cc = newInstance(options, 1, 1);
       utils.series([
         cc.init.bind(cc),
         helper.toTask(helper.ccmHelper.bootstrapNode, null, 3),
@@ -136,7 +136,7 @@ describe('ControlConnection', function () {
       ], done);
     });
     it('should subscribe to TOPOLOGY_CHANGE remove events and refresh ring info', function (done) {
-      var cc = newInstance();
+      const cc = newInstance();
       utils.series([
         cc.init.bind(cc),
         helper.toTask(helper.ccmHelper.decommissionNode, null, 2),
@@ -150,12 +150,12 @@ describe('ControlConnection', function () {
       ], done);
     });
     it('should reconnect when host used goes down', function (done) {
-      var options = clientOptions.extend(
+      const options = clientOptions.extend(
         utils.extend({ pooling: helper.getPoolingOptions(1, 1, 500) }, helper.baseOptions));
-      var cc = new ControlConnection(options, new ProfileManager(options));
-      var host1;
-      var host2;
-      var lbp;
+      const cc = new ControlConnection(options, new ProfileManager(options));
+      let host1;
+      let host2;
+      let lbp;
       utils.series([
         cc.init.bind(cc),
         function initLbp(next) {
@@ -193,10 +193,10 @@ describe('ControlConnection', function () {
       ], done);
     });
     it('should reconnect when all hosts go down and back up', function (done) {
-      var options = clientOptions.extend(utils.extend({ pooling: { coreConnectionsPerHost: {}}}, helper.baseOptions));
+      const options = clientOptions.extend(utils.extend({ pooling: { coreConnectionsPerHost: {}}}, helper.baseOptions));
       var reconnectionDelay = 200;
       options.policies.reconnection = new policies.reconnection.ConstantReconnectionPolicy(reconnectionDelay);
-      var cc = newInstance(options, 1, 1);
+      const cc = newInstance(options, 1, 1);
       utils.series([
         cc.init.bind(cc),
         function initLbp(next) {
@@ -243,7 +243,7 @@ describe('ControlConnection', function () {
     before(helper.ccmHelper.start(3, {vnodes: true}));
     after(helper.ccmHelper.remove);
     it('should contain keyspaces information', function (done) {
-      var cc = newInstance();
+      const cc = newInstance();
       cc.init(function () {
         assert.equal(cc.hosts.length, 3);
         assert.ok(cc.metadata);

--- a/test/integration/short/custom-payload-tests.js
+++ b/test/integration/short/custom-payload-tests.js
@@ -1,22 +1,22 @@
 "use strict";
-var assert = require('assert');
-var util = require('util');
+const assert = require('assert');
+const util = require('util');
 
-var helper = require('../../test-helper');
-var Client = require('../../../lib/client');
-var utils = require('../../../lib/utils');
-var types = require('../../../lib/types');
-var vit = helper.vit;
+const helper = require('../../test-helper');
+const Client = require('../../../lib/client');
+const utils = require('../../../lib/utils');
+const types = require('../../../lib/types');
+const vit = helper.vit;
 
 describe('custom payload', function () {
   this.timeout(60000);
-  var keyspace = helper.getRandomName('ks');
+  const keyspace = helper.getRandomName('ks');
   var table = keyspace + '.' + helper.getRandomName('tbl');
   before(helper.ccmHelper.start(1, {
     jvmArgs: ['-Dcassandra.custom_query_handler_class=org.apache.cassandra.cql3.CustomPayloadMirroringQueryHandler']
   }));
   before(function (done) {
-    var client = newInstance();
+    const client = newInstance();
     utils.series([
       client.connect.bind(client),
       helper.toTask(client.execute, client, helper.createKeyspaceCql(keyspace)),
@@ -27,7 +27,7 @@ describe('custom payload', function () {
   after(helper.ccmHelper.remove);
   describe('using Client#execute(query, params, { prepare: 0 }, callback)', function () {
     vit('2.2', 'should encode and decode the payload with rows response', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       var payload = {
         'key1': utils.allocBufferFromString('val1')
       };
@@ -47,14 +47,14 @@ describe('custom payload', function () {
       ], done);
     });
     vit('2.2', 'should encode and decode the payload with void response', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       var payload = {
         'key2': utils.allocBufferFromString('val2')
       };
       utils.series([
         client.connect.bind(client),
         function insert(next) {
-          var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
+          const query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
           client.execute(query, [types.Uuid.random(), 'text1'], { customPayload: payload}, function (err, result) {
             assert.ifError(err);
             assert.ok(result);
@@ -68,14 +68,14 @@ describe('custom payload', function () {
       ], done);
     });
     vit('2.2', 'should encode and decode the payload and trace', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       var payload = {
         'key3': utils.allocBufferFromString('val3')
       };
       utils.series([
         client.connect.bind(client),
         function insert(next) {
-          var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
+          const query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
           client.execute(query, [types.Uuid.random(), 'text3'], { customPayload: payload, traceQuery: true}, function (err, result) {
             assert.ifError(err);
             assert.ok(result);
@@ -92,7 +92,7 @@ describe('custom payload', function () {
   });
   describe('using Client#execute(query, params, { prepare: 1 }, callback)', function () {
     vit('2.2', 'should encode and decode the payload with rows response', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       var payload = {
         'key-prep1': utils.allocBufferFromString('val-prep1'),
         'key-prep2': utils.allocBufferFromString('val-prep2')
@@ -117,7 +117,7 @@ describe('custom payload', function () {
   });
   describe('using Client#batch(queries, { prepare: 0 }, callback)', function () {
     vit('2.2', 'should encode and decode the payload', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       var payload = {
         'key-batch1': utils.allocBufferFromString('val-batch1')
       };
@@ -142,7 +142,7 @@ describe('custom payload', function () {
       ], done);
     });
     vit('2.2', 'should encode and decode the payload with warnings', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       var payload = {
         'key-batch2': utils.allocBufferFromString('val-batch2')
       };
@@ -172,7 +172,7 @@ describe('custom payload', function () {
   });
   describe('using Client#batch(queries, { prepare: 1 }, callback)', function () {
     vit('2.2', 'should encode and decode the payload', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       var payload = {
         'key-batch-prep1': utils.allocBufferFromString('val-batch-prep1')
       };

--- a/test/integration/short/custom-payload-tests.js
+++ b/test/integration/short/custom-payload-tests.js
@@ -11,7 +11,7 @@ const vit = helper.vit;
 describe('custom payload', function () {
   this.timeout(60000);
   const keyspace = helper.getRandomName('ks');
-  var table = keyspace + '.' + helper.getRandomName('tbl');
+  const table = keyspace + '.' + helper.getRandomName('tbl');
   before(helper.ccmHelper.start(1, {
     jvmArgs: ['-Dcassandra.custom_query_handler_class=org.apache.cassandra.cql3.CustomPayloadMirroringQueryHandler']
   }));
@@ -28,7 +28,7 @@ describe('custom payload', function () {
   describe('using Client#execute(query, params, { prepare: 0 }, callback)', function () {
     vit('2.2', 'should encode and decode the payload with rows response', function (done) {
       const client = newInstance();
-      var payload = {
+      const payload = {
         'key1': utils.allocBufferFromString('val1')
       };
       utils.series([
@@ -48,7 +48,7 @@ describe('custom payload', function () {
     });
     vit('2.2', 'should encode and decode the payload with void response', function (done) {
       const client = newInstance();
-      var payload = {
+      const payload = {
         'key2': utils.allocBufferFromString('val2')
       };
       utils.series([
@@ -69,7 +69,7 @@ describe('custom payload', function () {
     });
     vit('2.2', 'should encode and decode the payload and trace', function (done) {
       const client = newInstance();
-      var payload = {
+      const payload = {
         'key3': utils.allocBufferFromString('val3')
       };
       utils.series([
@@ -93,7 +93,7 @@ describe('custom payload', function () {
   describe('using Client#execute(query, params, { prepare: 1 }, callback)', function () {
     vit('2.2', 'should encode and decode the payload with rows response', function (done) {
       const client = newInstance();
-      var payload = {
+      const payload = {
         'key-prep1': utils.allocBufferFromString('val-prep1'),
         'key-prep2': utils.allocBufferFromString('val-prep2')
       };
@@ -118,14 +118,14 @@ describe('custom payload', function () {
   describe('using Client#batch(queries, { prepare: 0 }, callback)', function () {
     vit('2.2', 'should encode and decode the payload', function (done) {
       const client = newInstance();
-      var payload = {
+      const payload = {
         'key-batch1': utils.allocBufferFromString('val-batch1')
       };
       utils.series([
         client.connect.bind(client),
         function executeBatch(next) {
-          var q = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
-          var queries = [
+          const q = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
+          const queries = [
             { query: q, params: [types.Uuid.random(), 'text-batch1'] },
             { query: q, params: [types.Uuid.random(), 'text-batch2'] }
           ];
@@ -143,14 +143,14 @@ describe('custom payload', function () {
     });
     vit('2.2', 'should encode and decode the payload with warnings', function (done) {
       const client = newInstance();
-      var payload = {
+      const payload = {
         'key-batch2': utils.allocBufferFromString('val-batch2')
       };
       utils.series([
         client.connect.bind(client),
         function executeBatch(next) {
-          var q = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
-          var queries = [
+          const q = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
+          const queries = [
             { query: q, params: [types.Uuid.random(), 'text-batch2'] },
             { query: q, params: [types.Uuid.random(), utils.stringRepeat('a', 5 * 1025)] }
           ];
@@ -173,14 +173,14 @@ describe('custom payload', function () {
   describe('using Client#batch(queries, { prepare: 1 }, callback)', function () {
     vit('2.2', 'should encode and decode the payload', function (done) {
       const client = newInstance();
-      var payload = {
+      const payload = {
         'key-batch-prep1': utils.allocBufferFromString('val-batch-prep1')
       };
       utils.series([
         client.connect.bind(client),
         function executeBatch(next) {
-          var q = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
-          var queries = [
+          const q = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
+          const queries = [
             { query: q, params: [types.Uuid.random(), 'text-batch1'] },
             { query: q, params: [types.Uuid.random(), 'text-batch2'] }
           ];

--- a/test/integration/short/duration-type-tests.js
+++ b/test/integration/short/duration-type-tests.js
@@ -16,7 +16,7 @@ vdescribe('3.10', 'Duration', function () {
   const client = setupInfo.client;
   describe('serialization', function () {
     it('should serialize and deserialize duration type instances', function (done) {
-      var values = [
+      const values = [
         '1y2mo',
         '-1y2mo',
         '1Y2MO',
@@ -62,14 +62,14 @@ vdescribe('3.10', 'Duration', function () {
         utils.eachSeries(values, function (v, next) {
           const query = 'INSERT INTO tbl_duration (pk, c1) VALUES (?, ?)';
           const id = types.Uuid.random();
-          var value = Duration.fromString(v);
+          const value = Duration.fromString(v);
           client.execute(query, [ id, value ], { prepare: prepare }, function (err) {
             assert.ifError(err);
             const query = 'SELECT pk, c1 FROM tbl_duration WHERE pk = ?';
             client.execute(query, [ id ], { prepare: prepare }, function (err, result) {
               assert.ifError(err);
               assert.strictEqual(result.rowLength, 1);
-              var actual = result.first()['c1'];
+              const actual = result.first()['c1'];
               helper.assertInstanceOf(actual, Duration);
               assert.ok(actual.equals(value), util.format('Assertion failed: %j !== %j', actual, value));
               next();
@@ -85,7 +85,7 @@ vdescribe('3.10', 'Duration', function () {
         assert.ifError(err);
         assert.ok(tableInfo);
         assert.strictEqual(tableInfo.columns.length, 2);
-        var c1 = tableInfo.columnsByName['c1'];
+        const c1 = tableInfo.columnsByName['c1'];
         assert.ok(c1);
         assert.strictEqual(c1.type.code, types.dataTypes.custom);
         assert.strictEqual(c1.type.info, 'org.apache.cassandra.db.marshal.DurationType');

--- a/test/integration/short/duration-type-tests.js
+++ b/test/integration/short/duration-type-tests.js
@@ -1,19 +1,19 @@
 'use strict';
-var assert = require('assert');
-var util = require('util');
-var helper = require('../../test-helper');
-var types = require('../../../lib/types');
-var utils = require('../../../lib/utils');
+const assert = require('assert');
+const util = require('util');
+const helper = require('../../test-helper');
+const types = require('../../../lib/types');
+const utils = require('../../../lib/utils');
 
-var vdescribe = helper.vdescribe;
-var Duration = types.Duration;
+const vdescribe = helper.vdescribe;
+const Duration = types.Duration;
 
 vdescribe('3.10', 'Duration', function () {
   this.timeout('30000');
-  var setupInfo = helper.setup(1, {
+  const setupInfo = helper.setup(1, {
     queries: ['CREATE TABLE tbl_duration (pk uuid PRIMARY KEY, c1 duration)']
   });
-  var client = setupInfo.client;
+  const client = setupInfo.client;
   describe('serialization', function () {
     it('should serialize and deserialize duration type instances', function (done) {
       var values = [
@@ -60,12 +60,12 @@ vdescribe('3.10', 'Duration', function () {
       ];
       utils.eachSeries([ true, false ], function (prepare, prepareNext) {
         utils.eachSeries(values, function (v, next) {
-          var query = 'INSERT INTO tbl_duration (pk, c1) VALUES (?, ?)';
-          var id = types.Uuid.random();
+          const query = 'INSERT INTO tbl_duration (pk, c1) VALUES (?, ?)';
+          const id = types.Uuid.random();
           var value = Duration.fromString(v);
           client.execute(query, [ id, value ], { prepare: prepare }, function (err) {
             assert.ifError(err);
-            var query = 'SELECT pk, c1 FROM tbl_duration WHERE pk = ?';
+            const query = 'SELECT pk, c1 FROM tbl_duration WHERE pk = ?';
             client.execute(query, [ id ], { prepare: prepare }, function (err, result) {
               assert.ifError(err);
               assert.strictEqual(result.rowLength, 1);

--- a/test/integration/short/error-tests.js
+++ b/test/integration/short/error-tests.js
@@ -13,7 +13,7 @@ describe('Client', function () {
   this.timeout(120000);
   vdescribe('2.2', 'with protocol v4 errors', function () {
     const failWritesKs = helper.getRandomName('ks');
-    var failWritesTable = failWritesKs + '.tbl1';
+    const failWritesTable = failWritesKs + '.tbl1';
     const setupInfo = helper.setup(2, {
       clientOptions: {
         policies: { retry: new helper.FallthroughRetryPolicy() }

--- a/test/integration/short/error-tests.js
+++ b/test/integration/short/error-tests.js
@@ -1,20 +1,20 @@
 'use strict';
-var assert = require('assert');
-var util = require('util');
+const assert = require('assert');
+const util = require('util');
 
-var helper = require('../../test-helper');
-var types = require('../../../lib/types');
-var utils = require('../../../lib/utils');
-var errors = require('../../../lib/errors');
-var protocolVersion = types.protocolVersion;
-var vdescribe = helper.vdescribe;
+const helper = require('../../test-helper');
+const types = require('../../../lib/types');
+const utils = require('../../../lib/utils');
+const errors = require('../../../lib/errors');
+const protocolVersion = types.protocolVersion;
+const vdescribe = helper.vdescribe;
 
 describe('Client', function () {
   this.timeout(120000);
   vdescribe('2.2', 'with protocol v4 errors', function () {
-    var failWritesKs = helper.getRandomName('ks');
+    const failWritesKs = helper.getRandomName('ks');
     var failWritesTable = failWritesKs + '.tbl1';
-    var setupInfo = helper.setup(2, {
+    const setupInfo = helper.setup(2, {
       clientOptions: {
         policies: { retry: new helper.FallthroughRetryPolicy() }
       },
@@ -34,11 +34,11 @@ describe('Client', function () {
       }
     });
     it('should callback with readFailure error when tombstone overwhelmed on replica', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       utils.series([
         function generateTombstones(next) {
           utils.timesSeries(2000, function (n, timesNext) {
-            var query = 'INSERT INTO read_fail_tbl (pk, cc, v) VALUES (?, ?, ?)';
+            const query = 'INSERT INTO read_fail_tbl (pk, cc, v) VALUES (?, ?, ?)';
             client.execute(query, [ 1, n, null ], { prepare: true }, timesNext);
           }, next);
         },
@@ -61,8 +61,8 @@ describe('Client', function () {
         }], done);
     });
     it('should callback with writeFailure error when encountered', function (done) {
-      var client = setupInfo.client;
-      var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', failWritesTable);
+      const client = setupInfo.client;
+      const query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', failWritesTable);
       client.execute(query, [ types.Uuid.random(), '1' ], { consistency: types.consistencies.all }, function (err) {
         helper.assertInstanceOf(err, errors.ResponseError);
         assert.strictEqual(err.code, types.responseErrorCodes.writeFailure);
@@ -81,7 +81,7 @@ describe('Client', function () {
       });
     });
     it('should callback with functionFailure error when the cql function throws an error', function (done) {
-      var client = setupInfo.client;
+      const client = setupInfo.client;
       client.execute('SELECT ks_func.div(v1,v2) FROM ks_func.tbl1 where id = 1', function (err) {
         helper.assertInstanceOf(err, errors.ResponseError);
         assert.strictEqual(err.code, types.responseErrorCodes.functionFailure);

--- a/test/integration/short/execution-profile-tests.js
+++ b/test/integration/short/execution-profile-tests.js
@@ -20,7 +20,7 @@ describe('ProfileManager', function() {
    * init is called.
    */
   function decorateInitWithCounter(policy) {
-    var baseInit = policy.init;
+    const baseInit = policy.init;
     policy._initCalled = 0;
     policy.init = function () {
       policy._initCalled++;
@@ -31,15 +31,15 @@ describe('ProfileManager', function() {
 
   function createProfiles() {
     // A profile that targets dc1.
-    var dc1Profile = new ExecutionProfile('default', {
+    const dc1Profile = new ExecutionProfile('default', {
       loadBalancing: decorateInitWithCounter(new DCAwareRoundRobinPolicy('dc1'))
     });
     // A profile that targets 127.0.0.4 specifically.
-    var wlProfile = new ExecutionProfile('whitelist', {
+    const wlProfile = new ExecutionProfile('whitelist', {
       loadBalancing: decorateInitWithCounter(new WhiteListPolicy(new DCAwareRoundRobinPolicy('dc2'), [helper.ipPrefix + '4:9042']))
     });
     // A profile with no defined lbp, it should fallback on the default profile's lbp.
-    var emptyProfile = new ExecutionProfile('empty');
+    const emptyProfile = new ExecutionProfile('empty');
 
     return [dc1Profile, wlProfile, emptyProfile];
   }
@@ -55,7 +55,7 @@ describe('ProfileManager', function() {
 
   function ensureOnlyHostsUsed(hostOctets, profile) {
     return (function test(done) {
-      var queryOptions = profile ? {executionProfile: profile} : {};
+      const queryOptions = profile ? {executionProfile: profile} : {};
       const hostsUsed = {};
 
       const client = newInstance();
@@ -101,15 +101,15 @@ describe('ProfileManager', function() {
     utils.series([
       client.connect.bind(client),
       function validateHostDistances(next) {
-        var hosts = client.hosts;
+        const hosts = client.hosts;
         assert.strictEqual(hosts.length, 4);
         hosts.forEach(function(h) {
           const n = helper.lastOctetOf(h);
-          var distance = client.profileManager.getDistance(h);
+          const distance = client.profileManager.getDistance(h);
           // all hosts except 3 should be at a distance of local since a profile exists for all DCs
           // with DC2 white listing host 4.  While host 5 is ignored in whitelist profile, it is remote in others
           // so it should be considered remote.
-          var expectedDistance = n === '3' ? types.distance.remote : types.distance.local;
+          const expectedDistance = n === '3' ? types.distance.remote : types.distance.local;
           assert.strictEqual(distance, expectedDistance, "Expected distance of " + expectedDistance + " for host " + n);
           assert.ok(h.isUp());
         });

--- a/test/integration/short/execution-profile-tests.js
+++ b/test/integration/short/execution-profile-tests.js
@@ -1,14 +1,14 @@
 "use strict";
-var assert = require('assert');
+const assert = require('assert');
 
-var helper = require('../../test-helper.js');
-var Client = require('../../../lib/client.js');
-var types = require('../../../lib/types');
-var utils = require('../../../lib/utils.js');
-var loadBalancing = require('../../../lib/policies/load-balancing.js');
-var DCAwareRoundRobinPolicy = loadBalancing.DCAwareRoundRobinPolicy;
-var WhiteListPolicy = loadBalancing.WhiteListPolicy;
-var ExecutionProfile = require('../../../lib/execution-profile.js').ExecutionProfile;
+const helper = require('../../test-helper.js');
+const Client = require('../../../lib/client.js');
+const types = require('../../../lib/types');
+const utils = require('../../../lib/utils.js');
+const loadBalancing = require('../../../lib/policies/load-balancing.js');
+const DCAwareRoundRobinPolicy = loadBalancing.DCAwareRoundRobinPolicy;
+const WhiteListPolicy = loadBalancing.WhiteListPolicy;
+const ExecutionProfile = require('../../../lib/execution-profile.js').ExecutionProfile;
 
 describe('ProfileManager', function() {
   this.timeout(120000);
@@ -56,9 +56,9 @@ describe('ProfileManager', function() {
   function ensureOnlyHostsUsed(hostOctets, profile) {
     return (function test(done) {
       var queryOptions = profile ? {executionProfile: profile} : {};
-      var hostsUsed = {};
+      const hostsUsed = {};
 
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         client.connect.bind(client),
         function executeQueries(next) {
@@ -82,7 +82,7 @@ describe('ProfileManager', function() {
   }
 
   it('should init each profile\'s load balancing policy exactly once', function(done) {
-    var client = newInstance();
+    const client = newInstance();
     utils.series([
       client.connect.bind(client),
       function validateInitCount(next) {
@@ -96,7 +96,7 @@ describe('ProfileManager', function() {
     ], done);
   });
   it('should consider all load balancing policies when establishing distance for hosts', function (done) {
-    var client = newInstance();
+    const client = newInstance();
 
     utils.series([
       client.connect.bind(client),
@@ -104,7 +104,7 @@ describe('ProfileManager', function() {
         var hosts = client.hosts;
         assert.strictEqual(hosts.length, 4);
         hosts.forEach(function(h) {
-          var n = helper.lastOctetOf(h);
+          const n = helper.lastOctetOf(h);
           var distance = client.profileManager.getDistance(h);
           // all hosts except 3 should be at a distance of local since a profile exists for all DCs
           // with DC2 white listing host 4.  While host 5 is ignored in whitelist profile, it is remote in others
@@ -123,11 +123,11 @@ describe('ProfileManager', function() {
   it('should only use hosts from the load balancing policy in the default profile when specified', ensureOnlyHostsUsed(['1', '2'], 'default'));
   it('should only use hosts from the load balancing policy in whitelist profile', ensureOnlyHostsUsed(['4'], 'whitelist'));
   it('should fallback on client load balancing policy when default profile has no lbp', function (done) {
-    var policy = new DCAwareRoundRobinPolicy('dc2');
-    var profiles = [new ExecutionProfile('default'), new ExecutionProfile('empty')];
+    const policy = new DCAwareRoundRobinPolicy('dc2');
+    const profiles = [new ExecutionProfile('default'), new ExecutionProfile('empty')];
     // also provide retry policy since the default would be overridden by provided policies options.
-    var client = newInstance({policies: {loadBalancing: policy, retry: new helper.RetryMultipleTimes(3)}}, profiles);
-    var hostsUsed = {};
+    const client = newInstance({policies: {loadBalancing: policy, retry: new helper.RetryMultipleTimes(3)}}, profiles);
+    const hostsUsed = {};
 
     utils.series([
       client.connect.bind(client),

--- a/test/integration/short/load-balancing-tests.js
+++ b/test/integration/short/load-balancing-tests.js
@@ -1,16 +1,16 @@
 "use strict";
-var assert = require('assert');
-var util = require('util');
+const assert = require('assert');
+const util = require('util');
 
-var helper = require('../../test-helper');
-var Client = require('../../../lib/client');
-var utils = require('../../../lib/utils');
-var types = require('../../../lib/types');
-var loadBalancing = require('../../../lib/policies/load-balancing');
+const helper = require('../../test-helper');
+const Client = require('../../../lib/client');
+const utils = require('../../../lib/utils');
+const types = require('../../../lib/types');
+const loadBalancing = require('../../../lib/policies/load-balancing');
 var RoundRobinPolicy = loadBalancing.RoundRobinPolicy;
 var TokenAwarePolicy = loadBalancing.TokenAwarePolicy;
 var WhiteListPolicy = loadBalancing.WhiteListPolicy;
-var vdescribe = helper.vdescribe;
+const vdescribe = helper.vdescribe;
 
 context('with a reusable 3 node cluster', function () {
   this.timeout(180000);
@@ -31,12 +31,12 @@ context('with a reusable 3 node cluster', function () {
   });
   vdescribe('2.0', 'WhiteListPolicy', function () {
     it('should use the hosts in the white list only', function (done) {
-      var policy = new WhiteListPolicy(new RoundRobinPolicy(), ['127.0.0.1:9042', '127.0.0.2:9042']);
-      var client = newInstance(policy);
+      const policy = new WhiteListPolicy(new RoundRobinPolicy(), ['127.0.0.1:9042', '127.0.0.2:9042']);
+      const client = newInstance(policy);
       utils.timesLimit(100, 20, function (n, next) {
         client.execute(helper.queries.basic, function (err, result) {
           assert.ifError(err);
-          var lastOctet = helper.lastOctetOf(result.info.queriedHost);
+          const lastOctet = helper.lastOctetOf(result.info.queriedHost);
           assert.ok(lastOctet === '1' || lastOctet === '2');
           next();
         });
@@ -64,13 +64,13 @@ context('with a reusable 3 node cluster', function () {
       testNoHops('ks_simple_rp1', 'ks_network_rp2.table_c', 2, done);
     });
     it('should target correct replica for composite routing key', function (done) {
-      var client = new Client({
+      const client = new Client({
         policies: { loadBalancing: new TokenAwarePolicy(new RoundRobinPolicy()) },
         keyspace: 'ks_network_rp2',
         contactPoints: helper.baseOptions.contactPoints
       });
-      var query = 'INSERT INTO table_composite (id1, id2) VALUES (?, ?)';
-      var queryOptions = { traceQuery: true, prepare: true, consistency: types.consistencies.all };
+      const query = 'INSERT INTO table_composite (id1, id2) VALUES (?, ?)';
+      const queryOptions = { traceQuery: true, prepare: true, consistency: types.consistencies.all };
       utils.mapSeries([
         utils.stringRepeat('a', 1),
         utils.stringRepeat('b', 0x3fff),
@@ -102,13 +102,13 @@ context('with a reusable 3 node cluster', function () {
  * @param {Function} done
  */
 function testNoHops(loggedKeyspace, table, expectedReplicas, done) {
-  var client = new Client({
+  const client = new Client({
     policies: { loadBalancing: new TokenAwarePolicy(new RoundRobinPolicy()) },
     keyspace: loggedKeyspace,
     contactPoints: helper.baseOptions.contactPoints
   });
-  var query = util.format('INSERT INTO %s (id, name) VALUES (?, ?)', table);
-  var queryOptions = { traceQuery: true, prepare: true, consistency: types.consistencies.all };
+  const query = util.format('INSERT INTO %s (id, name) VALUES (?, ?)', table);
+  const queryOptions = { traceQuery: true, prepare: true, consistency: types.consistencies.all };
   utils.timesLimit(50, 16, function (n, timesNext) {
     var params = [ n, n ];
     client.execute(query, params, queryOptions, function (err, result) {
@@ -137,18 +137,18 @@ function assertReplicas(result, client, expectedReplicas, next) {
  * @param {Function} done
  */
 function testAllReplicasAreUsedAsCoordinator(loggedKeyspace, table, expectedReplicas, done) {
-  var client = new Client({
+  const client = new Client({
     policies: { loadBalancing: new TokenAwarePolicy(new RoundRobinPolicy()) },
     keyspace: loggedKeyspace,
     contactPoints: helper.baseOptions.contactPoints
   });
-  var query = util.format('INSERT INTO %s (id, name) VALUES (?, ?)', table);
-  var queryOptions = { traceQuery: true, prepare: true, consistency: types.consistencies.all };
-  var results = [];
+  const query = util.format('INSERT INTO %s (id, name) VALUES (?, ?)', table);
+  const queryOptions = { traceQuery: true, prepare: true, consistency: types.consistencies.all };
+  const results = [];
   utils.timesSeries(10, function (i, nextParameters) {
     var params = [ i, i ];
-    var coordinators = {};
-    var replicas;
+    const coordinators = {};
+    let replicas;
     utils.timesLimit(100, 20, function (n, timesNext) {
       client.execute(query, params, queryOptions, function (err, result) {
         assert.ifError(err);
@@ -186,9 +186,9 @@ function testAllReplicasAreUsedAsCoordinator(loggedKeyspace, table, expectedRepl
  * Gets the query trace retrying additional times if it fails.
  */
 function getTrace(client, traceId, callback) {
-  var attempts = 0;
-  var trace;
-  var error;
+  let attempts = 0;
+  let trace;
+  let error;
   if (!traceId) {
     throw new Error('traceid was not provided');
   }
@@ -211,8 +211,8 @@ function getTrace(client, traceId, callback) {
 }
 
 function getReplicas(trace) {
-  var replicas = {};
-  var regex = /\b(?:from|to) \/([\da-f:.]+)$/i;
+  const replicas = {};
+  const regex = /\b(?:from|to) \/([\da-f:.]+)$/i;
   trace.events.forEach(function (event) {
     replicas[helper.lastOctetOf(event['source'].toString())] = true;
     var activityMatches = regex.exec(event['activity']);
@@ -224,6 +224,6 @@ function getReplicas(trace) {
 }
 
 function newInstance(policy) {
-  var options = utils.deepExtend({}, helper.baseOptions, { policies: { loadBalancing: policy}});
+  const options = utils.deepExtend({}, helper.baseOptions, { policies: { loadBalancing: policy}});
   return new Client(options);
 }

--- a/test/integration/short/load-balancing-tests.js
+++ b/test/integration/short/load-balancing-tests.js
@@ -7,9 +7,9 @@ const Client = require('../../../lib/client');
 const utils = require('../../../lib/utils');
 const types = require('../../../lib/types');
 const loadBalancing = require('../../../lib/policies/load-balancing');
-var RoundRobinPolicy = loadBalancing.RoundRobinPolicy;
-var TokenAwarePolicy = loadBalancing.TokenAwarePolicy;
-var WhiteListPolicy = loadBalancing.WhiteListPolicy;
+const RoundRobinPolicy = loadBalancing.RoundRobinPolicy;
+const TokenAwarePolicy = loadBalancing.TokenAwarePolicy;
+const WhiteListPolicy = loadBalancing.WhiteListPolicy;
 const vdescribe = helper.vdescribe;
 
 context('with a reusable 3 node cluster', function () {
@@ -110,7 +110,7 @@ function testNoHops(loggedKeyspace, table, expectedReplicas, done) {
   const query = util.format('INSERT INTO %s (id, name) VALUES (?, ?)', table);
   const queryOptions = { traceQuery: true, prepare: true, consistency: types.consistencies.all };
   utils.timesLimit(50, 16, function (n, timesNext) {
-    var params = [ n, n ];
+    const params = [ n, n ];
     client.execute(query, params, queryOptions, function (err, result) {
       assert.ifError(err);
       assertReplicas(result, client, expectedReplicas, timesNext);
@@ -122,7 +122,7 @@ function assertReplicas(result, client, expectedReplicas, next) {
   getTrace(client, result.info.traceId, function (err, trace) {
     assert.ifError(err);
     // Check where the events are coming from
-    var replicas = getReplicas(trace);
+    const replicas = getReplicas(trace);
     // Verify that only replicas were hit (coordinator + replica)
     assert.strictEqual(Object.keys(replicas).length, expectedReplicas);
     next();
@@ -146,7 +146,7 @@ function testAllReplicasAreUsedAsCoordinator(loggedKeyspace, table, expectedRepl
   const queryOptions = { traceQuery: true, prepare: true, consistency: types.consistencies.all };
   const results = [];
   utils.timesSeries(10, function (i, nextParameters) {
-    var params = [ i, i ];
+    const params = [ i, i ];
     const coordinators = {};
     let replicas;
     utils.timesLimit(100, 20, function (n, timesNext) {
@@ -215,7 +215,7 @@ function getReplicas(trace) {
   const regex = /\b(?:from|to) \/([\da-f:.]+)$/i;
   trace.events.forEach(function (event) {
     replicas[helper.lastOctetOf(event['source'].toString())] = true;
-    var activityMatches = regex.exec(event['activity']);
+    const activityMatches = regex.exec(event['activity']);
     if (activityMatches && activityMatches.length === 2) {
       replicas[helper.lastOctetOf(activityMatches[1])] = true;
     }

--- a/test/integration/short/metadata-simulator-tests.js
+++ b/test/integration/short/metadata-simulator-tests.js
@@ -8,16 +8,16 @@ const util = require('util');
 describe('Metadata', function () {
   this.timeout(20000);
   describe("#getTrace()", function () {
-    var setupInfo = simulacron.setup('3', null);
-    var sCluster = setupInfo.cluster;
+    const setupInfo = simulacron.setup('3', null);
+    const sCluster = setupInfo.cluster;
     const client = setupInfo.client;
 
     it('should set consistency level', function (done) {
       const traceId = types.Uuid.random();
-      var sessionQuery = util.format('SELECT * FROM system_traces.sessions WHERE session_id=%s', traceId);
-      var eventsQuery = util.format('SELECT * FROM system_traces.events WHERE session_id=%s', traceId);
+      const sessionQuery = util.format('SELECT * FROM system_traces.sessions WHERE session_id=%s', traceId);
+      const eventsQuery = util.format('SELECT * FROM system_traces.events WHERE session_id=%s', traceId);
 
-      var resultSessions = {
+      const resultSessions = {
         result: 'success',
         delay_in_ms: 0,
         rows: [
@@ -40,7 +40,7 @@ describe('Metadata', function () {
           started_at: "timestamp"
         }
       };
-      var resultEvents = {
+      const resultEvents = {
         result: 'success',
         delay_in_ms: 0,
         rows: [
@@ -88,13 +88,13 @@ describe('Metadata', function () {
           });
         },
         function getTraceWithConsistency(next) {
-          var node0 = sCluster.node(0);
+          const node0 = sCluster.node(0);
           node0.getLogs(function (err, logs) {
             assert.ifError(err);
             assert.notEqual(logs, null);
-            var verifyQuery = function(logsToSearch, query, consistency) {
+            const verifyQuery = function(logsToSearch, query, consistency) {
               for (let i = 0; i < logsToSearch.length; i++) {
-                var log = logsToSearch[i];
+                const log = logsToSearch[i];
                 if (log.type === "QUERY" && log.query === query && log.consistency_level === consistency) {
                   return true;
                 }

--- a/test/integration/short/metadata-simulator-tests.js
+++ b/test/integration/short/metadata-simulator-tests.js
@@ -1,19 +1,19 @@
 'use strict';
-var assert = require('assert');
-var utils = require('../../../lib/utils');
-var types = require('../../../lib/types/index');
-var simulacron = require('../simulacron');
-var util = require('util');
+const assert = require('assert');
+const utils = require('../../../lib/utils');
+const types = require('../../../lib/types/index');
+const simulacron = require('../simulacron');
+const util = require('util');
 
 describe('Metadata', function () {
   this.timeout(20000);
   describe("#getTrace()", function () {
     var setupInfo = simulacron.setup('3', null);
     var sCluster = setupInfo.cluster;
-    var client = setupInfo.client;
+    const client = setupInfo.client;
 
     it('should set consistency level', function (done) {
-      var traceId = types.Uuid.random();
+      const traceId = types.Uuid.random();
       var sessionQuery = util.format('SELECT * FROM system_traces.sessions WHERE session_id=%s', traceId);
       var eventsQuery = util.format('SELECT * FROM system_traces.events WHERE session_id=%s', traceId);
 
@@ -93,7 +93,7 @@ describe('Metadata', function () {
             assert.ifError(err);
             assert.notEqual(logs, null);
             var verifyQuery = function(logsToSearch, query, consistency) {
-              for (var i = 0; i < logsToSearch.length; i++) {
+              for (let i = 0; i < logsToSearch.length; i++) {
                 var log = logsToSearch[i];
                 if (log.type === "QUERY" && log.query === query && log.consistency_level === consistency) {
                   return true;

--- a/test/integration/short/metadata-tests.js
+++ b/test/integration/short/metadata-tests.js
@@ -18,7 +18,7 @@ describe('metadata', function () {
     describe('#keyspaces', function () {
       it('should keep keyspace information up to date', function (done) {
         const client = newInstance();
-        var nonSyncClient = newInstance({ isMetadataSyncEnabled: false });
+        const nonSyncClient = newInstance({ isMetadataSyncEnabled: false });
 
         function checkKeyspaceWithInfo(ks, strategy, optionName, optionValue) {
           assert.ok(ks);
@@ -28,8 +28,8 @@ describe('metadata', function () {
         }
 
         function checkKeyspace(client, name, strategy, optionName, optionValue) {
-          var m = client.metadata;
-          var ks = m.keyspaces[name];
+          const m = client.metadata;
+          const ks = m.keyspaces[name];
           checkKeyspaceWithInfo(ks, strategy, optionName, optionValue);
         }
 
@@ -37,7 +37,7 @@ describe('metadata', function () {
           client.connect.bind(client),
           nonSyncClient.connect.bind(nonSyncClient),
           function checkKeyspaces(next) {
-            var m = client.metadata;
+            const m = client.metadata;
             assert.ok(m);
             assert.ok(m.keyspaces);
             assert.ok(m.keyspaces['system']);
@@ -55,7 +55,7 @@ describe('metadata', function () {
             checkKeyspace(client, 'ks4', 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'datacenter1', '1');
 
             // There should be no keyspace metadata for the non sync client until its fetched via refreshKeyspaces.
-            var ks = nonSyncClient.metadata.keyspaces;
+            const ks = nonSyncClient.metadata.keyspaces;
             assert.ok(ks['ks1'] === undefined);
             assert.ok(ks['ks2'] === undefined);
             assert.ok(ks['ks3'] === undefined);
@@ -92,7 +92,7 @@ describe('metadata', function () {
         const client = newInstance({ refreshSchemaDelay: 50 });
         client.connect(function (err) {
           assert.ifError(err);
-          var m = client.metadata;
+          const m = client.metadata;
           assert.ok(m);
           assert.ok(!m.keyspaces['ks_todelete']);
           utils.series([
@@ -116,7 +116,7 @@ describe('metadata', function () {
         utils.series([
           client.connect.bind(client),
           function testWithCallbacks(next) {
-            var m = client.metadata;
+            const m = client.metadata;
             utils.timesSeries(10, function (n, timesNext) {
               m.getUdt('ks1', 'udt_does_not_exists', function (err, udtInfo) {
                 assert.ifError(err);
@@ -126,7 +126,7 @@ describe('metadata', function () {
             }, next);
           },
           function testWithPromises(next) {
-            var m = client.metadata;
+            const m = client.metadata;
             utils.timesSeries(10, function (n, timesNext) {
               m.getUdt('ks1', 'udt_does_not_exists')
                 .then(function (udtInfo) {
@@ -141,8 +141,8 @@ describe('metadata', function () {
       });
       it('should return the udt information', function (done) {
         const client = newInstance();
-        var createUdtQuery1 = "CREATE TYPE phone (alias text, number text, country_code int, second_number 'DynamicCompositeType(s => UTF8Type, i => Int32Type)')";
-        var createUdtQuery2 = 'CREATE TYPE address (street text, "ZIP" int, phones set<frozen<phone>>)';
+        const createUdtQuery1 = "CREATE TYPE phone (alias text, number text, country_code int, second_number 'DynamicCompositeType(s => UTF8Type, i => Int32Type)')";
+        const createUdtQuery2 = 'CREATE TYPE address (street text, "ZIP" int, phones set<frozen<phone>>)';
         utils.series([
           helper.toTask(client.connect, client),
           helper.toTask(client.execute, client, helper.createKeyspaceCql('ks_udt1', 2)),
@@ -150,7 +150,7 @@ describe('metadata', function () {
           helper.toTask(client.execute, client, createUdtQuery1),
           helper.toTask(client.execute, client, createUdtQuery2),
           function checkPhoneUdt(next) {
-            var m = client.metadata;
+            const m = client.metadata;
             m.getUdt('ks_udt1', 'phone', function (err, udtInfo) {
               assert.ifError(err);
               assert.ok(udtInfo);
@@ -172,7 +172,7 @@ describe('metadata', function () {
             });
           },
           function checkAddressUdt(next) {
-            var m = client.metadata;
+            const m = client.metadata;
             m.getUdt('ks_udt1', 'address', function (err, udtInfo) {
               assert.ifError(err);
               assert.ok(udtInfo);
@@ -192,7 +192,7 @@ describe('metadata', function () {
             });
           },
           function checkAddressUdtWithPromises(next) {
-            var m = client.metadata;
+            const m = client.metadata;
             m.getUdt('ks_udt1', 'address')
               .then(function (udtInfo) {
                 assert.ok(udtInfo);
@@ -209,7 +209,7 @@ describe('metadata', function () {
     describe('#getTrace()', function () {
       it('should retrieve the trace immediately after', function (done) {
         // use a single node
-        var lbp = new helper.WhiteListPolicy(['1']);
+        const lbp = new helper.WhiteListPolicy(['1']);
         const client = newInstance({ policies: { loadBalancing: lbp }});
         let traceId;
         utils.series([
@@ -248,7 +248,7 @@ describe('metadata', function () {
       });
       it('should retrieve the trace a few seconds after', function (done) {
         // use a single node
-        var lbp = new helper.WhiteListPolicy(['2']);
+        const lbp = new helper.WhiteListPolicy(['2']);
         const client = newInstance({ policies: { loadBalancing: lbp }});
         let traceId;
         utils.series([
@@ -303,7 +303,7 @@ describe('metadata', function () {
           const client = newInstance({isMetadataSyncEnabled: false});
           return client.connect()
             .then(function () {
-              var ks = client.metadata.keyspaces;
+              const ks = client.metadata.keyspaces;
               assert.ok(ks['system'] === undefined);
               return client.metadata.refreshKeyspace('system');
             })
@@ -321,7 +321,7 @@ describe('metadata', function () {
           const client = newInstance({ isMetadataSyncEnabled: false });
           return client.connect()
             .then(function () {
-              var ks = client.metadata.keyspaces;
+              const ks = client.metadata.keyspaces;
               assert.ok(ks['system'] === undefined);
               return client.metadata.refreshKeyspaces();
             })
@@ -334,12 +334,12 @@ describe('metadata', function () {
       });
     });
     describe('#getTable()', function () {
-      var keyspace = 'ks_tbl_meta';
+      const keyspace = 'ks_tbl_meta';
       const is3 = helper.isCassandraGreaterThan('3.0');
-      var valuesIndex = (is3 ? "(values(map_values))" : "(map_values)");
+      const valuesIndex = (is3 ? "(values(map_values))" : "(map_values)");
       before(function createTables(done) {
         const client = newInstance();
-        var queries = [
+        const queries = [
           "CREATE KEYSPACE ks_tbl_meta WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
           "USE ks_tbl_meta",
           "CREATE TABLE tbl1 (id uuid PRIMARY KEY, text_sample text)",
@@ -399,7 +399,7 @@ describe('metadata', function () {
             assert.strictEqual(table.bloomFilterFalsePositiveChance, 0.01);
             assert.ok(table.caching);
             assert.strictEqual(typeof table.caching, 'string');
-            var columns = table.columns
+            const columns = table.columns
               .map(function (c) { return c.name; })
               .sort();
             helper.assertValueEqual(columns, ['id', 'text_sample']);
@@ -420,7 +420,7 @@ describe('metadata', function () {
             assert.ifError(err);
             assert.ok(table);
             assert.strictEqual(table.columns.length, 2);
-            var columns = table.columns
+            const columns = table.columns
               .map(function (c) { return c.name; })
               .sort();
             helper.assertValueEqual(columns, ['id', 'text_sample']);
@@ -442,7 +442,7 @@ describe('metadata', function () {
             assert.strictEqual(table.bloomFilterFalsePositiveChance, 0.01);
             assert.ok(table.caching);
             assert.strictEqual(table.columns.length, 2);
-            var columns = table.columns
+            const columns = table.columns
               .map(function (c) { return c.name; })
               .sort();
             helper.assertValueEqual(columns, ['id', 'text_sample']);
@@ -467,7 +467,7 @@ describe('metadata', function () {
             assert.strictEqual(table.bloomFilterFalsePositiveChance, 0.01);
             assert.ok(table.caching);
             assert.strictEqual(table.columns.length, 4);
-            var columns = table.columns
+            const columns = table.columns
               .map(function (c) { return c.name; })
               .sort();
             helper.assertValueEqual(columns, ['id1', 'id3', 'int_sample', 'zid2']);
@@ -492,7 +492,7 @@ describe('metadata', function () {
             assert.ifError(err);
             assert.ok(table);
             assert.strictEqual(table.columns.length, 3);
-            var columns = table.columns
+            const columns = table.columns
               .map(function (c) { return c.name; })
               .sort();
             helper.assertValueEqual(columns, ['id', 'rating_value', 'rating_votes']);
@@ -519,7 +519,7 @@ describe('metadata', function () {
             assert.strictEqual(table.bloomFilterFalsePositiveChance, 0.01);
             assert.ok(table.caching);
             assert.strictEqual(table.columns.length, 3);
-            var columns = table.columns
+            const columns = table.columns
               .map(function (c) { return c.name; })
               .sort();
             helper.assertValueEqual(columns, ['id', 'text1', 'text2']);
@@ -539,7 +539,7 @@ describe('metadata', function () {
             assert.ifError(err);
             assert.ok(table);
             assert.strictEqual(table.columns.length, 3);
-            var columns = table.columns
+            const columns = table.columns
               .map(function (c) { return c.name; })
               .sort();
             helper.assertValueEqual(columns, ['id1', 'id2', 'text1']);
@@ -559,7 +559,7 @@ describe('metadata', function () {
           client.metadata.getTable(keyspace, 'tbl_collections', function (err, table) {
             assert.ifError(err);
             assert.ok(table);
-            var columns = table.columns
+            const columns = table.columns
               .map(function (c) { return c.name; })
               .sort();
             helper.assertValueEqual(columns, ['ck', 'id', 'int_sample', 'list_sample', 'map_sample', 'set_sample']);
@@ -582,7 +582,7 @@ describe('metadata', function () {
             assert.strictEqual(table.columns.length, 2);
             assert.ok(table.indexes);
             assert.strictEqual(table.indexes.length, 1);
-            var index = table.indexes[0];
+            const index = table.indexes[0];
             assert.strictEqual(index.name, 'text_index');
             assert.strictEqual(index.target, 'text_sample');
             assert.strictEqual(index.isCompositesKind(), true);
@@ -602,7 +602,7 @@ describe('metadata', function () {
             assert.ok(table);
             assert.ok(table.indexes);
             assert.ok(table.indexes.length > 0);
-            var index = table.indexes.filter(function (x) { return x.name === 'map_keys_index'; })[0];
+            const index = table.indexes.filter(function (x) { return x.name === 'map_keys_index'; })[0];
             assert.ok(index, 'Index not found');
             assert.strictEqual(index.name, 'map_keys_index');
             assert.strictEqual(index.target, 'keys(map_keys)');
@@ -623,7 +623,7 @@ describe('metadata', function () {
             assert.ok(table);
             assert.ok(table.indexes);
             assert.ok(table.indexes.length > 0);
-            var index = table.indexes.filter(function (x) { return x.name === 'map_values_index'; })[0];
+            const index = table.indexes.filter(function (x) { return x.name === 'map_values_index'; })[0];
             assert.ok(index, 'Index not found');
             assert.strictEqual(index.name, 'map_values_index');
             assert.strictEqual(index.target, is3 ? 'values(map_values)' : 'map_values');
@@ -644,7 +644,7 @@ describe('metadata', function () {
             assert.ok(table);
             assert.ok(table.indexes);
             assert.ok(table.indexes.length > 0);
-            var index = table.indexes.filter(function (x) { return x.name === 'map_entries_index'; })[0];
+            const index = table.indexes.filter(function (x) { return x.name === 'map_entries_index'; })[0];
             assert.ok(index, 'Index not found');
             assert.strictEqual(index.name, 'map_entries_index');
             assert.strictEqual(index.target, 'entries(map_entries)');
@@ -666,14 +666,14 @@ describe('metadata', function () {
             assert.ok(table.indexes);
             assert.ok(table.indexes.length > 0);
 
-            var indexes = [
+            const indexes = [
               {name: 'map_all_entries_index', target: 'entries(map_all)'},
               {name: 'map_all_keys_index', target: 'keys(map_all)'},
               {name: 'map_all_values_index', target: 'values(map_all)'}
             ];
 
             indexes.forEach(function(idx) {
-              var index = table.indexes.filter(function (x) { return x.name === idx.name; })[0];
+              const index = table.indexes.filter(function (x) { return x.name === idx.name; })[0];
               assert.ok(index, 'Index not found');
               assert.strictEqual(index.name, idx.name);
               assert.strictEqual(index.target, idx.target);
@@ -695,7 +695,7 @@ describe('metadata', function () {
             assert.ok(table);
             assert.ok(table.indexes);
             assert.ok(table.indexes.length > 0);
-            var index = table.indexes.filter(function (x) {
+            const index = table.indexes.filter(function (x) {
               return x.name === 'list_index';
             })[0];
             assert.ok(index, 'Index not found');
@@ -740,7 +740,7 @@ describe('metadata', function () {
               assert.ifError(err);
               assert.ok(table);
               assert.deepEqual(table.columns.map(function (c) { return c.name; }), ['id', 'udt_sample']);
-              var udtColumn = table.columnsByName['udt_sample'];
+              const udtColumn = table.columnsByName['udt_sample'];
               assert.ok(udtColumn);
               assert.strictEqual(udtColumn.type.code, types.dataTypes.udt);
               assert.ok(udtColumn.type.info);
@@ -761,7 +761,7 @@ describe('metadata', function () {
               assert.ifError(err);
               assert.ok(table);
               assert.deepEqual(table.columns.map(function (c) { return c.name; }), ['id']);
-              var udtColumn = table.columns[0];
+              const udtColumn = table.columns[0];
               assert.ok(udtColumn);
               assert.strictEqual(table.partitionKeys[0], udtColumn);
               assert.strictEqual(udtColumn.type.code, types.dataTypes.udt);
@@ -788,7 +788,7 @@ describe('metadata', function () {
               // Since c2 is a reversed type, clustering order should be DESC.
               assert.strictEqual(table.clusteringOrder[1], 'DESC');
 
-              var dynamicColumn = table.clusteringKeys[0];
+              const dynamicColumn = table.clusteringKeys[0];
               assert.ok(dynamicColumn);
               assert.strictEqual(dynamicColumn.name, 'c1');
               assert.strictEqual(dynamicColumn.type.code, types.dataTypes.custom);
@@ -796,7 +796,7 @@ describe('metadata', function () {
                 + 's=>org.apache.cassandra.db.marshal.UTF8Type,'
                 + 'i=>org.apache.cassandra.db.marshal.Int32Type)');
 
-              var reversedColumn = table.clusteringKeys[1];
+              const reversedColumn = table.clusteringKeys[1];
               assert.ok(reversedColumn);
               assert.strictEqual(reversedColumn.name, 'c2');
               assert.strictEqual(reversedColumn.type.code, types.dataTypes.custom);
@@ -804,7 +804,7 @@ describe('metadata', function () {
                 + 'org.apache.cassandra.db.marshal.UTF8Type,'
                 + 'org.apache.cassandra.db.marshal.Int32Type)');
 
-              var intColumn = table.columnsByName['c3'];
+              const intColumn = table.columnsByName['c3'];
               assert.ok(intColumn);
               assert.strictEqual(intColumn.type.code, types.dataTypes.int);
               next();
@@ -822,7 +822,7 @@ describe('metadata', function () {
               assert.ifError(err);
               assert.ok(table);
               assert.deepEqual(table.columns.map(function (c) { return c.name; }), ['id', 'udt_sample']);
-              var udtColumn = table.columnsByName['udt_sample'];
+              const udtColumn = table.columnsByName['udt_sample'];
               assert.ok(udtColumn);
               assert.strictEqual(udtColumn.type.code, types.dataTypes.udt);
               assert.ok(udtColumn.type.info);
@@ -850,8 +850,8 @@ describe('metadata', function () {
       });
       it('should retrieve the updated metadata after a schema change', function (done) {
         const client = newInstance();
-        var nonSyncClient = newInstance({ isMetadataSyncEnabled: false });
-        var clients = [client, nonSyncClient];
+        const nonSyncClient = newInstance({ isMetadataSyncEnabled: false });
+        const clients = [client, nonSyncClient];
         utils.series([
           client.connect.bind(client),
           nonSyncClient.connect.bind(nonSyncClient),
@@ -900,10 +900,10 @@ describe('metadata', function () {
       });
     });
     vdescribe('3.0', '#getMaterializedView()', function () {
-      var keyspace = 'ks_view_meta';
+      const keyspace = 'ks_view_meta';
       before(function createTables(done) {
         const client = newInstance();
-        var queries = [
+        const queries = [
           "CREATE KEYSPACE ks_view_meta WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
           "CREATE TABLE ks_view_meta.scores (user TEXT, game TEXT, year INT, month INT, day INT, score INT, PRIMARY KEY (user, game, year, month, day))",
           "CREATE MATERIALIZED VIEW ks_view_meta.dailyhigh AS SELECT user FROM scores WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL PRIMARY KEY ((game, year, month, day), score, user) WITH CLUSTERING ORDER BY (score DESC)"
@@ -941,8 +941,8 @@ describe('metadata', function () {
       });
       it('should refresh the view metadata via events', function (done) {
         const client = newInstance({ keyspace: 'ks_view_meta', refreshSchemaDelay: 50 });
-        var nonSyncClient = newInstance({ keyspace: 'ks_view_meta', isMetadataSyncEnabled: false });
-        var clients = [client, nonSyncClient];
+        const nonSyncClient = newInstance({ keyspace: 'ks_view_meta', isMetadataSyncEnabled: false });
+        const clients = [client, nonSyncClient];
         utils.series([
           client.connect.bind(client),
           nonSyncClient.connect.bind(nonSyncClient),
@@ -1082,8 +1082,8 @@ describe('metadata', function () {
       utils.series([
         client.connect.bind(client),
         function (next) {
-          var state = client.getState();
-          var hosts = state.getConnectedHosts();
+          const state = client.getState();
+          const hosts = state.getConnectedHosts();
           assert.deepEqual(
             hosts.map(function (h) {
               return state.getOpenConnections(h);
@@ -1103,7 +1103,7 @@ describe('metadata', function () {
           }, function (err) {
             assert.ifError(err);
             assert.ok(state);
-            var hosts = state.getConnectedHosts();
+            const hosts = state.getConnectedHosts();
             assert.strictEqual(hosts.length, 2);
             hosts.forEach(function (h) {
               assert.ok(state.getInFlightQueries(h) > 0);

--- a/test/integration/short/metadata-tests.js
+++ b/test/integration/short/metadata-tests.js
@@ -1,23 +1,23 @@
 "use strict";
-var assert = require('assert');
+const assert = require('assert');
 
-var helper = require('../../test-helper');
-var Client = require('../../../lib/client');
-var utils = require('../../../lib/utils');
-var types = require('../../../lib/types');
-var vit = helper.vit;
-var vdescribe = helper.vdescribe;
+const helper = require('../../test-helper');
+const Client = require('../../../lib/client');
+const utils = require('../../../lib/utils');
+const types = require('../../../lib/types');
+const vit = helper.vit;
+const vdescribe = helper.vdescribe;
 
 describe('metadata', function () {
   this.timeout(60000);
-  var setupInfo = helper.setup(2, { ccmOptions: {
+  const setupInfo = helper.setup(2, { ccmOptions: {
     vnodes: true,
     yaml: helper.isCassandraGreaterThan('3.10') ? ['cdc_enabled:true'] : null
   }});
   describe('Metadata', function () {
     describe('#keyspaces', function () {
       it('should keep keyspace information up to date', function (done) {
-        var client = newInstance();
+        const client = newInstance();
         var nonSyncClient = newInstance({ isMetadataSyncEnabled: false });
 
         function checkKeyspaceWithInfo(ks, strategy, optionName, optionValue) {
@@ -89,7 +89,7 @@ describe('metadata', function () {
         ], done);
       });
       it('should delete keyspace information on drop', function (done) {
-        var client = newInstance({ refreshSchemaDelay: 50 });
+        const client = newInstance({ refreshSchemaDelay: 50 });
         client.connect(function (err) {
           assert.ifError(err);
           var m = client.metadata;
@@ -112,7 +112,7 @@ describe('metadata', function () {
     });
     vdescribe('2.1', '#getUdt()', function () {
       it('should return null if it does not exists', function (done) {
-        var client = newInstance();
+        const client = newInstance();
         utils.series([
           client.connect.bind(client),
           function testWithCallbacks(next) {
@@ -140,7 +140,7 @@ describe('metadata', function () {
         ], done);
       });
       it('should return the udt information', function (done) {
-        var client = newInstance();
+        const client = newInstance();
         var createUdtQuery1 = "CREATE TYPE phone (alias text, number text, country_code int, second_number 'DynamicCompositeType(s => UTF8Type, i => Int32Type)')";
         var createUdtQuery2 = 'CREATE TYPE address (street text, "ZIP" int, phones set<frozen<phone>>)';
         utils.series([
@@ -210,8 +210,8 @@ describe('metadata', function () {
       it('should retrieve the trace immediately after', function (done) {
         // use a single node
         var lbp = new helper.WhiteListPolicy(['1']);
-        var client = newInstance({ policies: { loadBalancing: lbp }});
-        var traceId;
+        const client = newInstance({ policies: { loadBalancing: lbp }});
+        let traceId;
         utils.series([
           client.connect.bind(client),
           function executeQuery(next) {
@@ -249,8 +249,8 @@ describe('metadata', function () {
       it('should retrieve the trace a few seconds after', function (done) {
         // use a single node
         var lbp = new helper.WhiteListPolicy(['2']);
-        var client = newInstance({ policies: { loadBalancing: lbp }});
-        var traceId;
+        const client = newInstance({ policies: { loadBalancing: lbp }});
+        let traceId;
         utils.series([
           client.connect.bind(client),
           function executeQuery(next) {
@@ -275,7 +275,7 @@ describe('metadata', function () {
       });
       describe('with no callback specified', function () {
         it('should return the trace in a promise', function () {
-          var client = newInstance();
+          const client = newInstance();
           return client.connect()
             .then(function () {
               return client.execute(helper.queries.basic, [], { traceQuery: true });
@@ -300,7 +300,7 @@ describe('metadata', function () {
     describe('#refreshKeyspace()', function() {
       describe('with no callback specified', function () {
         it('should return keyspace in a promise', function () {
-          var client = newInstance({isMetadataSyncEnabled: false});
+          const client = newInstance({isMetadataSyncEnabled: false});
           return client.connect()
             .then(function () {
               var ks = client.metadata.keyspaces;
@@ -318,7 +318,7 @@ describe('metadata', function () {
     describe('#refreshKeyspaces()', function() {
       describe('with no callback specified', function () {
         it('should return keyspaces in a promise', function () {
-          var client = newInstance({ isMetadataSyncEnabled: false });
+          const client = newInstance({ isMetadataSyncEnabled: false });
           return client.connect()
             .then(function () {
               var ks = client.metadata.keyspaces;
@@ -335,10 +335,10 @@ describe('metadata', function () {
     });
     describe('#getTable()', function () {
       var keyspace = 'ks_tbl_meta';
-      var is3 = helper.isCassandraGreaterThan('3.0');
+      const is3 = helper.isCassandraGreaterThan('3.0');
       var valuesIndex = (is3 ? "(values(map_values))" : "(map_values)");
       before(function createTables(done) {
-        var client = newInstance();
+        const client = newInstance();
         var queries = [
           "CREATE KEYSPACE ks_tbl_meta WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
           "USE ks_tbl_meta",
@@ -390,7 +390,7 @@ describe('metadata', function () {
         utils.eachSeries(queries, client.execute.bind(client), helper.finish(client, done));
       });
       it('should retrieve the metadata of a single partition key table', function (done) {
-        var client = newInstance({ keyspace: keyspace});
+        const client = newInstance({ keyspace: keyspace});
         client.connect(function (err) {
           assert.ifError(err);
           client.metadata.getTable(keyspace, 'tbl1', function (err, table) {
@@ -413,7 +413,7 @@ describe('metadata', function () {
         });
       });
       it('should retrieve the metadata of a composite partition key table', function (done) {
-        var client = newInstance({ keyspace: keyspace});
+        const client = newInstance({ keyspace: keyspace});
         client.connect(function (err) {
           assert.ifError(err);
           client.metadata.getTable(keyspace, 'tbl2', function (err, table) {
@@ -433,7 +433,7 @@ describe('metadata', function () {
         });
       });
       it('should retrieve the metadata of a partition key and clustering key table', function (done) {
-        var client = newInstance({ keyspace: keyspace});
+        const client = newInstance({ keyspace: keyspace});
         client.connect(function (err) {
           assert.ifError(err);
           client.metadata.getTable(keyspace, 'tbl3', function (err, table) {
@@ -458,7 +458,7 @@ describe('metadata', function () {
         });
       });
       it('should retrieve the metadata of a table with reversed clustering order', function (done) {
-        var client = newInstance({ keyspace: keyspace});
+        const client = newInstance({ keyspace: keyspace});
         client.connect(function (err) {
           assert.ifError(err);
           client.metadata.getTable(keyspace, 'tbl7', function (err, table) {
@@ -485,7 +485,7 @@ describe('metadata', function () {
         });
       });
       it('should retrieve the metadata of a counter table', function (done) {
-        var client = newInstance({ keyspace: keyspace});
+        const client = newInstance({ keyspace: keyspace});
         client.connect(function (err) {
           assert.ifError(err);
           client.metadata.getTable(keyspace, 'tbl8', function (err, table) {
@@ -510,7 +510,7 @@ describe('metadata', function () {
         });
       });
       it('should retrieve the metadata of a compact storaged table', function (done) {
-        var client = newInstance({ keyspace: keyspace});
+        const client = newInstance({ keyspace: keyspace});
         client.connect(function (err) {
           assert.ifError(err);
           client.metadata.getTable(keyspace, 'tbl6', function (err, table) {
@@ -532,7 +532,7 @@ describe('metadata', function () {
         });
       });
       it('should retrieve the metadata of a compact storaged table with clustering key', function (done) {
-        var client = newInstance({ keyspace: keyspace});
+        const client = newInstance({ keyspace: keyspace});
         client.connect(function (err) {
           assert.ifError(err);
           client.metadata.getTable(keyspace, 'tbl5', function (err, table) {
@@ -553,7 +553,7 @@ describe('metadata', function () {
         });
       });
       it('should retrieve the metadata of a table with ColumnToCollectionType', function (done) {
-        var client = newInstance({ keyspace: keyspace});
+        const client = newInstance({ keyspace: keyspace});
         client.connect(function (err) {
           assert.ifError(err);
           client.metadata.getTable(keyspace, 'tbl_collections', function (err, table) {
@@ -573,7 +573,7 @@ describe('metadata', function () {
         });
       });
       it('should retrieve a simple secondary index', function (done) {
-        var client = newInstance({ keyspace: keyspace});
+        const client = newInstance({ keyspace: keyspace});
         client.connect(function (err) {
           assert.ifError(err);
           client.metadata.getTable(keyspace, 'tbl1', function (err, table) {
@@ -594,7 +594,7 @@ describe('metadata', function () {
         });
       });
       vit('2.1', 'should retrieve a secondary index on map keys', function (done) {
-        var client = newInstance({ keyspace: keyspace});
+        const client = newInstance({ keyspace: keyspace});
         client.connect(function (err) {
           assert.ifError(err);
           client.metadata.getTable(keyspace, 'tbl_indexes1', function (err, table) {
@@ -615,7 +615,7 @@ describe('metadata', function () {
         });
       });
       vit('2.1', 'should retrieve a secondary index on map values', function (done) {
-        var client = newInstance({ keyspace: keyspace});
+        const client = newInstance({ keyspace: keyspace});
         client.connect(function (err) {
           assert.ifError(err);
           client.metadata.getTable(keyspace, 'tbl_indexes1', function (err, table) {
@@ -636,7 +636,7 @@ describe('metadata', function () {
         });
       });
       vit('2.2', 'should retrieve a secondary index on map entries', function (done) {
-        var client = newInstance({ keyspace: keyspace});
+        const client = newInstance({ keyspace: keyspace});
         client.connect(function (err) {
           assert.ifError(err);
           client.metadata.getTable(keyspace, 'tbl_indexes1', function (err, table) {
@@ -657,7 +657,7 @@ describe('metadata', function () {
         });
       });
       vit('3.0', 'should retrieve multiple indexes on same map column', function (done) {
-        var client = newInstance({ keyspace: keyspace});
+        const client = newInstance({ keyspace: keyspace});
         client.connect(function (err) {
           assert.ifError(err);
           client.metadata.getTable(keyspace, 'tbl_indexes1', function (err, table) {
@@ -687,7 +687,7 @@ describe('metadata', function () {
         });
       });
       vit('2.1', 'should retrieve a secondary index on frozen list', function (done) {
-        var client = newInstance({keyspace: keyspace});
+        const client = newInstance({keyspace: keyspace});
         client.connect(function (err) {
           assert.ifError(err);
           client.metadata.getTable(keyspace, 'tbl_indexes1', function (err, table) {
@@ -710,7 +710,7 @@ describe('metadata', function () {
         });
       });
       vit('2.2', 'should retrieve the metadata of a table containing new 2.2 types', function (done) {
-        var client = newInstance({ keyspace: keyspace });
+        const client = newInstance({ keyspace: keyspace });
         utils.series([
           client.connect.bind(client),
           function checkTable(next) {
@@ -732,7 +732,7 @@ describe('metadata', function () {
         ], done);
       });
       vit('2.1', 'should retrieve the metadata of a table with udt column', function (done) {
-        var client = newInstance();
+        const client = newInstance();
         utils.series([
           client.connect.bind(client),
           function checkMetadata(next) {
@@ -753,7 +753,7 @@ describe('metadata', function () {
         ], done);
       });
       vit('2.1', 'should retrieve the metadata of a table with udt partition key', function (done) {
-        var client = newInstance();
+        const client = newInstance();
         utils.series([
           client.connect.bind(client),
           function checkMetadata(next) {
@@ -775,7 +775,7 @@ describe('metadata', function () {
         ], done);
       });
       it('should retrieve the metadata of a table with custom type columns', function (done) {
-        var client = newInstance();
+        const client = newInstance();
         utils.series([
           client.connect.bind(client),
           function checkMetadata(next) {
@@ -814,7 +814,7 @@ describe('metadata', function () {
         ], done);
       });
       vit('2.1', 'should retrieve the metadata of a table with quoted udt', function (done) {
-        var client = newInstance();
+        const client = newInstance();
         utils.series([
           client.connect.bind(client),
           function checkMetadata(next) {
@@ -835,7 +835,7 @@ describe('metadata', function () {
         ], done);
       });
       vit('3.10', 'should retrieve the cdc information of a table metadata', function (done) {
-        var client = setupInfo.client;
+        const client = setupInfo.client;
         utils.mapSeries([
           [ 'tbl_cdc_true', true ],
           [ 'tbl_cdc_false', false ],
@@ -849,7 +849,7 @@ describe('metadata', function () {
         }, done);
       });
       it('should retrieve the updated metadata after a schema change', function (done) {
-        var client = newInstance();
+        const client = newInstance();
         var nonSyncClient = newInstance({ isMetadataSyncEnabled: false });
         var clients = [client, nonSyncClient];
         utils.series([
@@ -885,7 +885,7 @@ describe('metadata', function () {
       });
       describe('with no callback specified', function () {
         it('should return the metadata in a promise', function () {
-          var client = newInstance();
+          const client = newInstance();
           return client.connect()
             .then(function () {
               return client.metadata.getTable(keyspace, 'tbl1');
@@ -902,7 +902,7 @@ describe('metadata', function () {
     vdescribe('3.0', '#getMaterializedView()', function () {
       var keyspace = 'ks_view_meta';
       before(function createTables(done) {
-        var client = newInstance();
+        const client = newInstance();
         var queries = [
           "CREATE KEYSPACE ks_view_meta WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
           "CREATE TABLE ks_view_meta.scores (user TEXT, game TEXT, year INT, month INT, day INT, score INT, PRIMARY KEY (user, game, year, month, day))",
@@ -917,7 +917,7 @@ describe('metadata', function () {
         });
       });
       it('should retrieve the view and table metadata', function (done) {
-        var client = newInstance();
+        const client = newInstance();
         utils.series([
           client.connect.bind(client),
           function checkMeta(next) {
@@ -940,7 +940,7 @@ describe('metadata', function () {
         ], done);
       });
       it('should refresh the view metadata via events', function (done) {
-        var client = newInstance({ keyspace: 'ks_view_meta', refreshSchemaDelay: 50 });
+        const client = newInstance({ keyspace: 'ks_view_meta', refreshSchemaDelay: 50 });
         var nonSyncClient = newInstance({ keyspace: 'ks_view_meta', isMetadataSyncEnabled: false });
         var clients = [client, nonSyncClient];
         utils.series([
@@ -993,7 +993,7 @@ describe('metadata', function () {
         ], done);
       });
       it('should refresh the view metadata as result of table change via events', function (done) {
-        var client = newInstance({ keyspace: 'ks_view_meta', refreshSchemaDelay: 50 });
+        const client = newInstance({ keyspace: 'ks_view_meta', refreshSchemaDelay: 50 });
         utils.series([
           client.connect.bind(client),
           helper.toTask(client.execute, client, 'CREATE TABLE users (user TEXT PRIMARY KEY, first_name TEXT)'),
@@ -1059,7 +1059,7 @@ describe('metadata', function () {
       });
       describe('with no callback specified', function () {
         it('should return the metadata in a promise', function () {
-          var client = newInstance();
+          const client = newInstance();
           return client.connect()
             .then(function () {
               return client.metadata.getMaterializedView(keyspace, 'dailyhigh');
@@ -1076,7 +1076,7 @@ describe('metadata', function () {
   });
   describe('Client#getState()', function () {
     it('should return a snapshot of the connection pool state', function (done) {
-      var client = newInstance({ pooling: { warmup: true, coreConnectionsPerHost: {
+      const client = newInstance({ pooling: { warmup: true, coreConnectionsPerHost: {
         '0': 3
       }}});
       utils.series([
@@ -1093,7 +1093,7 @@ describe('metadata', function () {
           next();
         },
         function (next) {
-          var state;
+          let state;
           utils.timesLimit(100, 64, function (n, timesNext) {
             if (n === 65) {
               // Take a snapshot while some requests are in-flight

--- a/test/integration/short/prepare-simulator-tests.js
+++ b/test/integration/short/prepare-simulator-tests.js
@@ -13,7 +13,7 @@ describe('Client', function () {
   this.timeout(20000);
   describe('Preparing statements on nodes behavior', function () {
     let sCluster = null;
-    const client = null;
+    let client = null;
     const query = util.format('SELECT * FROM ks.table1 WHERE id1 = ?');
     before(function (done) {
       simulacron.start(done);
@@ -62,7 +62,7 @@ describe('Client', function () {
             assert.ifError(err);
             let prepareQuery;
             for(let i = 0; i < logs.length; i++) {
-              var queryLog = logs[i];
+              const queryLog = logs[i];
               if (queryLog.type === "PREPARE" && queryLog.query === query) {
                 prepareQuery = queryLog;
               }
@@ -77,7 +77,7 @@ describe('Client', function () {
     });
     it('should re-prepare query when host go UP again', function (done) {
       const idRandom = types.Uuid.random();
-      var nodeDownAddress = sCluster.getContactPoints()[4];
+      const nodeDownAddress = sCluster.getContactPoints()[4];
       utils.series(
         [
           function stopLastNode(next) {
@@ -95,7 +95,7 @@ describe('Client', function () {
             }, next);
           },
           function verifyIfNodeIsMarkedDown(next) {
-            var nodeDown = client.hosts.get(nodeDownAddress);
+            const nodeDown = client.hosts.get(nodeDownAddress);
             assert(!nodeDown.isUp());
             next();
           },
@@ -114,7 +114,7 @@ describe('Client', function () {
                 assert.ifError(err);
                 let prepareQuery;
                 for(let i = 0; i < logs.length; i++) {
-                  var queryLog = logs[i];
+                  const queryLog = logs[i];
                   if (queryLog.type === "PREPARE" && queryLog.query === query) {
                     prepareQuery = queryLog;
                   }
@@ -129,7 +129,7 @@ describe('Client', function () {
             }, next);
           },
           function resumeLastNode(next) {
-            var nodeDown = client.hosts.get(nodeDownAddress);
+            const nodeDown = client.hosts.get(nodeDownAddress);
             nodeDown.on('up', function() {
               helper.trace("Node marked as UP");
               setTimeout(next, 1000); //give time for driver to re prepare statement
@@ -142,7 +142,7 @@ describe('Client', function () {
               assert.ifError(err);
               let prepareQuery;
               for(let i = 0; i < logs.length; i++) {
-                var queryLog = logs[i];
+                const queryLog = logs[i];
                 if (queryLog.type === "PREPARE" && queryLog.query === query) {
                   prepareQuery = queryLog;
                 }

--- a/test/integration/short/prepare-simulator-tests.js
+++ b/test/integration/short/prepare-simulator-tests.js
@@ -1,20 +1,20 @@
 'use strict';
-var assert = require('assert');
-var util = require('util');
+const assert = require('assert');
+const util = require('util');
 
-var Client = require('../../../lib/client');
-var types = require('../../../lib/types/index');
-var utils = require('../../../lib/utils');
-var helper = require('../../test-helper');
-var reconnection = require('../../../lib/policies/reconnection');
-var simulacron = require('../simulacron');
+const Client = require('../../../lib/client');
+const types = require('../../../lib/types/index');
+const utils = require('../../../lib/utils');
+const helper = require('../../test-helper');
+const reconnection = require('../../../lib/policies/reconnection');
+const simulacron = require('../simulacron');
 
 describe('Client', function () {
   this.timeout(20000);
   describe('Preparing statements on nodes behavior', function () {
-    var sCluster = null;
-    var client = null;
-    var query = util.format('SELECT * FROM ks.table1 WHERE id1 = ?');
+    let sCluster = null;
+    const client = null;
+    const query = util.format('SELECT * FROM ks.table1 WHERE id1 = ?');
     before(function (done) {
       simulacron.start(done);
     });
@@ -26,7 +26,7 @@ describe('Client', function () {
             sCluster.register([5], {}, next);
           },
           function connectCluster(next) {
-            var poolingOptions = {};
+            const poolingOptions = {};
             poolingOptions[types.distance.local] = 1;
             client = new Client({
               contactPoints: [sCluster.getContactPoints()[0]],
@@ -51,7 +51,7 @@ describe('Client', function () {
       simulacron.stop(done);
     });
     it('should prepare query on all hosts', function (done) {
-      var idRandom = types.Uuid.random();
+      const idRandom = types.Uuid.random();
       client.execute(query, [idRandom], {prepare: 1}, function (err, result) {
         assert.ifError(err);
         assert.strictEqual(client.hosts.length, 5);
@@ -60,8 +60,8 @@ describe('Client', function () {
         utils.eachSeries(client.hosts.values(), function(host, next) {
           sCluster.node(host.address).getLogs(function(err, logs) {
             assert.ifError(err);
-            var prepareQuery;
-            for(var i = 0; i < logs.length; i++) {
+            let prepareQuery;
+            for(let i = 0; i < logs.length; i++) {
               var queryLog = logs[i];
               if (queryLog.type === "PREPARE" && queryLog.query === query) {
                 prepareQuery = queryLog;
@@ -76,7 +76,7 @@ describe('Client', function () {
       });
     });
     it('should re-prepare query when host go UP again', function (done) {
-      var idRandom = types.Uuid.random();
+      const idRandom = types.Uuid.random();
       var nodeDownAddress = sCluster.getContactPoints()[4];
       utils.series(
         [
@@ -112,8 +112,8 @@ describe('Client', function () {
             utils.eachSeries(client.hosts.values(), function(host, nextHost) {
               sCluster.node(host.address).getLogs(function(err, logs) {
                 assert.ifError(err);
-                var prepareQuery;
-                for(var i = 0; i < logs.length; i++) {
+                let prepareQuery;
+                for(let i = 0; i < logs.length; i++) {
                   var queryLog = logs[i];
                   if (queryLog.type === "PREPARE" && queryLog.query === query) {
                     prepareQuery = queryLog;
@@ -140,8 +140,8 @@ describe('Client', function () {
           function verifyPrepareQueryOnLastNode(next) {
             sCluster.node(nodeDownAddress).getLogs(function(err, logs) {
               assert.ifError(err);
-              var prepareQuery;
-              for(var i = 0; i < logs.length; i++) {
+              let prepareQuery;
+              for(let i = 0; i < logs.length; i++) {
                 var queryLog = logs[i];
                 if (queryLog.type === "PREPARE" && queryLog.query === query) {
                   prepareQuery = queryLog;

--- a/test/integration/short/speculative-execution-simulator-tests.js
+++ b/test/integration/short/speculative-execution-simulator-tests.js
@@ -11,20 +11,20 @@ const NoSpeculativeExecutionPolicy = require('../../../lib/policies/speculative-
 const OrderedLoadBalancingPolicy = require('../../test-helper').OrderedLoadBalancingPolicy;
 
 const query = "select * from data";
-var delay = 100;
+const delay = 100;
 
 describe('Client', function() {
 
   this.timeout(20000);
-  var setupInfo = simulacron.setup([3], { initClient: false });
-  var cluster = setupInfo.cluster;
-  var assertQueryCount = function (nodeCounts, cb) {
+  const setupInfo = simulacron.setup([3], { initClient: false });
+  const cluster = setupInfo.cluster;
+  const assertQueryCount = function (nodeCounts, cb) {
     utils.times(nodeCounts.length, function(index, next) {
-      var node = cluster.node(index);
-      var expectedCount = nodeCounts[index];
+      const node = cluster.node(index);
+      const expectedCount = nodeCounts[index];
       node.getLogs(function(err, queries) {
         assert.ifError(err);
-        var matches = queries.filter(function (el) {
+        const matches = queries.filter(function (el) {
           return el.query === query;
         });
         assert.strictEqual(matches.length, expectedCount, "For node " + node.id);
@@ -33,7 +33,7 @@ describe('Client', function() {
     }, cb);
   };
 
-  var node0, node1, node2;
+  let node0, node1, node2;
   before(function done() {
     node0 = cluster.node(0);
     node1 = cluster.node(1);
@@ -70,7 +70,7 @@ describe('Client', function() {
               assert.strictEqual(Object.keys(result.info.triedHosts).length, 1);
 
               // Should have got response from 0th node.
-              var queriedHost = cluster.node(result.info.queriedHost);
+              const queriedHost = cluster.node(result.info.queriedHost);
               assert.strictEqual(queriedHost, node0);
 
               // Should have only sent request to 0th node.
@@ -104,7 +104,7 @@ describe('Client', function() {
             assert.strictEqual(Object.keys(result.info.triedHosts).length, 1);
             
             // Should have queried 0th node.
-            var queriedHost = cluster.node(result.info.queriedHost);
+            const queriedHost = cluster.node(result.info.queriedHost);
             assert.strictEqual(queriedHost, node0);
            
             // Should have only sent request to node 0.
@@ -123,7 +123,7 @@ describe('Client', function() {
             assert.strictEqual(Object.keys(result.info.triedHosts).length, 2);
 
             // Should have got response from 1st node.
-            var queriedHost = cluster.node(result.info.queriedHost);
+            const queriedHost = cluster.node(result.info.queriedHost);
             assert.strictEqual(queriedHost, node1);
 
             // Should have sent requests to node 0 and 1.
@@ -142,7 +142,7 @@ describe('Client', function() {
             assert.strictEqual(Object.keys(result.info.triedHosts).length, 3);
 
             // Should have got response from 0th node, the initial query.
-            var queriedHost = cluster.node(result.info.queriedHost);
+            const queriedHost = cluster.node(result.info.queriedHost);
             assert.strictEqual(queriedHost, node0);
 
             // Should have sent requests to all nodes.
@@ -162,7 +162,7 @@ describe('Client', function() {
             assert.strictEqual(Object.keys(result.info.triedHosts).length, 3);
 
             // Should have got response from 2nd node, the second speculative execution.
-            var queriedHost = cluster.node(result.info.queriedHost);
+            const queriedHost = cluster.node(result.info.queriedHost);
             assert.strictEqual(queriedHost, node2);
 
             // Should have sent requests to all nodes.
@@ -181,12 +181,12 @@ describe('Client', function() {
             assert.strictEqual(Object.keys(result.info.triedHosts).length, 2);
 
             // Should have got response from 1st node, the retry from the first error.
-            var queriedHost = cluster.node(result.info.queriedHost);
+            const queriedHost = cluster.node(result.info.queriedHost);
             assert.strictEqual(queriedHost, node1);
 
             // Expect isBootstrapping error on host that failed.
-            var failureHost = node0.address;
-            var code = result.info.triedHosts[failureHost].code;
+            const failureHost = node0.address;
+            const code = result.info.triedHosts[failureHost].code;
             assert.strictEqual(code, responseErrorCodes.isBootstrapping, "Expected isBootstrapping");
 
             // Should have sent requests to two nodes.
@@ -206,12 +206,12 @@ describe('Client', function() {
             assert.strictEqual(Object.keys(result.info.triedHosts).length, 3);
 
             // Should have got response from 2nd node, the retry after the speculative execution.
-            var queriedHost = cluster.node(result.info.queriedHost);
+            const queriedHost = cluster.node(result.info.queriedHost);
             assert.strictEqual(queriedHost, node2);
 
             // Expect isBootstrapping error on host that failed.
-            var failureHost = node1.address;
-            var code = result.info.triedHosts[failureHost].code;
+            const failureHost = node1.address;
+            const code = result.info.triedHosts[failureHost].code;
             assert.strictEqual(code, responseErrorCodes.isBootstrapping, "Expected isBootstrapping");
 
             // Should have sent requests to all nodes.
@@ -242,13 +242,13 @@ describe('Client', function() {
             assert.strictEqual(Object.keys(result.info.triedHosts).length, 3);
 
             // Should have got response from 0th node.
-            var queriedHost = cluster.node(result.info.queriedHost);
+            const queriedHost = cluster.node(result.info.queriedHost);
             assert.strictEqual(queriedHost, node0);
 
             // Expect isBootstrapping error on both hosts that failed.
             [1, 2].forEach(function(id) {
-              var failureHost = cluster.node(id).address;
-              var code = result.info.triedHosts[failureHost].code;
+              const failureHost = cluster.node(id).address;
+              const code = result.info.triedHosts[failureHost].code;
               assert.strictEqual(code, responseErrorCodes.isBootstrapping, "Expected isBootstrapping");
             });
 
@@ -284,8 +284,8 @@ describe('Client', function() {
 
             // Expect isBootstrapping error on both hosts that failed.
             [0, 1, 2].forEach(function(id) {
-              var failureHost = cluster.node(id).address;
-              var code = err.innerErrors[failureHost].code;
+              const failureHost = cluster.node(id).address;
+              const code = err.innerErrors[failureHost].code;
               assert.strictEqual(code, responseErrorCodes.isBootstrapping, "Expected isBootstrapping");
             });
 
@@ -316,7 +316,7 @@ describe('Client', function() {
             assert.strictEqual(Object.keys(result.info.triedHosts).length, 3);
 
             // Should have got response from 2nd node, since it had the lowest delay.
-            var queriedHost = cluster.node(result.info.queriedHost);
+            const queriedHost = cluster.node(result.info.queriedHost);
             assert.strictEqual(queriedHost, node2);
 
             // Should have sent requests to all nodes.

--- a/test/integration/short/speculative-execution-simulator-tests.js
+++ b/test/integration/short/speculative-execution-simulator-tests.js
@@ -1,16 +1,16 @@
 'use strict';
-var assert = require('assert');
-var responseErrorCodes = require('../../../lib/types').responseErrorCodes;
-var simulacron = require('../simulacron');
-var helper = require('../../test-helper');
-var utils = require('../../../lib/utils');
+const assert = require('assert');
+const responseErrorCodes = require('../../../lib/types').responseErrorCodes;
+const simulacron = require('../simulacron');
+const helper = require('../../test-helper');
+const utils = require('../../../lib/utils');
 
-var Client = require('../../../lib/client.js');
-var ConstantSpeculativeExecutionPolicy = require('../../../lib/policies/speculative-execution').ConstantSpeculativeExecutionPolicy;
-var NoSpeculativeExecutionPolicy = require('../../../lib/policies/speculative-execution').NoSpeculativeExecutionPolicy;
-var OrderedLoadBalancingPolicy = require('../../test-helper').OrderedLoadBalancingPolicy;
+const Client = require('../../../lib/client.js');
+const ConstantSpeculativeExecutionPolicy = require('../../../lib/policies/speculative-execution').ConstantSpeculativeExecutionPolicy;
+const NoSpeculativeExecutionPolicy = require('../../../lib/policies/speculative-execution').NoSpeculativeExecutionPolicy;
+const OrderedLoadBalancingPolicy = require('../../test-helper').OrderedLoadBalancingPolicy;
 
-var query = "select * from data";
+const query = "select * from data";
 var delay = 100;
 
 describe('Client', function() {
@@ -45,7 +45,7 @@ describe('Client', function() {
     {title: 'with NoSpeculativeExecutionPolicy', policy: new NoSpeculativeExecutionPolicy()}
   ].forEach(function (data) {
     describe(data.title, function () {
-      var clientOptions = {
+      const clientOptions = {
         contactPoints: [simulacron.startingIp],
         policies: { 
           loadBalancing: new OrderedLoadBalancingPolicy()
@@ -56,7 +56,7 @@ describe('Client', function() {
         clientOptions.policies.speculativeExecution = data.policy;
       }
 
-      var client = new Client(clientOptions);
+      const client = new Client(clientOptions);
       before(client.connect.bind(client));
       after(client.shutdown.bind(client));
 
@@ -82,7 +82,7 @@ describe('Client', function() {
     });
   });
   describe('with ConstantSpeculativeExecutionPolicy', function () {
-    var clientOptions = {
+    const clientOptions = {
       contactPoints: [simulacron.startingIp],
       policies: { 
         speculativeExecution: new ConstantSpeculativeExecutionPolicy(delay, 3), 
@@ -90,7 +90,7 @@ describe('Client', function() {
       }
     };
 
-    var client = new Client(clientOptions);
+    const client = new Client(clientOptions);
     before(client.connect.bind(client));
     after(client.shutdown.bind(client));
 
@@ -296,13 +296,13 @@ describe('Client', function() {
       ], done);
     });
     it('should allow zero delay', function (done) {
-      var clientOptions = {
+      const clientOptions = {
         contactPoints: cluster.getContactPoints(0),
         policies: { 
           speculativeExecution: new ConstantSpeculativeExecutionPolicy(0, 3),
         }
       };
-      var client = new Client(clientOptions);
+      const client = new Client(clientOptions);
 
       utils.series([
         client.connect.bind(client),

--- a/test/integration/short/ssl-tests.js
+++ b/test/integration/short/ssl-tests.js
@@ -11,8 +11,8 @@ describe('Client', function () {
   this.timeout(60000);
   context('with ssl enabled', function () {
     const keyspace = helper.getRandomName('ks');
-    var table = keyspace + '.' + helper.getRandomName('table');
-    var setupQueries = [
+    const table = keyspace + '.' + helper.getRandomName('table');
+    const setupQueries = [
       helper.createKeyspaceCql(keyspace, 1),
       helper.createTableCql(table)
     ];

--- a/test/integration/short/ssl-tests.js
+++ b/test/integration/short/ssl-tests.js
@@ -1,16 +1,16 @@
 "use strict";
-var assert = require('assert');
-var util = require('util');
+const assert = require('assert');
+const util = require('util');
 
-var helper = require('../../test-helper');
-var Client = require('../../../lib/client');
-var utils = require('../../../lib/utils');
-var types = require('../../../lib/types');
+const helper = require('../../test-helper');
+const Client = require('../../../lib/client');
+const utils = require('../../../lib/utils');
+const types = require('../../../lib/types');
 
 describe('Client', function () {
   this.timeout(60000);
   context('with ssl enabled', function () {
-    var keyspace = helper.getRandomName('ks');
+    const keyspace = helper.getRandomName('ks');
     var table = keyspace + '.' + helper.getRandomName('table');
     var setupQueries = [
       helper.createKeyspaceCql(keyspace, 1),
@@ -21,7 +21,7 @@ describe('Client', function () {
     after(helper.ccmHelper.remove);
     describe('#connect()', function () {
       it('should connect to a ssl enabled cluster', function (done) {
-        var client = newInstance();
+        const client = newInstance();
         client.connect(function (err) {
           assert.ifError(err);
           assert.strictEqual(client.hosts.length, 1);
@@ -31,12 +31,12 @@ describe('Client', function () {
     });
     describe('#execute()', function () {
       it('should handle multiple requests in parallel with queueing', function (done) {
-        var parallelLimit = helper.isCassandraGreaterThan('2.0') ? 2100 : 200;
-        var client = newInstance();
+        const parallelLimit = helper.isCassandraGreaterThan('2.0') ? 2100 : 200;
+        const client = newInstance();
         utils.series([
           client.connect.bind(client),
           function insert(next) {
-            var query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
+            const query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
             utils.timesLimit(40000, parallelLimit, function (n, timesNext) {
               client.execute(query, [ types.Uuid.random(), 'value ' + n ], { prepare: true }, timesNext);
             }, next);

--- a/test/integration/short/timeout-tests.js
+++ b/test/integration/short/timeout-tests.js
@@ -1,16 +1,16 @@
 "use strict";
-var assert = require('assert');
-var util = require('util');
+const assert = require('assert');
+const util = require('util');
 
-var helper = require('../../test-helper');
-var Client = require('../../../lib/client');
-var Connection = require('../../../lib/connection');
-var utils = require('../../../lib/utils');
-var types = require('../../../lib/types');
-var errors = require('../../../lib/errors');
-var ExecutionProfile = require('../../../lib/execution-profile').ExecutionProfile;
-var loadBalancing = require('../../../lib/policies').loadBalancing;
-var vdescribe = helper.vdescribe;
+const helper = require('../../test-helper');
+const Client = require('../../../lib/client');
+const Connection = require('../../../lib/connection');
+const utils = require('../../../lib/utils');
+const types = require('../../../lib/types');
+const errors = require('../../../lib/errors');
+const ExecutionProfile = require('../../../lib/execution-profile').ExecutionProfile;
+const loadBalancing = require('../../../lib/policies').loadBalancing;
+const vdescribe = helper.vdescribe;
 
 describe('client read timeouts', function () {
   this.timeout(120000);
@@ -39,9 +39,9 @@ describe('client read timeouts', function () {
     it('should move to next host for prepared requests', getMoveNextHostTest(true, false));
     it('should move to next host for the initial prepare', getMoveNextHostTest(true, false));
     it('should callback in error when retryOnTimeout is false', function (done) {
-      var client = newInstance({ socketOptions: { readTimeout: 3000 } });
-      var coordinators = {};
-      var errorsReceived = [];
+      const client = newInstance({ socketOptions: { readTimeout: 3000 } });
+      const coordinators = {};
+      const errorsReceived = [];
       utils.series([
         client.connect.bind(client),
         function warmup(next) {
@@ -90,7 +90,7 @@ describe('client read timeouts', function () {
       ], done);
     });
     it('defunct the connection when the threshold passed', function (done) {
-      var client = newInstance({
+      const client = newInstance({
         socketOptions: {
           readTimeout: 3000,
           defunctReadTimeoutThreshold: 32
@@ -104,8 +104,8 @@ describe('client read timeouts', function () {
           }
         }
       });
-      var coordinators = {};
-      var connection;
+      const coordinators = {};
+      let connection;
       utils.series([
         client.connect.bind(client),
         function warmup(next) {
@@ -161,13 +161,13 @@ describe('client read timeouts', function () {
       ], done);
     });
     it('should move to next host for eachRow() executions', function (done) {
-      var client = newInstance({ socketOptions: { readTimeout: 3000 } });
-      var coordinators = {};
+      const client = newInstance({ socketOptions: { readTimeout: 3000 } });
+      const coordinators = {};
       utils.series([
         client.connect.bind(client),
         function warmup(next) {
           utils.timesSeries(10, function (n, timesNext) {
-            var counter = 0;
+            let counter = 0;
             client.eachRow('SELECT key FROM system.local', [], function () {
               counter++;
             }, function (err, result) {
@@ -187,7 +187,7 @@ describe('client read timeouts', function () {
           assert.strictEqual(coordinators['2'], true);
           coordinators = {};
           utils.times(10, function (n, timesNext) {
-            var counter = 0;
+            let counter = 0;
             client.eachRow('SELECT key FROM system.local', [], function () {
               counter++;
             }, function (err, result) {
@@ -245,7 +245,7 @@ describe('client read timeouts', function () {
   });
   vdescribe('2.0', 'with prepared batches', function () {
     it('should retry when preparing multiple queries', function (done) {
-      var client = newInstance({
+      const client = newInstance({
         keyspace: 'ks_batch_test',
         // Use a lbp that always yields the hosts in the same order
         policies: { loadBalancing: new FixedOrderLoadBalancingPolicy() },
@@ -275,7 +275,7 @@ describe('client read timeouts', function () {
       ], helper.finish(client, done));
     });
     it('should produce a NoHostAvailableError when prepare tried and timed out on all hosts', function (done) {
-      var client = newInstance({
+      const client = newInstance({
         keyspace: 'ks_batch_test',
         // Use a lbp that always yields the hosts in the same order
         policies: { loadBalancing: new FixedOrderLoadBalancingPolicy() },
@@ -298,7 +298,6 @@ describe('client read timeouts', function () {
           // It should be tried on all nodes and produce a NoHostAvailableError.
           client.batch(queries, { prepare: true, logged: false }, function (err) {
             helper.assertInstanceOf(err, errors.NoHostAvailableError);
-            //noinspection JSUnresolvedVariable
             var numErrors = Object.keys(err.innerErrors).length;
             assert.strictEqual(numErrors, 2);
             next();
@@ -336,15 +335,15 @@ function getMoveNextHostTest(prepare, prepareWarmup, expectedTimeoutMillis, read
   }
   profiles = profiles || [];
   return (function moveNextHostTest(done) {
-    var client = newInstance({ profiles: profiles, socketOptions: { readTimeout: readTimeout } });
-    var timeoutLogs = [];
+    const client = newInstance({ profiles: profiles, socketOptions: { readTimeout: readTimeout } });
+    const timeoutLogs = [];
     client.on('log', function (level, constructorName, info) {
       if (level !== 'warning' || info.indexOf('timeout') === -1) {
         return;
       }
       timeoutLogs.push(info);
     });
-    var coordinators = {};
+    const coordinators = {};
     utils.series([
       client.connect.bind(client),
       function warmup(next) {
@@ -405,8 +404,8 @@ function getTimeoutErrorNotExpectedTest(prepare, prepareWarmup, readTimeout, que
   profiles = profiles || [];
 
   return (function timeoutErrorNotExpectedTest(done) {
-    var client = newInstance({ profiles: profiles, socketOptions: { readTimeout: readTimeout } });
-    var coordinators = {};
+    const client = newInstance({ profiles: profiles, socketOptions: { readTimeout: readTimeout } });
+    const coordinators = {};
     utils.series([
       client.connect.bind(client),
       function warmup(next) {
@@ -431,7 +430,7 @@ function getTimeoutErrorNotExpectedTest(prepare, prepareWarmup, readTimeout, que
           assert.ifError(err);
           coordinators[helper.lastOctetOf(result.info.queriedHost)] = true;
         };
-        for (var i = 0; i < 2; i++) {
+        for (let i = 0; i < 2; i++) {
           queryOptions = utils.extend({ }, queryOptions, { prepare: prepare });
           client.execute('SELECT key FROM system.local', [], queryOptions, cb);
         }

--- a/test/integration/short/timeout-tests.js
+++ b/test/integration/short/timeout-tests.js
@@ -40,7 +40,7 @@ describe('client read timeouts', function () {
     it('should move to next host for the initial prepare', getMoveNextHostTest(true, false));
     it('should callback in error when retryOnTimeout is false', function (done) {
       const client = newInstance({ socketOptions: { readTimeout: 3000 } });
-      const coordinators = {};
+      let coordinators = {};
       const errorsReceived = [];
       utils.series([
         client.connect.bind(client),
@@ -104,7 +104,7 @@ describe('client read timeouts', function () {
           }
         }
       });
-      const coordinators = {};
+      let coordinators = {};
       let connection;
       utils.series([
         client.connect.bind(client),
@@ -162,7 +162,7 @@ describe('client read timeouts', function () {
     });
     it('should move to next host for eachRow() executions', function (done) {
       const client = newInstance({ socketOptions: { readTimeout: 3000 } });
-      const coordinators = {};
+      let coordinators = {};
       utils.series([
         client.connect.bind(client),
         function warmup(next) {
@@ -257,7 +257,7 @@ describe('client read timeouts', function () {
         client.connect.bind(client),
         helper.toTask(helper.ccmHelper.pauseNode, null, 1),
         function checkPreparing(next) {
-          var queries = [{
+          const queries = [{
             query: 'INSERT INTO tbl1 (id, text_sample) VALUES (?, ?)',
             params: [types.Uuid.random(), 'one']
           }, {
@@ -288,7 +288,7 @@ describe('client read timeouts', function () {
         helper.toTask(helper.ccmHelper.pauseNode, null, 1),
         helper.toTask(helper.ccmHelper.pauseNode, null, 2),
         function checkPreparing(next) {
-          var queries = [{
+          const queries = [{
             query: 'INSERT INTO tbl2 (id, text_sample) VALUES (?, ?)',
             params: [types.Uuid.random(), 'one']
           }, {
@@ -298,7 +298,7 @@ describe('client read timeouts', function () {
           // It should be tried on all nodes and produce a NoHostAvailableError.
           client.batch(queries, { prepare: true, logged: false }, function (err) {
             helper.assertInstanceOf(err, errors.NoHostAvailableError);
-            var numErrors = Object.keys(err.innerErrors).length;
+            const numErrors = Object.keys(err.innerErrors).length;
             assert.strictEqual(numErrors, 2);
             next();
           });
@@ -343,7 +343,7 @@ function getMoveNextHostTest(prepare, prepareWarmup, expectedTimeoutMillis, read
       }
       timeoutLogs.push(info);
     });
-    const coordinators = {};
+    let coordinators = {};
     utils.series([
       client.connect.bind(client),
       function warmup(next) {
@@ -363,7 +363,7 @@ function getMoveNextHostTest(prepare, prepareWarmup, expectedTimeoutMillis, read
         assert.strictEqual(coordinators['1'], true);
         assert.strictEqual(coordinators['2'], true);
         coordinators = {};
-        var testAbortTimeout = setTimeout(function () {
+        const testAbortTimeout = setTimeout(function () {
           throw new Error('It should have been executed in the next (not paused) host.');
         }, expectedTimeoutMillis * 4);
         utils.times(10, function (n, timesNext) {
@@ -405,7 +405,7 @@ function getTimeoutErrorNotExpectedTest(prepare, prepareWarmup, readTimeout, que
 
   return (function timeoutErrorNotExpectedTest(done) {
     const client = newInstance({ profiles: profiles, socketOptions: { readTimeout: readTimeout } });
-    const coordinators = {};
+    let coordinators = {};
     utils.series([
       client.connect.bind(client),
       function warmup(next) {
@@ -426,7 +426,7 @@ function getTimeoutErrorNotExpectedTest(prepare, prepareWarmup, readTimeout, que
         assert.strictEqual(coordinators['2'], true);
         coordinators = {};
         //execute 2 queries without waiting for the response
-        var cb = function (err, result) {
+        const cb = function (err, result) {
           assert.ifError(err);
           coordinators[helper.lastOctetOf(result.info.queriedHost)] = true;
         };

--- a/test/integration/short/udf-tests.js
+++ b/test/integration/short/udf-tests.js
@@ -1,18 +1,18 @@
 "use strict";
-var assert = require('assert');
+const assert = require('assert');
 
-var helper = require('../../test-helper');
-var Client = require('../../../lib/client');
-var utils = require('../../../lib/utils');
-var types = require('../../../lib/types');
-var vdescribe = helper.vdescribe;
+const helper = require('../../test-helper');
+const Client = require('../../../lib/client');
+const utils = require('../../../lib/utils');
+const types = require('../../../lib/types');
+const vdescribe = helper.vdescribe;
 
 vdescribe('2.2', 'Metadata', function () {
   this.timeout(60000);
   before(helper.ccmHelper.start(1, { yaml: ['enable_user_defined_functions:true']}));
   var keyspace = 'ks_udf';
   before(function createSchema(done) {
-    var client = newInstance();
+    const client = newInstance();
     var queries = [
       "CREATE KEYSPACE  ks_udf WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
       "CREATE FUNCTION  ks_udf.return_one() RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return 1;'",
@@ -26,7 +26,7 @@ vdescribe('2.2', 'Metadata', function () {
   after(helper.ccmHelper.remove);
   describe('#getFunctions()', function () {
     it('should retrieve the metadata of cql functions', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
@@ -41,7 +41,7 @@ vdescribe('2.2', 'Metadata', function () {
       ], done);
     });
     it('should retrieve the metadata for a cql function without arguments', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
@@ -56,7 +56,7 @@ vdescribe('2.2', 'Metadata', function () {
       ], done);
     });
     it('should return an empty array when not found', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
@@ -70,7 +70,7 @@ vdescribe('2.2', 'Metadata', function () {
       ], done);
     });
     it('should return an empty array when the keyspace does not exists', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
@@ -85,7 +85,7 @@ vdescribe('2.2', 'Metadata', function () {
     });
     describe('with no callback specified', function () {
       it('should return functions in a promise', function () {
-        var client = newInstance();
+        const client = newInstance();
         return client.connect()
           .then(function () {
             return client.metadata.getFunctions(keyspace, 'plus');
@@ -99,7 +99,7 @@ vdescribe('2.2', 'Metadata', function () {
   });
   describe('#getFunction()', function () {
     it('should retrieve the metadata of a cql function', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
@@ -119,7 +119,7 @@ vdescribe('2.2', 'Metadata', function () {
       ], done);
     });
     it('should retrieve the metadata for a cql function without arguments', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
@@ -138,7 +138,7 @@ vdescribe('2.2', 'Metadata', function () {
       ], done);
     });
     it('should return null when not found', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
@@ -152,7 +152,7 @@ vdescribe('2.2', 'Metadata', function () {
       ], done);
     });
     it('should return null when not found by signature', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
@@ -166,7 +166,7 @@ vdescribe('2.2', 'Metadata', function () {
       ], done);
     });
     it('should return null when the keyspace does not exists', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
@@ -180,7 +180,7 @@ vdescribe('2.2', 'Metadata', function () {
       ], done);
     });
     it('should retrieve the most up to date metadata', function (done) {
-      var client = newInstance({ keyspace: keyspace });
+      const client = newInstance({ keyspace: keyspace });
       var nonSyncClient = newInstance({ keyspace: keyspace, isMetadataSyncEnabled: false });
       var clients = [client, nonSyncClient];
       utils.series([
@@ -216,7 +216,7 @@ vdescribe('2.2', 'Metadata', function () {
     });
     describe('with no callback specified', function () {
       it('should return function in a promise', function () {
-        var client = newInstance();
+        const client = newInstance();
         return client.connect()
           .then(function () {
             return client.metadata.getFunction(keyspace, 'plus', ['int', 'int']);
@@ -235,7 +235,7 @@ vdescribe('2.2', 'Metadata', function () {
   });
   describe('#getAggregates()', function () {
     it('should retrieve the metadata of cql aggregates', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
@@ -252,7 +252,7 @@ vdescribe('2.2', 'Metadata', function () {
       ], done);
     });
     it('should return an empty array when not found', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
@@ -266,7 +266,7 @@ vdescribe('2.2', 'Metadata', function () {
       ], done);
     });
     it('should return an empty array when the keyspace does not exists', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
@@ -281,7 +281,7 @@ vdescribe('2.2', 'Metadata', function () {
     });
     describe('with no callback specified', function () {
       it('should return aggregates in a promise', function () {
-        var client = newInstance();
+        const client = newInstance();
         return client.connect()
           .then(function () {
             return client.metadata.getAggregates(keyspace, 'sum');
@@ -297,7 +297,7 @@ vdescribe('2.2', 'Metadata', function () {
   });
   describe('#getAggregate()', function () {
     it('should retrieve the metadata of a cql aggregate', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
@@ -318,7 +318,7 @@ vdescribe('2.2', 'Metadata', function () {
       ], done);
     });
     it('should return null when not found', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
@@ -332,7 +332,7 @@ vdescribe('2.2', 'Metadata', function () {
       ], done);
     });
     it('should return null when not found by signature', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
@@ -346,7 +346,7 @@ vdescribe('2.2', 'Metadata', function () {
       ], done);
     });
     it('should return null when the keyspace does not exists', function (done) {
-      var client = newInstance();
+      const client = newInstance();
       utils.series([
         client.connect.bind(client),
         function checkMeta(next) {
@@ -360,7 +360,7 @@ vdescribe('2.2', 'Metadata', function () {
       ], done);
     });
     it('should retrieve the most up to date metadata', function (done) {
-      var client = newInstance({ keyspace: keyspace });
+      const client = newInstance({ keyspace: keyspace });
       var nonSyncClient = newInstance({ keyspace: keyspace, isMetadataSyncEnabled: false });
       var clients = [client, nonSyncClient];
       utils.series([
@@ -397,7 +397,7 @@ vdescribe('2.2', 'Metadata', function () {
     });
     describe('with no callback specified', function () {
       it('should return aggregate in a promise', function () {
-        var client = newInstance();
+        const client = newInstance();
         return client.connect()
           .then(function () {
             return client.metadata.getAggregate(keyspace, 'sum', ['int']);

--- a/test/integration/short/udf-tests.js
+++ b/test/integration/short/udf-tests.js
@@ -10,10 +10,10 @@ const vdescribe = helper.vdescribe;
 vdescribe('2.2', 'Metadata', function () {
   this.timeout(60000);
   before(helper.ccmHelper.start(1, { yaml: ['enable_user_defined_functions:true']}));
-  var keyspace = 'ks_udf';
+  const keyspace = 'ks_udf';
   before(function createSchema(done) {
     const client = newInstance();
-    var queries = [
+    const queries = [
       "CREATE KEYSPACE  ks_udf WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
       "CREATE FUNCTION  ks_udf.return_one() RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return 1;'",
       "CREATE FUNCTION  ks_udf.plus(s int, v int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return s+v;'",
@@ -181,8 +181,8 @@ vdescribe('2.2', 'Metadata', function () {
     });
     it('should retrieve the most up to date metadata', function (done) {
       const client = newInstance({ keyspace: keyspace });
-      var nonSyncClient = newInstance({ keyspace: keyspace, isMetadataSyncEnabled: false });
-      var clients = [client, nonSyncClient];
+      const nonSyncClient = newInstance({ keyspace: keyspace, isMetadataSyncEnabled: false });
+      const clients = [client, nonSyncClient];
       utils.series([
         client.connect.bind(client),
         nonSyncClient.connect.bind(nonSyncClient),
@@ -361,8 +361,8 @@ vdescribe('2.2', 'Metadata', function () {
     });
     it('should retrieve the most up to date metadata', function (done) {
       const client = newInstance({ keyspace: keyspace });
-      var nonSyncClient = newInstance({ keyspace: keyspace, isMetadataSyncEnabled: false });
-      var clients = [client, nonSyncClient];
+      const nonSyncClient = newInstance({ keyspace: keyspace, isMetadataSyncEnabled: false });
+      const clients = [client, nonSyncClient];
       utils.series([
         client.connect.bind(client),
         nonSyncClient.connect.bind(nonSyncClient),

--- a/test/integration/simulacron.js
+++ b/test/integration/simulacron.js
@@ -9,17 +9,17 @@ const Client = require('../../lib/client.js');
 
 const simulacronHelper = {
   _execute: function(processName, params, cb) {
-    var originalProcessName = processName;
+    const originalProcessName = processName;
 
     // If process hasn't completed in 10 seconds.
-    var timeout = undefined;
+    let timeout = undefined;
     if(cb) {
       timeout = setTimeout(function() {
         cb('Timed out while waiting for ' + processName + ' to complete.');
       }, 10000);
     }
 
-    var p = spawn(processName, params, {});
+    const p = spawn(processName, params, {});
     p.stdout.setEncoding('utf8');
     p.stderr.setEncoding('utf8');
     p.stdout.on('data', function (data) {
@@ -55,7 +55,7 @@ const simulacronHelper = {
    */
   start: function(cb) {
     const self = this;
-    var simulacronJarPath = process.env['SIMULACRON_PATH'];
+    let simulacronJarPath = process.env['SIMULACRON_PATH'];
     if (!simulacronJarPath) {
       simulacronJarPath = process.env['HOME'] + "/simulacron.jar";
       helper.trace("SIMULACRON_PATH not set, using " + simulacronJarPath);
@@ -64,11 +64,11 @@ const simulacronHelper = {
       throw new Error('Simulacron jar not found at: ' + simulacronJarPath);
     }
 
-    var processName = 'java';
-    var params = ['-jar', simulacronJarPath, '--ip', self.startingIp, '-p', this.defaultPort];
+    const processName = 'java';
+    const params = ['-jar', simulacronJarPath, '--ip', self.startingIp, '-p', this.defaultPort];
     let initialized = false;
 
-    var timeout = setTimeout(function() {
+    const timeout = setTimeout(function() {
       cb(new Error('Timed out while waiting for Simulacron server to start.'));
     }, 10000);
 
@@ -101,7 +101,7 @@ const simulacronHelper = {
         cb();
       } else {
         if (helper.isWin()) {
-          var params = ['Stop-Process', this.sProcess.pid];
+          const params = ['Stop-Process', this.sProcess.pid];
           this._execute('powershell', params, cb);
         } else {
           this.sProcess.on('close', function () {
@@ -128,9 +128,9 @@ const simulacronHelper = {
   setup: function (dcs, options) {
     const self = this;
     options = options || utils.emptyObject;
-    var clientOptions = options.clientOptions || {};
-    var simulacronCluster = new SimulacronCluster();
-    var initClient = options.initClient !== false;
+    const clientOptions = options.clientOptions || {};
+    const simulacronCluster = new SimulacronCluster();
+    const initClient = options.initClient !== false;
     let client;
     before(function (done) {
       self.start(function () {
@@ -169,8 +169,8 @@ const simulacronHelper = {
 function _makeRequest(options, callback) {
   const request = http.request(options, function(response) {
     // Continuously update stream with data
-    var body = '';
-    var statusCode = response.statusCode;
+    let body = '';
+    const statusCode = response.statusCode;
     response.on('data', function(d) {
       body += d;
     });
@@ -277,6 +277,7 @@ SimulacronTopic.prototype.clear = function(callback) {
  * Stops listening for connections and closes existing connections for all associated nodes.
  */
 SimulacronTopic.prototype.stop = function(callback) {
+  const stopNodePath = '/listener/%s?type=stop';
   const options = {
     host: this.baseAddress,
     path: encodeURI(util.format(stopNodePath, this.id)),
@@ -396,11 +397,12 @@ SimulacronCluster.prototype.unregister = function(callback) {
  */
 SimulacronCluster.prototype.node = function(key, datacenterIndex) {
   // if the first argument is a string, assume its an address.
+  let dc;
   if (typeof key === "string") {
     // iterate over DCs and their nodes looking for first node that matches.
     for (let dcIndex = 0; dcIndex < this.dcs.length; dcIndex++) {
-      var dc = this.dcs[dcIndex];
-      var node = dc.nodes.filter(function (n) {
+      dc = this.dcs[dcIndex];
+      const node = dc.nodes.filter(function (n) {
         return n.address === key;
       })[0];
       if (node) {
@@ -468,7 +470,7 @@ SimulacronDataCenter.prototype.node = function(id) {
   // if the first argument is a string, assume its an address.
   if (typeof id === "string") {
     for (let nodeIndex = 0; nodeIndex < this.nodes.length; nodeIndex++) {
-      var n = this.nodes[nodeIndex];
+      const n = this.nodes[nodeIndex];
       if (n.address === id) {
         return n;
       }

--- a/test/integration/simulacron.js
+++ b/test/integration/simulacron.js
@@ -1,13 +1,13 @@
 'use strict';
-var helper = require('../test-helper');
-var http = require('http');
-var spawn = require('child_process').spawn;
-var util = require('util');
-var fs = require('fs');
-var utils = require('../../lib/utils.js');
-var Client = require('../../lib/client.js');
+const helper = require('../test-helper');
+const http = require('http');
+const spawn = require('child_process').spawn;
+const util = require('util');
+const fs = require('fs');
+const utils = require('../../lib/utils.js');
+const Client = require('../../lib/client.js');
 
-var simulacronHelper = {
+const simulacronHelper = {
   _execute: function(processName, params, cb) {
     var originalProcessName = processName;
 
@@ -54,7 +54,7 @@ var simulacronHelper = {
    * @param {Function} cb Callback to be executed when completed, raised with Error if fails.
    */
   start: function(cb) {
-    var self = this;
+    const self = this;
     var simulacronJarPath = process.env['SIMULACRON_PATH'];
     if (!simulacronJarPath) {
       simulacronJarPath = process.env['HOME'] + "/simulacron.jar";
@@ -66,7 +66,7 @@ var simulacronHelper = {
 
     var processName = 'java';
     var params = ['-jar', simulacronJarPath, '--ip', self.startingIp, '-p', this.defaultPort];
-    var initialized = false;
+    let initialized = false;
 
     var timeout = setTimeout(function() {
       cb(new Error('Timed out while waiting for Simulacron server to start.'));
@@ -126,12 +126,12 @@ var simulacronHelper = {
    * @param {Object} [options.clientOptions] The options to use to initialize the client.
    */
   setup: function (dcs, options) {
-    var self = this;
+    const self = this;
     options = options || utils.emptyObject;
     var clientOptions = options.clientOptions || {};
     var simulacronCluster = new SimulacronCluster();
     var initClient = options.initClient !== false;
-    var client;
+    let client;
     before(function (done) {
       self.start(function () {
         simulacronCluster.register(dcs, clientOptions, function() {
@@ -140,7 +140,7 @@ var simulacronHelper = {
       });
     });
     if (initClient) {
-      var baseOptions = { contactPoints: [self.startingIp] };
+      const baseOptions = { contactPoints: [self.startingIp] };
       client = new Client(utils.extend({}, options.clientOptions, baseOptions));
       before(client.connect.bind(client));
       after(client.shutdown.bind(client));
@@ -167,7 +167,7 @@ var simulacronHelper = {
 };
 
 function _makeRequest(options, callback) {
-  var request = http.request(options, function(response) {
+  const request = http.request(options, function(response) {
     // Continuously update stream with data
     var body = '';
     var statusCode = response.statusCode;
@@ -203,7 +203,7 @@ function SimulacronTopic() {
  * @returns {Array} query log entries for the given topic.
  */
 SimulacronTopic.prototype.getLogs = function(callback) {
-  var self = this;
+  const self = this;
   _makeRequest(this._getOptions('log', this.id, 'GET'), function(err, data) {
     if (err) {
       callback(err);
@@ -229,7 +229,7 @@ SimulacronTopic.prototype.clearLogs = function(callback) {
  * @param {Function} callback
  */
 SimulacronTopic.prototype.prime = function(body, callback) {
-  var request = _makeRequest(this._getOptions('prime', this.id, 'POST'), function(err, data) {
+  const request = _makeRequest(this._getOptions('prime', this.id, 'POST'), function(err, data) {
     callback(err, data);
   });
   request.write(JSON.stringify(body));
@@ -266,7 +266,7 @@ SimulacronTopic.prototype.clearPrimes = function(callback) {
  * Clears all primes and activity logs associated with this topic.  Also clears data for underlying members.
  */
 SimulacronTopic.prototype.clear = function(callback) {
-  var self = this;
+  const self = this;
   utils.parallel([
     self.clearPrimes.bind(self), 
     self.clearLogs.bind(self)
@@ -277,8 +277,7 @@ SimulacronTopic.prototype.clear = function(callback) {
  * Stops listening for connections and closes existing connections for all associated nodes.
  */
 SimulacronTopic.prototype.stop = function(callback) {
-  var stopNodePath = '/listener/%s?type=stop';
-  var options = {
+  const options = {
     host: this.baseAddress,
     path: encodeURI(util.format(stopNodePath, this.id)),
     port: this.port,
@@ -293,8 +292,8 @@ SimulacronTopic.prototype.stop = function(callback) {
  * Resume listening for connections for all associated nodes.
  */
 SimulacronTopic.prototype.start = function(callback) {
-  var resumeNodePath = '/listener/%s';
-  var options = {
+  const resumeNodePath = '/listener/%s';
+  const options = {
     host: this.baseAddress,
     path: encodeURI(util.format(resumeNodePath, this.id)),
     port: this.port,
@@ -311,7 +310,7 @@ SimulacronTopic.prototype._filterLogs = function(data) {
 };
 
 SimulacronTopic.prototype._getPath = function (endpoint, id) {
-  var path = '/' + endpoint + '/' + id;
+  const path = '/' + endpoint + '/' + id;
   return encodeURI(path);
 };
 
@@ -346,15 +345,15 @@ util.inherits(SimulacronCluster, SimulacronTopic);
  * @param {Function} callback
  */
 SimulacronCluster.prototype.register = function(dcs, options, callback) {
-  var self = this;
-  var createClusterPath = '/cluster?data_centers=%s&cassandra_version=%s&dse_version=%s&name=%s&activity_log=%s&num_tokens=%d';
+  const self = this;
+  const createClusterPath = '/cluster?data_centers=%s&cassandra_version=%s&dse_version=%s&name=%s&activity_log=%s&num_tokens=%d';
 
   options = utils.extend({}, simulacronHelper.baseOptions, options);
 
-  var urlPath = encodeURI(util.format(createClusterPath, dcs, options.cassandraVersion, options.dseVersion,
+  const urlPath = encodeURI(util.format(createClusterPath, dcs, options.cassandraVersion, options.dseVersion,
     options.clusterName, options.activityLog, options.numTokens));
 
-  var requestOptions = {
+  const requestOptions = {
     host: self.baseAddress,
     port: self.port,
     path: urlPath,
@@ -399,7 +398,7 @@ SimulacronCluster.prototype.node = function(key, datacenterIndex) {
   // if the first argument is a string, assume its an address.
   if (typeof key === "string") {
     // iterate over DCs and their nodes looking for first node that matches.
-    for (var dcIndex = 0; dcIndex < this.dcs.length; dcIndex++) {
+    for (let dcIndex = 0; dcIndex < this.dcs.length; dcIndex++) {
       var dc = this.dcs[dcIndex];
       var node = dc.nodes.filter(function (n) {
         return n.address === key;
@@ -450,7 +449,7 @@ function SimulacronDataCenter(cluster, dc) {
   this.data = dc;
   this.localId = dc.id;
   this.id = cluster.id + '/' + dc.id;
-  var self = this;
+  const self = this;
   this.nodes = dc.nodes.map(function(node) {
     return new SimulacronNode(self, node);
   });
@@ -468,7 +467,7 @@ util.inherits(SimulacronDataCenter, SimulacronTopic);
 SimulacronDataCenter.prototype.node = function(id) {
   // if the first argument is a string, assume its an address.
   if (typeof id === "string") {
-    for (var nodeIndex = 0; nodeIndex < this.nodes.length; nodeIndex++) {
+    for (let nodeIndex = 0; nodeIndex < this.nodes.length; nodeIndex++) {
       var n = this.nodes[nodeIndex];
       if (n.address === id) {
         return n;

--- a/test/other/memory/basic-profile.js
+++ b/test/other/memory/basic-profile.js
@@ -1,7 +1,7 @@
 'use strict';
-var assert = require('assert');
-var util = require('util');
-var heapdump;
+const assert = require('assert');
+const util = require('util');
+let heapdump;
 var heapdumpPath = '/var/log/nodejs-driver';
 try {
   // eslint-disable-next-line global-require
@@ -12,14 +12,14 @@ catch (e) {
   console.error('There was an error while trying to import heapdump', e);
 }
 
-var helper = require('../../test-helper.js');
-var cassandra = require('../../../index.js');
-var Client = cassandra.Client;
+const helper = require('../../test-helper.js');
+const cassandra = require('../../../index.js');
+const client = cassandra.Client;
 var types = cassandra.types;
-var utils = require('../../../lib/utils');
+const utils = require('../../../lib/utils');
 
-var client = new Client(utils.extend({ encoding: { copyBuffer: true}}, helper.baseOptions));
-var keyspace = helper.getRandomName('ks');
+const client = new Client(utils.extend({ encoding: { copyBuffer: true}}, helper.baseOptions));
+const keyspace = helper.getRandomName('ks');
 var table = keyspace + '.' + helper.getRandomName('tbl');
 
 if (!global.gc) {
@@ -42,13 +42,13 @@ utils.series([
   },
   function insertData(next) {
     console.log('Starting to insert data...');
-    var query = util.format('INSERT INTO %s (id, int_sample, blob_sample) VALUES (?, ?, ?)', table);
-    var counter = 0;
-    var callbackCounter = 0;
+    const query = util.format('INSERT INTO %s (id, int_sample, blob_sample) VALUES (?, ?, ?)', table);
+    let counter = 0;
+    let callbackCounter = 0;
     global.gc();
     utils.timesLimit(10000, 500, function (v, timesNext) {
       var n = counter++;
-      var buffer = utils.allocBufferFromString(generateAsciiString(1024), 'utf8');
+      const buffer = utils.allocBufferFromString(generateAsciiString(1024), 'utf8');
       client.execute(query, [types.Uuid.random(), n, buffer], {prepare: true}, function (err) {
         if ((callbackCounter++) % 1000 === 0) {
           console.log('Inserted', callbackCounter);
@@ -69,10 +69,10 @@ utils.series([
       return next();
     }
     console.log('Retrieving data...');
-    var query = util.format('SELECT * FROM %s', table);
-    var totalByteLength = 0;
+    const query = util.format('SELECT * FROM %s', table);
+    let totalByteLength = 0;
     global.gc();
-    var rowCount = 0;
+    let rowCount = 0;
     client.eachRow(query, [], {prepare: true, autoPage: true}, function (n, row) {
       //Buffer + int + uuid
       totalByteLength += row['blob_sample'].length + 4 + 16;

--- a/test/other/memory/basic-profile.js
+++ b/test/other/memory/basic-profile.js
@@ -2,7 +2,7 @@
 const assert = require('assert');
 const util = require('util');
 let heapdump;
-var heapdumpPath = '/var/log/nodejs-driver';
+const heapdumpPath = '/var/log/nodejs-driver';
 try {
   // eslint-disable-next-line global-require
   heapdump = require('heapdump');
@@ -14,21 +14,21 @@ catch (e) {
 
 const helper = require('../../test-helper.js');
 const cassandra = require('../../../index.js');
-const client = cassandra.Client;
-var types = cassandra.types;
+const Client = cassandra.Client;
+const types = cassandra.types;
 const utils = require('../../../lib/utils');
 
-const client = new Client(utils.extend({ encoding: { copyBuffer: true}}, helper.baseOptions));
+let client = new Client(utils.extend({ encoding: { copyBuffer: true}}, helper.baseOptions));
 const keyspace = helper.getRandomName('ks');
-var table = keyspace + '.' + helper.getRandomName('tbl');
+const table = keyspace + '.' + helper.getRandomName('tbl');
 
 if (!global.gc) {
   console.log('You must run this test exposing the GC');
   return;
 }
 
-var insertOnly = process.argv.indexOf('--insert-only') > 0;
-var heapUsed = process.memoryUsage().heapUsed;
+const insertOnly = process.argv.indexOf('--insert-only') > 0;
+const heapUsed = process.memoryUsage().heapUsed;
 
 utils.series([
   helper.ccmHelper.removeIfAny,
@@ -47,7 +47,7 @@ utils.series([
     let callbackCounter = 0;
     global.gc();
     utils.timesLimit(10000, 500, function (v, timesNext) {
-      var n = counter++;
+      const n = counter++;
       const buffer = utils.allocBufferFromString(generateAsciiString(1024), 'utf8');
       client.execute(query, [types.Uuid.random(), n, buffer], {prepare: true}, function (err) {
         if ((callbackCounter++) % 1000 === 0) {
@@ -92,7 +92,7 @@ utils.series([
     setImmediate(function () {
       client = null;
       global.gc();
-      var diff = process.memoryUsage().heapUsed - heapUsed;
+      const diff = process.memoryUsage().heapUsed - heapUsed;
       console.log('Heap used difference', formatLength(diff));
       if (heapdump) {
         heapdump.writeSnapshot(heapdumpPath + '/' + Date.now() + '.heapsnapshot');
@@ -108,10 +108,10 @@ function formatLength(value) {
 }
 
 function generateAsciiString(length) {
-  var text = '';
-  var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let text = '';
+  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
-  for( var i=0; i < length; i++ ){
+  for( let i=0; i < length; i++ ){
     text += possible.charAt(Math.floor(Math.random() * possible.length));
   }
   return text;

--- a/test/other/memory/profile-keeping-ref.js
+++ b/test/other/memory/profile-keeping-ref.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const util = require('util');
 let heapdump;
-var heapdumpPath = '/var/log/nodejs-driver';
+const heapdumpPath = '/var/log/nodejs-driver';
 try {
   // eslint-disable-next-line global-require
   heapdump = require('heapdump');
@@ -14,21 +14,21 @@ catch (e) {
 
 const helper = require('../../test-helper.js');
 const cassandra = require('../../../index.js');
-const client = cassandra.Client;
-var types = cassandra.types;
+const Client = cassandra.Client;
+const types = cassandra.types;
 const utils = require('../../../lib/utils');
 
-const client = new Client(utils.extend({ encoding: { copyBuffer: true}}, helper.baseOptions));
+let client = new Client(utils.extend({ encoding: { copyBuffer: true}}, helper.baseOptions));
 const keyspace = helper.getRandomName('ks');
-var table = keyspace + '.' + helper.getRandomName('tbl');
+const table = keyspace + '.' + helper.getRandomName('tbl');
 
 if (!global.gc) {
   console.log('You must run this test exposing the GC');
   return;
 }
 
-var totalLength = 100;
-var heapUsed = process.memoryUsage().heapUsed;
+const totalLength = 100;
+const heapUsed = process.memoryUsage().heapUsed;
 let totalByteLength = 0;
 const values = [];
 
@@ -49,7 +49,7 @@ utils.series([
     let callbackCounter = 0;
     global.gc();
     utils.timesLimit(totalLength, 500, function (v, timesNext) {
-      var n = counter++;
+      const n = counter++;
       const buffer = utils.allocBufferFromString(generateAsciiString(1024));
       client.execute(query, [types.uuid(), n, types.Long.fromNumber(n), buffer], {prepare: 1}, function (err) {
         if ((callbackCounter++) % 1000 === 0) {
@@ -81,7 +81,7 @@ utils.series([
     setImmediate(function () {
       client = null;
       global.gc();
-      var diff = process.memoryUsage().heapUsed - heapUsed;
+      const diff = process.memoryUsage().heapUsed - heapUsed;
       console.log('Byte length %s in %d values', formatLength(totalByteLength), values.length);
       console.log('Heap used difference', formatLength(diff));
       if (heapdump) {
@@ -94,7 +94,7 @@ utils.series([
 });
 
 function formatLength(value) {
-  var kbValues = Math.floor(value / 1024);
+  const kbValues = Math.floor(value / 1024);
   if (kbValues > 1024) {
     return (kbValues / 1024).toFixed(2) + 'MiB';
   }
@@ -102,9 +102,9 @@ function formatLength(value) {
 }
 
 function generateAsciiString(length) {
-  var text = '';
-  var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  for( var i=0; i < length; i++ ){
+  let text = '';
+  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  for( let i=0; i < length; i++ ){
     text += possible.charAt(Math.floor(Math.random() * possible.length));
   }
   return text;

--- a/test/other/memory/profile-keeping-ref.js
+++ b/test/other/memory/profile-keeping-ref.js
@@ -1,8 +1,8 @@
 'use strict';
 /* eslint-disable no-console, no-undef */
-var assert = require('assert');
-var util = require('util');
-var heapdump;
+const assert = require('assert');
+const util = require('util');
+let heapdump;
 var heapdumpPath = '/var/log/nodejs-driver';
 try {
   // eslint-disable-next-line global-require
@@ -12,14 +12,14 @@ catch (e) {
   console.log(e);
 }
 
-var helper = require('../../test-helper.js');
-var cassandra = require('../../../index.js');
-var Client = cassandra.Client;
+const helper = require('../../test-helper.js');
+const cassandra = require('../../../index.js');
+const client = cassandra.Client;
 var types = cassandra.types;
-var utils = require('../../../lib/utils');
+const utils = require('../../../lib/utils');
 
-var client = new Client(utils.extend({ encoding: { copyBuffer: true}}, helper.baseOptions));
-var keyspace = helper.getRandomName('ks');
+const client = new Client(utils.extend({ encoding: { copyBuffer: true}}, helper.baseOptions));
+const keyspace = helper.getRandomName('ks');
 var table = keyspace + '.' + helper.getRandomName('tbl');
 
 if (!global.gc) {
@@ -29,8 +29,8 @@ if (!global.gc) {
 
 var totalLength = 100;
 var heapUsed = process.memoryUsage().heapUsed;
-var totalByteLength = 0;
-var values = [];
+let totalByteLength = 0;
+const values = [];
 
 utils.series([
   helper.ccmHelper.removeIfAny,
@@ -44,13 +44,13 @@ utils.series([
   },
   function insertData(next) {
     console.log('------------Starting to insert data...');
-    var query = util.format('INSERT INTO %s (id, int_sample, bigint_sample, blob_sample) VALUES (?, ?, ?, ?)', table);
-    var counter = 0;
-    var callbackCounter = 0;
+    const query = util.format('INSERT INTO %s (id, int_sample, bigint_sample, blob_sample) VALUES (?, ?, ?, ?)', table);
+    let counter = 0;
+    let callbackCounter = 0;
     global.gc();
     utils.timesLimit(totalLength, 500, function (v, timesNext) {
       var n = counter++;
-      var buffer = utils.allocBufferFromString(generateAsciiString(1024));
+      const buffer = utils.allocBufferFromString(generateAsciiString(1024));
       client.execute(query, [types.uuid(), n, types.Long.fromNumber(n), buffer], {prepare: 1}, function (err) {
         if ((callbackCounter++) % 1000 === 0) {
           console.log('Inserted', callbackCounter);
@@ -64,8 +64,8 @@ utils.series([
   },
   function selectData(next) {
     console.log('------------Retrieving data...');
-    var query = util.format('SELECT id, int_sample, bigint_sample, blob_sample FROM %s', table);
-    //var query = util.format('SELECT blob_sample FROM %s', table);
+    const query = util.format('SELECT id, int_sample, bigint_sample, blob_sample FROM %s', table);
+    //const query = util.format('SELECT blob_sample FROM %s', table);
     global.gc();
     client.eachRow(query, [], {prepare: true, autoPage: true}, function (n, row) {
       //Buffer length + uuid + int + bigint

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -1,15 +1,15 @@
 "use strict";
-var assert = require('assert');
-var util = require('util');
-var path = require('path');
-var policies = require('../lib/policies');
-var types = require('../lib/types');
-var utils = require('../lib/utils.js');
-var spawn = require('child_process').spawn;
-var Client = require('../lib/client');
-var defaultOptions = require('../lib/client-options').defaultOptions;
-var Host = require('../lib/host').Host;
-var OperationState = require('../lib/operation-state');
+const assert = require('assert');
+const util = require('util');
+const path = require('path');
+const policies = require('../lib/policies');
+const types = require('../lib/types');
+const utils = require('../lib/utils.js');
+const spawn = require('child_process').spawn;
+const Client = require('../lib/client');
+const defaultOptions = require('../lib/client-options').defaultOptions;
+const Host = require('../lib/host').Host;
+const OperationState = require('../lib/operation-state');
 
 util.inherits(RetryMultipleTimes, policies.retry.RetryPolicy);
 
@@ -29,8 +29,8 @@ var helper = {
     options = options || utils.emptyObject;
     before(helper.ccmHelper.start(nodeLength || 1, options.ccmOptions));
     var initClient = options.initClient !== false;
-    var client;
-    var keyspace;
+    let client;
+    let keyspace;
     if (initClient) {
       client = new Client(utils.extend({}, options.clientOptions, helper.baseOptions));
       before(client.connect.bind(client));
@@ -147,7 +147,7 @@ var helper = {
      * @param {Function} callback
      */
     bootstrapNode: function (nodeIndex, callback) {
-      var ipPrefix = helper.ipPrefix;
+      const ipPrefix = helper.ipPrefix;
       new Ccm().exec([
         'add',
         'node' + nodeIndex,
@@ -319,7 +319,6 @@ var helper = {
     });
   },
   getCassandraVersion: function() {
-    //noinspection JSUnresolvedVariable
     var version = process.env.TEST_CASSANDRA_VERSION;
     if (!version) {
       version = '3.0.5';
@@ -334,7 +333,7 @@ var helper = {
   isCassandraGreaterThan: function (version) {
     var instanceVersion = this.getCassandraVersion().split('.').map(function (x) { return parseInt(x, 10);});
     var compareVersion = version.split('.').map(function (x) { return parseInt(x, 10) || 0;});
-    for (var i = 0; i < compareVersion.length; i++) {
+    for (let i = 0; i < compareVersion.length; i++) {
       var compare = compareVersion[i] || 0;
       if (instanceVersion[i] > compare) {
         //is greater
@@ -354,7 +353,6 @@ var helper = {
     }
     return (function (l) {
       if (levels.indexOf(l) >= 0) {
-        //noinspection JSUnresolvedVariable
         // eslint-disable-next-line no-console, no-undef
         console.log.apply(console, arguments);
       }
@@ -364,8 +362,8 @@ var helper = {
    * @returns {Array}
    */
   fillArray: function (length, val) {
-    var result = new Array(length);
-    for (var i = 0; i < length; i++) {
+    const result = new Array(length);
+    for (let i = 0; i < length; i++) {
       result[i] = val;
     }
     return result;
@@ -374,7 +372,7 @@ var helper = {
    * @returns {Array}
    */
   iteratorToArray: function (iterator) {
-    var result = [];
+    const result = [];
     var item = iterator.next();
     while (!item.done) {
       result.push(item.value);
@@ -401,8 +399,8 @@ var helper = {
     if (typeof predicate !== 'function') {
       throw new TypeError('predicate must be a function');
     }
-    var value;
-    for (var i = 0; i < arr.length; i++) {
+    let value;
+    for (let i = 0; i < arr.length; i++) {
       value = arr[i];
       if (predicate.call(null, value, i, arr)) {
         return value;
@@ -426,7 +424,7 @@ var helper = {
    * @param {Object} obj
    */
   values : function (obj) {
-    var vals = [];
+    const vals = [];
     for (var key in obj) {
       if (!obj.hasOwnProperty(key)) {
         continue;
@@ -495,7 +493,7 @@ var helper = {
    */
   findHost: function(client, number) {
     var host = undefined;
-    var self = this;
+    const self = this;
     client.hosts.forEach(function(h) {
       if(self.lastOctetOf(h) === number.toString()) {
         host = h;
@@ -511,7 +509,7 @@ var helper = {
    * @param {Number} number last octet of requested host.
    */
   waitOnHostUp: function(client, number) {
-    var self = this;
+    const self = this;
     var hostIsUp = function() {
       var host = self.findHost(client, number);
       return host === undefined ? false : host.isUp();
@@ -527,7 +525,7 @@ var helper = {
    * @param {Number} number last octet of requested host.
    */
   waitOnHostDown: function(client, number) {
-    var self = this;
+    const self = this;
     var hostIsDown = function() {
       var host = self.findHost(client, number);
       return host === undefined ? false : !host.isUp();
@@ -543,7 +541,7 @@ var helper = {
    * @param {Number} number last octet of requested host.
    */
   waitOnHostGone: function(client, number) {
-    var self = this;
+    const self = this;
     var hostIsGone = function() {
       var host = self.findHost(client, number);
       return host === undefined;
@@ -592,7 +590,7 @@ var helper = {
    * @param {Function} done
    */
   setIntervalUntil: function (condition, delay, maxAttempts, done) {
-    var attempts = 0;
+    let attempts = 0;
     utils.whilst(
       function whilstCondition() {
         return !condition();
@@ -614,7 +612,7 @@ var helper = {
    * @param {Number} maxAttempts
    */
   setIntervalUntilTask: function (condition, delay, maxAttempts) {
-    var self = this;
+    const self = this;
     return (function setIntervalUntilHandler(done) {
       self.setIntervalUntil(condition, delay, maxAttempts, done);
     });
@@ -740,9 +738,9 @@ function Ccm() {
  * @param {Function} callback
  */
 Ccm.prototype.startAll = function (nodeLength, options, callback) {
-  var self = this;
+  const self = this;
   options = options || {};
-  var version = helper.getCassandraVersion();
+  const version = helper.getCassandraVersion();
   helper.trace('Starting test C* cluster v%s with %s node(s)', version, nodeLength);
   utils.series([
     function (next) {
@@ -772,7 +770,7 @@ Ccm.prototype.startAll = function (nodeLength, options, callback) {
         return next();
       }
       helper.trace('With conf', options.yaml);
-      var i = 0;
+      let i = 0;
       utils.whilst(
         function condition() {
           return i < options.yaml.length;
@@ -801,7 +799,7 @@ Ccm.prototype.startAll = function (nodeLength, options, callback) {
       if (util.isArray(options.jvmArgs)) {
         options.jvmArgs.forEach(function (arg) {
           // Windows requires jvm arguments to be quoted, while *nix requires unquoted.
-          var jvmArg = helper.isWin() ? '"' + arg + '"' : arg;
+          const jvmArg = helper.isWin() ? '"' + arg + '"' : arg;
           start.push('--jvm_arg', jvmArg);
         }, this);
         helper.trace('With jvm args', options.jvmArgs);
@@ -831,7 +829,7 @@ Ccm.prototype.spawn = function (processName, params, callback) {
   var p = spawn(processName, params);
   var stdoutArray= [];
   var stderrArray= [];
-  var closing = 0;
+  let closing = 0;
   p.stdout.setEncoding('utf8');
   p.stderr.setEncoding('utf8');
   p.stdout.on('data', function (data) {
@@ -848,7 +846,7 @@ Ccm.prototype.spawn = function (processName, params, callback) {
       return;
     }
     var info = {code: code, stdout: stdoutArray, stderr: stderrArray};
-    var err = null;
+    let err = null;
     if (code !== 0) {
       err = new Error(
         'Error executing ' + originalProcessName + ':\n' +
@@ -870,9 +868,9 @@ Ccm.prototype.remove = function (callback) {
  * @param callback
  */
 Ccm.prototype.waitForUp = function (callback) {
-  var started = false;
-  var retryCount = 0;
-  var self = this;
+  let started = false;
+  let retryCount = 0;
+  const self = this;
   utils.whilst(function () {
     return !started && retryCount < 10;
   }, function iterator (next) {
@@ -880,7 +878,7 @@ Ccm.prototype.waitForUp = function (callback) {
       if (err) {
         return next(err);
       }
-      var regex = /Starting listening for CQL clients/mi;
+      const regex = /Starting listening for CQL clients/mi;
       started = regex.test(info.stdout.join(''));
       retryCount++;
       if (!started) {
@@ -911,7 +909,7 @@ Ccm.prototype.getPath = function (subPath) {
  */
 function MapPolyFill(arr) {
   this.arr = arr || [];
-  var self = this;
+  const self = this;
   Object.defineProperty(this, 'size', {
     get: function() { return self.arr.length; },
     configurable: false
@@ -1009,7 +1007,6 @@ WhiteListPolicy.prototype.newQueryPlan = function (keyspace, queryOptions, callb
       next: function () {
         var item = iterator.next();
         while (!item.done) {
-          //noinspection JSCheckFunctionSignatures
           if (list.indexOf(helper.lastOctetOf(item.value)) >= 0) {
             break;
           }

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -13,7 +13,7 @@ const OperationState = require('../lib/operation-state');
 
 util.inherits(RetryMultipleTimes, policies.retry.RetryPolicy);
 
-var helper = {
+const helper = {
   /**
    * Creates a ccm cluster, initializes a Client instance the before() and after() hooks, create
    * @param {Number} nodeLength
@@ -28,7 +28,7 @@ var helper = {
   setup: function (nodeLength, options) {
     options = options || utils.emptyObject;
     before(helper.ccmHelper.start(nodeLength || 1, options.ccmOptions));
-    var initClient = options.initClient !== false;
+    const initClient = options.initClient !== false;
     let client;
     let keyspace;
     if (initClient) {
@@ -73,8 +73,8 @@ var helper = {
    * Uses the last parameter as callback, invokes it via setImmediate
    */
   callbackNoop: function () {
-    var args = Array.prototype.slice.call(arguments);
-    var cb = args[args.length-1];
+    const args = Array.prototype.slice.call(arguments);
+    const cb = args[args.length-1];
     if (typeof cb !== 'function') {
       throw new Error('Helper method needs a callback as last parameter');
     }
@@ -108,7 +108,7 @@ var helper = {
     if (!prefix) {
       prefix = 'ab';
     }
-    var value = Math.floor(Math.random() * utils.maxInt);
+    const value = Math.floor(Math.random() * utils.maxInt);
     return prefix + ('000000000000000' + value.toString()).slice(-16);
   },
   ipPrefix: '127.0.0.',
@@ -163,7 +163,7 @@ var helper = {
      * @param {Function} callback
      */
     startNode: function (nodeIndex, callback) {
-      var args = ['node' + nodeIndex, 'start', '--wait-other-notice', '--wait-for-binary-proto'];
+      const args = ['node' + nodeIndex, 'start', '--wait-other-notice', '--wait-for-binary-proto'];
       if (helper.isWin() && helper.isCassandraGreaterThan('2.2.4')) {
         args.push('--quiet-windows');
       }
@@ -270,7 +270,7 @@ var helper = {
   },
   assertContains: function (value, searchValue, caseInsensitive) {
     assert.strictEqual(typeof value, 'string');
-    var message = 'String: "%s" does not contain "%s"';
+    const message = 'String: "%s" does not contain "%s"';
     if (caseInsensitive !== false) {
       value = value.toLowerCase();
       searchValue = searchValue.toLowerCase();
@@ -301,7 +301,7 @@ var helper = {
    * @returns {Function} A function with a single callback param, applying the fn with parameters
    */
   toTask: function (fn, context) {
-    var params = Array.prototype.slice.call(arguments, 2);
+    const params = Array.prototype.slice.call(arguments, 2);
     return (function (next) {
       params.push(next);
       fn.apply(context, params);
@@ -319,7 +319,7 @@ var helper = {
     });
   },
   getCassandraVersion: function() {
-    var version = process.env.TEST_CASSANDRA_VERSION;
+    let version = process.env.TEST_CASSANDRA_VERSION;
     if (!version) {
       version = '3.0.5';
     }
@@ -331,10 +331,10 @@ var helper = {
    * @returns {Boolean}
    */
   isCassandraGreaterThan: function (version) {
-    var instanceVersion = this.getCassandraVersion().split('.').map(function (x) { return parseInt(x, 10);});
-    var compareVersion = version.split('.').map(function (x) { return parseInt(x, 10) || 0;});
+    const instanceVersion = this.getCassandraVersion().split('.').map(function (x) { return parseInt(x, 10);});
+    const compareVersion = version.split('.').map(function (x) { return parseInt(x, 10) || 0;});
     for (let i = 0; i < compareVersion.length; i++) {
-      var compare = compareVersion[i] || 0;
+      const compare = compareVersion[i] || 0;
       if (instanceVersion[i] > compare) {
         //is greater
         return true;
@@ -373,7 +373,7 @@ var helper = {
    */
   iteratorToArray: function (iterator) {
     const result = [];
-    var item = iterator.next();
+    let item = iterator.next();
     while (!item.done) {
       result.push(item.value);
       item = iterator.next();
@@ -391,7 +391,7 @@ var helper = {
       throw new TypeError('Array.prototype.find called on null or undefined');
     }
     if (typeof predicate === 'string') {
-      var propName = predicate;
+      const propName = predicate;
       predicate = function (item) {
         return (item && item[propName] === val);
       };
@@ -413,7 +413,7 @@ var helper = {
    * @param {Function }predicate
    */
   first: function (arr, predicate) {
-    var filterArr = arr.filter(predicate);
+    const filterArr = arr.filter(predicate);
     if (filterArr.length === 0) {
       throw new Error('Item not found: ' + predicate);
     }
@@ -425,7 +425,7 @@ var helper = {
    */
   values : function (obj) {
     const vals = [];
-    for (var key in obj) {
+    for (const key in obj) {
       if (!obj.hasOwnProperty(key)) {
         continue;
       }
@@ -479,8 +479,8 @@ var helper = {
    * @returns {string} Last octet of the host address.
    */
   lastOctetOf: function(host) {
-    var address = typeof host === "string" ? host : host.address;
-    var ipAddress = address.split(':')[0].split('.');
+    const address = typeof host === "string" ? host : host.address;
+    const ipAddress = address.split(':')[0].split('.');
     return ipAddress[ipAddress.length-1];
   },
 
@@ -492,7 +492,7 @@ var helper = {
    * @returns {Host}
    */
   findHost: function(client, number) {
-    var host = undefined;
+    let host = undefined;
     const self = this;
     client.hosts.forEach(function(h) {
       if(self.lastOctetOf(h) === number.toString()) {
@@ -510,8 +510,8 @@ var helper = {
    */
   waitOnHostUp: function(client, number) {
     const self = this;
-    var hostIsUp = function() {
-      var host = self.findHost(client, number);
+    const hostIsUp = function() {
+      const host = self.findHost(client, number);
       return host === undefined ? false : host.isUp();
     };
 
@@ -526,8 +526,8 @@ var helper = {
    */
   waitOnHostDown: function(client, number) {
     const self = this;
-    var hostIsDown = function() {
-      var host = self.findHost(client, number);
+    const hostIsDown = function() {
+      const host = self.findHost(client, number);
       return host === undefined ? false : !host.isUp();
     };
 
@@ -542,8 +542,8 @@ var helper = {
    */
   waitOnHostGone: function(client, number) {
     const self = this;
-    var hostIsGone = function() {
-      var host = self.findHost(client, number);
+    const hostIsGone = function() {
+      const host = self.findHost(client, number);
       return host === undefined;
     };
 
@@ -640,7 +640,7 @@ var helper = {
     if (except) {
       props = props.slice(0);
       except.forEach(function (p) {
-        var index = props.indexOf(p);
+        const index = props.indexOf(p);
         if (index >= 0) {
           props.splice(index, 1);
         }
@@ -651,7 +651,7 @@ var helper = {
     });
   },
   getPoolingOptions: function (localLength, remoteLength, heartBeatInterval) {
-    var pooling = {
+    const pooling = {
       heartBeatInterval: heartBeatInterval || 0,
       coreConnectionsPerHost: {}
     };
@@ -662,7 +662,7 @@ var helper = {
   },
   getHostsMock: function (hostsInfo, prepareQueryCb, sendStreamCb) {
     return hostsInfo.map(function (info, index) {
-      var h = new Host(index.toString(), types.protocolVersion.maxSupported, defaultOptions(), {});
+      const h = new Host(index.toString(), types.protocolVersion.maxSupported, defaultOptions(), {});
       h.isUp = function () {
         return !(info.isUp === false);
       };
@@ -689,7 +689,7 @@ var helper = {
             if (sendStreamCb) {
               return sendStreamCb(r, h, cb);
             }
-            var op = new OperationState(r, o, cb);
+            const op = new OperationState(r, o, cb);
             setImmediate(function () {
               op.setResult(null, {});
             });
@@ -705,7 +705,7 @@ var helper = {
     });
   },
   getLoadBalancingPolicyFake: function getLoadBalancingPolicyFake(hostsInfo, prepareQueryCb, sendStreamCb) {
-    var hosts = this.getHostsMock(hostsInfo, prepareQueryCb, sendStreamCb);
+    const hosts = this.getHostsMock(hostsInfo, prepareQueryCb, sendStreamCb);
     return ({
       newQueryPlan: function (q, ks, cb) {
         cb(null, utils.arrayIterator(hosts));
@@ -751,7 +751,7 @@ Ccm.prototype.startAll = function (nodeLength, options, callback) {
       });
     },
     function (next) {
-      var create = ['create', 'test', '-v', version];
+      let create = ['create', 'test', '-v', version];
       if (process.env.TEST_CASSANDRA_DIR) {
         create = ['create', 'test', '--install-dir=' + process.env.TEST_CASSANDRA_DIR];
         helper.trace('With', create[2]);
@@ -782,7 +782,7 @@ Ccm.prototype.startAll = function (nodeLength, options, callback) {
       );
     },
     function (next) {
-      var populate = ['populate', '-n', nodeLength.toString()];
+      const populate = ['populate', '-n', nodeLength.toString()];
       if (options.vnodes) {
         populate.push('--vnodes');
       }
@@ -792,7 +792,7 @@ Ccm.prototype.startAll = function (nodeLength, options, callback) {
       self.exec(populate, helper.wait(options.sleep, next));
     },
     function (next) {
-      var start = ['start', '--wait-for-binary-proto'];
+      const start = ['start', '--wait-for-binary-proto'];
       if (helper.isWin() && helper.isCassandraGreaterThan('2.2.4')) {
         start.push('--quiet-windows');
       }
@@ -821,14 +821,14 @@ Ccm.prototype.spawn = function (processName, params, callback) {
     callback = function () {};
   }
   params = params || [];
-  var originalProcessName = processName;
+  const originalProcessName = processName;
   if (helper.isWin()) {
     params = ['-ExecutionPolicy', 'Unrestricted', processName].concat(params);
     processName = 'powershell.exe';
   }
-  var p = spawn(processName, params);
-  var stdoutArray= [];
-  var stderrArray= [];
+  const p = spawn(processName, params);
+  const stdoutArray= [];
+  const stderrArray= [];
   let closing = 0;
   p.stdout.setEncoding('utf8');
   p.stderr.setEncoding('utf8');
@@ -845,7 +845,7 @@ Ccm.prototype.spawn = function (processName, params, callback) {
       //avoid calling multiple times
       return;
     }
-    var info = {code: code, stdout: stdoutArray, stderr: stderrArray};
+    const info = {code: code, stdout: stdoutArray, stderr: stderrArray};
     let err = null;
     if (code !== 0) {
       err = new Error(
@@ -895,7 +895,7 @@ Ccm.prototype.waitForUp = function (callback) {
  * @param subPath
  */
 Ccm.prototype.getPath = function (subPath) {
-  var ccmPath = process.env.CCM_PATH;
+  let ccmPath = process.env.CCM_PATH;
   if (!ccmPath) {
     ccmPath = (process.platform === 'win32') ? process.env.HOMEPATH : process.env.HOME;
     ccmPath = path.join(ccmPath, 'workspace/tools/ccm');
@@ -1001,11 +1001,11 @@ WhiteListPolicy.prototype.init = function (client, hosts, callback) {
 };
 
 WhiteListPolicy.prototype.newQueryPlan = function (keyspace, queryOptions, callback) {
-  var list = this.list;
+  const list = this.list;
   this.childPolicy.newQueryPlan(keyspace, queryOptions, function (err, iterator) {
     callback(err, {
       next: function () {
-        var item = iterator.next();
+        let item = iterator.next();
         while (!item.done) {
           if (list.indexOf(helper.lastOctetOf(item.value)) >= 0) {
             break;

--- a/test/unit/address-resolution-tests.js
+++ b/test/unit/address-resolution-tests.js
@@ -1,22 +1,22 @@
 'use strict';
-var assert = require('assert');
-var dns = require('dns');
+const assert = require('assert');
+const dns = require('dns');
 
-var addressResolution = require('../../lib/policies/address-resolution');
-var EC2MultiRegionTranslator = addressResolution.EC2MultiRegionTranslator;
+const addressResolution = require('../../lib/policies/address-resolution');
+const EC2MultiRegionTranslator = addressResolution.EC2MultiRegionTranslator;
 
 describe('EC2MultiRegionTranslator', function () {
   this.timeout(10000);
   describe('#translate()', function () {
     it('should return the same address when it could not be resolved', function (done) {
-      var t = new EC2MultiRegionTranslator();
+      const t = new EC2MultiRegionTranslator();
       t.translate('127.100.100.1', 9042, function (endPoint) {
         assert.strictEqual(endPoint, '127.100.100.1:9042');
         done();
       });
     });
     it('should do a reverse and a forward dns lookup', function (done) {
-      var t = new EC2MultiRegionTranslator();
+      const t = new EC2MultiRegionTranslator();
       dns.lookup('datastax.com', function (err, address) {
         assert.ifError(err);
         assert.ok(address);

--- a/test/unit/basic-tests.js
+++ b/test/unit/basic-tests.js
@@ -63,7 +63,7 @@ describe('types', function () {
   describe('Integer', function () {
     const Integer = types.Integer;
     /* eslint-disable no-multi-spaces */
-    var values = [
+    const values = [
       //hex value                      |      string varint
       ['02000001',                            '33554433'],
       ['02000000',                            '33554432'],
@@ -93,7 +93,7 @@ describe('types', function () {
     it('should create from buffer', function () {
       values.forEach(function (item) {
         const buffer = utils.allocBufferFromString(item[0], 'hex');
-        var value = Integer.fromBuffer(buffer);
+        const value = Integer.fromBuffer(buffer);
         assert.strictEqual(value.toString(), item[1]);
       });
     });
@@ -108,7 +108,7 @@ describe('types', function () {
     const Tuple = types.Tuple;
     describe('#get()', function () {
       it('should return the element at position', function () {
-        var t = new Tuple('first', 'second');
+        const t = new Tuple('first', 'second');
         assert.strictEqual(t.get(0), 'first');
         assert.strictEqual(t.get(1), 'second');
         assert.strictEqual(t.get(2), undefined);
@@ -119,7 +119,7 @@ describe('types', function () {
       it('should return the string of the elements surrounded by parenthesis', function () {
         const id = types.Uuid.random();
         const decimal = types.BigDecimal.fromString('1.2');
-        var t = new Tuple(id, decimal, 0);
+        const t = new Tuple(id, decimal, 0);
         assert.strictEqual(t.toString(), '(' + id.toString() + ',' + decimal.toString() + ',0)');
       });
     });
@@ -127,15 +127,15 @@ describe('types', function () {
       it('should return the string of the elements surrounded by square brackets', function () {
         const id = types.TimeUuid.now();
         const decimal = types.BigDecimal.fromString('-1');
-        var t = new Tuple(id, decimal, 1, {z: 1});
+        const t = new Tuple(id, decimal, 1, {z: 1});
         assert.strictEqual(JSON.stringify(t), '["' + id.toString() + '","' + decimal.toString() + '",1,{"z":1}]');
       });
     });
     describe('#values()', function () {
       it('should return the Array representation of the Tuple', function () {
-        var t = new Tuple('first2', 'second2', 'third2');
+        const t = new Tuple('first2', 'second2', 'third2');
         assert.strictEqual(t.length, 3);
-        var values = t.values();
+        const values = t.values();
         assert.ok(util.isArray(values));
         assert.strictEqual(values.length, 3);
         assert.strictEqual(values[0], 'first2');
@@ -143,8 +143,8 @@ describe('types', function () {
         assert.strictEqual(values[2], 'third2');
       });
       it('when modifying the returned Array the Tuple should not change its values', function () {
-        var t = new Tuple('first3', 'second3', 'third3');
-        var values = t.values();
+        const t = new Tuple('first3', 'second3', 'third3');
+        const values = t.values();
         assert.strictEqual(values.length, 3);
         values[0] = 'whatever';
         values.shift();
@@ -179,9 +179,9 @@ describe('types', function () {
     });
     describe('#fromBuffer() and #toBuffer()', function () {
       it('should encode and decode a LocalDate', function () {
-        var value = new LocalDate(2010, 8, 5);
-        var encoded = value.toBuffer();
-        var decoded = LocalDate.fromBuffer(encoded);
+        const value = new LocalDate(2010, 8, 5);
+        const encoded = value.toBuffer();
+        const decoded = LocalDate.fromBuffer(encoded);
         assert.strictEqual(decoded.toString(), value.toString());
         assert.ok(decoded.equals(value));
         assert.ok(value.equals(decoded));
@@ -200,7 +200,7 @@ describe('types', function () {
           ['-1201-04-03', -1201, 4, 3],
           ['0-1-1', 0, 1, 1]
         ].forEach(function (item) {
-          var value = LocalDate.fromString(item[0]);
+          const value = LocalDate.fromString(item[0]);
           assert.strictEqual(value.year, item[1]);
           assert.strictEqual(value.month, item[2]);
           assert.strictEqual(value.day, item[3]);
@@ -214,7 +214,7 @@ describe('types', function () {
           ['-2147483648', '-2147483648'],
           ['-719162', '0001-01-01']
         ].forEach(function (item) {
-          var value = LocalDate.fromString(item[0]);
+          const value = LocalDate.fromString(item[0]);
           assert.strictEqual(value.toString(), item[1]);
         });
       });
@@ -238,7 +238,7 @@ describe('types', function () {
     const LocalTime = types.LocalTime;
     const Long = types.Long;
     /* eslint-disable no-multi-spaces */
-    var values = [
+    const values = [
       //Long value         |     string representation  |   hour/min/sec/nanos
       ['1000000001',             '00:00:01.000000001',      [0, 0, 1, 1]],
       ['0',                      '00:00:00',                [0, 0, 0, 0]],
@@ -262,7 +262,7 @@ describe('types', function () {
     describe('#toString()', function () {
       it('should return the string representation', function () {
         values.forEach(function (item) {
-          var val = new LocalTime(Long.fromString(item[0]));
+          const val = new LocalTime(Long.fromString(item[0]));
           assert.strictEqual(val.toString(), item[1]);
         });
       });
@@ -270,7 +270,7 @@ describe('types', function () {
     describe('#toJSON()', function () {
       it('should return the string representation', function () {
         values.forEach(function (item) {
-          var val = new LocalTime(Long.fromString(item[0]));
+          const val = new LocalTime(Long.fromString(item[0]));
           assert.strictEqual(val.toString(), item[1]);
         });
       });
@@ -278,7 +278,7 @@ describe('types', function () {
     describe('#fromString()', function () {
       it('should parse the string representation', function () {
         values.forEach(function (item) {
-          var val = LocalTime.fromString(item[1]);
+          const val = LocalTime.fromString(item[1]);
           assert.ok(new LocalTime(Long.fromString(item[0])).equals(val));
           assert.ok(new LocalTime(Long.fromString(item[0]))
             .getTotalNanoseconds()
@@ -288,9 +288,9 @@ describe('types', function () {
     });
     describe('#toBuffer() and fromBuffer()', function () {
       values.forEach(function (item) {
-        var val = new LocalTime(Long.fromString(item[0]));
-        var encoded = val.toBuffer();
-        var decoded = LocalTime.fromBuffer(encoded);
+        const val = new LocalTime(Long.fromString(item[0]));
+        const encoded = val.toBuffer();
+        const decoded = LocalTime.fromBuffer(encoded);
         assert.ok(decoded.equals(val));
         assert.strictEqual(val.toString(), decoded.toString());
       });
@@ -298,8 +298,8 @@ describe('types', function () {
     describe('#hour #minute #second #nanosecond', function () {
       it('should get the correct parts', function () {
         values.forEach(function (item) {
-          var val = new LocalTime(Long.fromString(item[0]));
-          var parts = item[2];
+          const val = new LocalTime(Long.fromString(item[0]));
+          const parts = item[2];
           assert.strictEqual(val.hour, parts[0]);
           assert.strictEqual(val.minute, parts[1]);
           assert.strictEqual(val.second, parts[2]);
@@ -309,8 +309,8 @@ describe('types', function () {
     });
     describe('fromDate()', function () {
       it('should use the local time', function () {
-        var date = new Date();
-        var time = LocalTime.fromDate(date, 1);
+        const date = new Date();
+        const time = LocalTime.fromDate(date, 1);
         assert.strictEqual(time.hour, date.getHours());
         assert.strictEqual(time.minute, date.getMinutes());
         assert.strictEqual(time.second, date.getSeconds());
@@ -319,7 +319,7 @@ describe('types', function () {
     });
     describe('fromMilliseconds', function () {
       it('should default nanoseconds to 0 when not provided', function () {
-        var time = LocalTime.fromMilliseconds(1);
+        const time = LocalTime.fromMilliseconds(1);
         assert.ok(time.equals(LocalTime.fromMilliseconds(1, 0)));
       });
     });
@@ -327,7 +327,7 @@ describe('types', function () {
   describe('ResultStream', function () {
     it('should be readable as soon as it has data', function (done) {
       const buf = [];
-      var stream = new types.ResultStream();
+      const stream = new types.ResultStream();
       
       stream.on('end', function streamEnd() {
         assert.equal(Buffer.concat(buf).toString(), 'Jimmy McNulty');
@@ -347,7 +347,7 @@ describe('types', function () {
 
     it('should buffer until is read', function (done) {
       const buf = [];
-      var stream = new types.ResultStream();
+      const stream = new types.ResultStream();
       stream.add(utils.allocBufferFromString('Stringer'));
       stream.add(utils.allocBufferFromString(' '));
       stream.add(utils.allocBufferFromString('Bell'));
@@ -367,7 +367,7 @@ describe('types', function () {
 
     it('should be readable until the end', function (done) {
       const buf = [];
-      var stream = new types.ResultStream();
+      const stream = new types.ResultStream();
       stream.add(utils.allocBufferFromString('Omar'));
       stream.add(utils.allocBufferFromString(' '));
 
@@ -388,7 +388,7 @@ describe('types', function () {
 
     it('should be readable on objectMode', function (done) {
       const buf = [];
-      var stream = new types.ResultStream({objectMode: true});
+      const stream = new types.ResultStream({objectMode: true});
       //passing objects
       stream.add({toString: function (){return 'One';}});
       stream.add({toString: function (){return 'Two';}});
@@ -407,8 +407,8 @@ describe('types', function () {
   });
   describe('Row', function () {
     it('should get the value by column name or index', function () {
-      var columns = [{name: 'first', type: { code: dataTypes.varchar}}, {name: 'second', type: { code: dataTypes.varchar}}];
-      var row = new types.Row(columns);
+      const columns = [{name: 'first', type: { code: dataTypes.varchar}}, {name: 'second', type: { code: dataTypes.varchar}}];
+      const row = new types.Row(columns);
       row['first'] = 'hello';
       row['second'] = 'world';
       assert.ok(row.get, 'It should contain a get method');
@@ -419,16 +419,16 @@ describe('types', function () {
       assert.strictEqual(row.get(1), row['second']);
     });
     it('should enumerate only columns defined', function () {
-      var columns = [{name: 'col1', type: { code: dataTypes.varchar}}, {name: 'col2', type: { code: dataTypes.varchar}}];
-      var row = new types.Row(columns);
+      const columns = [{name: 'col1', type: { code: dataTypes.varchar}}, {name: 'col2', type: { code: dataTypes.varchar}}];
+      const row = new types.Row(columns);
       row['col1'] = 'val1';
       row['col2'] = 'val2';
       assert.strictEqual(JSON.stringify(row), JSON.stringify({col1: 'val1', col2: 'val2'}));
     });
     it('should be serializable to json', function () {
       let i;
-      var columns = [{name: 'col1', type: { code: dataTypes.varchar}}, {name: 'col2', type: { code: dataTypes.varchar}}];
-      var row = new types.Row(columns, [utils.allocBufferFromString('val1'), utils.allocBufferFromString('val2')]);
+      let columns = [{name: 'col1', type: { code: dataTypes.varchar}}, {name: 'col2', type: { code: dataTypes.varchar}}];
+      let row = new types.Row(columns, [utils.allocBufferFromString('val1'), utils.allocBufferFromString('val2')]);
       row['col1'] = 'val1';
       row['col2'] = 'val2';
       assert.strictEqual(JSON.stringify(row), JSON.stringify({col1: 'val1', col2: 'val2'}));
@@ -439,7 +439,7 @@ describe('types', function () {
         {name: 'clong', type: { code: dataTypes.bigint}},
         {name: 'cvarint', type: { code: dataTypes.varint}}
       ];
-      var rowValues = [
+      let rowValues = [
         types.Uuid.random(),
         types.TimeUuid.now(),
         types.Long.fromNumber(1000),
@@ -469,8 +469,8 @@ describe('types', function () {
       assert.strictEqual(JSON.stringify(row), expected);
     });
     it('should have values that can be inspected', function () {
-      var columns = [{name: 'col10', type: { code: dataTypes.varchar}}, {name: 'col2', type: { code: dataTypes.int}}];
-      var row = new types.Row(columns);
+      const columns = [{name: 'col10', type: { code: dataTypes.varchar}}, {name: 'col2', type: { code: dataTypes.int}}];
+      const row = new types.Row(columns);
       row['col10'] = 'val1';
       row['col2'] = 2;
       helper.assertContains(util.inspect(row), util.inspect({col10: 'val1', col2: 2}));
@@ -486,7 +486,7 @@ describe('types', function () {
       assert.notEqual(val, types.uuid());
     });
     it('should fill in the values in a buffer', function () {
-      var buf = utils.allocBufferUnsafe(16);
+      const buf = utils.allocBufferUnsafe(16);
       const val = types.uuid(null, buf);
       assert.strictEqual(val, buf);
     });
@@ -501,7 +501,7 @@ describe('types', function () {
       assert.notEqual(val, types.timeuuid());
     });
     it('should fill in the values in a buffer', function () {
-      var buf = utils.allocBufferUnsafe(16);
+      const buf = utils.allocBufferUnsafe(16);
       const val = types.timeuuid(null, buf);
       assert.strictEqual(val, buf);
     });
@@ -538,7 +538,7 @@ describe('utils', function () {
   });
   describe('#funcCompare()', function () {
     it('should return a compare function valid for Array#sort', function () {
-      var values = [
+      const values = [
         {id: 1, getValue : function () { return 100;}},
         {id: 2, getValue : function () { return 3;}},
         {id: 3, getValue : function () { return 1;}}
@@ -551,7 +551,7 @@ describe('utils', function () {
   });
   describe('#binarySearch()', function () {
     it('should return the key index if found, or the bitwise compliment of the first larger value', function () {
-      var compareFunc = function (a, b) {
+      const compareFunc = function (a, b) {
         if (a > b) {
           return 1;
         }
@@ -607,7 +607,7 @@ describe('utils', function () {
       value = utils.deepExtend({z: 3}, null);
       assert.strictEqual(value.z, 3);
       //undefined
-      var o = undefined;
+      const o = undefined;
       value = utils.deepExtend({z: 4}, o);
       assert.strictEqual(value.z, 4);
     });
@@ -647,8 +647,8 @@ describe('clientOptions', function () {
       assert.notStrictEqual(options, clientOptions.defaultOptions());
     });
     it('should validate the policies', function () {
-      var policy1 = new loadBalancing.RoundRobinPolicy();
-      var policy2 = new retry.RetryPolicy();
+      const policy1 = new loadBalancing.RoundRobinPolicy();
+      const policy2 = new retry.RetryPolicy();
       const options = clientOptions.extend({
         contactPoints: ['host1'],
         policies: {
@@ -746,7 +746,7 @@ describe('writers', function () {
     it('should buffer until threshold is passed', function (done) {
       let itemCallbackCounter = 0;
       const buffers = [];
-      var socketMock = {
+      const socketMock = {
         write: function (buf, cb) {
           buffers.push(buf);
           setTimeout(cb, 50);
@@ -755,8 +755,8 @@ describe('writers', function () {
       const options = utils.extend({}, clientOptions.defaultOptions());
       options.socketOptions.coalescingThreshold = 50;
       const encoder = new Encoder(3, options);
-      var queue = new writers.WriteQueue(socketMock, encoder, options);
-      var request = {
+      const queue = new writers.WriteQueue(socketMock, encoder, options);
+      const request = {
         write: function () {
           return utils.allocBufferUnsafe(10);
         }

--- a/test/unit/basic-tests.js
+++ b/test/unit/basic-tests.js
@@ -1,24 +1,24 @@
 "use strict";
-var assert = require('assert');
-var util = require('util');
+const assert = require('assert');
+const util = require('util');
 
-var Client = require('../../lib/client.js');
-var clientOptions = require('../../lib/client-options.js');
-var types = require('../../lib/types');
-var dataTypes = types.dataTypes;
-var loadBalancing = require('../../lib/policies/load-balancing.js');
-var retry = require('../../lib/policies/retry.js');
-var speculativeExecution = require('../../lib/policies/speculative-execution');
-var timestampGeneration = require('../../lib/policies/timestamp-generation');
-var Encoder = require('../../lib/encoder');
-var utils = require('../../lib/utils.js');
-var writers = require('../../lib/writers');
-var OperationState = require('../../lib/operation-state');
-var helper = require('../test-helper.js');
+const Client = require('../../lib/client.js');
+const clientOptions = require('../../lib/client-options.js');
+const types = require('../../lib/types');
+const dataTypes = types.dataTypes;
+const loadBalancing = require('../../lib/policies/load-balancing.js');
+const retry = require('../../lib/policies/retry.js');
+const speculativeExecution = require('../../lib/policies/speculative-execution');
+const timestampGeneration = require('../../lib/policies/timestamp-generation');
+const Encoder = require('../../lib/encoder');
+const utils = require('../../lib/utils.js');
+const writers = require('../../lib/writers');
+const OperationState = require('../../lib/operation-state');
+const helper = require('../test-helper.js');
 
 describe('types', function () {
   describe('Long', function () {
-    var Long = types.Long;
+    const Long = types.Long;
     it('should convert from and to Buffer', function () {
       /* eslint-disable no-multi-spaces */
       [
@@ -35,8 +35,8 @@ describe('types', function () {
         ['789456'            ,  '00000000000c0bd0'],
         ['888888888888888888',  '0c55f7bc23038e38']
       ].forEach(function (item) {
-        var buffer = utils.allocBufferFromString(item[1], 'hex');
-        var value = Long.fromBuffer(buffer);
+        const buffer = utils.allocBufferFromString(item[1], 'hex');
+        const value = Long.fromBuffer(buffer);
         assert.strictEqual(value.toString(), item[0]);
         assert.strictEqual(Long.toBuffer(value).toString('hex'), buffer.toString('hex'),
           'Hexadecimal values should match for ' + item[1]);
@@ -61,7 +61,7 @@ describe('types', function () {
     });
   });
   describe('Integer', function () {
-    var Integer = types.Integer;
+    const Integer = types.Integer;
     /* eslint-disable no-multi-spaces */
     var values = [
       //hex value                      |      string varint
@@ -92,20 +92,20 @@ describe('types', function () {
     /* eslint-enable no-multi-spaces */
     it('should create from buffer', function () {
       values.forEach(function (item) {
-        var buffer = utils.allocBufferFromString(item[0], 'hex');
+        const buffer = utils.allocBufferFromString(item[0], 'hex');
         var value = Integer.fromBuffer(buffer);
         assert.strictEqual(value.toString(), item[1]);
       });
     });
     it('should convert to buffer', function () {
       values.forEach(function (item) {
-        var buffer = Integer.toBuffer(Integer.fromString(item[1]));
+        const buffer = Integer.toBuffer(Integer.fromString(item[1]));
         assert.strictEqual(buffer.toString('hex'), item[0]);
       });
     });
   });
   describe('Tuple', function () {
-    var Tuple = types.Tuple;
+    const Tuple = types.Tuple;
     describe('#get()', function () {
       it('should return the element at position', function () {
         var t = new Tuple('first', 'second');
@@ -117,16 +117,16 @@ describe('types', function () {
     });
     describe('#toString()', function () {
       it('should return the string of the elements surrounded by parenthesis', function () {
-        var id = types.Uuid.random();
-        var decimal = types.BigDecimal.fromString('1.2');
+        const id = types.Uuid.random();
+        const decimal = types.BigDecimal.fromString('1.2');
         var t = new Tuple(id, decimal, 0);
         assert.strictEqual(t.toString(), '(' + id.toString() + ',' + decimal.toString() + ',0)');
       });
     });
     describe('#toJSON()', function () {
       it('should return the string of the elements surrounded by square brackets', function () {
-        var id = types.TimeUuid.now();
-        var decimal = types.BigDecimal.fromString('-1');
+        const id = types.TimeUuid.now();
+        const decimal = types.BigDecimal.fromString('-1');
         var t = new Tuple(id, decimal, 1, {z: 1});
         assert.strictEqual(JSON.stringify(t), '["' + id.toString() + '","' + decimal.toString() + '",1,{"z":1}]');
       });
@@ -155,7 +155,7 @@ describe('types', function () {
     });
   });
   describe('LocalDate', function () {
-    var LocalDate = types.LocalDate;
+    const LocalDate = types.LocalDate;
     describe('new LocalDate', function (){
       it('should refuse to create LocalDate from invalid values.', function () {
         assert.throws(function () { return new types.LocalDate(); }, Error);
@@ -235,8 +235,8 @@ describe('types', function () {
     });
   });
   describe('LocalTime', function () {
-    var LocalTime = types.LocalTime;
-    var Long = types.Long;
+    const LocalTime = types.LocalTime;
+    const Long = types.Long;
     /* eslint-disable no-multi-spaces */
     var values = [
       //Long value         |     string representation  |   hour/min/sec/nanos
@@ -326,7 +326,7 @@ describe('types', function () {
   });
   describe('ResultStream', function () {
     it('should be readable as soon as it has data', function (done) {
-      var buf = [];
+      const buf = [];
       var stream = new types.ResultStream();
       
       stream.on('end', function streamEnd() {
@@ -334,7 +334,7 @@ describe('types', function () {
         done();
       });
       stream.on('readable', function streamReadable() {
-        var item;
+        let item;
         while ((item = stream.read())) {
           buf.push(item);
         }
@@ -346,7 +346,7 @@ describe('types', function () {
     });
 
     it('should buffer until is read', function (done) {
-      var buf = [];
+      const buf = [];
       var stream = new types.ResultStream();
       stream.add(utils.allocBufferFromString('Stringer'));
       stream.add(utils.allocBufferFromString(' '));
@@ -358,7 +358,7 @@ describe('types', function () {
         done();
       });
       stream.on('readable', function streamReadable() {
-        var item;
+        let item;
         while ((item = stream.read())) {
           buf.push(item);
         }
@@ -366,7 +366,7 @@ describe('types', function () {
     });
 
     it('should be readable until the end', function (done) {
-      var buf = [];
+      const buf = [];
       var stream = new types.ResultStream();
       stream.add(utils.allocBufferFromString('Omar'));
       stream.add(utils.allocBufferFromString(' '));
@@ -376,7 +376,7 @@ describe('types', function () {
         done();
       });
       stream.on('readable', function streamReadable() {
-        var item;
+        let item;
         while ((item = stream.read())) {
           buf.push(item);
         }
@@ -387,7 +387,7 @@ describe('types', function () {
     });
 
     it('should be readable on objectMode', function (done) {
-      var buf = [];
+      const buf = [];
       var stream = new types.ResultStream({objectMode: true});
       //passing objects
       stream.add({toString: function (){return 'One';}});
@@ -398,7 +398,7 @@ describe('types', function () {
         done();
       });
       stream.on('readable', function streamReadable() {
-        var item;
+        let item;
         while ((item = stream.read())) {
           buf.push(item);
         }
@@ -426,7 +426,7 @@ describe('types', function () {
       assert.strictEqual(JSON.stringify(row), JSON.stringify({col1: 'val1', col2: 'val2'}));
     });
     it('should be serializable to json', function () {
-      var i;
+      let i;
       var columns = [{name: 'col1', type: { code: dataTypes.varchar}}, {name: 'col2', type: { code: dataTypes.varchar}}];
       var row = new types.Row(columns, [utils.allocBufferFromString('val1'), utils.allocBufferFromString('val2')]);
       row['col1'] = 'val1';
@@ -449,7 +449,7 @@ describe('types', function () {
       for (i = 0; i < columns.length; i++) {
         row[columns[i].name] = rowValues[i];
       }
-      var expected = util.format('{"cid":"%s","ctid":"%s","clong":"1000","cvarint":"22"}',
+      let expected = util.format('{"cid":"%s","ctid":"%s","clong":"1000","cvarint":"22"}',
         rowValues[0].toString(), rowValues[1].toString());
       assert.strictEqual(JSON.stringify(row), expected);
       rowValues = [
@@ -478,8 +478,8 @@ describe('types', function () {
   });
   describe('uuid() backward-compatibility', function () {
     it('should generate a random string uuid', function () {
-      var uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-      var val = types.uuid();
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      const val = types.uuid();
       assert.strictEqual(typeof val, 'string');
       assert.strictEqual(val.length, 36);
       assert.ok(uuidRegex.test(val));
@@ -487,14 +487,14 @@ describe('types', function () {
     });
     it('should fill in the values in a buffer', function () {
       var buf = utils.allocBufferUnsafe(16);
-      var val = types.uuid(null, buf);
+      const val = types.uuid(null, buf);
       assert.strictEqual(val, buf);
     });
   });
   describe('timeuuid() backward-compatibility', function () {
     it('should generate a string uuid', function () {
-      var uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-      var val = types.timeuuid();
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      const val = types.timeuuid();
       assert.strictEqual(typeof val, 'string');
       assert.strictEqual(val.length, 36);
       assert.ok(uuidRegex.test(val));
@@ -502,14 +502,14 @@ describe('types', function () {
     });
     it('should fill in the values in a buffer', function () {
       var buf = utils.allocBufferUnsafe(16);
-      var val = types.timeuuid(null, buf);
+      const val = types.timeuuid(null, buf);
       assert.strictEqual(val, buf);
     });
   });
   describe('generateTimestamp()', function () {
     it('should generate using date and microseconds parts', function () {
-      var date = new Date();
-      var value = types.generateTimestamp(date, 123);
+      let date = new Date();
+      let value = types.generateTimestamp(date, 123);
       helper.assertInstanceOf(value, types.Long);
       assert.strictEqual(value.toString(), types.Long
         .fromNumber(date.getTime())
@@ -531,8 +531,8 @@ describe('types', function () {
 describe('utils', function () {
   describe('#extend()', function () {
     it('should allow null sources', function () {
-      var originalObject = {};
-      var extended = utils.extend(originalObject, null);
+      const originalObject = {};
+      const extended = utils.extend(originalObject, null);
       assert.strictEqual(originalObject, extended);
     });
   });
@@ -560,7 +560,7 @@ describe('utils', function () {
         }
         return 0;
       };
-      var val;
+      let val;
       val = utils.binarySearch([0, 1, 2, 3, 4], 2, compareFunc);
       assert.strictEqual(val, 2);
       val = utils.binarySearch(['A', 'B', 'C', 'D', 'E'], 'D', compareFunc);
@@ -573,7 +573,7 @@ describe('utils', function () {
   });
   describe('#deepExtend', function () {
     it('should override only the most inner props', function () {
-      var value;
+      let value;
       //single values
       value = utils.deepExtend({}, {a: '1'});
       assert.strictEqual(value.a, '1');
@@ -633,12 +633,12 @@ describe('clientOptions', function () {
       });
     });
     it('should create a new instance', function () {
-      var a = {contactPoints: ['host1']};
-      var options = clientOptions.extend(a);
+      const a = {contactPoints: ['host1']};
+      let options = clientOptions.extend(a);
       assert.notStrictEqual(a, options);
       assert.notStrictEqual(options, clientOptions.defaultOptions());
       //it should use baseOptions as source
-      var b = {};
+      const b = {};
       options = clientOptions.extend(b, a);
       //B is the instance source
       assert.strictEqual(b, options);
@@ -649,7 +649,7 @@ describe('clientOptions', function () {
     it('should validate the policies', function () {
       var policy1 = new loadBalancing.RoundRobinPolicy();
       var policy2 = new retry.RetryPolicy();
-      var options = clientOptions.extend({
+      const options = clientOptions.extend({
         contactPoints: ['host1'],
         policies: {
           loadBalancing: policy1,
@@ -729,7 +729,7 @@ describe('clientOptions', function () {
     });
   });
   describe('#defaultOptions()', function () {
-    var options = clientOptions.defaultOptions();
+    const options = clientOptions.defaultOptions();
     it('should set LOCAL_QUORUM as default consistency level', function () {
       assert.strictEqual(types.consistencies.localOne, options.queryOptions.consistency);
     });
@@ -744,18 +744,17 @@ describe('clientOptions', function () {
 describe('writers', function () {
   describe('WriteQueue', function () {
     it('should buffer until threshold is passed', function (done) {
-      var itemCallbackCounter = 0;
-      var buffers = [];
+      let itemCallbackCounter = 0;
+      const buffers = [];
       var socketMock = {
         write: function (buf, cb) {
           buffers.push(buf);
           setTimeout(cb, 50);
         }
       };
-      var options = utils.extend({}, clientOptions.defaultOptions());
+      const options = utils.extend({}, clientOptions.defaultOptions());
       options.socketOptions.coalescingThreshold = 50;
-      var encoder = new Encoder(3, options);
-      //noinspection JSCheckFunctionSignatures
+      const encoder = new Encoder(3, options);
       var queue = new writers.WriteQueue(socketMock, encoder, options);
       var request = {
         write: function () {
@@ -765,7 +764,7 @@ describe('writers', function () {
       function itemCallback() {
         itemCallbackCounter++;
       }
-      for (var i = 0; i < 10; i++) {
+      for (let i = 0; i < 10; i++) {
         queue.push(new OperationState(request, null, utils.noop), itemCallback);
       }
       setTimeout(function () {
@@ -788,7 +787,7 @@ describe('exports', function () {
     //test that the exposed API is the one expected
     //it looks like a dumb test and it is, but it is necessary!
     /* eslint-disable global-require */
-    var api = require('../../index.js');
+    const api = require('../../index.js');
     assert.strictEqual(api.Client, Client);
     assert.ok(api.errors);
     assert.ok(typeof api.errors.DriverError, 'function');

--- a/test/unit/big-decimal-tests.js
+++ b/test/unit/big-decimal-tests.js
@@ -7,7 +7,7 @@ const utils = require('../../lib/utils');
 describe('BigDecimal', function () {
   const BigDecimal = types.BigDecimal;
   const Integer = types.Integer;
-  var hexToDecimalValues = [
+  const hexToDecimalValues = [
     ['000000050100', '0.00256'],
     ['0000000304', '0.004'],
     ['0000000103', '0.3'],
@@ -26,7 +26,7 @@ describe('BigDecimal', function () {
     ['0000000527e41b3246bec9b16e398115', '123456789012345678901234.56789'],
     ['000000090785ee10d5da46d900f4369fffffffff', '9999999999999999999999999999.999999999']
   ];
-  var intAndScaleToString = [
+  const intAndScaleToString = [
     ['12345', 1, '1234.5'],
     ['12345', 2, '123.45'],
     ['12345', 4, '1.2345'],
@@ -42,8 +42,8 @@ describe('BigDecimal', function () {
   describe('constructor', function () {
     it('should allow Number and Integer unscaled values', function () {
       intAndScaleToString.forEach(function (item) {
-        var value1 = new BigDecimal(parseInt(item[0], 10), item[1]);
-        var value2 = new BigDecimal(Integer.fromString(item[0]), item[1]);
+        const value1 = new BigDecimal(parseInt(item[0], 10), item[1]);
+        const value2 = new BigDecimal(Integer.fromString(item[0]), item[1]);
         assert.ok(value1.equals(value2));
       });
     });
@@ -51,7 +51,7 @@ describe('BigDecimal', function () {
   describe('fromString()', function () {
     it('should convert from string in decimal representation', function () {
       intAndScaleToString.forEach(function (item) {
-        var value = new BigDecimal(Integer.fromString(item[0]), item[1]);
+        const value = new BigDecimal(Integer.fromString(item[0]), item[1]);
         assert.ok(value.equals(BigDecimal.fromString(item[2])), 'BigDecimals not equal for value ' + item[2]);
       });
     });
@@ -68,7 +68,7 @@ describe('BigDecimal', function () {
     it('should convert from buffer (scale + unscaledValue in BE)', function () {
       hexToDecimalValues.forEach(function (item) {
         const buffer = utils.allocBufferFromString(item[0], 'hex');
-        var value = BigDecimal.fromBuffer(buffer);
+        const value = BigDecimal.fromBuffer(buffer);
         assert.strictEqual(value.toString(), item[1]);
       });
     });
@@ -76,11 +76,11 @@ describe('BigDecimal', function () {
   describe('toBuffer()', function () {
     it('should convert to buffer (scale + unscaledValue in BE)', function () {
       hexToDecimalValues.forEach(function (item) {
-        var avoidConvert = item[2];
+        const avoidConvert = item[2];
         if (avoidConvert) {
           return;
         }
-        var value = BigDecimal.toBuffer(BigDecimal.fromString(item[1]));
+        const value = BigDecimal.toBuffer(BigDecimal.fromString(item[1]));
         assert.strictEqual(value.toString('hex'), item[0]);
       });
     });
@@ -88,7 +88,7 @@ describe('BigDecimal', function () {
   describe('fromNumber()', function () {
     it('should convert from string in decimal representation', function () {
       intAndScaleToString.forEach(function (item) {
-        var value = BigDecimal.fromNumber(Number(item[2]));
+        const value = BigDecimal.fromNumber(Number(item[2]));
         assert.strictEqual(value.toNumber(), parseFloat(item[2]));
       });
     });
@@ -96,7 +96,7 @@ describe('BigDecimal', function () {
   describe('#toString()', function () {
     it('should convert to string decimal representation', function () {
       intAndScaleToString.forEach(function (item) {
-        var value = new BigDecimal(Integer.fromString(item[0]), item[1]);
+        const value = new BigDecimal(Integer.fromString(item[0]), item[1]);
         assert.strictEqual(value.toString(), item[2]);
       });
     });
@@ -113,8 +113,8 @@ describe('BigDecimal', function () {
         ['102.1', '100.05', '2.05'],
         ['10201.00', '10201', '0.00']
       ].forEach(function (item) {
-        var first = BigDecimal.fromString(item[0]);
-        var second = BigDecimal.fromString(item[1]);
+        const first = BigDecimal.fromString(item[0]);
+        const second = BigDecimal.fromString(item[1]);
         assert.strictEqual(first.subtract(second).toString(), item[2]);
         // check mutations
         assert.strictEqual(first.toString(), item[0]);
@@ -133,8 +133,8 @@ describe('BigDecimal', function () {
         ['102.1', '100.05', '202.15'],
         ['10201.00', '-10201', '0.00']
       ].forEach(function (item) {
-        var first = BigDecimal.fromString(item[0]);
-        var second = BigDecimal.fromString(item[1]);
+        const first = BigDecimal.fromString(item[0]);
+        const second = BigDecimal.fromString(item[1]);
         assert.strictEqual(first.add(second).toString(), item[2]);
         // check mutations
         assert.strictEqual(first.toString(), item[0]);
@@ -155,8 +155,8 @@ describe('BigDecimal', function () {
         ['-1.010', '-1.01', 0],
         ['-1.01', '-1.01', 0]
       ].forEach(function (item) {
-        var first = BigDecimal.fromString(item[0]);
-        var second = BigDecimal.fromString(item[1]);
+        const first = BigDecimal.fromString(item[0]);
+        const second = BigDecimal.fromString(item[1]);
         assert.strictEqual(first.compare(second), item[2]);
         // check mutations
         assert.strictEqual(first.toString(), item[0]);

--- a/test/unit/big-decimal-tests.js
+++ b/test/unit/big-decimal-tests.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var assert = require('assert');
-var types = require('../../lib/types');
-var utils = require('../../lib/utils');
+const assert = require('assert');
+const types = require('../../lib/types');
+const utils = require('../../lib/utils');
 
 describe('BigDecimal', function () {
-  var BigDecimal = types.BigDecimal;
-  var Integer = types.Integer;
+  const BigDecimal = types.BigDecimal;
+  const Integer = types.Integer;
   var hexToDecimalValues = [
     ['000000050100', '0.00256'],
     ['0000000304', '0.004'],
@@ -67,7 +67,7 @@ describe('BigDecimal', function () {
   describe('fromBuffer()', function () {
     it('should convert from buffer (scale + unscaledValue in BE)', function () {
       hexToDecimalValues.forEach(function (item) {
-        var buffer = utils.allocBufferFromString(item[0], 'hex');
+        const buffer = utils.allocBufferFromString(item[0], 'hex');
         var value = BigDecimal.fromBuffer(buffer);
         assert.strictEqual(value.toString(), item[1]);
       });

--- a/test/unit/client-tests.js
+++ b/test/unit/client-tests.js
@@ -68,7 +68,7 @@ describe('Client', function () {
           loadBalancing: new policies.loadBalancing.RoundRobinPolicy()
         }
       });
-      var ccMock = getControlConnectionMock(null, options);
+      const ccMock = getControlConnectionMock(null, options);
       ccMock.prototype.init = function (cb) {
         initCounter++;
         //Async
@@ -121,7 +121,7 @@ describe('Client', function () {
       it('should return a promise', function (done) {
         const Client = require('../../lib/client');
         const client = new Client(helper.baseOptions);
-        var p = client.connect();
+        const p = client.connect();
         helper.assertInstanceOf(p, Promise);
         p.catch(function (err) {
           helper.assertInstanceOf(err, errors.NoHostAvailableError);
@@ -139,10 +139,10 @@ describe('Client', function () {
       });
     });
     it('should build the routingKey based on routingNames', function (done) {
-      var requestHandlerMock = function (request, options) {
+      const requestHandlerMock = function (request, options) {
         this._options = options;
       };
-      var prepareHandlerMock = {
+      const prepareHandlerMock = {
         getPrepared: function (c, lbp, q, ks, cb) {
           cb(null, utils.allocBufferFromArray([1]), { columns: [
             { name: 'key1', type: { code: types.dataTypes.int} },
@@ -165,7 +165,7 @@ describe('Client', function () {
     });
     it('should fill parameter information for string hints', function (done) {
       let options;
-      var requestHandlerMock = function (r, o) {
+      const requestHandlerMock = function (r, o) {
         options = o;
       };
       const client = newConnectedInstance(requestHandlerMock);
@@ -208,7 +208,7 @@ describe('Client', function () {
       });
     });
     it('should callback with an argument error when the hints are not valid strings', function (done) {
-      var requestHandlerMock = function () {};
+      const requestHandlerMock = function () {};
       const client = newConnectedInstance(requestHandlerMock);
       requestHandlerMock.prototype.send = function (q, o, cb) {
         cb();
@@ -250,7 +250,7 @@ describe('Client', function () {
     });
     it('should use the default execution profile options', function () {
       const Client = require('../../lib/client');
-      var profile = new ExecutionProfile('default', {
+      const profile = new ExecutionProfile('default', {
         consistency: types.consistencies.three,
         readTimeout: 12345,
         retry: new policies.retry.RetryPolicy(),
@@ -267,7 +267,7 @@ describe('Client', function () {
     });
     it('should use the provided execution profile options', function () {
       const Client = require('../../lib/client');
-      var profile = new ExecutionProfile('profile1', {
+      const profile = new ExecutionProfile('profile1', {
         consistency: types.consistencies.three,
         readTimeout: 54321,
         retry: new policies.retry.RetryPolicy(),
@@ -282,14 +282,14 @@ describe('Client', function () {
       // profile by name
       client.execute('Q1', [], { executionProfile: 'profile1' }, utils.noop);
       helper.compareProps(queryOptions, profile, Object.keys(profile), ['loadBalancing', 'name']);
-      var previousQueryOptions = queryOptions;
+      const previousQueryOptions = queryOptions;
       // profile by instance
       client.execute('Q1', [], { executionProfile: profile }, utils.noop);
       helper.compareProps(queryOptions, previousQueryOptions, Object.keys(queryOptions), ['executionProfile']);
     });
     it('should override the provided execution profile options with provided options', function () {
       const Client = require('../../lib/client');
-      var profile = new ExecutionProfile('profile1', {
+      const profile = new ExecutionProfile('profile1', {
         consistency: types.consistencies.three,
         readTimeout: 54321,
         retry: new policies.retry.RetryPolicy(),
@@ -305,14 +305,14 @@ describe('Client', function () {
       client.execute('Q1', [], { consistency: types.consistencies.all, executionProfile: 'profile1' }, utils.noop);
       helper.compareProps(queryOptions, profile, Object.keys(profile), ['consistency', 'loadBalancing', 'name']);
       assert.strictEqual(queryOptions.consistency, types.consistencies.all);
-      var previousQueryOptions = queryOptions;
+      const previousQueryOptions = queryOptions;
       // profile by instance
       client.execute('Q1', [], { consistency: types.consistencies.all, executionProfile: profile }, utils.noop);
       helper.compareProps(queryOptions, previousQueryOptions, Object.keys(queryOptions), ['executionProfile']);
     });
     it('should set the timestamp', function (done) {
       let actualOptions;
-      var handlerMock = function (r, o) {
+      const handlerMock = function (r, o) {
         actualOptions = o;
       };
       handlerMock.prototype.send = function (callback) {
@@ -337,7 +337,7 @@ describe('Client', function () {
     });
     it('should not set the timestamp when timestampGeneration is null', function (done) {
       let actualOptions;
-      var handlerMock = function (r, o) {
+      const handlerMock = function (r, o) {
         actualOptions = o;
       };
       handlerMock.prototype.send = function (callback) {
@@ -356,7 +356,7 @@ describe('Client', function () {
       it('should return a promise', function (done) {
         const Client = require('../../lib/client');
         const client = new Client(helper.baseOptions);
-        var p = client.execute('Q', [ 1, 2 ], { prepare: true });
+        const p = client.execute('Q', [ 1, 2 ], { prepare: true });
         helper.assertInstanceOf(p, Promise);
         p.catch(function (err) {
           helper.assertInstanceOf(err, errors.NoHostAvailableError);
@@ -366,7 +366,7 @@ describe('Client', function () {
       it('should reject the promise when an ExecutionProfile is not found', function (done) {
         const Client = require('../../lib/client');
         const client = new Client(helper.baseOptions);
-        var p = client.execute('Q', [ 1, 2 ], { executionProfile: 'non_existent' });
+        const p = client.execute('Q', [ 1, 2 ], { executionProfile: 'non_existent' });
         helper.assertInstanceOf(p, Promise);
         p.catch(function (err) {
           helper.assertInstanceOf(err, errors.ArgumentError);
@@ -377,7 +377,7 @@ describe('Client', function () {
   });
   describe('#eachRow()', function () {
     it('should pass optional parameters as null when not defined', function () {
-      var createQueryOptions = clientOptions.createQueryOptions;
+      const createQueryOptions = clientOptions.createQueryOptions;
       const client = newConnectedInstance();
       let params = null;
       client._innerExecute = function (q, p, o, c) {
@@ -397,7 +397,7 @@ describe('Client', function () {
   });
   describe('#batch()', function () {
     const Client = rewire('../../lib/client.js');
-    var requestHandlerMock = function () {};
+    const requestHandlerMock = function () {};
     requestHandlerMock.prototype.send = function noop (cb) {
       //make it async
       setTimeout(function () {
@@ -420,7 +420,7 @@ describe('Client', function () {
     });
     it('should set the timestamp', function (done) {
       let actualOptions;
-      var handlerMock = function (r, o) {
+      const handlerMock = function (r, o) {
         actualOptions = o;
       };
       handlerMock.prototype.send = function (callback) {
@@ -447,7 +447,7 @@ describe('Client', function () {
       it('should return a promise', function (done) {
         const Client = require('../../lib/client');
         const client = new Client(helper.baseOptions);
-        var p = client.batch(['Q'], null);
+        const p = client.batch(['Q'], null);
         helper.assertInstanceOf(p, Promise);
         p.catch(function (err) {
           helper.assertInstanceOf(err, errors.NoHostAvailableError);
@@ -457,7 +457,7 @@ describe('Client', function () {
       it('should reject the promise when queries is not an Array', function (done) {
         const Client = require('../../lib/client');
         const client = new Client(helper.baseOptions);
-        var p = client.batch('Q', null);
+        const p = client.batch('Q', null);
         helper.assertInstanceOf(p, Promise);
         p.catch(function (err) {
           helper.assertInstanceOf(err, errors.ArgumentError);
@@ -488,11 +488,11 @@ describe('Client', function () {
       logEmitter: helper.noop
     });
     it('should set connected flag to false when hosts successfully shutdown', function(done) {
-      var hosts = new HostMap();
-      var h1 = new Host('192.1.1.1', 1, options);
+      const hosts = new HostMap();
+      const h1 = new Host('192.1.1.1', 1, options);
       h1.datacenter = "dc1";
       h1.pool.connections = [{close: setImmediate}];
-      var h2 = new Host('192.1.1.2', 1, options);
+      const h2 = new Host('192.1.1.2', 1, options);
       h2.datacenter = "dc1";
       h2.pool.connections = [{close: setImmediate}];
       hosts.push(h1.address, h1);
@@ -506,11 +506,11 @@ describe('Client', function () {
       });
     });
     it('should callback when called multiple times serially', function (done) {
-      var hosts = new HostMap();
-      var h1 = new Host('192.1.1.1', 1, options);
+      const hosts = new HostMap();
+      const h1 = new Host('192.1.1.1', 1, options);
       h1.datacenter = "dc1";
       h1.pool.connections = [{close: setImmediate}];
-      var h2 = new Host('192.1.1.2', 1, options);
+      const h2 = new Host('192.1.1.2', 1, options);
       h2.datacenter = "dc1";
       h2.pool.connections = [{close: setImmediate}];
       hosts.push(h1.address, h1);
@@ -528,11 +528,11 @@ describe('Client', function () {
       ], done);
     });
     it('should callback when called multiple times in parallel', function (done) {
-      var hosts = new HostMap();
-      var h1 = new Host('192.1.1.1', 1, options);
+      const hosts = new HostMap();
+      const h1 = new Host('192.1.1.1', 1, options);
       h1.datacenter = "dc1";
       h1.pool.connections = [{close: setImmediate}];
-      var h2 = new Host('192.1.1.2', 1, options);
+      const h2 = new Host('192.1.1.2', 1, options);
       h2.datacenter = "dc1";
       h2.pool.connections = [{close: setImmediate}];
       hosts.push(h1.address, h1);
@@ -550,7 +550,7 @@ describe('Client', function () {
       ], done);
     });
     it('should not attempt reconnection and log after shutdown', function (done) {
-      var rp = new policies.reconnection.ConstantReconnectionPolicy(50);
+      const rp = new policies.reconnection.ConstantReconnectionPolicy(50);
       const Client = require('../../lib/client');
       const client = new Client(utils.extend({}, helper.baseOptions, { policies: { reconnection: rp } }));
       const logEvents = [];
@@ -574,7 +574,7 @@ describe('Client', function () {
       it('should return a promise', function (done) {
         const Client = require('../../lib/client');
         const client = new Client(helper.baseOptions);
-        var p = client.shutdown();
+        const p = client.shutdown();
         helper.assertInstanceOf(p, Promise);
         p.then(done);
       });
@@ -653,7 +653,7 @@ describe('Client', function () {
     it('should callback when there is an error retrieving versions', function (done) {
       const client = new Client(helper.baseOptions);
       client.hosts = {length: 3};
-      var dummyError = new Error('dummy error');
+      const dummyError = new Error('dummy error');
       client.metadata = {
         getLocalSchemaVersion: function (c, cb) {
           setImmediate(function () { cb(); });
@@ -707,7 +707,7 @@ describe('Client', function () {
       const client = new Client(helper.baseOptions);
       client._getEncoder = function () { return { setRoutingKey: helper.noop}; };
       client.controlConnection = { protocolVersion: 2};
-      var meta = {
+      const meta = {
         columns: [
           { type: types.dataTypes.int },
           { type: types.dataTypes.text }
@@ -727,7 +727,7 @@ describe('Client', function () {
       const client = new Client(helper.baseOptions);
       client._getEncoder = function () { return { setRoutingKey: helper.noop}; };
       client.controlConnection = { protocolVersion: 4};
-      var meta = {
+      const meta = {
         columns: [
           { type: types.dataTypes.uuid },
           { type: types.dataTypes.text }
@@ -752,7 +752,7 @@ describe('Client', function () {
       let metaCalled = 0;
       client._getEncoder = function () { return { setRoutingKey: helper.noop}; };
       client.controlConnection = { protocolVersion: 3};
-      var meta = {
+      const meta = {
         keyspace: 'ks1',
         table: 'table1',
         columns: [
@@ -780,7 +780,7 @@ describe('Client', function () {
       };
       const options = { prepare: true};
       utils.timesSeries(20, function (n, next) {
-        var params = [types.Uuid.random(), 'hello', types.TimeUuid.now()];
+        const params = [types.Uuid.random(), 'hello', types.TimeUuid.now()];
         client._setQueryOptions(options, params, meta, function (err) {
           assert.ifError(err);
           assert.strictEqual(metaCalled, 1);

--- a/test/unit/client-tests.js
+++ b/test/unit/client-tests.js
@@ -1,21 +1,21 @@
 'use strict';
-var assert = require('assert');
-var util = require('util');
-var rewire = require('rewire');
+const assert = require('assert');
+const util = require('util');
+const rewire = require('rewire');
 
-var policies = require('../../lib/policies');
-var helper = require('../test-helper');
-var errors = require('../../lib/errors');
-var utils = require('../../lib/utils');
-var types = require('../../lib/types');
-var HostMap = require('../../lib/host').HostMap;
-var Host = require('../../lib/host').Host;
-var Metadata = require('../../lib/metadata');
-var Encoder = require('../../lib/encoder');
-var ProfileManager = require('../../lib/execution-profile').ProfileManager;
-var ExecutionProfile = require('../../lib/execution-profile').ExecutionProfile;
-var clientOptions = require('../../lib/client-options');
-var PrepareHandler = require('../../lib/prepare-handler');
+const policies = require('../../lib/policies');
+const helper = require('../test-helper');
+const errors = require('../../lib/errors');
+const utils = require('../../lib/utils');
+const types = require('../../lib/types');
+const HostMap = require('../../lib/host').HostMap;
+const Host = require('../../lib/host').Host;
+const Metadata = require('../../lib/metadata');
+const Encoder = require('../../lib/encoder');
+const ProfileManager = require('../../lib/execution-profile').ProfileManager;
+const ExecutionProfile = require('../../lib/execution-profile').ExecutionProfile;
+const clientOptions = require('../../lib/client-options');
+const PrepareHandler = require('../../lib/prepare-handler');
 
 // allow non-global require as Client gets rewired.
 /* eslint-disable global-require */
@@ -23,7 +23,7 @@ var PrepareHandler = require('../../lib/prepare-handler');
 describe('Client', function () {
   describe('constructor', function () {
     it('should throw an exception when contactPoints are not provided', function () {
-      var Client = require('../../lib/client');
+      const Client = require('../../lib/client');
       assert.throws(function () {
         return new Client({});
       }, TypeError);
@@ -38,17 +38,17 @@ describe('Client', function () {
       }, TypeError);
     });
     it('should create Metadata instance', function () {
-      var Client = require('../../lib/client');
-      var client = new Client({ contactPoints: ['192.168.10.10'] });
+      const Client = require('../../lib/client');
+      const client = new Client({ contactPoints: ['192.168.10.10'] });
       helper.assertInstanceOf(client.metadata, Metadata);
     });
   });
   describe('#connect()', function () {
     this.timeout(35000);
     it('should fail if no host name can be resolved', function (done) {
-      var options = utils.extend({}, helper.baseOptions, {contactPoints: ['not1.existent-host', 'not2.existent-host']});
-      var Client = require('../../lib/client.js');
-      var client = new Client(options);
+      const options = utils.extend({}, helper.baseOptions, {contactPoints: ['not1.existent-host', 'not2.existent-host']});
+      const Client = require('../../lib/client.js');
+      const client = new Client(options);
       client.connect(function (err) {
         assert.ok(err);
         helper.assertInstanceOf(err, errors.NoHostAvailableError);
@@ -59,10 +59,10 @@ describe('Client', function () {
       });
     });
     it('should connect once and queue if multiple calls in parallel', function (done) {
-      var Client = rewire('../../lib/client.js');
-      var initCounter = 0;
-      var emitCounter = 0;
-      var options = utils.extend({
+      const Client = rewire('../../lib/client.js');
+      let initCounter = 0;
+      let emitCounter = 0;
+      const options = utils.extend({
         contactPoints: helper.baseOptions.contactPoints,
         policies: {
           loadBalancing: new policies.loadBalancing.RoundRobinPolicy()
@@ -75,7 +75,7 @@ describe('Client', function () {
         setTimeout(cb, 100);
       };
       Client.__set__("ControlConnection", ccMock);
-      var client = new Client(options);
+      const client = new Client(options);
       client.on('connected', function () {emitCounter++;});
       utils.times(1000, function (n, next) {
         client.connect(function (err) {
@@ -90,14 +90,14 @@ describe('Client', function () {
       });
     });
     it('should fail when trying to connect after shutdown', function (done) {
-      var Client = require('../../lib/client');
-      var options = utils.extend({
+      const Client = require('../../lib/client');
+      const options = utils.extend({
         contactPoints: helper.baseOptions.contactPoints,
         policies: {
           loadBalancing: new policies.loadBalancing.RoundRobinPolicy()
         }
       });
-      var client = new Client(options);
+      const client = new Client(options);
       client.controlConnection = {
         init: helper.callbackNoop,
         hosts: new HostMap(),
@@ -119,8 +119,8 @@ describe('Client', function () {
     });
     context('with no callback specified', function () {
       it('should return a promise', function (done) {
-        var Client = require('../../lib/client');
-        var client = new Client(helper.baseOptions);
+        const Client = require('../../lib/client');
+        const client = new Client(helper.baseOptions);
         var p = client.connect();
         helper.assertInstanceOf(p, Promise);
         p.catch(function (err) {
@@ -132,7 +132,7 @@ describe('Client', function () {
   });
   describe('#execute()', function () {
     it('should not support named parameters for simple statements', function (done) {
-      var client = newConnectedInstance();
+      const client = newConnectedInstance();
       client.execute('QUERY', {named: 'parameter'}, function (err) {
         helper.assertInstanceOf(err, errors.ArgumentError);
         done();
@@ -150,7 +150,7 @@ describe('Client', function () {
           ]});
         }
       };
-      var client = newConnectedInstance(requestHandlerMock, null, prepareHandlerMock);
+      const client = newConnectedInstance(requestHandlerMock, null, prepareHandlerMock);
       requestHandlerMock.prototype.send = function (cb) {
         assert.ok(this._options);
         assert.ok(this._options.routingKey);
@@ -159,24 +159,24 @@ describe('Client', function () {
         cb();
         done();
       };
-      var query = 'SELECT * FROM dummy WHERE id2=:key2 and id1=:key1';
-      var queryOptions = { prepare: true, routingNames: ['key1', 'key2']};
+      const query = 'SELECT * FROM dummy WHERE id2=:key2 and id1=:key1';
+      const queryOptions = { prepare: true, routingNames: ['key1', 'key2']};
       client.execute(query, {key2: 2, key1: 1}, queryOptions, helper.throwop);
     });
     it('should fill parameter information for string hints', function (done) {
-      var options;
+      let options;
       var requestHandlerMock = function (r, o) {
         options = o;
       };
-      var client = newConnectedInstance(requestHandlerMock);
+      const client = newConnectedInstance(requestHandlerMock);
       client.metadata.getUdt = function (ks, n, cb) {
         cb(null, {keyspace: ks, name: n});
       };
       requestHandlerMock.prototype.send = function (cb) {
         cb();
       };
-      var query = 'SELECT * FROM dummy WHERE id2=:key2 and id1=:key1';
-      var queryOptions = { prepare: false, hints: ['int', 'list<uuid>', 'map<text, timestamp>', 'udt<ks1.udt1>', 'map<uuid, set<text>>']};
+      const query = 'SELECT * FROM dummy WHERE id2=:key2 and id1=:key1';
+      const queryOptions = { prepare: false, hints: ['int', 'list<uuid>', 'map<text, timestamp>', 'udt<ks1.udt1>', 'map<uuid, set<text>>']};
       client.execute(query, [0, 1, 2, 3, 4], queryOptions, function (err) {
         assert.ifError(err);
         assert.ok(options);
@@ -209,11 +209,11 @@ describe('Client', function () {
     });
     it('should callback with an argument error when the hints are not valid strings', function (done) {
       var requestHandlerMock = function () {};
-      var client = newConnectedInstance(requestHandlerMock);
+      const client = newConnectedInstance(requestHandlerMock);
       requestHandlerMock.prototype.send = function (q, o, cb) {
         cb();
       };
-      var query = 'SELECT * FROM dummy WHERE id2=:key2 and id1=:key1';
+      const query = 'SELECT * FROM dummy WHERE id2=:key2 and id1=:key1';
       utils.series([
         function (next) {
           client.execute(query, [], { hints: ['int2']}, function (err) {
@@ -236,8 +236,8 @@ describe('Client', function () {
       ], done);
     });
     it('should pass optional parameters as null when not defined', function () {
-      var client = newConnectedInstance();
-      var params = null;
+      const client = newConnectedInstance();
+      let params = null;
       client._innerExecute = function (q, p, o, c) {
         params = [q, p, o, c];
       };
@@ -249,16 +249,16 @@ describe('Client', function () {
       assert.deepEqual(params, ['Q3', null, clientOptions.createQueryOptions(client, { fetchSize: 20 }), utils.noop]);
     });
     it('should use the default execution profile options', function () {
-      var Client = require('../../lib/client');
+      const Client = require('../../lib/client');
       var profile = new ExecutionProfile('default', {
         consistency: types.consistencies.three,
         readTimeout: 12345,
         retry: new policies.retry.RetryPolicy(),
         serialConsistency: types.consistencies.localSerial
       });
-      var options = getOptions({ profiles: [ profile ] });
-      var client = new Client(options);
-      var queryOptions = null;
+      const options = getOptions({ profiles: [ profile ] });
+      const client = new Client(options);
+      let queryOptions = null;
       client._innerExecute = function (q, p, o) {
         queryOptions = o;
       };
@@ -266,16 +266,16 @@ describe('Client', function () {
       helper.compareProps(queryOptions, profile, Object.keys(profile), ['loadBalancing', 'name']);
     });
     it('should use the provided execution profile options', function () {
-      var Client = require('../../lib/client');
+      const Client = require('../../lib/client');
       var profile = new ExecutionProfile('profile1', {
         consistency: types.consistencies.three,
         readTimeout: 54321,
         retry: new policies.retry.RetryPolicy(),
         serialConsistency: types.consistencies.localSerial
       });
-      var options = getOptions({ profiles: [ profile ] });
-      var client = new Client(options);
-      var queryOptions = null;
+      const options = getOptions({ profiles: [ profile ] });
+      const client = new Client(options);
+      let queryOptions = null;
       client._innerExecute = function (q, p, o) {
         queryOptions = o;
       };
@@ -288,16 +288,16 @@ describe('Client', function () {
       helper.compareProps(queryOptions, previousQueryOptions, Object.keys(queryOptions), ['executionProfile']);
     });
     it('should override the provided execution profile options with provided options', function () {
-      var Client = require('../../lib/client');
+      const Client = require('../../lib/client');
       var profile = new ExecutionProfile('profile1', {
         consistency: types.consistencies.three,
         readTimeout: 54321,
         retry: new policies.retry.RetryPolicy(),
         serialConsistency: types.consistencies.localSerial
       });
-      var options = getOptions({ profiles: [ profile ] });
-      var client = new Client(options);
-      var queryOptions = null;
+      const options = getOptions({ profiles: [ profile ] });
+      const client = new Client(options);
+      let queryOptions = null;
       client._innerExecute = function (q, p, o) {
         queryOptions = o;
       };
@@ -311,14 +311,14 @@ describe('Client', function () {
       helper.compareProps(queryOptions, previousQueryOptions, Object.keys(queryOptions), ['executionProfile']);
     });
     it('should set the timestamp', function (done) {
-      var actualOptions;
+      let actualOptions;
       var handlerMock = function (r, o) {
         actualOptions = o;
       };
       handlerMock.prototype.send = function (callback) {
         callback(null, {});
       };
-      var client = newConnectedInstance(handlerMock);
+      const client = newConnectedInstance(handlerMock);
       utils.eachSeries([1, 2, 3, 4], function (version, next) {
         client.controlConnection.protocolVersion = version;
         client.execute('Q', function (err) {
@@ -336,14 +336,14 @@ describe('Client', function () {
       }, done);
     });
     it('should not set the timestamp when timestampGeneration is null', function (done) {
-      var actualOptions;
+      let actualOptions;
       var handlerMock = function (r, o) {
         actualOptions = o;
       };
       handlerMock.prototype.send = function (callback) {
         callback(null, {});
       };
-      var client = newConnectedInstance(handlerMock, { policies: { timestampGeneration: null }});
+      const client = newConnectedInstance(handlerMock, { policies: { timestampGeneration: null }});
       client.controlConnection.protocolVersion = 4;
       client.execute('Q', function (err) {
         assert.ifError(err);
@@ -354,8 +354,8 @@ describe('Client', function () {
     });
     context('with no callback specified', function () {
       it('should return a promise', function (done) {
-        var Client = require('../../lib/client');
-        var client = new Client(helper.baseOptions);
+        const Client = require('../../lib/client');
+        const client = new Client(helper.baseOptions);
         var p = client.execute('Q', [ 1, 2 ], { prepare: true });
         helper.assertInstanceOf(p, Promise);
         p.catch(function (err) {
@@ -364,8 +364,8 @@ describe('Client', function () {
         });
       });
       it('should reject the promise when an ExecutionProfile is not found', function (done) {
-        var Client = require('../../lib/client');
-        var client = new Client(helper.baseOptions);
+        const Client = require('../../lib/client');
+        const client = new Client(helper.baseOptions);
         var p = client.execute('Q', [ 1, 2 ], { executionProfile: 'non_existent' });
         helper.assertInstanceOf(p, Promise);
         p.catch(function (err) {
@@ -378,8 +378,8 @@ describe('Client', function () {
   describe('#eachRow()', function () {
     it('should pass optional parameters as null when not defined', function () {
       var createQueryOptions = clientOptions.createQueryOptions;
-      var client = newConnectedInstance();
-      var params = null;
+      const client = newConnectedInstance();
+      let params = null;
       client._innerExecute = function (q, p, o, c) {
         params = [q, p, o, c];
       };
@@ -396,7 +396,7 @@ describe('Client', function () {
     });
   });
   describe('#batch()', function () {
-    var Client = rewire('../../lib/client.js');
+    const Client = rewire('../../lib/client.js');
     var requestHandlerMock = function () {};
     requestHandlerMock.prototype.send = function noop (cb) {
       //make it async
@@ -406,8 +406,8 @@ describe('Client', function () {
     };
     Client.__set__("RequestHandler", requestHandlerMock);
     it('should internally call to connect', function (done) {
-      var client = new Client(helper.baseOptions);
-      var connectCalled = false;
+      const client = new Client(helper.baseOptions);
+      let connectCalled = false;
       client.connect = function (cb) {
         connectCalled = true;
         cb();
@@ -419,14 +419,14 @@ describe('Client', function () {
       });
     });
     it('should set the timestamp', function (done) {
-      var actualOptions;
+      let actualOptions;
       var handlerMock = function (r, o) {
         actualOptions = o;
       };
       handlerMock.prototype.send = function (callback) {
         callback(null, {});
       };
-      var client = newConnectedInstance(handlerMock);
+      const client = newConnectedInstance(handlerMock);
       utils.eachSeries([1, 2, 3, 4], function (version, next) {
         client.controlConnection.protocolVersion = version;
         client.batch(['q1', 'q2', 'q3'], function (err) {
@@ -445,8 +445,8 @@ describe('Client', function () {
     });
     context('with no callback specified', function () {
       it('should return a promise', function (done) {
-        var Client = require('../../lib/client');
-        var client = new Client(helper.baseOptions);
+        const Client = require('../../lib/client');
+        const client = new Client(helper.baseOptions);
         var p = client.batch(['Q'], null);
         helper.assertInstanceOf(p, Promise);
         p.catch(function (err) {
@@ -455,8 +455,8 @@ describe('Client', function () {
         });
       });
       it('should reject the promise when queries is not an Array', function (done) {
-        var Client = require('../../lib/client');
-        var client = new Client(helper.baseOptions);
+        const Client = require('../../lib/client');
+        const client = new Client(helper.baseOptions);
         var p = client.batch('Q', null);
         helper.assertInstanceOf(p, Promise);
         p.catch(function (err) {
@@ -468,14 +468,14 @@ describe('Client', function () {
   });
   describe('#batch(queries, {prepare: 1}, callback)', function () {
     it('should callback with error if the queries are not string', function (done) {
-      var client = newConnectedInstance(undefined, undefined, PrepareHandler);
+      const client = newConnectedInstance(undefined, undefined, PrepareHandler);
       client.batch([{ noQuery: true }], { prepare: true }, function (err) {
         helper.assertInstanceOf(err, errors.ArgumentError);
         done();
       });
     });
     it('should callback with error if the queries are undefined', function (done) {
-      var client = newConnectedInstance(undefined, undefined, PrepareHandler);
+      const client = newConnectedInstance(undefined, undefined, PrepareHandler);
       client.batch([ undefined, undefined, 'q3' ], { prepare: true }, function (err) {
         helper.assertInstanceOf(err, errors.ArgumentError);
         done();
@@ -483,7 +483,7 @@ describe('Client', function () {
     });
   });
   describe('#shutdown()', function () {
-    var options = clientOptions.extend({}, helper.baseOptions, {
+    const options = clientOptions.extend({}, helper.baseOptions, {
       policies: { reconnection: new policies.reconnection.ConstantReconnectionPolicy(100)},
       logEmitter: helper.noop
     });
@@ -497,9 +497,9 @@ describe('Client', function () {
       h2.pool.connections = [{close: setImmediate}];
       hosts.push(h1.address, h1);
       hosts.push(h2.address, h2);
-      var Client = rewire('../../lib/client.js');
+      const Client = rewire('../../lib/client.js');
       Client.__set__("ControlConnection", getControlConnectionMock(hosts));
-      var client = new Client(options);
+      const client = new Client(options);
       client.shutdown(function(){
         assert.equal(client.connected, false);
         done();
@@ -515,9 +515,9 @@ describe('Client', function () {
       h2.pool.connections = [{close: setImmediate}];
       hosts.push(h1.address, h1);
       hosts.push(h2.address, h2);
-      var Client = rewire('../../lib/client.js');
+      const Client = rewire('../../lib/client.js');
       Client.__set__("ControlConnection", getControlConnectionMock(hosts));
-      var client = new Client(options);
+      const client = new Client(options);
       utils.series([
         client.connect.bind(client),
         function shutDownMultiple(seriesNext) {
@@ -537,9 +537,9 @@ describe('Client', function () {
       h2.pool.connections = [{close: setImmediate}];
       hosts.push(h1.address, h1);
       hosts.push(h2.address, h2);
-      var Client = rewire('../../lib/client.js');
+      const Client = rewire('../../lib/client.js');
       Client.__set__("ControlConnection", getControlConnectionMock(hosts));
-      var client = new Client(options);
+      const client = new Client(options);
       utils.series([
         client.connect.bind(client),
         function shutDownMultiple(seriesNext) {
@@ -551,9 +551,9 @@ describe('Client', function () {
     });
     it('should not attempt reconnection and log after shutdown', function (done) {
       var rp = new policies.reconnection.ConstantReconnectionPolicy(50);
-      var Client = require('../../lib/client');
-      var client = new Client(utils.extend({}, helper.baseOptions, { policies: { reconnection: rp } }));
-      var logEvents = [];
+      const Client = require('../../lib/client');
+      const client = new Client(utils.extend({}, helper.baseOptions, { policies: { reconnection: rp } }));
+      const logEvents = [];
       client.on('log', logEvents.push.bind(logEvents));
       client.connect(function (err) {
         helper.assertInstanceOf(err, errors.NoHostAvailableError);
@@ -572,8 +572,8 @@ describe('Client', function () {
     });
     context('with no callback specified', function () {
       it('should return a promise', function (done) {
-        var Client = require('../../lib/client');
-        var client = new Client(helper.baseOptions);
+        const Client = require('../../lib/client');
+        const client = new Client(helper.baseOptions);
         var p = client.shutdown();
         helper.assertInstanceOf(p, Promise);
         p.then(done);
@@ -581,12 +581,12 @@ describe('Client', function () {
     });
   });
   describe('#_waitForSchemaAgreement()', function () {
-    var Client = require('../../lib/client.js');
+    const Client = require('../../lib/client.js');
     it('should use the control connection to retrieve schema information', function (done) {
-      var client = new Client(helper.baseOptions);
+      const client = new Client(helper.baseOptions);
       client.hosts = {length: 3};
-      var localCalls = 0;
-      var peerCalls = 0;
+      let localCalls = 0;
+      let peerCalls = 0;
       client.metadata = {
         getLocalSchemaVersion: function (c, cb) {
           localCalls++;
@@ -605,10 +605,10 @@ describe('Client', function () {
       });
     });
     it('should continue querying until the version matches', function (done) {
-      var client = new Client(helper.baseOptions);
+      const client = new Client(helper.baseOptions);
       client.hosts = {length: 3};
-      var localCalls = 0;
-      var peerCalls = 0;
+      let localCalls = 0;
+      let peerCalls = 0;
       client.metadata = {
         getLocalSchemaVersion: function (c, cb) {
           localCalls++;
@@ -628,10 +628,10 @@ describe('Client', function () {
       });
     });
     it('should timeout if there is no agreement', function (done) {
-      var client = new Client(utils.extend({}, helper.baseOptions, {protocolOptions: {maxSchemaAgreementWaitSeconds: 1}}));
+      const client = new Client(utils.extend({}, helper.baseOptions, {protocolOptions: {maxSchemaAgreementWaitSeconds: 1}}));
       client.hosts = {length: 3};
-      var localCalls = 0;
-      var peerCalls = 0;
+      let localCalls = 0;
+      let peerCalls = 0;
       client.metadata = {
         getLocalSchemaVersion: function (c, cb) {
           localCalls++;
@@ -651,7 +651,7 @@ describe('Client', function () {
       });
     });
     it('should callback when there is an error retrieving versions', function (done) {
-      var client = new Client(helper.baseOptions);
+      const client = new Client(helper.baseOptions);
       client.hosts = {length: 3};
       var dummyError = new Error('dummy error');
       client.metadata = {
@@ -670,19 +670,18 @@ describe('Client', function () {
   });
   describe('#_setQueryOptions()', function () {
     it('should not allow named parameters when protocol version is lower than 3 and the query is not prepared', function (done) {
-      var Client = rewire('../../lib/client');
-      var client = new Client(helper.baseOptions);
+      const Client = rewire('../../lib/client');
+      const client = new Client(helper.baseOptions);
       client.controlConnection = { protocolVersion: 2};
-      //noinspection JSAccessibilityCheck
       client._setQueryOptions({ prepare: false}, { named: 'val'}, null, function (err) {
         assert.ok(err);
         done();
       });
     });
     it('should adapt user hints using table metadata', function (done) {
-      var Client = rewire('../../lib/client');
-      var client = new Client(helper.baseOptions);
-      var metaCalled = 0;
+      const Client = rewire('../../lib/client');
+      const client = new Client(helper.baseOptions);
+      let metaCalled = 0;
       client._getEncoder = function () { return { setRoutingKey: helper.noop}; };
       client.controlConnection = { protocolVersion: 2};
       client.metadata = {
@@ -694,8 +693,7 @@ describe('Client', function () {
           });
         }
       };
-      var options = { prepare: false, hints: [null, 'text']};
-      //noinspection JSAccessibilityCheck
+      const options = { prepare: false, hints: [null, 'text']};
       client._setQueryOptions(options, ['one', 'two'], null, function (err) {
         assert.ifError(err);
         assert.strictEqual(options.hints.length, 2);
@@ -705,8 +703,8 @@ describe('Client', function () {
       });
     });
     it('should use meta columns', function (done) {
-      var Client = rewire('../../lib/client');
-      var client = new Client(helper.baseOptions);
+      const Client = rewire('../../lib/client');
+      const client = new Client(helper.baseOptions);
       client._getEncoder = function () { return { setRoutingKey: helper.noop}; };
       client.controlConnection = { protocolVersion: 2};
       var meta = {
@@ -715,7 +713,7 @@ describe('Client', function () {
           { type: types.dataTypes.text }
         ]
       };
-      var options = { prepare: true, routingKey: utils.allocBufferUnsafe(2)};
+      const options = { prepare: true, routingKey: utils.allocBufferUnsafe(2)};
       client._setQueryOptions(options, [1, 'two'], meta, function (err) {
         assert.ifError(err);
         assert.strictEqual(options.hints.length, 2);
@@ -725,8 +723,8 @@ describe('Client', function () {
       });
     });
     it('should use the meta partition keys to fill the routingIndexes', function (done) {
-      var Client = rewire('../../lib/client');
-      var client = new Client(helper.baseOptions);
+      const Client = rewire('../../lib/client');
+      const client = new Client(helper.baseOptions);
       client._getEncoder = function () { return { setRoutingKey: helper.noop}; };
       client.controlConnection = { protocolVersion: 4};
       var meta = {
@@ -736,7 +734,7 @@ describe('Client', function () {
         ],
         partitionKeys: [1, 0]
       };
-      var options = { prepare: true};
+      const options = { prepare: true};
       client._setQueryOptions(options, [types.Uuid.random(), 'another'], meta, function (err) {
         assert.ifError(err);
         assert.strictEqual(options.hints.length, 2);
@@ -749,9 +747,9 @@ describe('Client', function () {
       });
     });
     it('should use the table metadata to fill in the routing indexes', function (done) {
-      var Client = rewire('../../lib/client');
-      var client = new Client(helper.baseOptions);
-      var metaCalled = 0;
+      const Client = rewire('../../lib/client');
+      const client = new Client(helper.baseOptions);
+      let metaCalled = 0;
       client._getEncoder = function () { return { setRoutingKey: helper.noop}; };
       client.controlConnection = { protocolVersion: 3};
       var meta = {
@@ -780,10 +778,9 @@ describe('Client', function () {
           });
         }
       };
-      var options = { prepare: true};
+      const options = { prepare: true};
       utils.timesSeries(20, function (n, next) {
         var params = [types.Uuid.random(), 'hello', types.TimeUuid.now()];
-        //noinspection JSAccessibilityCheck
         client._setQueryOptions(options, params, meta, function (err) {
           assert.ifError(err);
           assert.strictEqual(metaCalled, 1);
@@ -807,7 +804,6 @@ function getControlConnectionMock(hosts, options) {
     this.hosts = hosts || new HostMap();
     this.metadata = new Metadata(options || {});
     this.profileManager = newProfileManager(options);
-    //noinspection JSUnresolvedVariable
     this.host = { setDistance: utils.noop };
     this.shutdown = utils.noop;
   }
@@ -825,10 +821,10 @@ function newProfileManager(options) {
 }
 
 function newConnectedInstance(requestHandlerMock, options, prepareHandlerMock) {
-  var Client = rewire('../../lib/client.js');
+  const Client = rewire('../../lib/client.js');
   Client.__set__("RequestHandler", requestHandlerMock || function () {});
   Client.__set__("PrepareHandler", prepareHandlerMock || function () {});
-  var client = new Client(utils.extend({}, helper.baseOptions, options));
+  const client = new Client(utils.extend({}, helper.baseOptions, options));
   client._getEncoder = function () { return new Encoder(2, {});};
   client.connect = helper.callbackNoop;
   return client;

--- a/test/unit/connection-tests.js
+++ b/test/unit/connection-tests.js
@@ -16,7 +16,7 @@ const idleQuery = 'SELECT key from system.local';
 describe('Connection', function () {
   describe('constructor', function () {
     it('should parse host endpoint into address and port', function () {
-      var values = [
+      const values = [
         ['127.0.0.1:9042', '127.0.0.1', '9042'],
         ['10.1.1.255:8888', '10.1.1.255', '8888'],
         ['::1:8888', '::1', '8888'],
@@ -24,7 +24,7 @@ describe('Connection', function () {
         ['aabb::eeff:11:2233:4455:6677:8899:9999', 'aabb::eeff:11:2233:4455:6677:8899', '9999']
       ];
       values.forEach(function (item) {
-        var c = new Connection(item[0], 4, defaultOptions);
+        const c = new Connection(item[0], 4, defaultOptions);
         assert.strictEqual(c.address, item[1]);
         assert.strictEqual(c.port, item[2]);
       });
@@ -121,8 +121,8 @@ describe('Connection', function () {
     this.timeout(1000);
     it('should set the timeout for the idle request', function (done) {
       const sent = [];
-      var writeQueueFake = getWriteQueueFake(sent);
-      var c = newInstance(undefined, undefined, { pooling: { heartBeatInterval: 20 } }, writeQueueFake);
+      const writeQueueFake = getWriteQueueFake(sent);
+      const c = newInstance(undefined, undefined, { pooling: { heartBeatInterval: 20 } }, writeQueueFake);
       c.sendStream(new requests.QueryRequest('QUERY1'), null, utils.noop);
       setTimeout(function () {
         // 2 requests were sent, the user query plus the idle query
@@ -135,8 +135,8 @@ describe('Connection', function () {
     });
     it('should not set the timeout for the idle request when heartBeatInterval is 0', function (done) {
       const sent = [];
-      var writeQueueFake = getWriteQueueFake(sent);
-      var c = newInstance(undefined, undefined, { pooling: { heartBeatInterval: 0 } }, writeQueueFake);
+      const writeQueueFake = getWriteQueueFake(sent);
+      const c = newInstance(undefined, undefined, { pooling: { heartBeatInterval: 0 } }, writeQueueFake);
       c.sendStream(new requests.QueryRequest('QUERY1'), null, utils.noop);
       setTimeout(function () {
         // Only 1 request was sent, no idle query
@@ -149,8 +149,8 @@ describe('Connection', function () {
     });
     it('should reset the timeout after each new request', function (done) {
       const sent = [];
-      var writeQueueFake = getWriteQueueFake(sent);
-      var c = newInstance(undefined, undefined, { pooling: { heartBeatInterval: 20 } }, writeQueueFake);
+      const writeQueueFake = getWriteQueueFake(sent);
+      const c = newInstance(undefined, undefined, { pooling: { heartBeatInterval: 20 } }, writeQueueFake);
       for (let i = 0; i < 4; i++) {
         setTimeout(function (query) {
           c.sendStream(new requests.QueryRequest(query), null, utils.noop);
@@ -166,8 +166,8 @@ describe('Connection', function () {
       }, 40);
     });
     it('should set the request timeout', function (done) {
-      var writeQueueFake = getWriteQueueFake();
-      var c = newInstance(undefined, undefined, { pooling: { heartBeatInterval: 0 } }, writeQueueFake);
+      const writeQueueFake = getWriteQueueFake();
+      const c = newInstance(undefined, undefined, { pooling: { heartBeatInterval: 0 } }, writeQueueFake);
       c.sendStream(new requests.QueryRequest('QUERY1'), { readTimeout: 20 }, function (err) {
         helper.assertInstanceOf(err, errors.OperationTimedOutError);
         c.close();
@@ -177,7 +177,7 @@ describe('Connection', function () {
   });
   describe('#close', function () {
     it('should allow socket.close event to be emitted before calling back when connected', function (done) {
-      var ConnectionInjected = rewire('../../lib/connection');
+      const ConnectionInjected = rewire('../../lib/connection');
       function SocketMock() {
       }
       util.inherits(SocketMock, events.EventEmitter);
@@ -196,7 +196,7 @@ describe('Connection', function () {
       SocketMock.prototype.setNoDelay = helper.noop;
       SocketMock.prototype.pipe = function () {return this;};
       ConnectionInjected.__set__("net", { Socket: SocketMock});
-      var c = new ConnectionInjected('127.0.0.1:9042', 9042, utils.extend({}, defaultOptions));
+      const c = new ConnectionInjected('127.0.0.1:9042', 9042, utils.extend({}, defaultOptions));
       c.logEmitter = helper.noop;
       c.sendStream = function (r, o, cb) {
         cb(null, {});
@@ -205,7 +205,7 @@ describe('Connection', function () {
         assert.ifError(err);
         assert.ok(c.connected);
         //it is now connected
-        var socket = c.netClient;
+        const socket = c.netClient;
         let closeEmitted = 0;
         socket.on('close', function () {
           closeEmitted++;
@@ -218,7 +218,7 @@ describe('Connection', function () {
       });
     });
     it('should allow socket.close event to be emitted before calling back when disconnected', function (done) {
-      var ConnectionInjected = rewire('../../lib/connection');
+      const ConnectionInjected = rewire('../../lib/connection');
       function SocketMock() {
       }
       util.inherits(SocketMock, events.EventEmitter);
@@ -236,7 +236,7 @@ describe('Connection', function () {
       SocketMock.prototype.setNoDelay = helper.noop;
       SocketMock.prototype.pipe = function () {return this;};
       ConnectionInjected.__set__("net", { Socket: SocketMock});
-      var c = new ConnectionInjected('127.0.0.1:9042', 9042, utils.extend({}, defaultOptions));
+      const c = new ConnectionInjected('127.0.0.1:9042', 9042, utils.extend({}, defaultOptions));
       c.logEmitter = helper.noop;
       c.sendStream = function (r, o, cb) {
         cb(null, {});
@@ -246,7 +246,7 @@ describe('Connection', function () {
         assert.ok(c.connected);
         //force destroy
         c.connected = false;
-        var socket = c.netClient;
+        const socket = c.netClient;
         let closeEmitted = 0;
         socket.on('close', function () {
           closeEmitted++;
@@ -265,7 +265,7 @@ describe('Connection', function () {
 function newInstance(address, protocolVersion, options, writeQueue){
   address = address || helper.baseOptions.contactPoints[0];
   options = utils.deepExtend({ logEmitter: helper.noop }, defaultOptions, options);
-  var c = new Connection(address + ':' + 9000, protocolVersion || 1, options);
+  const c = new Connection(address + ':' + 9000, protocolVersion || 1, options);
   c.connected = !!writeQueue;
   c.writeQueue = writeQueue;
   return c;

--- a/test/unit/connection-tests.js
+++ b/test/unit/connection-tests.js
@@ -1,17 +1,17 @@
 "use strict";
-var assert = require('assert');
-var util = require('util');
-var events = require('events');
-var rewire = require('rewire');
+const assert = require('assert');
+const util = require('util');
+const events = require('events');
+const rewire = require('rewire');
 
-var Connection = require('../../lib/connection');
-var requests = require('../../lib/requests');
-var defaultOptions = require('../../lib/client-options').defaultOptions();
-var utils = require('../../lib/utils');
-var errors = require('../../lib/errors');
-var helper = require('../test-helper');
+const Connection = require('../../lib/connection');
+const requests = require('../../lib/requests');
+const defaultOptions = require('../../lib/client-options').defaultOptions();
+const utils = require('../../lib/utils');
+const errors = require('../../lib/errors');
+const helper = require('../test-helper');
 
-var idleQuery = 'SELECT key from system.local';
+const idleQuery = 'SELECT key from system.local';
 
 describe('Connection', function () {
   describe('constructor', function () {
@@ -41,7 +41,7 @@ describe('Connection', function () {
       });
     }
     it('should prepare different queries', function (done) {
-      var connection = newInstance();
+      const connection = newInstance();
       //override sendStream behaviour
       connection.sendStream = function(r, o, cb) {
         setImmediate(function () {
@@ -58,7 +58,7 @@ describe('Connection', function () {
       });
     });
     it('should prepare different queries with keyspace', function (done) {
-      var connection = newInstance();
+      const connection = newInstance();
       connection.keyspace = 'ks1';
       //override sendStream behaviour
       connection.sendStream = function(r, o, cb) {
@@ -76,8 +76,8 @@ describe('Connection', function () {
       });
     });
     it('should prepare the same query once', function (done) {
-      var connection = newInstance();
-      var ioCount = 0;
+      const connection = newInstance();
+      let ioCount = 0;
       //override sendStream behaviour
       connection.sendStream = function(r, o, cb) {
         setImmediate(function () {
@@ -96,9 +96,9 @@ describe('Connection', function () {
       });
     });
     it('should prepare the same query once with keyspace', function (done) {
-      var connection = newInstance();
+      const connection = newInstance();
       connection.keyspace = 'ks1';
-      var ioCount = 0;
+      let ioCount = 0;
       //override sendStream behaviour
       connection.sendStream = function(r, o, cb) {
         setImmediate(function () {
@@ -120,7 +120,7 @@ describe('Connection', function () {
   describe('#sendStream()', function () {
     this.timeout(1000);
     it('should set the timeout for the idle request', function (done) {
-      var sent = [];
+      const sent = [];
       var writeQueueFake = getWriteQueueFake(sent);
       var c = newInstance(undefined, undefined, { pooling: { heartBeatInterval: 20 } }, writeQueueFake);
       c.sendStream(new requests.QueryRequest('QUERY1'), null, utils.noop);
@@ -134,7 +134,7 @@ describe('Connection', function () {
       }, 30);
     });
     it('should not set the timeout for the idle request when heartBeatInterval is 0', function (done) {
-      var sent = [];
+      const sent = [];
       var writeQueueFake = getWriteQueueFake(sent);
       var c = newInstance(undefined, undefined, { pooling: { heartBeatInterval: 0 } }, writeQueueFake);
       c.sendStream(new requests.QueryRequest('QUERY1'), null, utils.noop);
@@ -148,10 +148,10 @@ describe('Connection', function () {
       }, 20);
     });
     it('should reset the timeout after each new request', function (done) {
-      var sent = [];
+      const sent = [];
       var writeQueueFake = getWriteQueueFake(sent);
       var c = newInstance(undefined, undefined, { pooling: { heartBeatInterval: 20 } }, writeQueueFake);
-      for (var i = 0; i < 4; i++) {
+      for (let i = 0; i < 4; i++) {
         setTimeout(function (query) {
           c.sendStream(new requests.QueryRequest(query), null, utils.noop);
         }, 10 * i, 'QUERY' + i);
@@ -185,7 +185,7 @@ describe('Connection', function () {
         setImmediate(cb);
       };
       SocketMock.prototype.destroy = function () {
-        var self = this;
+        const self = this;
         setImmediate(function () {
           self.emit('close');
         });
@@ -205,9 +205,8 @@ describe('Connection', function () {
         assert.ifError(err);
         assert.ok(c.connected);
         //it is now connected
-        //noinspection JSUnresolvedVariable
         var socket = c.netClient;
-        var closeEmitted = 0;
+        let closeEmitted = 0;
         socket.on('close', function () {
           closeEmitted++;
         });
@@ -227,7 +226,7 @@ describe('Connection', function () {
         setImmediate(cb);
       };
       SocketMock.prototype.end = function () {
-        var self = this;
+        const self = this;
         setImmediate(function () {
           self.emit('close');
         });
@@ -247,9 +246,8 @@ describe('Connection', function () {
         assert.ok(c.connected);
         //force destroy
         c.connected = false;
-        //noinspection JSUnresolvedVariable
         var socket = c.netClient;
-        var closeEmitted = 0;
+        let closeEmitted = 0;
         socket.on('close', function () {
           closeEmitted++;
         });

--- a/test/unit/control-connection-tests.js
+++ b/test/unit/control-connection-tests.js
@@ -1,30 +1,30 @@
 "use strict";
-var assert = require('assert');
-var events = require('events');
-var rewire = require('rewire');
-var dns = require('dns');
+const assert = require('assert');
+const events = require('events');
+const rewire = require('rewire');
+const dns = require('dns');
 
-var helper = require('../test-helper.js');
-var ControlConnection = require('../../lib/control-connection');
-var Host = require('../../lib/host').Host;
-var utils = require('../../lib/utils');
-var Metadata = require('../../lib/metadata');
-var types = require('../../lib/types');
-var errors = require('../../lib/errors');
-var policies = require('../../lib/policies');
-var clientOptions = require('../../lib/client-options');
-var ProfileManager = require('../../lib/execution-profile').ProfileManager;
+const helper = require('../test-helper.js');
+const ControlConnection = require('../../lib/control-connection');
+const Host = require('../../lib/host').Host;
+const utils = require('../../lib/utils');
+const Metadata = require('../../lib/metadata');
+const types = require('../../lib/types');
+const errors = require('../../lib/errors');
+const policies = require('../../lib/policies');
+const clientOptions = require('../../lib/client-options');
+const ProfileManager = require('../../lib/execution-profile').ProfileManager;
 
 describe('ControlConnection', function () {
   describe('constructor', function () {
     it('should create a new metadata instance', function () {
-      var cc = new ControlConnection(clientOptions.extend({}, helper.baseOptions));
+      const cc = new ControlConnection(clientOptions.extend({}, helper.baseOptions));
       helper.assertInstanceOf(cc.metadata, Metadata);
     });
   });
   describe('#init()', function () {
     this.timeout(20000);
-    var useLocalhost;
+    let useLocalhost;
     before(function (done) {
       dns.resolve('localhost', function (err) {
         if (err) {
@@ -35,7 +35,7 @@ describe('ControlConnection', function () {
       });
     });
     function testResolution(CcMock, expectedHosts, done) {
-      var cc = new CcMock(clientOptions.extend({ contactPoints: ['my-host-name'] }), null, getContext({
+      const cc = new CcMock(clientOptions.extend({ contactPoints: ['my-host-name'] }), null, getContext({
         queryResults: { 'system\\.peers': {
           rows: expectedHosts
             .filter(function (address) { return address !== '1:9042'; })
@@ -54,7 +54,7 @@ describe('ControlConnection', function () {
       if (!useLocalhost) {
         return done();
       }
-      var cc = newInstance({ contactPoints: [ 'localhost' ] }, getContext());
+      const cc = newInstance({ contactPoints: [ 'localhost' ] }, getContext());
       cc.init(function (err) {
         cc.shutdown();
         assert.ifError(err);
@@ -68,7 +68,7 @@ describe('ControlConnection', function () {
       if (!useLocalhost) {
         return done();
       }
-      var cc = newInstance({ contactPoints: [ 'localhost:9999' ] }, getContext());
+      const cc = newInstance({ contactPoints: [ 'localhost:9999' ] }, getContext());
       cc.init(function (err) {
         cc.shutdown();
         assert.ifError(err);
@@ -139,8 +139,8 @@ describe('ControlConnection', function () {
       testResolution(ControlConnectionMock, [ '123:9042' ], done);
     });
     it('should continue iterating through the hosts when borrowing a connection fails', function (done) {
-      var hosts = [];
-      var cc = newInstance({ contactPoints: [ '::1', '::2' ] }, getContext({ hosts: hosts, failBorrow: [ 0 ] }));
+      const hosts = [];
+      const cc = newInstance({ contactPoints: [ '::1', '::2' ] }, getContext({ hosts: hosts, failBorrow: [ 0 ] }));
       cc.init(function (err) {
         cc.shutdown();
         assert.ifError(err);
@@ -150,8 +150,8 @@ describe('ControlConnection', function () {
       });
     });
     it('should callback with NoHostAvailableError when borrowing all connections fail', function (done) {
-      var hosts = [];
-      var cc = newInstance({ contactPoints: [ '::1', '::2' ] }, getContext({ hosts: hosts, failBorrow: [ 0, 1] }));
+      const hosts = [];
+      const cc = newInstance({ contactPoints: [ '::1', '::2' ] }, getContext({ hosts: hosts, failBorrow: [ 0, 1] }));
       cc.init(function (err) {
         cc.shutdown();
         helper.assertInstanceOf(err, errors.NoHostAvailableError);
@@ -162,8 +162,8 @@ describe('ControlConnection', function () {
       });
     });
     it('should continue iterating through the hosts when metadata retrieval fails', function (done) {
-      var hosts = [];
-      var cc = newInstance({ contactPoints: [ '::1', '::2' ] }, getContext({
+      const hosts = [];
+      const cc = newInstance({ contactPoints: [ '::1', '::2' ] }, getContext({
         hosts: hosts, queryResults: { '::1': 'Test error, failed query' }
       }));
       cc.init(function (err) {
@@ -173,10 +173,10 @@ describe('ControlConnection', function () {
       });
     });
     it('should listen to socketClose and reconnect', function (done) {
-      var state = {};
-      var hostsTried = [];
+      const state = {};
+      const hostsTried = [];
       var lbp = new policies.loadBalancing.RoundRobinPolicy();
-      var cc = newInstance({ contactPoints: [ '::1', '::2' ], policies: { loadBalancing: lbp } }, getContext({
+      const cc = newInstance({ contactPoints: [ '::1', '::2' ], policies: { loadBalancing: lbp } }, getContext({
         state: state, hosts: hostsTried
       }));
       cc.init(function (err) {
@@ -196,8 +196,8 @@ describe('ControlConnection', function () {
   });
   describe('#getAddressForPeerHost()', function() {
     it('should handle null, 0.0.0.0 and valid addresses', function (done) {
-      var options = clientOptions.extend({}, helper.baseOptions);
-      var cc = newInstance(options);
+      const options = clientOptions.extend({}, helper.baseOptions);
+      const cc = newInstance(options);
       cc.host = new Host('2.2.2.2', 1, options);
       cc.log = helper.noop;
       var peer = getInet([100, 100, 100, 100]);
@@ -228,16 +228,16 @@ describe('ControlConnection', function () {
       ], done);
     });
     it('should call the AddressTranslator', function (done) {
-      var options = clientOptions.extend({}, helper.baseOptions);
-      var address = null;
-      var port = null;
+      const options = clientOptions.extend({}, helper.baseOptions);
+      let address = null;
+      let port = null;
       options.policies.addressResolution = policies.defaultAddressTranslator();
       options.policies.addressResolution.translate = function (addr, p, cb) {
         address = addr;
         port = p;
         cb(addr + ':' + p);
       };
-      var cc = newInstance(options);
+      const cc = newInstance(options);
       cc.host = new Host('2.2.2.2', 1, options);
       cc.log = helper.noop;
       var row = {'rpc_address': getInet([5, 2, 3, 4]), peer: null};
@@ -251,8 +251,8 @@ describe('ControlConnection', function () {
   });
   describe('#setPeersInfo()', function () {
     it('should use not add invalid addresses', function () {
-      var options = clientOptions.extend({}, helper.baseOptions);
-      var cc = newInstance(options);
+      const options = clientOptions.extend({}, helper.baseOptions);
+      const cc = newInstance(options);
       cc.host = new Host('18.18.18.18', 1, options);
       var rows = [
         //valid rpc address
@@ -273,8 +273,8 @@ describe('ControlConnection', function () {
       });
     });
     it('should set the host datacenter and cassandra version', function () {
-      var options = clientOptions.extend({}, helper.baseOptions);
-      var cc = newInstance(options);
+      const options = clientOptions.extend({}, helper.baseOptions);
+      const cc = newInstance(options);
       var rows = [
         //valid rpc address
         {'rpc_address': getInet([5, 4, 3, 2]), peer: getInet([1, 1, 1, 1]), data_center: 'dc100', release_version: '2.1.4'},
@@ -295,8 +295,8 @@ describe('ControlConnection', function () {
   });
   describe('#refresh()', function () {
     it('should schedule reconnection when it cant borrow a connection', function (done) {
-      var state = {};
-      var hostsTried = [];
+      const state = {};
+      const hostsTried = [];
       var lbp = new policies.loadBalancing.RoundRobinPolicy();
       lbp.queryPlanCount = 0;
       lbp.newQueryPlan = function (ks, o, cb) {
@@ -316,7 +316,7 @@ describe('ControlConnection', function () {
           }
         };
       };
-      var cc = newInstance({ contactPoints: [ '::1', '::2' ], policies: { loadBalancing: lbp, reconnection: rp } },
+      const cc = newInstance({ contactPoints: [ '::1', '::2' ], policies: { loadBalancing: lbp, reconnection: rp } },
         getContext({ state: state, hosts: hostsTried }));
       cc.init(function (err) {
         assert.ifError(err);
@@ -369,8 +369,8 @@ function getFakeConnection(endpoint, queryResults) {
   var defaultResult = { rows: [ {} ] };
   c.sendStream = function (request, options, cb) {
     c.requests.push(request);
-    var result;
-    for (var i = 0; i < queryResultKeys.length; i++) {
+    let result;
+    for (let i = 0; i < queryResultKeys.length; i++) {
       var key = queryResultKeys[i];
       var re = new RegExp(key);
       if (re.test(request.query) || re.test(endpoint)) {

--- a/test/unit/control-connection-tests.js
+++ b/test/unit/control-connection-tests.js
@@ -43,7 +43,7 @@ describe('ControlConnection', function () {
         }}
       }));
       cc.init(function (err) {
-        var hosts = cc.hosts.values();
+        const hosts = cc.hosts.values();
         cc.shutdown();
         assert.ifError(err);
         assert.deepEqual(hosts.map(function (h) { return h.address; }), expectedHosts);
@@ -58,7 +58,7 @@ describe('ControlConnection', function () {
       cc.init(function (err) {
         cc.shutdown();
         assert.ifError(err);
-        var hosts = cc.hosts.values();
+        const hosts = cc.hosts.values();
         assert.strictEqual(hosts.length, 2);
         assert.deepEqual(hosts.map(function (h) { return h.address; }).sort(), [ '127.0.0.1:9042', '::1:9042' ]);
         done();
@@ -72,14 +72,14 @@ describe('ControlConnection', function () {
       cc.init(function (err) {
         cc.shutdown();
         assert.ifError(err);
-        var hosts = cc.hosts.values();
+        const hosts = cc.hosts.values();
         assert.ok(hosts.length >= 1);
         assert.strictEqual(hosts.filter(function (h) { return h.address === '127.0.0.1:9999'; }).length, 1);
         done();
       });
     });
     it('should resolve all IPv4 and IPv6 addresses provided by dns.resolve()', function (done) {
-      var ControlConnectionMock = rewire('../../lib/control-connection');
+      const ControlConnectionMock = rewire('../../lib/control-connection');
       ControlConnectionMock.__set__('dns', {
         resolve4: function (name, cb) {
           cb(null, ['1', '2']);
@@ -94,7 +94,7 @@ describe('ControlConnection', function () {
       testResolution(ControlConnectionMock, [ '1:9042', '2:9042', '10:9042', '20:9042' ], done);
     });
     it('should ignore IPv4 or IPv6 resolution errors', function (done) {
-      var ControlConnectionMock = rewire('../../lib/control-connection');
+      const ControlConnectionMock = rewire('../../lib/control-connection');
       ControlConnectionMock.__set__('dns', {
         resolve4: function (name, cb) {
           cb(null, ['1', '2']);
@@ -109,7 +109,7 @@ describe('ControlConnection', function () {
       testResolution(ControlConnectionMock, [ '1:9042', '2:9042'], done);
     });
     it('should use dns.lookup() as failover', function (done) {
-      var ControlConnectionMock = rewire('../../lib/control-connection');
+      const ControlConnectionMock = rewire('../../lib/control-connection');
       ControlConnectionMock.__set__('dns', {
         resolve4: function (name, cb) {
           cb(new Error('Test error'));
@@ -124,7 +124,7 @@ describe('ControlConnection', function () {
       testResolution(ControlConnectionMock, [ '123:9042' ], done);
     });
     it('should use dns.lookup() when no address was resolved', function (done) {
-      var ControlConnectionMock = rewire('../../lib/control-connection');
+      const ControlConnectionMock = rewire('../../lib/control-connection');
       ControlConnectionMock.__set__('dns', {
         resolve4: function (name, cb) {
           cb(null);
@@ -175,7 +175,7 @@ describe('ControlConnection', function () {
     it('should listen to socketClose and reconnect', function (done) {
       const state = {};
       const hostsTried = [];
-      var lbp = new policies.loadBalancing.RoundRobinPolicy();
+      const lbp = new policies.loadBalancing.RoundRobinPolicy();
       const cc = newInstance({ contactPoints: [ '::1', '::2' ], policies: { loadBalancing: lbp } }, getContext({
         state: state, hosts: hostsTried
       }));
@@ -200,17 +200,17 @@ describe('ControlConnection', function () {
       const cc = newInstance(options);
       cc.host = new Host('2.2.2.2', 1, options);
       cc.log = helper.noop;
-      var peer = getInet([100, 100, 100, 100]);
+      const peer = getInet([100, 100, 100, 100]);
       utils.series([
         function (next) {
-          var row = {'rpc_address': getInet([1, 2, 3, 4]), peer: peer};
+          const row = {'rpc_address': getInet([1, 2, 3, 4]), peer: peer};
           cc.getAddressForPeerHost(row, 9042, function (endPoint) {
             assert.strictEqual(endPoint, '1.2.3.4:9042');
             next();
           });
         },
         function (next) {
-          var row = {'rpc_address': getInet([0, 0, 0, 0]), peer: peer};
+          const row = {'rpc_address': getInet([0, 0, 0, 0]), peer: peer};
           cc.getAddressForPeerHost(row, 9001, function (endPoint) {
             //should return peer address
             assert.strictEqual(endPoint, '100.100.100.100:9001');
@@ -218,7 +218,7 @@ describe('ControlConnection', function () {
           });
         },
         function (next) {
-          var row = {'rpc_address': null, peer: peer};
+          const row = {'rpc_address': null, peer: peer};
           cc.getAddressForPeerHost(row, 9042, function (endPoint) {
             //should callback with null
             assert.strictEqual(endPoint, null);
@@ -240,7 +240,7 @@ describe('ControlConnection', function () {
       const cc = newInstance(options);
       cc.host = new Host('2.2.2.2', 1, options);
       cc.log = helper.noop;
-      var row = {'rpc_address': getInet([5, 2, 3, 4]), peer: null};
+      const row = {'rpc_address': getInet([5, 2, 3, 4]), peer: null};
       cc.getAddressForPeerHost(row, 9055, function (endPoint) {
         assert.strictEqual(endPoint, '5.2.3.4:9055');
         assert.strictEqual(address, '5.2.3.4');
@@ -254,7 +254,7 @@ describe('ControlConnection', function () {
       const options = clientOptions.extend({}, helper.baseOptions);
       const cc = newInstance(options);
       cc.host = new Host('18.18.18.18', 1, options);
-      var rows = [
+      const rows = [
         //valid rpc address
         {'rpc_address': getInet([5, 4, 3, 2]), peer: getInet([1, 1, 1, 1])},
         //valid rpc address
@@ -275,7 +275,7 @@ describe('ControlConnection', function () {
     it('should set the host datacenter and cassandra version', function () {
       const options = clientOptions.extend({}, helper.baseOptions);
       const cc = newInstance(options);
-      var rows = [
+      const rows = [
         //valid rpc address
         {'rpc_address': getInet([5, 4, 3, 2]), peer: getInet([1, 1, 1, 1]), data_center: 'dc100', release_version: '2.1.4'},
         //valid rpc address
@@ -297,7 +297,7 @@ describe('ControlConnection', function () {
     it('should schedule reconnection when it cant borrow a connection', function (done) {
       const state = {};
       const hostsTried = [];
-      var lbp = new policies.loadBalancing.RoundRobinPolicy();
+      const lbp = new policies.loadBalancing.RoundRobinPolicy();
       lbp.queryPlanCount = 0;
       lbp.newQueryPlan = function (ks, o, cb) {
         if (lbp.queryPlanCount++ === 0) {
@@ -306,7 +306,7 @@ describe('ControlConnection', function () {
         }
         return cb(null, utils.arrayIterator(lbp.hosts.values()));
       };
-      var rp = new policies.reconnection.ConstantReconnectionPolicy(10);
+      const rp = new policies.reconnection.ConstantReconnectionPolicy(10);
       rp.nextDelayCount = 0;
       rp.newSchedule = function () {
         return {
@@ -324,7 +324,7 @@ describe('ControlConnection', function () {
         assert.strictEqual(hostsTried.length, 1);
         lbp.init(null, cc.hosts, utils.noop);
         state.connection.emit('socketClose');
-        var previousConnection = state.connection;
+        const previousConnection = state.connection;
         setImmediate(function () {
           // Attempted reconnection and there isn't a host available
           assert.strictEqual(hostsTried.length, 1);
@@ -360,19 +360,19 @@ function newInstance(options, context) {
 
 function getFakeConnection(endpoint, queryResults) {
   queryResults = queryResults || {};
-  var c = new events.EventEmitter();
+  const c = new events.EventEmitter();
   c.protocolVersion = types.protocolVersion.maxSupported;
   c.endpoint = endpoint;
   c.connected = true;
   c.requests = [];
-  var queryResultKeys = Object.keys(queryResults);
-  var defaultResult = { rows: [ {} ] };
+  const queryResultKeys = Object.keys(queryResults);
+  const defaultResult = { rows: [ {} ] };
   c.sendStream = function (request, options, cb) {
     c.requests.push(request);
     let result;
     for (let i = 0; i < queryResultKeys.length; i++) {
-      var key = queryResultKeys[i];
-      var re = new RegExp(key);
+      const key = queryResultKeys[i];
+      const re = new RegExp(key);
       if (re.test(request.query) || re.test(endpoint)) {
         result = queryResults[key];
         break;
@@ -394,12 +394,12 @@ function getFakeConnection(endpoint, queryResults) {
 function getContext(options) {
   options = options || {};
   // hosts that the ControlConnection used to borrow a connection
-  var hosts = options.hosts || [];
-  var state = options.state || {};
-  var failBorrow = options.failBorrow || [];
+  const hosts = options.hosts || [];
+  const state = options.state || {};
+  const failBorrow = options.failBorrow || [];
   return {
     borrowHostConnection: function (h, callback) {
-      var i = hosts.length;
+      const i = hosts.length;
       hosts.push(h);
       state.host = h;
       if (failBorrow.indexOf(i) >= 0) {

--- a/test/unit/duration-type-tests.js
+++ b/test/unit/duration-type-tests.js
@@ -1,10 +1,10 @@
 'use strict';
-var assert = require('assert');
-var util = require('util');
-var types = require('../../lib/types');
-var utils = require('../../lib/utils');
-var Duration = types.Duration;
-var Long = types.Long;
+const assert = require('assert');
+const util = require('util');
+const types = require('../../lib/types');
+const utils = require('../../lib/utils');
+const Duration = types.Duration;
+const Long = types.Long;
 
 var values = [
   // [ Duration representation, hex value, standard format, ISO 8601, ISO 8601 Week

--- a/test/unit/duration-type-tests.js
+++ b/test/unit/duration-type-tests.js
@@ -6,7 +6,7 @@ const utils = require('../../lib/utils');
 const Duration = types.Duration;
 const Long = types.Long;
 
-var values = [
+const values = [
   // [ Duration representation, hex value, standard format, ISO 8601, ISO 8601 Week
   [ new Duration(0, 0, Long.fromNumber(1)), '000002', '1ns'],
   [ new Duration(0, 0, Long.fromNumber(128)), '00008100', '128ns'],
@@ -50,7 +50,7 @@ describe('Duration', function () {
       ['should parse ISO 8601 week format', 4]
     ].forEach(function (testInfo) {
       it(testInfo[0], function () {
-        var index = testInfo[1];
+        const index = testInfo[1];
         values.forEach(function (item) {
           if (!item[index]) {
             return;

--- a/test/unit/encoder-tests.js
+++ b/test/unit/encoder-tests.js
@@ -1,12 +1,12 @@
 'use strict';
-var assert = require('assert');
-var util = require('util');
-var utils = require('../../lib/utils');
+const assert = require('assert');
+const util = require('util');
+const utils = require('../../lib/utils');
 
-var Encoder = require('../../lib/encoder');
-var types = require('../../lib/types');
-var dataTypes = types.dataTypes;
-var helper = require('../test-helper');
+const Encoder = require('../../lib/encoder');
+const types = require('../../lib/types');
+const dataTypes = types.dataTypes;
+const helper = require('../test-helper');
 
 describe('encoder', function () {
   describe('Encoder.guessDataType()', function () {
@@ -52,14 +52,14 @@ describe('encoder', function () {
       assert.strictEqual(decoded, value);
     });
     it('should encode and decode a guessed string', function () {
-      var value = 'Pennsatucky';
-      var encoded = typeEncoder.encode(value);
-      var decoded = typeEncoder.decode(encoded, {code: dataTypes.text});
+      const value = 'Pennsatucky';
+      const encoded = typeEncoder.encode(value);
+      const decoded = typeEncoder.decode(encoded, {code: dataTypes.text});
       assert.strictEqual(decoded, value);
     });
     it('should encode stringified uuids for backward-compatibility', function () {
-      var uuid = types.Uuid.random();
-      var encoded = typeEncoder.encode(uuid.toString(), types.dataTypes.uuid);
+      let uuid = types.Uuid.random();
+      let encoded = typeEncoder.encode(uuid.toString(), types.dataTypes.uuid);
       assert.strictEqual(encoded.toString('hex'), uuid.getBuffer().toString('hex'));
 
       uuid = types.TimeUuid.now();
@@ -73,7 +73,6 @@ describe('encoder', function () {
     });
     it('should encode undefined as null', function () {
       var hinted = typeEncoder.encode(undefined, 'set<text>');
-      //noinspection JSCheckFunctionSignatures
       var unHinted = typeEncoder.encode();
       assert.strictEqual(hinted, null);
       assert.strictEqual(unHinted, null);
@@ -107,8 +106,8 @@ describe('encoder', function () {
       }, TypeError);
     });
     it('should encode Long/Date/Number/String as timestamps', function () {
-      var encoder = new Encoder(2, {});
-      var buffer = encoder.encode(types.Long.fromBits(0x00fafafa, 0x07090909), dataTypes.timestamp);
+      const encoder = new Encoder(2, {});
+      let buffer = encoder.encode(types.Long.fromBits(0x00fafafa, 0x07090909), dataTypes.timestamp);
       assert.strictEqual(buffer.toString('hex'), '0709090900fafafa');
       buffer = encoder.encode(1421755130012, dataTypes.timestamp);
       assert.strictEqual(buffer.toString('hex'), '0000014b0735a09c');
@@ -126,8 +125,8 @@ describe('encoder', function () {
       }, TypeError);
     });
     it('should encode String/Number (not NaN) as int', function () {
-      var encoder = new Encoder(2, {});
-      var buffer = encoder.encode(0x071272ab, dataTypes.int);
+      const encoder = new Encoder(2, {});
+      let buffer = encoder.encode(0x071272ab, dataTypes.int);
       assert.strictEqual(buffer.toString('hex'), '071272ab');
       buffer = encoder.encode('0x071272ab', dataTypes.int);
       assert.strictEqual(buffer.toString('hex'), '071272ab');
@@ -144,8 +143,8 @@ describe('encoder', function () {
       }, TypeError);
     });
     it('should encode String/Long/Number as bigint', function () {
-      var encoder = new Encoder(2, {});
-      var buffer = encoder.encode(types.Long.fromString('506946367331695353'), dataTypes.bigint);
+      const encoder = new Encoder(2, {});
+      let buffer = encoder.encode(types.Long.fromString('506946367331695353'), dataTypes.bigint);
       assert.strictEqual(buffer.toString('hex'), '0709090900fafaf9');
       buffer = encoder.encode('506946367331695353', dataTypes.bigint);
       assert.strictEqual(buffer.toString('hex'), '0709090900fafaf9');
@@ -155,8 +154,8 @@ describe('encoder', function () {
       assert.strictEqual(buffer.toString('hex'), '00000000000000ff');
     });
     it('should encode String/Integer/Number as varint', function () {
-      var encoder = new Encoder(2, {});
-      var buffer = encoder.encode(types.Integer.fromString('33554433'), dataTypes.varint);
+      const encoder = new Encoder(2, {});
+      let buffer = encoder.encode(types.Integer.fromString('33554433'), dataTypes.varint);
       assert.strictEqual(buffer.toString('hex'), '02000001');
       buffer = encoder.encode('-150012', dataTypes.varint);
       assert.strictEqual(buffer.toString('hex'), 'fdb604');
@@ -168,8 +167,8 @@ describe('encoder', function () {
       assert.strictEqual(buffer.toString('hex'), '9c');
     });
     it('should encode String/BigDecimal/Number as decimal', function () {
-      var encoder = new Encoder(2, {});
-      var buffer = encoder.encode(types.BigDecimal.fromString('0.00256'), dataTypes.decimal);
+      const encoder = new Encoder(2, {});
+      let buffer = encoder.encode(types.BigDecimal.fromString('0.00256'), dataTypes.decimal);
       assert.strictEqual(buffer.toString('hex'), '000000050100');
       buffer = encoder.encode('-0.01', dataTypes.decimal);
       assert.strictEqual(buffer.toString('hex'), '00000002ff');
@@ -181,8 +180,8 @@ describe('encoder', function () {
       assert.strictEqual(buffer.toString('hex'), '00000001ff01');
     });
     it('should encode/decode InetAddress/Buffer as inet', function () {
-      var InetAddress = types.InetAddress;
-      var encoder = new Encoder(2, {});
+      const InetAddress = types.InetAddress;
+      const encoder = new Encoder(2, {});
       var val1 = new InetAddress(utils.allocBufferFromArray([15, 15, 15, 1]));
       var encoded = encoder.encode(val1, dataTypes.inet);
       assert.strictEqual(encoded.toString('hex'), '0f0f0f01');
@@ -198,7 +197,7 @@ describe('encoder', function () {
       assert.strictEqual(encoded.toString('hex'), val1.getBuffer().toString('hex'));
     });
     it('should decode uuids into Uuid', function () {
-      var uuid = types.Uuid.random();
+      const uuid = types.Uuid.random();
       var decoded = typeEncoder.decode(uuid.getBuffer(), {code: dataTypes.uuid});
       helper.assertInstanceOf(decoded, types.Uuid);
       assert.strictEqual(uuid.toString(), decoded.toString());
@@ -207,7 +206,7 @@ describe('encoder', function () {
       assert.ok(!decoded.equals(decoded2));
     });
     it('should decode timeuuids into TimeUuid', function () {
-      var uuid = types.TimeUuid.now();
+      const uuid = types.TimeUuid.now();
       var decoded = typeEncoder.decode(uuid.getBuffer(), {code: dataTypes.timeuuid});
       helper.assertInstanceOf(decoded, types.TimeUuid);
       assert.strictEqual(uuid.toString(), decoded.toString());
@@ -216,7 +215,7 @@ describe('encoder', function () {
       assert.ok(!decoded.equals(decoded2));
     });
     [2, 3].forEach(function (version) {
-      var encoder = new Encoder(version, {});
+      const encoder = new Encoder(version, {});
       it(util.format('should encode and decode maps for protocol v%d', version), function () {
         var value = {value1: 'Surprise', value2: 'Madafaka'};
         //Minimum info, guessed
@@ -252,7 +251,7 @@ describe('encoder', function () {
         assert.strictEqual(util.inspect(decoded), util.inspect(value));
       });
       it(util.format('should encode and decode maps with stringified keys for protocol v%d', version), function () {
-        var value = {};
+        let value = {};
         value[new Date(1421756675488)] = 'date1';
         value[new Date(1411756633461)] = 'date2';
 
@@ -375,14 +374,13 @@ describe('encoder', function () {
         assert.strictEqual(util.inspect(decoded), util.inspect(value));
       });
       it(util.format('should encode/decode ES6 Set as maps for protocol v%d', version), function () {
-        //noinspection JSUnresolvedVariable
         if (typeof Set !== 'function') {
           //Set not supported in Node.js runtime
           return;
         }
         // eslint-disable-next-line no-undef
         var Es6Set = Set;
-        var encoder = new Encoder(version, { encoding: { set: Es6Set}});
+        const encoder = new Encoder(version, { encoding: { set: Es6Set}});
         var m = new Es6Set(['k1', 'k2', 'k3']);
         var encoded = encoder.encode(m, 'set<text>');
         if (version === 2) {
@@ -401,7 +399,7 @@ describe('encoder', function () {
         assert.strictEqual(decoded.toString(), m.toString());
       });
       it(util.format('should encode/decode Map polyfills as maps for protocol v%d', version), function () {
-        var encoder = new Encoder(version, { encoding: { map: helper.Map}});
+        const encoder = new Encoder(version, { encoding: { map: helper.Map}});
         var m = new helper.Map();
         m.set('k1', 'v1');
         m.set('k2', 'v2');
@@ -425,13 +423,8 @@ describe('encoder', function () {
         assert.strictEqual(decoded.arr.toString(), m.arr.toString());
       });
       it(util.format('should encode/decode ES6 Map as maps for protocol v%d', version), function () {
-        //noinspection JSUnresolvedVariable
-        if (typeof Map !== 'function') {
-          //Running on Node.js version where Ecmascript 6 Maps are not available
-          return;
-        }
         function getValues(m) {
-          var arr = [];
+          const arr = [];
           m.forEach(function (val, key) {
             arr.push([key, val]);
           });
@@ -439,7 +432,7 @@ describe('encoder', function () {
         }
         // eslint-disable-next-line no-undef
         var Es6Map = Map;
-        var encoder = new Encoder(version, { encoding: { map: Es6Map}});
+        const encoder = new Encoder(version, { encoding: { map: Es6Map}});
         var m = new Es6Map();
         m.set('k1', 'v1');
         m.set('k2', 'v2');
@@ -470,7 +463,7 @@ describe('encoder', function () {
         assert.strictEqual(getValues(decoded), getValues(m));
       });
       it(util.format('should encode/decode Set polyfills as maps for protocol v%d', version), function () {
-        var encoder = new Encoder(version, { encoding: { set: helper.Set}});
+        const encoder = new Encoder(version, { encoding: { set: helper.Set}});
         var m = new helper.Set(['k1', 'k2', 'k3']);
         var encoded = encoder.encode(m, 'set<text>');
         if (version === 2) {
@@ -490,7 +483,7 @@ describe('encoder', function () {
       });
     });
     it('should encode/decode udts', function () {
-      var encoder = new Encoder(3, {});
+      const encoder = new Encoder(3, {});
       var type = { code: dataTypes.udt, info: { fields:[
         {name: 'alias', type:{code:dataTypes.text}},
         {name: 'number', type:{code:dataTypes.text}}] }};
@@ -500,7 +493,7 @@ describe('encoder', function () {
       assert.strictEqual(decoded['number'], null);
     });
     it('should encode/decode nested collections', function () {
-      var encoder = new Encoder(3, {});
+      const encoder = new Encoder(3, {});
       var type = { code: dataTypes.map, info: [{code: dataTypes.text}, {code: dataTypes.set, info: {code: dataTypes.text}}]};
       var encoded = encoder.encode({ key1: ['first', 'second', 'third'], key2: ['2-first']}, type);
       var decoded = encoder.decode(encoded, type);
@@ -514,7 +507,7 @@ describe('encoder', function () {
       assert.strictEqual(decoded.key2[0], '2-first');
     });
     it('should encode/decode tuples', function () {
-      var encoder = new Encoder(3, {});
+      const encoder = new Encoder(3, {});
       var type = { code: dataTypes.tuple, info: [ { code: dataTypes.text}, { code: dataTypes.timestamp }]};
       var encoded = encoder.encode(new types.Tuple('one', new Date(1429259123607)), type);
       var decoded = encoder.decode(encoded, type);
@@ -523,7 +516,7 @@ describe('encoder', function () {
       assert.strictEqual(decoded.get(1).getTime(), 1429259123607);
     });
     it('should encode/decode LocalDate as date', function () {
-      var encoder = new Encoder(4, {});
+      const encoder = new Encoder(4, {});
       var type = {code: dataTypes.date};
 
       var year1day1 = new Date(Date.UTC(1970, 0, 1));
@@ -570,7 +563,7 @@ describe('encoder', function () {
       });
     });
     it('should refuse to encode invalid values as LocalDate.', function () {
-      var encoder = new Encoder(4, {});
+      const encoder = new Encoder(4, {});
       var type = {code: dataTypes.date};
       // Non Date/String/LocalDate
       assert.throws(function () { encoder.encode(23.0, type);}, TypeError);
@@ -578,7 +571,7 @@ describe('encoder', function () {
       assert.throws(function () { encoder.encode('', type);}, TypeError);
     });
     it('should encode/decode LocalTime as time', function () {
-      var encoder = new Encoder(3, {});
+      const encoder = new Encoder(3, {});
       var type = {code: dataTypes.time};
       /* eslint-disable no-multi-spaces */
       [
@@ -599,7 +592,7 @@ describe('encoder', function () {
       /* eslint-enable no-multi-spaces */
     });
     it('should refuse to encode invalid values as LocalTime.', function () {
-      var encoder = new Encoder(4, {});
+      const encoder = new Encoder(4, {});
       var type = {code: dataTypes.time};
       // Negative value string.
       assert.throws(function () { encoder.encode('-1:00:00', type);}, TypeError);
@@ -609,34 +602,34 @@ describe('encoder', function () {
   });
   describe('#encode()', function () {
     it('should return null when value is null', function () {
-      var encoder = new Encoder(2, {});
+      const encoder = new Encoder(2, {});
       assert.strictEqual(encoder.encode(null), null);
     });
     it('should return unset when value is unset', function () {
-      var encoder = new Encoder(4, {});
+      const encoder = new Encoder(4, {});
       assert.strictEqual(encoder.encode(types.unset), types.unset);
     });
     it('should return null when value is undefined', function () {
-      var encoder = new Encoder(2, {});
+      const encoder = new Encoder(2, {});
       assert.strictEqual(encoder.encode(undefined), null);
     });
     it('should return unset when value is undefined and flag set', function () {
-      var encoder = new Encoder(4, { encoding: { useUndefinedAsUnset: true}});
+      const encoder = new Encoder(4, { encoding: { useUndefinedAsUnset: true}});
       assert.strictEqual(encoder.encode(undefined), types.unset);
     });
     it('should throw TypeError when value is unset with low protocol version', function () {
-      var encoder = new Encoder(2, {});
+      const encoder = new Encoder(2, {});
       assert.throws(function () {
         encoder.encode(types.unset);
       }, TypeError);
     });
     it('should return null when value is undefined and flag set with low protocol version', function () {
-      var encoder = new Encoder(2, { encoding: { useUndefinedAsUnset: true}});
+      const encoder = new Encoder(2, { encoding: { useUndefinedAsUnset: true}});
       assert.strictEqual(encoder.encode(undefined), null);
     });
     it('should decode 0-length map values, v2', function () {
-      var encoder = new Encoder(2, {});
-      var buffer = utils.allocBufferFromString('000100046b6579310000', 'hex');
+      const encoder = new Encoder(2, {});
+      const buffer = utils.allocBufferFromString('000100046b6579310000', 'hex');
       var value = encoder.decode(buffer,
         { code: types.dataTypes.map, info: [ { code: types.dataTypes.text }, { code: types.dataTypes.text } ]});
       assert.ok(value);
@@ -644,8 +637,8 @@ describe('encoder', function () {
       assert.strictEqual(value['key1'], '');
     });
     it('should decode 0-length map values, v3', function () {
-      var encoder = new Encoder(3, {});
-      var buffer = utils.allocBufferFromString('00000001000000046b65793100000000', 'hex');
+      const encoder = new Encoder(3, {});
+      const buffer = utils.allocBufferFromString('00000001000000046b65793100000000', 'hex');
       var value = encoder.decode(buffer,
         { code: types.dataTypes.map, info: [ { code: types.dataTypes.text }, { code: types.dataTypes.text } ]});
       assert.ok(value);
@@ -655,8 +648,8 @@ describe('encoder', function () {
     it('should decode null map values', function () {
       // technically this should not be possible as nulls are not allowed in collections.
       // at a protocol level this is only possible with v3+ as v2 uses unsigned short for collection element size.
-      var encoder = new Encoder(3, {});
-      var buffer = utils.allocBufferFromString('00000001000000046b657931FFFFFFFF', 'hex');
+      const encoder = new Encoder(3, {});
+      const buffer = utils.allocBufferFromString('00000001000000046b657931FFFFFFFF', 'hex');
       var value = encoder.decode(buffer,
         { code: types.dataTypes.map, info: [ { code: types.dataTypes.text }, { code: types.dataTypes.text } ]});
       assert.ok(value);
@@ -665,10 +658,10 @@ describe('encoder', function () {
     });
   });
   describe('#setRoutingKey()', function () {
-    var encoder = new Encoder(2, {});
+    const encoder = new Encoder(2, {});
     it('should concat Array of buffers in the correct format',function () {
       /** @type {QueryOptions} */
-      var options = {
+      let options = {
         //Its an array of 3 values
         /** @type {Array|Buffer} */
         routingKey: [utils.allocBufferFromArray([1]), utils.allocBufferFromArray([2]), utils.allocBufferFromArray([3, 3])]
@@ -689,7 +682,7 @@ describe('encoder', function () {
     });
     it('should not affect Buffer routing keys', function () {
       /** @type {QueryOptions} */
-      var options = {
+      let options = {
         routingKey: utils.allocBufferFromArray([1, 2, 3, 4])
       };
       var initialRoutingKey = options.routingKey.toString('hex');
@@ -706,7 +699,7 @@ describe('encoder', function () {
     });
     it('should build routing key based on routingIndexes', function () {
       /** @type {QueryOptions} */
-      var options = {
+      let options = {
         hints: ['int'],
         routingIndexes: [0]
       };
@@ -742,7 +735,7 @@ describe('encoder', function () {
     });
     it('should allow undefined routingIndexes', function () {
       /** @type {QueryOptions} */
-      var options = {
+      const options = {
         hints: ['int', 'text'],
         routingIndexes: [0, null, 2]
       };
@@ -751,7 +744,7 @@ describe('encoder', function () {
     });
     it('should allow null or undefined routingKey parts', function () {
       /** @type {QueryOptions} */
-      var options = {
+      const options = {
         routingKey: [utils.allocBufferFromArray([0]), null, utils.allocBufferFromArray([1])]
       };
       encoder.setRoutingKey([], options);
@@ -763,14 +756,14 @@ describe('encoder', function () {
     it('should throw if the type could not be encoded', function () {
       assert.throws(function () {
         /** @type {QueryOptions} */
-        var options = {
+        const options = {
           routingIndexes: [0]
         };
         encoder.setRoutingKey([{a: 1}], options);
       }, TypeError);
       assert.throws(function () {
         /** @type {QueryOptions} */
-        var options = {
+        const options = {
           hints: ['int'],
           routingIndexes: [0]
         };
@@ -780,7 +773,7 @@ describe('encoder', function () {
   });
   describe('#parseFqTypeName()', function () {
     it('should parse single type names', function () {
-      var encoder = new Encoder(2, {});
+      const encoder = new Encoder(2, {});
       var type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.Int32Type');
       assert.strictEqual(dataTypes.int, type.code);
       type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.UUIDType');
@@ -815,7 +808,7 @@ describe('encoder', function () {
       assert.strictEqual(dataTypes.ascii, type.code);
     });
     it('should parse complex type names', function () {
-      var encoder = new Encoder(2, {});
+      const encoder = new Encoder(2, {});
       var type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)');
       assert.strictEqual(dataTypes.list, type.code);
       assert.ok(type.info);
@@ -844,7 +837,7 @@ describe('encoder', function () {
       assert.strictEqual(dataTypes.int, type.info[1].code);
     });
     it('should parse frozen types', function () {
-      var encoder = new Encoder(2, {});
+      const encoder = new Encoder(2, {});
       var type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.TimeUUIDType))');
       assert.strictEqual(dataTypes.list, type.code);
       assert.ok(type.info);
@@ -860,7 +853,7 @@ describe('encoder', function () {
       assert.strictEqual(dataTypes.int, subType.code);
     });
     it('should parse udt types', function () {
-      var encoder = new Encoder(2, {});
+      const encoder = new Encoder(2, {});
       var typeText =
         'org.apache.cassandra.db.marshal.UserType(' +
         'tester,70686f6e65,616c696173:org.apache.cassandra.db.marshal.UTF8Type,6e756d626572:org.apache.cassandra.db.marshal.UTF8Type' +
@@ -877,7 +870,7 @@ describe('encoder', function () {
       assert.strictEqual(dataTypes.varchar, dataType.info.fields[1].type.code);
     });
     it('should parse nested udt types', function () {
-      var encoder = new Encoder(2, {});
+      const encoder = new Encoder(2, {});
       var typeText =
         'org.apache.cassandra.db.marshal.UserType(' +
         'tester,' +
@@ -917,7 +910,7 @@ describe('encoder', function () {
       throw new Error('This function should not be called');
     }
     it('should parse single type names', function (done) {
-      var encoder = new Encoder(4, {});
+      const encoder = new Encoder(4, {});
       /* eslint-disable no-multi-spaces */
       var items = [
         ['int',        dataTypes.int],
@@ -948,7 +941,7 @@ describe('encoder', function () {
       }, done);
     });
     it('should parse complex type names', function (done) {
-      var encoder = new Encoder(4, {});
+      const encoder = new Encoder(4, {});
       var items = [
         ['list<int>', dataTypes.list, dataTypes.int],
         ['set<uuid>', dataTypes.set, dataTypes.uuid],
@@ -978,7 +971,7 @@ describe('encoder', function () {
       }, done);
     });
     it('should parse nested subtypes', function (done) {
-      var encoder = new Encoder(4, {});
+      const encoder = new Encoder(4, {});
       utils.series([
         function (next) {
           var name = 'map<text,frozen<list<frozen<map<text,frozen<list<int>>>>>>>';
@@ -999,10 +992,10 @@ describe('encoder', function () {
       ], done);
     });
     it('should parse udts', function (done) {
-      var encoder = new Encoder(4, {});
+      const encoder = new Encoder(4, {});
       utils.series([
         function (next) {
-          var called = 0;
+          let called = 0;
           function udtResolver(ks, udtName, callback) {
             assert.strictEqual(ks, 'ks2');
             assert.strictEqual(udtName, 'address');
@@ -1022,7 +1015,7 @@ describe('encoder', function () {
           });
         },
         function (next) {
-          var called = 0;
+          let called = 0;
           function udtResolver(ks, udtName, callback) {
             assert.strictEqual(ks, 'ks2');
             assert.strictEqual(udtName, 'address');
@@ -1044,10 +1037,10 @@ describe('encoder', function () {
       ], done);
     });
     it('should parse quoted udts', function (done) {
-      var encoder = new Encoder(4, {});
+      const encoder = new Encoder(4, {});
       utils.series([
         function (next) {
-          var called = 0;
+          let called = 0;
           function udtResolver(ks, udtName, callback) {
             assert.strictEqual(ks, 'ks2');
             assert.strictEqual(udtName, 'PHONE');
@@ -1067,7 +1060,7 @@ describe('encoder', function () {
           });
         },
         function (next) {
-          var called = 0;
+          let called = 0;
           function udtResolver(ks, udtName, callback) {
             assert.strictEqual(ks, 'ks2');
             assert.strictEqual(udtName, 'PhoNe');
@@ -1089,9 +1082,8 @@ describe('encoder', function () {
       ], done);
     });
     it('should callback with TypeError when not found', function (done) {
-      var encoder = new Encoder(4, {});
-      var called = 0;
-      //noinspection JSUnusedLocalSymbols
+      const encoder = new Encoder(4, {});
+      let called = 0;
       function udtResolver(k, u, callback) {
         called++;
         setImmediate(function () {
@@ -1106,10 +1098,9 @@ describe('encoder', function () {
       });
     });
     it('should callback with the same error if udtResolver fails', function (done) {
-      var encoder = new Encoder(4, {});
-      var called = 0;
+      const encoder = new Encoder(4, {});
+      let called = 0;
       var testError = new Error('Test error');
-      //noinspection JSUnusedLocalSymbols
       function udtResolver(k, u, callback) {
         called++;
         setImmediate(function () {
@@ -1125,7 +1116,7 @@ describe('encoder', function () {
     });
   });
   describe('#parseKeyTypes', function () {
-    var encoder = new Encoder(1, {});
+    const encoder = new Encoder(1, {});
     it('should parse single type', function () {
       var value = 'org.apache.cassandra.db.marshal.UTF8Type';
       var result = encoder.parseKeyTypes(value);
@@ -1159,7 +1150,7 @@ describe('encoder', function () {
   });
   describe('constructor', function () {
     it('should define instance members', function () {
-      var encoder = new Encoder(4, {});
+      const encoder = new Encoder(4, {});
       assert.strictEqual(typeof encoder.encodeBlob, 'function');
       assert.strictEqual(typeof encoder.decodeBlob, 'function');
       assert.strictEqual(typeof encoder.protocolVersion, 'number');
@@ -1167,11 +1158,9 @@ describe('encoder', function () {
   });
   describe('prototype', function () {
     it('should only expose encode() and decode() functions', function () {
-      //noinspection JSUnresolvedVariable
       var keys = Object.keys(Encoder.prototype);
       assert.deepEqual(keys, ['decode', 'encode']);
       keys.forEach(function (k) {
-        //noinspection JSUnresolvedVariable
         assert.strictEqual(typeof Encoder.prototype[k], 'function');
       });
     });

--- a/test/unit/encoder-tests.js
+++ b/test/unit/encoder-tests.js
@@ -33,7 +33,7 @@ describe('encoder', function () {
       assertGuessed({}, null, 'Objects must not be guessed');
     });
     function assertGuessed(value, expectedType, message) {
-      var type = Encoder.guessDataType(value);
+      const type = Encoder.guessDataType(value);
       if (type === null) {
         if (expectedType !== null) {
           assert.ok(false, 'Type not guessed for value ' + value);
@@ -44,11 +44,11 @@ describe('encoder', function () {
     }
   });
   describe('#encode() and #decode()', function () {
-    var typeEncoder = new Encoder(2, {});
+    const typeEncoder = new Encoder(2, {});
     it('should encode and decode a guessed double', function () {
-      var value = 1111;
-      var encoded = typeEncoder.encode(value);
-      var decoded = typeEncoder.decode(encoded, {code: dataTypes.double});
+      const value = 1111;
+      const encoded = typeEncoder.encode(value);
+      const decoded = typeEncoder.decode(encoded, {code: dataTypes.double});
       assert.strictEqual(decoded, value);
     });
     it('should encode and decode a guessed string', function () {
@@ -72,8 +72,8 @@ describe('encoder', function () {
       }, TypeError);
     });
     it('should encode undefined as null', function () {
-      var hinted = typeEncoder.encode(undefined, 'set<text>');
-      var unHinted = typeEncoder.encode();
+      const hinted = typeEncoder.encode(undefined, 'set<text>');
+      const unHinted = typeEncoder.encode();
       assert.strictEqual(hinted, null);
       assert.strictEqual(unHinted, null);
     });
@@ -182,10 +182,10 @@ describe('encoder', function () {
     it('should encode/decode InetAddress/Buffer as inet', function () {
       const InetAddress = types.InetAddress;
       const encoder = new Encoder(2, {});
-      var val1 = new InetAddress(utils.allocBufferFromArray([15, 15, 15, 1]));
-      var encoded = encoder.encode(val1, dataTypes.inet);
+      let val1 = new InetAddress(utils.allocBufferFromArray([15, 15, 15, 1]));
+      let encoded = encoder.encode(val1, dataTypes.inet);
       assert.strictEqual(encoded.toString('hex'), '0f0f0f01');
-      var val2 = encoder.decode(encoded, {code: dataTypes.inet});
+      let val2 = encoder.decode(encoded, {code: dataTypes.inet});
       assert.strictEqual(val2.toString(), '15.15.15.1');
       assert.ok(val1.equals(val2));
       val1 = new InetAddress(utils.allocBufferFromString('00000000000100112233445500aa00bb', 'hex'));
@@ -198,29 +198,29 @@ describe('encoder', function () {
     });
     it('should decode uuids into Uuid', function () {
       const uuid = types.Uuid.random();
-      var decoded = typeEncoder.decode(uuid.getBuffer(), {code: dataTypes.uuid});
+      const decoded = typeEncoder.decode(uuid.getBuffer(), {code: dataTypes.uuid});
       helper.assertInstanceOf(decoded, types.Uuid);
       assert.strictEqual(uuid.toString(), decoded.toString());
       assert.ok(uuid.equals(decoded));
-      var decoded2 = typeEncoder.decode(types.Uuid.random().getBuffer(), {code: dataTypes.uuid});
+      const decoded2 = typeEncoder.decode(types.Uuid.random().getBuffer(), {code: dataTypes.uuid});
       assert.ok(!decoded.equals(decoded2));
     });
     it('should decode timeuuids into TimeUuid', function () {
       const uuid = types.TimeUuid.now();
-      var decoded = typeEncoder.decode(uuid.getBuffer(), {code: dataTypes.timeuuid});
+      const decoded = typeEncoder.decode(uuid.getBuffer(), {code: dataTypes.timeuuid});
       helper.assertInstanceOf(decoded, types.TimeUuid);
       assert.strictEqual(uuid.toString(), decoded.toString());
       assert.ok(uuid.equals(decoded));
-      var decoded2 = typeEncoder.decode(types.TimeUuid.now().getBuffer(), {code: dataTypes.timeuuid});
+      const decoded2 = typeEncoder.decode(types.TimeUuid.now().getBuffer(), {code: dataTypes.timeuuid});
       assert.ok(!decoded.equals(decoded2));
     });
     [2, 3].forEach(function (version) {
       const encoder = new Encoder(version, {});
       it(util.format('should encode and decode maps for protocol v%d', version), function () {
-        var value = {value1: 'Surprise', value2: 'Madafaka'};
+        let value = {value1: 'Surprise', value2: 'Madafaka'};
         //Minimum info, guessed
-        var encoded = encoder.encode(value, dataTypes.map);
-        var decoded = encoder.decode(encoded, {code: dataTypes.map, info: [{code: dataTypes.text}, {code: dataTypes.text}]});
+        let encoded = encoder.encode(value, dataTypes.map);
+        let decoded = encoder.decode(encoded, {code: dataTypes.map, info: [{code: dataTypes.text}, {code: dataTypes.text}]});
         assert.strictEqual(util.inspect(decoded), util.inspect(value));
         //Minimum info, guessed
         value = {value1: 1.1, valueN: 1.2};
@@ -255,8 +255,8 @@ describe('encoder', function () {
         value[new Date(1421756675488)] = 'date1';
         value[new Date(1411756633461)] = 'date2';
 
-        var encoded = encoder.encode(value, {code: dataTypes.map, info: [{code: dataTypes.timestamp}, {code: dataTypes.text}]});
-        var decoded = encoder.decode(encoded, {code: dataTypes.map, info: [{code: dataTypes.timestamp}, {code: dataTypes.text}]});
+        let encoded = encoder.encode(value, {code: dataTypes.map, info: [{code: dataTypes.timestamp}, {code: dataTypes.text}]});
+        let decoded = encoder.decode(encoded, {code: dataTypes.map, info: [{code: dataTypes.timestamp}, {code: dataTypes.text}]});
         assert.strictEqual(util.inspect(decoded), util.inspect(value));
 
         value = {};
@@ -340,27 +340,27 @@ describe('encoder', function () {
         assert.strictEqual(util.inspect(decoded), util.inspect(value));
       });
       it(util.format('should encode and decode list<int> for protocol v%d', version), function () {
-        var value = [1, 2, 3, 4];
-        var encoded = encoder.encode(value, 'list<int>');
-        var decoded = encoder.decode(encoded, {code: dataTypes.list, info: {code: dataTypes.int}});
+        const value = [1, 2, 3, 4];
+        const encoded = encoder.encode(value, 'list<int>');
+        const decoded = encoder.decode(encoded, {code: dataTypes.list, info: {code: dataTypes.int}});
         assert.strictEqual(util.inspect(decoded), util.inspect(value));
       });
       it(util.format('should encode and decode list<double> for protocol v%d', version), function () {
-        var value = [1, 2, 3, 100];
-        var encoded = encoder.encode(value, 'list<double>');
-        var decoded = encoder.decode(encoded, {code: dataTypes.list, info: {code: dataTypes.double}});
+        const value = [1, 2, 3, 100];
+        const encoded = encoder.encode(value, 'list<double>');
+        const decoded = encoder.decode(encoded, {code: dataTypes.list, info: {code: dataTypes.double}});
         assert.strictEqual(util.inspect(decoded), util.inspect(value));
       });
       it(util.format('should encode and decode list<double> without hint for protocol v%d', version), function () {
-        var value = [1, 2, 3, 100.1];
-        var encoded = encoder.encode(value);
-        var decoded = encoder.decode(encoded, {code: dataTypes.list, info: {code: dataTypes.double}});
+        const value = [1, 2, 3, 100.1];
+        const encoded = encoder.encode(value);
+        const decoded = encoder.decode(encoded, {code: dataTypes.list, info: {code: dataTypes.double}});
         assert.strictEqual(util.inspect(decoded), util.inspect(value));
       });
       it(util.format('should encode and decode set<text> for protocol v%d', version), function () {
-        var value = ['Alex Vause', 'Piper Chapman', '3', '4'];
-        var encoded = encoder.encode(value, 'set<text>');
-        var decoded = encoder.decode(encoded, {code: dataTypes.set, info: {code: dataTypes.text}});
+        const value = ['Alex Vause', 'Piper Chapman', '3', '4'];
+        let encoded = encoder.encode(value, 'set<text>');
+        let decoded = encoder.decode(encoded, {code: dataTypes.set, info: {code: dataTypes.text}});
         assert.strictEqual(util.inspect(decoded), util.inspect(value));
         //with type info
         encoded = encoder.encode(value, {code: dataTypes.set, info: {code: dataTypes.text}});
@@ -368,9 +368,9 @@ describe('encoder', function () {
         assert.strictEqual(util.inspect(decoded), util.inspect(value));
       });
       it(util.format('should encode and decode list<float> with typeInfo for protocol v%d', version), function () {
-        var value = [1.1122000217437744, 2.212209939956665, 3.3999900817871094, 4.412120819091797, -1000, 1];
-        var encoded = encoder.encode(value, {code: dataTypes.list, info: {code: dataTypes.float}});
-        var decoded = encoder.decode(encoded, {code: dataTypes.list, info: {code: dataTypes.float}});
+        const value = [1.1122000217437744, 2.212209939956665, 3.3999900817871094, 4.412120819091797, -1000, 1];
+        const encoded = encoder.encode(value, {code: dataTypes.list, info: {code: dataTypes.float}});
+        const decoded = encoder.decode(encoded, {code: dataTypes.list, info: {code: dataTypes.float}});
         assert.strictEqual(util.inspect(decoded), util.inspect(value));
       });
       it(util.format('should encode/decode ES6 Set as maps for protocol v%d', version), function () {
@@ -379,14 +379,14 @@ describe('encoder', function () {
           return;
         }
         // eslint-disable-next-line no-undef
-        var Es6Set = Set;
+        const Es6Set = Set;
         const encoder = new Encoder(version, { encoding: { set: Es6Set}});
-        var m = new Es6Set(['k1', 'k2', 'k3']);
-        var encoded = encoder.encode(m, 'set<text>');
+        let m = new Es6Set(['k1', 'k2', 'k3']);
+        let encoded = encoder.encode(m, 'set<text>');
         if (version === 2) {
           assert.strictEqual(encoded.toString('hex'), '000300026b3100026b3200026b33');
         }
-        var decoded = encoder.decode(encoded, {code: dataTypes.set, info: {code: dataTypes.text}});
+        let decoded = encoder.decode(encoded, {code: dataTypes.set, info: {code: dataTypes.text}});
         helper.assertInstanceOf(decoded, Es6Set);
         assert.strictEqual(decoded.toString(), m.toString());
 
@@ -400,14 +400,14 @@ describe('encoder', function () {
       });
       it(util.format('should encode/decode Map polyfills as maps for protocol v%d', version), function () {
         const encoder = new Encoder(version, { encoding: { map: helper.Map}});
-        var m = new helper.Map();
+        let m = new helper.Map();
         m.set('k1', 'v1');
         m.set('k2', 'v2');
-        var encoded = encoder.encode(m, 'map<text,text>');
+        let encoded = encoder.encode(m, 'map<text,text>');
         if (version === 2) {
           assert.strictEqual(encoded.toString('hex'), '000200026b310002763100026b3200027632');
         }
-        var decoded = encoder.decode(encoded, {code: dataTypes.map, info: [{code: dataTypes.text}, {code: dataTypes.text}]});
+        let decoded = encoder.decode(encoded, {code: dataTypes.map, info: [{code: dataTypes.text}, {code: dataTypes.text}]});
         helper.assertInstanceOf(decoded, helper.Map);
         assert.strictEqual(decoded.arr.toString(), m.arr.toString());
 
@@ -431,16 +431,16 @@ describe('encoder', function () {
           return arr.toString();
         }
         // eslint-disable-next-line no-undef
-        var Es6Map = Map;
+        const Es6Map = Map;
         const encoder = new Encoder(version, { encoding: { map: Es6Map}});
-        var m = new Es6Map();
+        let m = new Es6Map();
         m.set('k1', 'v1');
         m.set('k2', 'v2');
-        var encoded = encoder.encode(m, 'map<text,text>');
+        let encoded = encoder.encode(m, 'map<text,text>');
         if (version === 2) {
           assert.strictEqual(encoded.toString('hex'), '000200026b310002763100026b3200027632');
         }
-        var decoded = encoder.decode(encoded, {code: dataTypes.map, info: [{code: dataTypes.text}, {code: dataTypes.text}]});
+        let decoded = encoder.decode(encoded, {code: dataTypes.map, info: [{code: dataTypes.text}, {code: dataTypes.text}]});
         helper.assertInstanceOf(decoded, Es6Map);
         assert.strictEqual(getValues(decoded), getValues(m));
 
@@ -464,12 +464,12 @@ describe('encoder', function () {
       });
       it(util.format('should encode/decode Set polyfills as maps for protocol v%d', version), function () {
         const encoder = new Encoder(version, { encoding: { set: helper.Set}});
-        var m = new helper.Set(['k1', 'k2', 'k3']);
-        var encoded = encoder.encode(m, 'set<text>');
+        let m = new helper.Set(['k1', 'k2', 'k3']);
+        let encoded = encoder.encode(m, 'set<text>');
         if (version === 2) {
           assert.strictEqual(encoded.toString('hex'), '000300026b3100026b3200026b33');
         }
-        var decoded = encoder.decode(encoded, {code: dataTypes.set, info: {code: dataTypes.text}});
+        let decoded = encoder.decode(encoded, {code: dataTypes.set, info: {code: dataTypes.text}});
         helper.assertInstanceOf(decoded, helper.Set);
         assert.strictEqual(decoded.toString(), m.toString());
 
@@ -484,19 +484,19 @@ describe('encoder', function () {
     });
     it('should encode/decode udts', function () {
       const encoder = new Encoder(3, {});
-      var type = { code: dataTypes.udt, info: { fields:[
+      const type = { code: dataTypes.udt, info: { fields:[
         {name: 'alias', type:{code:dataTypes.text}},
         {name: 'number', type:{code:dataTypes.text}}] }};
-      var encoded = encoder.encode({ alias: 'zeta'}, type);
-      var decoded = encoder.decode(encoded, type);
+      const encoded = encoder.encode({ alias: 'zeta'}, type);
+      const decoded = encoder.decode(encoded, type);
       assert.strictEqual(decoded['alias'], 'zeta');
       assert.strictEqual(decoded['number'], null);
     });
     it('should encode/decode nested collections', function () {
       const encoder = new Encoder(3, {});
-      var type = { code: dataTypes.map, info: [{code: dataTypes.text}, {code: dataTypes.set, info: {code: dataTypes.text}}]};
-      var encoded = encoder.encode({ key1: ['first', 'second', 'third'], key2: ['2-first']}, type);
-      var decoded = encoder.decode(encoded, type);
+      const type = { code: dataTypes.map, info: [{code: dataTypes.text}, {code: dataTypes.set, info: {code: dataTypes.text}}]};
+      const encoded = encoder.encode({ key1: ['first', 'second', 'third'], key2: ['2-first']}, type);
+      const decoded = encoder.decode(encoded, type);
       assert.ok(decoded.key1);
       assert.strictEqual(decoded.key1.length, 3);
       assert.strictEqual(decoded.key1[0], 'first');
@@ -508,24 +508,24 @@ describe('encoder', function () {
     });
     it('should encode/decode tuples', function () {
       const encoder = new Encoder(3, {});
-      var type = { code: dataTypes.tuple, info: [ { code: dataTypes.text}, { code: dataTypes.timestamp }]};
-      var encoded = encoder.encode(new types.Tuple('one', new Date(1429259123607)), type);
-      var decoded = encoder.decode(encoded, type);
+      const type = { code: dataTypes.tuple, info: [ { code: dataTypes.text}, { code: dataTypes.timestamp }]};
+      const encoded = encoder.encode(new types.Tuple('one', new Date(1429259123607)), type);
+      const decoded = encoder.decode(encoded, type);
       assert.strictEqual(decoded.length, 2);
       assert.strictEqual(decoded.get(0), 'one');
       assert.strictEqual(decoded.get(1).getTime(), 1429259123607);
     });
     it('should encode/decode LocalDate as date', function () {
       const encoder = new Encoder(4, {});
-      var type = {code: dataTypes.date};
+      const type = {code: dataTypes.date};
 
-      var year1day1 = new Date(Date.UTC(1970, 0, 1));
+      const year1day1 = new Date(Date.UTC(1970, 0, 1));
       year1day1.setUTCFullYear(1);
 
-      var year0day1 = new Date(Date.UTC(1970, 0, 1));
+      const year0day1 = new Date(Date.UTC(1970, 0, 1));
       year0day1.setUTCFullYear(0);
 
-      var dates = [
+      const dates = [
         // At epoch.
         {ldate: new types.LocalDate(1970, 1, 1), string: '1970-01-01', date: new Date(Date.UTC(1970, 0, 1))},
         // 10 days after epoch.
@@ -549,8 +549,8 @@ describe('encoder', function () {
       ];
 
       dates.forEach(function(item) {
-        var encoded = encoder.encode(item.ldate, type);
-        var decoded = encoder.decode(encoded, type);
+        const encoded = encoder.encode(item.ldate, type);
+        const decoded = encoder.decode(encoded, type);
         helper.assertInstanceOf(decoded, types.LocalDate);
         assert.ok(decoded.equals(item.ldate));
         assert.strictEqual(decoded.toString(), item.string, "String mismatch for " + item.date);
@@ -564,7 +564,7 @@ describe('encoder', function () {
     });
     it('should refuse to encode invalid values as LocalDate.', function () {
       const encoder = new Encoder(4, {});
-      var type = {code: dataTypes.date};
+      const type = {code: dataTypes.date};
       // Non Date/String/LocalDate
       assert.throws(function () { encoder.encode(23.0, type);}, TypeError);
       assert.throws(function () { encoder.encode('zzz', type);}, TypeError);
@@ -572,7 +572,7 @@ describe('encoder', function () {
     });
     it('should encode/decode LocalTime as time', function () {
       const encoder = new Encoder(3, {});
-      var type = {code: dataTypes.time};
+      const type = {code: dataTypes.time};
       /* eslint-disable no-multi-spaces */
       [
         //Long value         |     string representation
@@ -584,8 +584,8 @@ describe('encoder', function () {
         ['52171800000000',         '14:29:31.8'],
         ['52171800600000',         '14:29:31.8006']
       ].forEach(function (item) {
-        var encoded = encoder.encode(new types.LocalTime(types.Long.fromString(item[0])), type);
-        var decoded = encoder.decode(encoded, type);
+        const encoded = encoder.encode(new types.LocalTime(types.Long.fromString(item[0])), type);
+        const decoded = encoder.decode(encoded, type);
         helper.assertInstanceOf(decoded, types.LocalTime);
         assert.strictEqual(decoded.toString(), item[1]);
       });
@@ -593,7 +593,7 @@ describe('encoder', function () {
     });
     it('should refuse to encode invalid values as LocalTime.', function () {
       const encoder = new Encoder(4, {});
-      var type = {code: dataTypes.time};
+      const type = {code: dataTypes.time};
       // Negative value string.
       assert.throws(function () { encoder.encode('-1:00:00', type);}, TypeError);
       // Non string/LocalTime value.
@@ -630,7 +630,7 @@ describe('encoder', function () {
     it('should decode 0-length map values, v2', function () {
       const encoder = new Encoder(2, {});
       const buffer = utils.allocBufferFromString('000100046b6579310000', 'hex');
-      var value = encoder.decode(buffer,
+      const value = encoder.decode(buffer,
         { code: types.dataTypes.map, info: [ { code: types.dataTypes.text }, { code: types.dataTypes.text } ]});
       assert.ok(value);
       assert.deepEqual(Object.keys(value), ['key1']);
@@ -639,7 +639,7 @@ describe('encoder', function () {
     it('should decode 0-length map values, v3', function () {
       const encoder = new Encoder(3, {});
       const buffer = utils.allocBufferFromString('00000001000000046b65793100000000', 'hex');
-      var value = encoder.decode(buffer,
+      const value = encoder.decode(buffer,
         { code: types.dataTypes.map, info: [ { code: types.dataTypes.text }, { code: types.dataTypes.text } ]});
       assert.ok(value);
       assert.deepEqual(Object.keys(value), ['key1']);
@@ -650,7 +650,7 @@ describe('encoder', function () {
       // at a protocol level this is only possible with v3+ as v2 uses unsigned short for collection element size.
       const encoder = new Encoder(3, {});
       const buffer = utils.allocBufferFromString('00000001000000046b657931FFFFFFFF', 'hex');
-      var value = encoder.decode(buffer,
+      const value = encoder.decode(buffer,
         { code: types.dataTypes.map, info: [ { code: types.dataTypes.text }, { code: types.dataTypes.text } ]});
       assert.ok(value);
       assert.deepEqual(Object.keys(value), ['key1']);
@@ -685,7 +685,7 @@ describe('encoder', function () {
       let options = {
         routingKey: utils.allocBufferFromArray([1, 2, 3, 4])
       };
-      var initialRoutingKey = options.routingKey.toString('hex');
+      const initialRoutingKey = options.routingKey.toString('hex');
       encoder.setRoutingKey([1, 'text'], options);
       assert.strictEqual(options.routingKey.toString('hex'), initialRoutingKey);
 
@@ -774,7 +774,7 @@ describe('encoder', function () {
   describe('#parseFqTypeName()', function () {
     it('should parse single type names', function () {
       const encoder = new Encoder(2, {});
-      var type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.Int32Type');
+      let type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.Int32Type');
       assert.strictEqual(dataTypes.int, type.code);
       type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.UUIDType');
       assert.strictEqual(dataTypes.uuid, type.code);
@@ -809,7 +809,7 @@ describe('encoder', function () {
     });
     it('should parse complex type names', function () {
       const encoder = new Encoder(2, {});
-      var type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)');
+      let type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type)');
       assert.strictEqual(dataTypes.list, type.code);
       assert.ok(type.info);
       assert.strictEqual(dataTypes.int, type.info.code);
@@ -838,7 +838,7 @@ describe('encoder', function () {
     });
     it('should parse frozen types', function () {
       const encoder = new Encoder(2, {});
-      var type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.TimeUUIDType))');
+      let type = encoder.parseFqTypeName('org.apache.cassandra.db.marshal.FrozenType(org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.TimeUUIDType))');
       assert.strictEqual(dataTypes.list, type.code);
       assert.ok(type.info);
       assert.strictEqual(dataTypes.timeuuid, type.info.code);
@@ -848,17 +848,17 @@ describe('encoder', function () {
       assert.ok(util.isArray(type.info));
       assert.strictEqual(dataTypes.varchar, type.info[0].code);
       assert.strictEqual(dataTypes.list, type.info[1].code);
-      var subType = type.info[1].info;
+      const subType = type.info[1].info;
       assert.ok(subType);
       assert.strictEqual(dataTypes.int, subType.code);
     });
     it('should parse udt types', function () {
       const encoder = new Encoder(2, {});
-      var typeText =
+      const typeText =
         'org.apache.cassandra.db.marshal.UserType(' +
         'tester,70686f6e65,616c696173:org.apache.cassandra.db.marshal.UTF8Type,6e756d626572:org.apache.cassandra.db.marshal.UTF8Type' +
         ')';
-      var dataType = encoder.parseFqTypeName(typeText);
+      const dataType = encoder.parseFqTypeName(typeText);
       assert.strictEqual(dataTypes.udt, dataType.code);
       //Udt name
       assert.ok(dataType.info);
@@ -871,7 +871,7 @@ describe('encoder', function () {
     });
     it('should parse nested udt types', function () {
       const encoder = new Encoder(2, {});
-      var typeText =
+      const typeText =
         'org.apache.cassandra.db.marshal.UserType(' +
         'tester,' +
         '61646472657373,' +
@@ -884,11 +884,11 @@ describe('encoder', function () {
         '616c696173:org.apache.cassandra.db.marshal.UTF8Type,' +
         '6e756d626572:org.apache.cassandra.db.marshal.UTF8Type))' +
         ')';
-      var dataType = encoder.parseFqTypeName(typeText);
+      const dataType = encoder.parseFqTypeName(typeText);
       assert.strictEqual(dataTypes.udt, dataType.code);
       assert.strictEqual('address', dataType.info.name);
       assert.strictEqual('tester', dataType.info.keyspace);
-      var subTypes = dataType.info.fields;
+      const subTypes = dataType.info.fields;
       assert.strictEqual(3, subTypes.length);
       assert.strictEqual('street,ZIP,phones', subTypes.map(function (f) {return f.name;}).join(','));
       assert.strictEqual(dataTypes.varchar, subTypes[0].type.code);
@@ -896,7 +896,7 @@ describe('encoder', function () {
       //field name
       assert.strictEqual('phones', subTypes[2].name);
 
-      var phonesSubType = subTypes[2].type.info;
+      const phonesSubType = subTypes[2].type.info;
       assert.strictEqual(dataTypes.udt, phonesSubType.code);
       assert.strictEqual('phone', phonesSubType.info.name);
       assert.strictEqual('tester', phonesSubType.info.keyspace);
@@ -912,7 +912,7 @@ describe('encoder', function () {
     it('should parse single type names', function (done) {
       const encoder = new Encoder(4, {});
       /* eslint-disable no-multi-spaces */
-      var items = [
+      const items = [
         ['int',        dataTypes.int],
         ['uuid',       dataTypes.uuid],
         ['text',       dataTypes.text],
@@ -942,7 +942,7 @@ describe('encoder', function () {
     });
     it('should parse complex type names', function (done) {
       const encoder = new Encoder(4, {});
-      var items = [
+      const items = [
         ['list<int>', dataTypes.list, dataTypes.int],
         ['set<uuid>', dataTypes.set, dataTypes.uuid],
         ['set<timeuuid>', dataTypes.set, dataTypes.timeuuid],
@@ -974,16 +974,16 @@ describe('encoder', function () {
       const encoder = new Encoder(4, {});
       utils.series([
         function (next) {
-          var name = 'map<text,frozen<list<frozen<map<text,frozen<list<int>>>>>>>';
+          const name = 'map<text,frozen<list<frozen<map<text,frozen<list<int>>>>>>>';
           encoder.parseTypeName('ks1', name, 0, null, throwIfCalled, function (err, type) {
             assert.ifError(err);
             assert.ok(type);
             assert.strictEqual(type.code, dataTypes.map);
             assert.strictEqual(type.info[0].code, dataTypes.text);
             assert.strictEqual(type.info[1].code, dataTypes.list);
-            var subType1 = type.info[1];
+            const subType1 = type.info[1];
             assert.strictEqual(subType1.info.code, dataTypes.map);
-            var subType2 = subType1.info.info[1];
+            const subType2 = subType1.info.info[1];
             assert.strictEqual(subType2.code, dataTypes.list);
             assert.strictEqual(subType2.info.code, dataTypes.int);
             next();
@@ -1004,7 +1004,7 @@ describe('encoder', function () {
               callback(null, 'udt info dummy');
             });
           }
-          var name = 'frozen<address>';
+          const name = 'frozen<address>';
           encoder.parseTypeName('ks2', name, 0, null, udtResolver, function (err, type) {
             assert.ifError(err);
             assert.ok(type);
@@ -1024,7 +1024,7 @@ describe('encoder', function () {
               callback(null, 'udt info dummy');
             });
           }
-          var name = 'address';
+          const name = 'address';
           encoder.parseTypeName('ks2', name, 0, null, udtResolver, function (err, type) {
             assert.ifError(err);
             assert.ok(type);
@@ -1049,7 +1049,7 @@ describe('encoder', function () {
               callback(null, 'udt info dummy');
             });
           }
-          var name = 'frozen<"PHONE">';
+          const name = 'frozen<"PHONE">';
           encoder.parseTypeName('ks2', name, 0, null, udtResolver, function (err, type) {
             assert.ifError(err);
             assert.ok(type);
@@ -1069,7 +1069,7 @@ describe('encoder', function () {
               callback(null, 'udt info dummy');
             });
           }
-          var name = '"PhoNe"';
+          const name = '"PhoNe"';
           encoder.parseTypeName('ks2', name, 0, null, udtResolver, function (err, type) {
             assert.ifError(err);
             assert.ok(type);
@@ -1100,7 +1100,7 @@ describe('encoder', function () {
     it('should callback with the same error if udtResolver fails', function (done) {
       const encoder = new Encoder(4, {});
       let called = 0;
-      var testError = new Error('Test error');
+      const testError = new Error('Test error');
       function udtResolver(k, u, callback) {
         called++;
         setImmediate(function () {
@@ -1118,8 +1118,8 @@ describe('encoder', function () {
   describe('#parseKeyTypes', function () {
     const encoder = new Encoder(1, {});
     it('should parse single type', function () {
-      var value = 'org.apache.cassandra.db.marshal.UTF8Type';
-      var result = encoder.parseKeyTypes(value);
+      let value = 'org.apache.cassandra.db.marshal.UTF8Type';
+      let result = encoder.parseKeyTypes(value);
       assert.strictEqual(result.types.length, 1);
       assert.strictEqual(result.types[0].code, types.dataTypes.varchar);
       value = 'org.apache.cassandra.db.marshal.TimeUUIDType';
@@ -1130,8 +1130,8 @@ describe('encoder', function () {
       assert.strictEqual(result.hasCollections, false);
     });
     it('should parse composites', function () {
-      var value = 'org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.UTF8Type)';
-      var result = encoder.parseKeyTypes(value);
+      const value = 'org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.UTF8Type)';
+      const result = encoder.parseKeyTypes(value);
       assert.strictEqual(result.types.length, 2);
       assert.strictEqual(result.types[0].code, types.dataTypes.int);
       assert.strictEqual(result.types[1].code, types.dataTypes.varchar);
@@ -1139,8 +1139,8 @@ describe('encoder', function () {
       assert.strictEqual(result.hasCollections, false);
     });
     it('should parse composites with collection types', function () {
-      var value = 'org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.ColumnToCollectionType(6c6973745f73616d706c65:org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type),6d61705f73616d706c65:org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.Int32Type)))';
-      var result = encoder.parseKeyTypes(value);
+      const value = 'org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type,org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.ColumnToCollectionType(6c6973745f73616d706c65:org.apache.cassandra.db.marshal.ListType(org.apache.cassandra.db.marshal.Int32Type),6d61705f73616d706c65:org.apache.cassandra.db.marshal.MapType(org.apache.cassandra.db.marshal.Int32Type,org.apache.cassandra.db.marshal.Int32Type)))';
+      const result = encoder.parseKeyTypes(value);
       assert.strictEqual(result.types.length, 4);
       assert.strictEqual(result.types[0].code, types.dataTypes.varchar);
       assert.strictEqual(result.types[1].code, types.dataTypes.int);
@@ -1158,7 +1158,7 @@ describe('encoder', function () {
   });
   describe('prototype', function () {
     it('should only expose encode() and decode() functions', function () {
-      var keys = Object.keys(Encoder.prototype);
+      const keys = Object.keys(Encoder.prototype);
       assert.deepEqual(keys, ['decode', 'encode']);
       keys.forEach(function (k) {
         assert.strictEqual(typeof Encoder.prototype[k], 'function');

--- a/test/unit/error-tests.js
+++ b/test/unit/error-tests.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var assert = require('assert');
-var path = require('path');
-var errors = require('../../lib/errors');
-var helper = require('../test-helper');
+const assert = require('assert');
+const path = require('path');
+const errors = require('../../lib/errors');
+const helper = require('../test-helper');
 var fileName = path.basename(__filename);
 
 describe('DriverError', function () {

--- a/test/unit/error-tests.js
+++ b/test/unit/error-tests.js
@@ -4,24 +4,24 @@ const assert = require('assert');
 const path = require('path');
 const errors = require('../../lib/errors');
 const helper = require('../test-helper');
-var fileName = path.basename(__filename);
+const fileName = path.basename(__filename);
 
 describe('DriverError', function () {
   it('should inherit from Error and have properties defined', function () {
-    var error = new errors.DriverError('My message');
+    const error = new errors.DriverError('My message');
     assertError(error, errors.DriverError);
   });
 });
 describe('NoHostAvailableError', function () {
   it('should inherit from DriverError and have properties defined', function () {
-    var error = new errors.NoHostAvailableError({});
+    const error = new errors.NoHostAvailableError({});
     assert.strictEqual(error.message, 'All host(s) tried for query failed.');
     assertError(error, errors.NoHostAvailableError);
   });
 });
 describe('ResponseError', function () {
   it('should inherit from DriverError and have properties defined', function () {
-    var error = new errors.ResponseError(1, 'My message');
+    const error = new errors.ResponseError(1, 'My message');
     assertError(error, errors.ResponseError);
     assert.strictEqual(error.message, 'My message');
   });
@@ -36,7 +36,7 @@ describe('ResponseError', function () {
 ].forEach(function (errorConstructor) {
   describe(errorConstructor.name, function () {
     it('should inherit from DriverError and have properties defined', function () {
-      var error = new errorConstructor('My message');
+      const error = new errorConstructor('My message');
       assertError(error, errorConstructor);
       assert.strictEqual(error.message, 'My message');
     });

--- a/test/unit/event-debouncer-tests.js
+++ b/test/unit/event-debouncer-tests.js
@@ -1,9 +1,9 @@
 "use strict";
 
-var assert = require('assert');
+const assert = require('assert');
 
-var helper = require('../test-helper');
-var EventDebouncer = require('../../lib/metadata/event-debouncer');
+const helper = require('../test-helper');
+const EventDebouncer = require('../../lib/metadata/event-debouncer');
 
 describe('EventDebouncer', function () {
   describe('timeoutElapsed()', function () {
@@ -13,7 +13,6 @@ describe('EventDebouncer', function () {
         mainEvent: { handler: helper.callbackNoop },
         callbacks: [ helper.noop ]
       };
-      //noinspection JSAccessibilityCheck
       debouncer._slideDelay(1);
       setTimeout(function () {
         assert.strictEqual(debouncer._queue, null);
@@ -22,13 +21,12 @@ describe('EventDebouncer', function () {
     });
     it('should process the main event and invoke all the callbacks', function (done) {
       var debouncer = newInstance(1);
-      var callbackCounter = 0;
+      let callbackCounter = 0;
       function increaseCounter() { callbackCounter++; }
       debouncer._queue = {
         mainEvent: { handler: helper.callbackNoop },
         callbacks: helper.fillArray(10, increaseCounter)
       };
-      //noinspection JSAccessibilityCheck
       debouncer._slideDelay(1);
       setTimeout(function () {
         assert.strictEqual(callbackCounter, 10);
@@ -37,8 +35,8 @@ describe('EventDebouncer', function () {
     });
     it('should process each keyspace the main event and invoke all child the callbacks', function (done) {
       var debouncer = newInstance(1);
-      var callbackCounter = 0;
-      var ksMainEventCalled = 0;
+      let callbackCounter = 0;
+      let ksMainEventCalled = 0;
       function increaseCounter() { callbackCounter++; }
       debouncer._queue = {
         callbacks: [ assert.fail ],
@@ -52,7 +50,6 @@ describe('EventDebouncer', function () {
           }
         }
       };
-      //noinspection JSAccessibilityCheck
       debouncer._slideDelay(1);
       setTimeout(function () {
         assert.strictEqual(callbackCounter, 2);
@@ -62,9 +59,9 @@ describe('EventDebouncer', function () {
     });
     it('should process each keyspace and invoke handlers and callbacks', function (done) {
       var debouncer = newInstance(1);
-      var callbackCounter = 0;
+      let callbackCounter = 0;
       function increaseCounter() { callbackCounter++; }
-      var handlersCalled = [];
+      const handlersCalled = [];
       function getHandler(name) {
         return (function() { handlersCalled.push(name); });
       }
@@ -79,7 +76,6 @@ describe('EventDebouncer', function () {
           }
         }
       };
-      //noinspection JSAccessibilityCheck
       debouncer._slideDelay(1);
       setTimeout(function () {
         assert.strictEqual(callbackCounter, 2);
@@ -91,8 +87,8 @@ describe('EventDebouncer', function () {
   describe('#eventReceived()', function () {
     it('should invoke 1 handler and all the callbacks when one event is flagged as `all`', function (done) {
       var debouncer = newInstance(20);
-      var callbackCounter = 0;
-      var mainEventHandlerCalled = 0;
+      let callbackCounter = 0;
+      let mainEventHandlerCalled = 0;
       function increaseCounter() { callbackCounter++; }
       debouncer.eventReceived({ handler: helper.failop, callback: increaseCounter, keyspace: 'ks1' }, false);
       debouncer.eventReceived({ handler: helper.failop, callback: increaseCounter, keyspace: 'ks1', cqlObject: 'abc' },
@@ -113,9 +109,9 @@ describe('EventDebouncer', function () {
     });
     it('should invoke 1 keyspace handler and all the callbacks when cqlObject is undefined', function (done) {
       var debouncer = newInstance(30);
-      var callbackCounter = 0;
+      let callbackCounter = 0;
       function increaseCounter() { callbackCounter++; }
-      var handlersCalled = [];
+      const handlersCalled = [];
       function getHandler(name) {
         return (function(cb) {
           handlersCalled.push(name);
@@ -147,9 +143,9 @@ describe('EventDebouncer', function () {
     });
     it('should not invoke handlers before time elapses', function (done) {
       var debouncer = newInstance(200);
-      var callbackCounter = 0;
+      let callbackCounter = 0;
       function increaseCounter() { callbackCounter++; }
-      var handlersCalled = [];
+      const handlersCalled = [];
       function getHandler(name) {
         return (function(cb) {
           handlersCalled.push(name);
@@ -168,9 +164,9 @@ describe('EventDebouncer', function () {
     });
     it('should process queue immediately when processNow is true', function (done) {
       var debouncer = newInstance(40);
-      var callbackCounter = 0;
+      let callbackCounter = 0;
       function increaseCounter() { callbackCounter++; }
-      var handlersCalled = [];
+      const handlersCalled = [];
       function getHandler(name) {
         return (function(cb) {
           handlersCalled.push(name);
@@ -203,7 +199,7 @@ describe('EventDebouncer', function () {
   describe('#shutdown()', function () {
     it('should invoke all callbacks', function (done) {
       var debouncer = newInstance(20);
-      var callbackCounter = 0;
+      let callbackCounter = 0;
       function increaseCounter() { callbackCounter++; }
       debouncer.eventReceived({ handler: helper.failop, callback: increaseCounter, keyspace: 'ks1' }, false);
       debouncer.eventReceived({ handler: helper.failop, callback: increaseCounter, keyspace: 'ks1', cqlObject: '1a' },

--- a/test/unit/event-debouncer-tests.js
+++ b/test/unit/event-debouncer-tests.js
@@ -8,7 +8,7 @@ const EventDebouncer = require('../../lib/metadata/event-debouncer');
 describe('EventDebouncer', function () {
   describe('timeoutElapsed()', function () {
     it('should set the queue to null', function (done) {
-      var debouncer = newInstance(1);
+      const debouncer = newInstance(1);
       debouncer._queue = {
         mainEvent: { handler: helper.callbackNoop },
         callbacks: [ helper.noop ]
@@ -20,7 +20,7 @@ describe('EventDebouncer', function () {
       }, 40);
     });
     it('should process the main event and invoke all the callbacks', function (done) {
-      var debouncer = newInstance(1);
+      const debouncer = newInstance(1);
       let callbackCounter = 0;
       function increaseCounter() { callbackCounter++; }
       debouncer._queue = {
@@ -34,7 +34,7 @@ describe('EventDebouncer', function () {
       }, 40);
     });
     it('should process each keyspace the main event and invoke all child the callbacks', function (done) {
-      var debouncer = newInstance(1);
+      const debouncer = newInstance(1);
       let callbackCounter = 0;
       let ksMainEventCalled = 0;
       function increaseCounter() { callbackCounter++; }
@@ -58,7 +58,7 @@ describe('EventDebouncer', function () {
       }, 40);
     });
     it('should process each keyspace and invoke handlers and callbacks', function (done) {
-      var debouncer = newInstance(1);
+      const debouncer = newInstance(1);
       let callbackCounter = 0;
       function increaseCounter() { callbackCounter++; }
       const handlersCalled = [];
@@ -86,7 +86,7 @@ describe('EventDebouncer', function () {
   });
   describe('#eventReceived()', function () {
     it('should invoke 1 handler and all the callbacks when one event is flagged as `all`', function (done) {
-      var debouncer = newInstance(20);
+      const debouncer = newInstance(20);
       let callbackCounter = 0;
       let mainEventHandlerCalled = 0;
       function increaseCounter() { callbackCounter++; }
@@ -108,7 +108,7 @@ describe('EventDebouncer', function () {
       }, 40);
     });
     it('should invoke 1 keyspace handler and all the callbacks when cqlObject is undefined', function (done) {
-      var debouncer = newInstance(30);
+      const debouncer = newInstance(30);
       let callbackCounter = 0;
       function increaseCounter() { callbackCounter++; }
       const handlersCalled = [];
@@ -142,7 +142,7 @@ describe('EventDebouncer', function () {
       }, 50);
     });
     it('should not invoke handlers before time elapses', function (done) {
-      var debouncer = newInstance(200);
+      const debouncer = newInstance(200);
       let callbackCounter = 0;
       function increaseCounter() { callbackCounter++; }
       const handlersCalled = [];
@@ -163,7 +163,7 @@ describe('EventDebouncer', function () {
       }, 30);
     });
     it('should process queue immediately when processNow is true', function (done) {
-      var debouncer = newInstance(40);
+      const debouncer = newInstance(40);
       let callbackCounter = 0;
       function increaseCounter() { callbackCounter++; }
       const handlersCalled = [];
@@ -198,7 +198,7 @@ describe('EventDebouncer', function () {
   });
   describe('#shutdown()', function () {
     it('should invoke all callbacks', function (done) {
-      var debouncer = newInstance(20);
+      const debouncer = newInstance(20);
       let callbackCounter = 0;
       function increaseCounter() { callbackCounter++; }
       debouncer.eventReceived({ handler: helper.failop, callback: increaseCounter, keyspace: 'ks1' }, false);

--- a/test/unit/execution-profile-tests.js
+++ b/test/unit/execution-profile-tests.js
@@ -11,8 +11,8 @@ describe('ProfileManager', function () {
   describe('constructor', function () {
     it('should set the default profile based on the client options', function () {
       const options = clientOptions.defaultOptions();
-      var manager = new ProfileManager(options);
-      var profile = manager.getDefault();
+      const manager = new ProfileManager(options);
+      const profile = manager.getDefault();
       assert.ok(profile);
       assert.strictEqual(profile.loadBalancing, options.policies.loadBalancing);
       assert.strictEqual(profile.retry, options.policies.retry);
@@ -22,8 +22,8 @@ describe('ProfileManager', function () {
       options.profiles = [
         new ExecutionProfile('default')
       ];
-      var manager = new ProfileManager(options);
-      var profile = manager.getDefault();
+      const manager = new ProfileManager(options);
+      const profile = manager.getDefault();
       assert.ok(profile);
       assert.strictEqual(profile, options.profiles[0]);
       assert.strictEqual(profile.loadBalancing, options.policies.loadBalancing);
@@ -36,8 +36,8 @@ describe('ProfileManager', function () {
       options.profiles = [
         new ExecutionProfile('metrics', { consistency: types.consistencies.localQuorum })
       ];
-      var manager = new ProfileManager(options);
-      var profile = manager.getProfile('metrics');
+      const manager = new ProfileManager(options);
+      const profile = manager.getProfile('metrics');
       assert.ok(profile);
       assert.strictEqual(profile, options.profiles[0]);
       assert.strictEqual(profile.consistency, types.consistencies.localQuorum);
@@ -47,17 +47,17 @@ describe('ProfileManager', function () {
     });
     it('should get the default profile when name is undefined', function () {
       const options = clientOptions.defaultOptions();
-      var manager = new ProfileManager(options);
-      var profile = manager.getProfile(undefined);
+      const manager = new ProfileManager(options);
+      const profile = manager.getProfile(undefined);
       assert.ok(profile);
       assert.strictEqual(manager.getDefault(), profile);
     });
     it('should return same the execution profile if provided', function () {
       const options = clientOptions.defaultOptions();
-      var manager = new ProfileManager(options);
-      var metricsProfile = new ExecutionProfile('metrics');
+      const manager = new ProfileManager(options);
+      const metricsProfile = new ExecutionProfile('metrics');
       options.profiles = [ metricsProfile ];
-      var profile = manager.getProfile(metricsProfile);
+      const profile = manager.getProfile(metricsProfile);
       assert.ok(profile);
       assert.strictEqual(profile, metricsProfile);
     });

--- a/test/unit/execution-profile-tests.js
+++ b/test/unit/execution-profile-tests.js
@@ -1,16 +1,16 @@
 "use strict";
 
-var assert = require('assert');
+const assert = require('assert');
 
-var clientOptions = require('../../lib/client-options');
-var ExecutionProfile = require('../../lib/execution-profile').ExecutionProfile;
-var ProfileManager = require('../../lib/execution-profile').ProfileManager;
-var types = require('../../lib/types');
+const clientOptions = require('../../lib/client-options');
+const ExecutionProfile = require('../../lib/execution-profile').ExecutionProfile;
+const ProfileManager = require('../../lib/execution-profile').ProfileManager;
+const types = require('../../lib/types');
 
 describe('ProfileManager', function () {
   describe('constructor', function () {
     it('should set the default profile based on the client options', function () {
-      var options = clientOptions.defaultOptions();
+      const options = clientOptions.defaultOptions();
       var manager = new ProfileManager(options);
       var profile = manager.getDefault();
       assert.ok(profile);
@@ -18,7 +18,7 @@ describe('ProfileManager', function () {
       assert.strictEqual(profile.retry, options.policies.retry);
     });
     it('should set the default profile required options', function () {
-      var options = clientOptions.defaultOptions();
+      const options = clientOptions.defaultOptions();
       options.profiles = [
         new ExecutionProfile('default')
       ];
@@ -32,7 +32,7 @@ describe('ProfileManager', function () {
   });
   describe('#getProfile()', function () {
     it('should get the profile by name', function () {
-      var options = clientOptions.defaultOptions();
+      const options = clientOptions.defaultOptions();
       options.profiles = [
         new ExecutionProfile('metrics', { consistency: types.consistencies.localQuorum })
       ];
@@ -46,14 +46,14 @@ describe('ProfileManager', function () {
       assert.strictEqual(manager.getProfile('metrics'), profile);
     });
     it('should get the default profile when name is undefined', function () {
-      var options = clientOptions.defaultOptions();
+      const options = clientOptions.defaultOptions();
       var manager = new ProfileManager(options);
       var profile = manager.getProfile(undefined);
       assert.ok(profile);
       assert.strictEqual(manager.getDefault(), profile);
     });
     it('should return same the execution profile if provided', function () {
-      var options = clientOptions.defaultOptions();
+      const options = clientOptions.defaultOptions();
       var manager = new ProfileManager(options);
       var metricsProfile = new ExecutionProfile('metrics');
       options.profiles = [ metricsProfile ];

--- a/test/unit/host-tests.js
+++ b/test/unit/host-tests.js
@@ -4,18 +4,18 @@ const util = require('util');
 const events = require('events');
 
 const hostModule = require('../../lib/host');
-var Host = hostModule.Host;
+const Host = hostModule.Host;
 const HostConnectionPool = require('../../lib/host-connection-pool');
 const Metadata = require('../../lib/metadata');
-var HostMap = hostModule.HostMap;
+const HostMap = hostModule.HostMap;
 const types = require('../../lib/types');
 const clientOptions = require('../../lib/client-options');
-var defaultOptions = clientOptions.defaultOptions();
+const defaultOptions = clientOptions.defaultOptions();
 defaultOptions.pooling.coreConnectionsPerHost = clientOptions.coreConnectionsPerHostV3;
 const utils = require('../../lib/utils.js');
 const policies = require('../../lib/policies');
 const helper = require('../test-helper');
-var reconnection = policies.reconnection;
+const reconnection = policies.reconnection;
 
 describe('HostConnectionPool', function () {
   this.timeout(5000);
@@ -53,7 +53,7 @@ describe('HostConnectionPool', function () {
         setTimeout(function () {
           hostPool.create(false, function (err) {
             assert.ifError(err);
-            var closedConnections = hostPool.connections.filter(function (x) {return !x.connected;}).length;
+            const closedConnections = hostPool.connections.filter(function (x) {return !x.connected;}).length;
             if (closedConnections)
             {
               return next(new Error('All connections should be opened: ' + closedConnections + ' closed'));
@@ -83,7 +83,7 @@ describe('HostConnectionPool', function () {
         hostPool.create(false, function (err) {
           setImmediate(function () {
             assert.ifError(err);
-            var closedConnections = hostPool.connections.filter(function (x) {return !x.connected;}).length;
+            const closedConnections = hostPool.connections.filter(function (x) {return !x.connected;}).length;
             if (closedConnections) {
               return next(new Error('All connections should be opened: ' + closedConnections + ' closed'));
             }
@@ -137,14 +137,14 @@ describe('HostConnectionPool', function () {
   describe('#drainAndShutdown()', function () {
     it('should wait for connections to drain before shutting down', function (done) {
       const hostPool = newHostConnectionPoolInstance();
-      var c = new events.EventEmitter();
+      const c = new events.EventEmitter();
       c.getInFlight = helper.functionOf(100);
       hostPool.connections = [
         c,
         { close: helper.noop, getInFlight: helper.functionOf(0) }
       ];
       hostPool.drainAndShutdown();
-      var drained, closed;
+      let drained, closed;
       hostPool.once('close', function () {
         assert.ok(drained);
         assert.ok(closed);
@@ -160,7 +160,7 @@ describe('HostConnectionPool', function () {
     });
     it('should timeout when draining connections takes longer than expected', function (done) {
       const hostPool = newHostConnectionPoolInstance({ socketOptions: { readTimeout: 20 } });
-      var c = new events.EventEmitter();
+      const c = new events.EventEmitter();
       c.getInFlight = helper.functionOf(100);
       hostPool.connections = [ c ];
       hostPool.drainAndShutdown();
@@ -205,7 +205,7 @@ describe('HostConnectionPool', function () {
     it('should create and attempt to open a connection', function (done) {
       const hostPool = newHostConnectionPoolInstance();
       let openCalled = 0;
-      var c = {
+      const c = {
         open: function (cb) {
           openCalled++;
           setImmediate(cb);
@@ -224,7 +224,7 @@ describe('HostConnectionPool', function () {
       const hostPool = newHostConnectionPoolInstance();
       let openCalled = 0;
       let closeCalled = 0;
-      var c = {
+      const c = {
         open: function (cb) {
           openCalled++;
           setImmediate(function () {
@@ -247,7 +247,7 @@ describe('HostConnectionPool', function () {
     });
     it('should callback when open succeeds', function (done) {
       const hostPool = newHostConnectionPoolInstance();
-      var c = {
+      const c = {
         open: function (cb) {
           setImmediate(cb);
         }
@@ -282,8 +282,8 @@ describe('Host', function () {
       host._distance = types.distance.local;
       //should be marked as down
       host.on('down', done);
-      var create = host.pool._createConnection.bind(host.pool);
-      var c = create();
+      const create = host.pool._createConnection.bind(host.pool);
+      const c = create();
       host.pool._createConnection = function () {
         c.open = helper.callbackNoop;
         return c;
@@ -304,9 +304,9 @@ describe('Host', function () {
     };
     it('should get an open connection', function (done) {
       const host = newHostInstance(defaultOptions);
-      var create = host.pool._createConnection.bind(host.pool);
+      const create = host.pool._createConnection.bind(host.pool);
       host.pool._createConnection = function () {
-        var c = create();
+        const c = create();
         c.open = helper.callbackNoop;
         return c;
       };
@@ -323,9 +323,9 @@ describe('Host', function () {
     it('should trigger the creation of a pool of size determined by the distance', function (done) {
       options.pooling.coreConnectionsPerHost[types.distance.local] = 5;
       const host = newHostInstance(options);
-      var create = host.pool._createConnection.bind(host.pool);
+      const create = host.pool._createConnection.bind(host.pool);
       host.pool._createConnection = function () {
-        var c = create();
+        const c = create();
         c.open = helper.callbackNoop;
         return c;
       };
@@ -348,9 +348,9 @@ describe('Host', function () {
     it('should resize the pool after distance is set', function (done) {
       options.pooling.coreConnectionsPerHost[types.distance.local] = 3;
       const host = newHostInstance(options);
-      var create = host.pool._createConnection.bind(host.pool);
+      const create = host.pool._createConnection.bind(host.pool);
       host.pool._createConnection = function () {
-        var c = create();
+        const c = create();
         c.open = helper.callbackNoop;
         return c;
       };
@@ -389,19 +389,19 @@ describe('Host', function () {
   });
   describe('#setUp()', function () {
     it('should reset the reconnection schedule when bring it up', function () {
-      var maxDelay = 1000;
+      const maxDelay = 1000;
       const options = utils.extend({
         policies: {
           reconnection: new reconnection.ExponentialReconnectionPolicy(50, maxDelay, false)
         }}, defaultOptions);
       const host = newHostInstance(options);
-      var create = host.pool._createConnection.bind(host.pool);
+      const create = host.pool._createConnection.bind(host.pool);
       host.pool._createConnection = function () {
-        var c = create();
+        const c = create();
         c.open = helper.callbackNoop;
         return c;
       };
-      var initialSchedule = options.policies.reconnection.newSchedule();
+      const initialSchedule = options.policies.reconnection.newSchedule();
       host.reconnectionSchedule = initialSchedule;
       host.setDownAt = 1;
       host.setUp();
@@ -463,7 +463,7 @@ describe('Host', function () {
   describe('#removeFromPool()', function () {
     it('should remove the connection in a new array instance', function () {
       const host = newHostInstance(defaultOptions);
-      var initialConnections = [ newConnectionMock(), newConnectionMock() ];
+      const initialConnections = [ newConnectionMock(), newConnectionMock() ];
       host.pool.connections = initialConnections;
       host.removeFromPool(initialConnections[0]);
       assert.deepEqual(host.pool.connections, [ initialConnections[1] ]);
@@ -472,7 +472,7 @@ describe('Host', function () {
     });
     it('should issue a new connection attempt when pool size is smaller than config', function () {
       const host = newHostInstance(defaultOptions);
-      var initialConnections = [ newConnectionMock(), newConnectionMock() ];
+      const initialConnections = [ newConnectionMock(), newConnectionMock() ];
       host.pool.connections = initialConnections;
       host.pool.coreConnectionsLength = 10;
       assert.ok(!host.pool.hasScheduledNewConnection());
@@ -484,7 +484,7 @@ describe('Host', function () {
     });
     it('should set the host down when no connections', function () {
       const host = newHostInstance(defaultOptions);
-      var initialConnections = [ newConnectionMock()];
+      const initialConnections = [ newConnectionMock()];
       host.pool.connections = initialConnections;
       host._distance = types.distance.local;
       assert.ok(!host.pool.hasScheduledNewConnection());
@@ -497,7 +497,7 @@ describe('Host', function () {
     });
     it('should not set the host down when it is ignored', function () {
       const host = newHostInstance(defaultOptions);
-      var initialConnections = [ newConnectionMock()];
+      const initialConnections = [ newConnectionMock()];
       host.pool.connections = initialConnections;
       host._distance = types.distance.ignored;
       assert.ok(host.isUp());
@@ -511,13 +511,13 @@ describe('Host', function () {
     it('should remove connection from Array and invoke close', function (done) {
       const host = newHostInstance(defaultOptions);
       let closeInvoked = 0;
-      var c = {
+      const c = {
         timedOutOperations: 1000,
         close: function () {
           closeInvoked++;
         }
       };
-      var initialConnections = [ newConnectionMock(), newConnectionMock(), c];
+      const initialConnections = [ newConnectionMock(), newConnectionMock(), c];
       host.pool.connections = initialConnections;
       host.checkHealth(c);
       setImmediate(function () {
@@ -556,7 +556,7 @@ describe('Host', function () {
       const host = newHostInstance(defaultOptions);
       host.setDownAt = 1;
       host.reconnectionDelay = 1;
-      var reconnectionSchedule = host.reconnectionSchedule;
+      const reconnectionSchedule = host.reconnectionSchedule;
       assert.ok(!host.pool.hasScheduledNewConnection());
       host.checkIsUp();
       assert.notStrictEqual(host.reconnectionSchedule, reconnectionSchedule);
@@ -651,29 +651,29 @@ describe('Host', function () {
 describe('HostMap', function () {
   describe('#values()', function () {
     it('should return a frozen array', function () {
-      var map = new HostMap();
+      const map = new HostMap();
       map.set('h1', 'h1');
-      var values = map.values();
+      const values = map.values();
       assert.strictEqual(values.length, 1);
       assert.ok(Object.isFrozen(values));
     });
     it('should return the same instance as long as the value does not change', function () {
-      var map = new HostMap();
+      const map = new HostMap();
       map.set('h1', 'h1');
-      var values1 = map.values();
-      var values2 = map.values();
+      const values1 = map.values();
+      const values2 = map.values();
       assert.strictEqual(values1, values2);
       map.set('h2', 'h2');
-      var values3 = map.values();
+      const values3 = map.values();
       assert.strictEqual(values3.length, 2);
       assert.notEqual(values3, values1);
     });
   });
   describe('#set()', function () {
     it('should modify the cached values', function () {
-      var map = new HostMap();
+      const map = new HostMap();
       map.set('h1', 'v1');
-      var values = map.values();
+      const values = map.values();
       assert.strictEqual(util.inspect(values), util.inspect(['v1']));
       map.set('h1', 'v1a');
       assert.strictEqual(util.inspect(map.values()), util.inspect(['v1a']));

--- a/test/unit/host-tests.js
+++ b/test/unit/host-tests.js
@@ -1,27 +1,27 @@
 "use strict";
-var assert = require('assert');
-var util = require('util');
-var events = require('events');
+const assert = require('assert');
+const util = require('util');
+const events = require('events');
 
-var hostModule = require('../../lib/host');
+const hostModule = require('../../lib/host');
 var Host = hostModule.Host;
-var HostConnectionPool = require('../../lib/host-connection-pool');
-var Metadata = require('../../lib/metadata');
+const HostConnectionPool = require('../../lib/host-connection-pool');
+const Metadata = require('../../lib/metadata');
 var HostMap = hostModule.HostMap;
-var types = require('../../lib/types');
-var clientOptions = require('../../lib/client-options');
+const types = require('../../lib/types');
+const clientOptions = require('../../lib/client-options');
 var defaultOptions = clientOptions.defaultOptions();
 defaultOptions.pooling.coreConnectionsPerHost = clientOptions.coreConnectionsPerHostV3;
-var utils = require('../../lib/utils.js');
-var policies = require('../../lib/policies');
-var helper = require('../test-helper');
+const utils = require('../../lib/utils.js');
+const policies = require('../../lib/policies');
+const helper = require('../test-helper');
 var reconnection = policies.reconnection;
 
 describe('HostConnectionPool', function () {
   this.timeout(5000);
   describe('#create()', function () {
     it('should create the pool once', function (done) {
-      var hostPool = newHostConnectionPoolInstance( { pooling: { warmup: true }} );
+      const hostPool = newHostConnectionPoolInstance( { pooling: { warmup: true }} );
       hostPool._createConnection = function () {
         return { open: function (cb) {
           setTimeout(cb, 30);
@@ -39,7 +39,7 @@ describe('HostConnectionPool', function () {
       }, done);
     });
     it('should never callback with unopened connections', function (done) {
-      var hostPool = newHostConnectionPoolInstance();
+      const hostPool = newHostConnectionPoolInstance();
       hostPool.coreConnectionsLength = 10;
       hostPool._createConnection = function () {
         return {
@@ -67,7 +67,7 @@ describe('HostConnectionPool', function () {
       });
     });
     it('should never callback with unopened connections when resizing', function (done) {
-      var hostPool = newHostConnectionPoolInstance();
+      const hostPool = newHostConnectionPoolInstance();
       hostPool.coreConnectionsLength = 1;
       hostPool._createConnection = function () {
         return {
@@ -77,7 +77,7 @@ describe('HostConnectionPool', function () {
           }
         };
       };
-      var counter = 0;
+      let counter = 0;
       utils.timesLimit(10, 4, function(n, next) {
         counter++;
         hostPool.create(false, function (err) {
@@ -96,7 +96,7 @@ describe('HostConnectionPool', function () {
       }, done);
     });
     it('should remove connections and callback in error if state changed to closing', function (done) {
-      var hostPool = newHostConnectionPoolInstance();
+      const hostPool = newHostConnectionPoolInstance();
       hostPool._createConnection = function () {
         return { open: helper.callbackNoop, close: helper.noop };
       };
@@ -114,7 +114,7 @@ describe('HostConnectionPool', function () {
   });
   describe('#borrowConnection()', function () {
     it('should get an open connection', function (done) {
-      var hostPool = newHostConnectionPoolInstance();
+      const hostPool = newHostConnectionPoolInstance();
       hostPool.coreConnectionsLength = 10;
       hostPool._createConnection = function () {
         return {
@@ -136,7 +136,7 @@ describe('HostConnectionPool', function () {
   });
   describe('#drainAndShutdown()', function () {
     it('should wait for connections to drain before shutting down', function (done) {
-      var hostPool = newHostConnectionPoolInstance();
+      const hostPool = newHostConnectionPoolInstance();
       var c = new events.EventEmitter();
       c.getInFlight = helper.functionOf(100);
       hostPool.connections = [
@@ -159,12 +159,12 @@ describe('HostConnectionPool', function () {
       });
     });
     it('should timeout when draining connections takes longer than expected', function (done) {
-      var hostPool = newHostConnectionPoolInstance({ socketOptions: { readTimeout: 20 } });
+      const hostPool = newHostConnectionPoolInstance({ socketOptions: { readTimeout: 20 } });
       var c = new events.EventEmitter();
       c.getInFlight = helper.functionOf(100);
       hostPool.connections = [ c ];
       hostPool.drainAndShutdown();
-      var closed;
+      let closed;
       hostPool.once('close', function () {
         assert.ok(closed);
       });
@@ -183,12 +183,12 @@ describe('HostConnectionPool', function () {
       }, 140);
     });
     it('should wait for creation before setting state to init', function (done) {
-      var hostPool = newHostConnectionPoolInstance();
+      const hostPool = newHostConnectionPoolInstance();
       hostPool._createConnection = function () {
         return { open: helper.callbackNoop, close: helper.noop };
       };
-      var created;
-      var sync = true;
+      let created;
+      let sync = true;
       hostPool.create(false, function (err) {
         assert.ok(err);
         created = sync !== true;
@@ -203,8 +203,8 @@ describe('HostConnectionPool', function () {
   });
   describe('#_attemptNewConnection()', function () {
     it('should create and attempt to open a connection', function (done) {
-      var hostPool = newHostConnectionPoolInstance();
-      var openCalled = 0;
+      const hostPool = newHostConnectionPoolInstance();
+      let openCalled = 0;
       var c = {
         open: function (cb) {
           openCalled++;
@@ -221,9 +221,9 @@ describe('HostConnectionPool', function () {
       }, 50);
     });
     it('should callback in error when open fails', function (done) {
-      var hostPool = newHostConnectionPoolInstance();
-      var openCalled = 0;
-      var closeCalled = 0;
+      const hostPool = newHostConnectionPoolInstance();
+      let openCalled = 0;
+      let closeCalled = 0;
       var c = {
         open: function (cb) {
           openCalled++;
@@ -246,7 +246,7 @@ describe('HostConnectionPool', function () {
       });
     });
     it('should callback when open succeeds', function (done) {
-      var hostPool = newHostConnectionPoolInstance();
+      const hostPool = newHostConnectionPoolInstance();
       var c = {
         open: function (cb) {
           setImmediate(cb);
@@ -264,13 +264,12 @@ describe('HostConnectionPool', function () {
   describe('minInFlight()', function () {
     it('should round robin with between connections with the same amount of in-flight requests', function () {
       /** @type {Array.<Connection>} */
-      var connections = [];
-      for (var i = 0; i < 3; i++) {
-        //noinspection JSCheckFunctionSignatures
+      const connections = [];
+      for (let i = 0; i < 3; i++) {
         connections.push({ getInFlight: helper.functionOf(0), index: i});
       }
-      var initial = HostConnectionPool.minInFlight(connections).index;
-      for (i = 1; i < 10; i++) {
+      const initial = HostConnectionPool.minInFlight(connections).index;
+      for (let i = 1; i < 10; i++) {
         assert.strictEqual((initial + i) % connections.length, HostConnectionPool.minInFlight(connections).index);
       }
     });
@@ -279,7 +278,7 @@ describe('HostConnectionPool', function () {
 describe('Host', function () {
   describe('constructor', function () {
     it('should listen for pool idleRequestError event', function (done) {
-      var host = newHostInstance(defaultOptions);
+      const host = newHostInstance(defaultOptions);
       host._distance = types.distance.local;
       //should be marked as down
       host.on('down', done);
@@ -295,7 +294,7 @@ describe('Host', function () {
     });
   });
   describe('#borrowConnection()', function () {
-    var options = {
+    const options = {
       pooling: {
         coreConnectionsPerHost: {}
       },
@@ -304,7 +303,7 @@ describe('Host', function () {
       }
     };
     it('should get an open connection', function (done) {
-      var host = newHostInstance(defaultOptions);
+      const host = newHostInstance(defaultOptions);
       var create = host.pool._createConnection.bind(host.pool);
       host.pool._createConnection = function () {
         var c = create();
@@ -323,7 +322,7 @@ describe('Host', function () {
     });
     it('should trigger the creation of a pool of size determined by the distance', function (done) {
       options.pooling.coreConnectionsPerHost[types.distance.local] = 5;
-      var host = newHostInstance(options);
+      const host = newHostInstance(options);
       var create = host.pool._createConnection.bind(host.pool);
       host.pool._createConnection = function () {
         var c = create();
@@ -348,7 +347,7 @@ describe('Host', function () {
     });
     it('should resize the pool after distance is set', function (done) {
       options.pooling.coreConnectionsPerHost[types.distance.local] = 3;
-      var host = newHostInstance(options);
+      const host = newHostInstance(options);
       var create = host.pool._createConnection.bind(host.pool);
       host.pool._createConnection = function () {
         var c = create();
@@ -391,11 +390,11 @@ describe('Host', function () {
   describe('#setUp()', function () {
     it('should reset the reconnection schedule when bring it up', function () {
       var maxDelay = 1000;
-      var options = utils.extend({
+      const options = utils.extend({
         policies: {
           reconnection: new reconnection.ExponentialReconnectionPolicy(50, maxDelay, false)
         }}, defaultOptions);
-      var host = newHostInstance(options);
+      const host = newHostInstance(options);
       var create = host.pool._createConnection.bind(host.pool);
       host.pool._createConnection = function () {
         var c = create();
@@ -411,7 +410,7 @@ describe('Host', function () {
   });
   describe('#setDown()', function () {
     it('should emit event when called', function (done) {
-      var host = newHostInstance(defaultOptions);
+      const host = newHostInstance(defaultOptions);
       host.on('down', done);
       host.setDown();
       host.shutdown(false);
@@ -419,25 +418,25 @@ describe('Host', function () {
   });
   describe('#getActiveConnection()', function () {
     it('should return null if a the pool is initialized', function () {
-      var h = newHostInstance(defaultOptions);
+      const h = newHostInstance(defaultOptions);
       assert.strictEqual(h.getActiveConnection(), null);
     });
   });
   describe('#setDistance()', function () {
     it('should call checkIsUp() when the new distance is local and was down', function () {
-      var host = newHostInstance(defaultOptions);
+      const host = newHostInstance(defaultOptions);
       host._distance = types.distance.ignored;
       host.setDownAt = 1;
-      var checkIsUpCalled = 0;
+      let checkIsUpCalled = 0;
       host.checkIsUp = function () { checkIsUpCalled++; };
       host.setDistance(types.distance.local);
       assert.strictEqual(checkIsUpCalled, 1);
     });
     it('should call drainAndShutdown() and emit when the new distance is ignored', function () {
-      var host = newHostInstance(defaultOptions);
+      const host = newHostInstance(defaultOptions);
       host._distance = types.distance.local;
-      var drainAndShutdownCalled = 0;
-      var ignoreEventCalled = 0;
+      let drainAndShutdownCalled = 0;
+      let ignoreEventCalled = 0;
       host.pool.drainAndShutdown = function () { drainAndShutdownCalled++; };
       host.once('ignore', function () {
         ignoreEventCalled++;
@@ -448,10 +447,10 @@ describe('Host', function () {
       assert.strictEqual(host.pool.coreConnectionsLength, 0);
     });
     it('should not call drainAndShutdown() when the new distance is ignored and was previously ignored', function () {
-      var host = newHostInstance(defaultOptions);
+      const host = newHostInstance(defaultOptions);
       host._distance = types.distance.ignored;
-      var drainAndShutdownCalled = 0;
-      var ignoreEventCalled = 0;
+      let drainAndShutdownCalled = 0;
+      let ignoreEventCalled = 0;
       host.pool.drainAndShutdown = function () { drainAndShutdownCalled++; };
       host.once('ignore', function () {
         ignoreEventCalled++;
@@ -463,7 +462,7 @@ describe('Host', function () {
   });
   describe('#removeFromPool()', function () {
     it('should remove the connection in a new array instance', function () {
-      var host = newHostInstance(defaultOptions);
+      const host = newHostInstance(defaultOptions);
       var initialConnections = [ newConnectionMock(), newConnectionMock() ];
       host.pool.connections = initialConnections;
       host.removeFromPool(initialConnections[0]);
@@ -472,7 +471,7 @@ describe('Host', function () {
       host.shutdown(false);
     });
     it('should issue a new connection attempt when pool size is smaller than config', function () {
-      var host = newHostInstance(defaultOptions);
+      const host = newHostInstance(defaultOptions);
       var initialConnections = [ newConnectionMock(), newConnectionMock() ];
       host.pool.connections = initialConnections;
       host.pool.coreConnectionsLength = 10;
@@ -484,7 +483,7 @@ describe('Host', function () {
       host.shutdown(false);
     });
     it('should set the host down when no connections', function () {
-      var host = newHostInstance(defaultOptions);
+      const host = newHostInstance(defaultOptions);
       var initialConnections = [ newConnectionMock()];
       host.pool.connections = initialConnections;
       host._distance = types.distance.local;
@@ -497,7 +496,7 @@ describe('Host', function () {
       host.shutdown(false);
     });
     it('should not set the host down when it is ignored', function () {
-      var host = newHostInstance(defaultOptions);
+      const host = newHostInstance(defaultOptions);
       var initialConnections = [ newConnectionMock()];
       host.pool.connections = initialConnections;
       host._distance = types.distance.ignored;
@@ -510,8 +509,8 @@ describe('Host', function () {
   });
   describe('#checkHealth()', function () {
     it('should remove connection from Array and invoke close', function (done) {
-      var host = newHostInstance(defaultOptions);
-      var closeInvoked = 0;
+      const host = newHostInstance(defaultOptions);
+      let closeInvoked = 0;
       var c = {
         timedOutOperations: 1000,
         close: function () {
@@ -531,7 +530,7 @@ describe('Host', function () {
       });
     });
     it('should remove set host down when no more connections available', function (done) {
-      var host = newHostInstance(defaultOptions);
+      const host = newHostInstance(defaultOptions);
       host._distance = types.distance.local;
       host.pool.connections = [ newConnectionMock() ];
       assert.ok(host.isUp());
@@ -546,7 +545,7 @@ describe('Host', function () {
   });
   describe('#checkIsUp()', function () {
     it('should schedule a connection attempt', function () {
-      var host = newHostInstance(defaultOptions);
+      const host = newHostInstance(defaultOptions);
       host.setDownAt = 1;
       assert.ok(!host.pool.hasScheduledNewConnection());
       host.checkIsUp();
@@ -554,7 +553,7 @@ describe('Host', function () {
       host.shutdown(false);
     });
     it('should reset the reconnection schedule and set the delay to 0', function () {
-      var host = newHostInstance(defaultOptions);
+      const host = newHostInstance(defaultOptions);
       host.setDownAt = 1;
       host.reconnectionDelay = 1;
       var reconnectionSchedule = host.reconnectionSchedule;
@@ -566,7 +565,7 @@ describe('Host', function () {
       host.shutdown(false);
     });
     it('should not issue a connection attempt if host is UP', function () {
-      var host = newHostInstance(defaultOptions);
+      const host = newHostInstance(defaultOptions);
       assert.ok(!host.pool.hasScheduledNewConnection());
       host.checkIsUp();
       assert.ok(!host.pool.hasScheduledNewConnection());
@@ -574,7 +573,7 @@ describe('Host', function () {
   });
   describe('#warmupPool()', function () {
     it('should create the exact amount of connections after borrowing when opening is instant', function (done) {
-      var host = newHostInstance(defaultOptions);
+      const host = newHostInstance(defaultOptions);
       host._distance = types.distance.local;
       host.pool.coreConnectionsLength = 4;
       host.pool._createConnection = function () {
@@ -593,7 +592,7 @@ describe('Host', function () {
       });
     });
     it('should create the exact amount of connections after borrowing when opening takes some time', function (done) {
-      var host = newHostInstance(defaultOptions);
+      const host = newHostInstance(defaultOptions);
       host._distance = types.distance.local;
       host.pool.coreConnectionsLength = 3;
       host.pool._createConnection = function () {
@@ -614,7 +613,7 @@ describe('Host', function () {
       });
     });
     it('should create the exact amount of connections when opening is instant', function (done) {
-      var host = newHostInstance(defaultOptions);
+      const host = newHostInstance(defaultOptions);
       host._distance = types.distance.local;
       host.pool.coreConnectionsLength = 4;
       host.pool._createConnection = function () {
@@ -630,7 +629,7 @@ describe('Host', function () {
       });
     });
     it('should create the exact amount of connections when opening takes some time', function (done) {
-      var host = newHostInstance(defaultOptions);
+      const host = newHostInstance(defaultOptions);
       host._distance = types.distance.local;
       host.pool.coreConnectionsLength = 3;
       host.pool._createConnection = function () {
@@ -653,7 +652,6 @@ describe('HostMap', function () {
   describe('#values()', function () {
     it('should return a frozen array', function () {
       var map = new HostMap();
-      //noinspection JSCheckFunctionSignatures
       map.set('h1', 'h1');
       var values = map.values();
       assert.strictEqual(values.length, 1);
@@ -661,12 +659,10 @@ describe('HostMap', function () {
     });
     it('should return the same instance as long as the value does not change', function () {
       var map = new HostMap();
-      //noinspection JSCheckFunctionSignatures
       map.set('h1', 'h1');
       var values1 = map.values();
       var values2 = map.values();
       assert.strictEqual(values1, values2);
-      //noinspection JSCheckFunctionSignatures
       map.set('h2', 'h2');
       var values3 = map.values();
       assert.strictEqual(values3.length, 2);
@@ -676,11 +672,9 @@ describe('HostMap', function () {
   describe('#set()', function () {
     it('should modify the cached values', function () {
       var map = new HostMap();
-      //noinspection JSCheckFunctionSignatures
       map.set('h1', 'v1');
       var values = map.values();
       assert.strictEqual(util.inspect(values), util.inspect(['v1']));
-      //noinspection JSCheckFunctionSignatures
       map.set('h1', 'v1a');
       assert.strictEqual(util.inspect(map.values()), util.inspect(['v1a']));
       assert.strictEqual(map.get('h1'), 'v1a');
@@ -710,7 +704,6 @@ function newHostInstance(options) {
  * @returns {Connection}
  */
 function newConnectionMock() {
-  //noinspection JSValidateTypes
   return ({
     close: helper.noop
   });

--- a/test/unit/inet-address-tests.js
+++ b/test/unit/inet-address-tests.js
@@ -26,7 +26,7 @@ describe('InetAddress', function () {
   });
   describe('#toString()', function () {
     it('should convert IPv6 to string representation', function () {
-      var val = new InetAddress(utils.allocBufferFromString('aabb0000eeff00112233445566778899', 'hex'));
+      let val = new InetAddress(utils.allocBufferFromString('aabb0000eeff00112233445566778899', 'hex'));
       assert.strictEqual(val.version, 6);
       assert.strictEqual(val.toString(), 'aabb::eeff:11:2233:4455:6677:8899');
       val = new InetAddress(utils.allocBufferFromString('aabbccddeeff00112233445566778899', 'hex'));
@@ -43,7 +43,7 @@ describe('InetAddress', function () {
       assert.strictEqual(val.toString(), '::1');
     });
     it('should convert IPv4 to string representation', function () {
-      var val = new InetAddress(utils.allocBufferFromArray([127, 0, 0, 1]));
+      let val = new InetAddress(utils.allocBufferFromArray([127, 0, 0, 1]));
       assert.strictEqual(val.version, 4);
       assert.strictEqual(val.toString(), '127.0.0.1');
       val = new InetAddress(utils.allocBufferFromArray([198, 168, 1, 1]));
@@ -54,11 +54,11 @@ describe('InetAddress', function () {
   });
   describe('#equals()', function () {
     it('should return true when the bytes are the same', function () {
-      var hex1 = 'aabb0000eeff00112233445566778899';
-      var hex2 = 'ffff0000eeff00112233445566778899';
-      var buf1 = utils.allocBufferFromString(hex1, 'hex');
-      var val1 = new InetAddress(buf1);
-      var val2 = new InetAddress(utils.allocBufferFromString(hex2, 'hex'));
+      const hex1 = 'aabb0000eeff00112233445566778899';
+      const hex2 = 'ffff0000eeff00112233445566778899';
+      const buf1 = utils.allocBufferFromString(hex1, 'hex');
+      const val1 = new InetAddress(buf1);
+      const val2 = new InetAddress(utils.allocBufferFromString(hex2, 'hex'));
       assert.ok(val1.equals(new InetAddress(buf1)));
       assert.ok(val1.equals(new InetAddress(utils.allocBufferFromString(hex1, 'hex'))));
       assert.ok(!val1.equals(val2));
@@ -78,13 +78,13 @@ describe('InetAddress', function () {
         '3ffe:0:0:1::a', // ensure furthest groups of 0-bytes are compressed when longest, but last non-0 bytes group is not truncated.
         '3ffe:0:0:1::' // ensure final groups of 0-bytes are compressed when longest and last group is also 0-bytes.
       ].forEach(function (item) {
-        var val = InetAddress.fromString(item);
+        const val = InetAddress.fromString(item);
         helper.assertInstanceOf(val, InetAddress);
         assert.strictEqual(val.toString(), item);
       });
     });
     it('should parse IPv4 string representation', function () {
-      var val = InetAddress.fromString('127.0.0.1');
+      let val = InetAddress.fromString('127.0.0.1');
       helper.assertInstanceOf(val, InetAddress);
       assert.strictEqual(val.toString(), '127.0.0.1');
       val = InetAddress.fromString('198.168.1.1');
@@ -101,7 +101,7 @@ describe('InetAddress', function () {
         ['::ffff:129.144.52.38',            '00000000000000000000ffff81903426'],
         ['::ffff:254.255.52.32',            '00000000000000000000fffffeff3420']
       ].forEach(function (item) {
-        var ip = InetAddress.fromString(item[0]);
+        const ip = InetAddress.fromString(item[0]);
         assert.strictEqual(ip.toString('hex'), item[1]);
       });
       /* eslint-enable no-multi-spaces */

--- a/test/unit/inet-address-tests.js
+++ b/test/unit/inet-address-tests.js
@@ -1,8 +1,8 @@
 'use strict';
-var assert = require('assert');
-var helper = require('../test-helper');
-var utils = require('../../lib/utils');
-var InetAddress = require('../../lib/types').InetAddress;
+const assert = require('assert');
+const helper = require('../test-helper');
+const utils = require('../../lib/utils');
+const InetAddress = require('../../lib/types').InetAddress;
 
 describe('InetAddress', function () {
   describe('constructor', function () {

--- a/test/unit/load-balancing-tests.js
+++ b/test/unit/load-balancing-tests.js
@@ -9,11 +9,11 @@ const HostMap = require('../../lib/host.js').HostMap;
 const types = require('../../lib/types');
 const utils = require('../../lib/utils.js');
 const loadBalancing = require('../../lib/policies/load-balancing.js');
-var LoadBalancingPolicy = loadBalancing.LoadBalancingPolicy;
-var TokenAwarePolicy = loadBalancing.TokenAwarePolicy;
-var RoundRobinPolicy = loadBalancing.RoundRobinPolicy;
-var DCAwareRoundRobinPolicy = loadBalancing.DCAwareRoundRobinPolicy;
-var WhiteListPolicy = loadBalancing.WhiteListPolicy;
+const LoadBalancingPolicy = loadBalancing.LoadBalancingPolicy;
+const TokenAwarePolicy = loadBalancing.TokenAwarePolicy;
+const RoundRobinPolicy = loadBalancing.RoundRobinPolicy;
+const DCAwareRoundRobinPolicy = loadBalancing.DCAwareRoundRobinPolicy;
+const WhiteListPolicy = loadBalancing.WhiteListPolicy;
 
 describe('RoundRobinPolicy', function () {
   it('should yield an error when the hosts are not set', function(done) {
@@ -27,13 +27,13 @@ describe('RoundRobinPolicy', function () {
   it('should yield nodes in a round robin manner even in parallel', function (done) {
     const policy = new RoundRobinPolicy();
     const hosts = [];
-    var originalHosts = createHostMap(['A', 'B', 'C', 'E']);
-    var times = 100;
+    const originalHosts = createHostMap(['A', 'B', 'C', 'E']);
+    const times = 100;
     policy.init(null, originalHosts, function () {
       utils.times(times, function (n, next) {
         policy.newQueryPlan(null, null, function (err, iterator) {
           assert.equal(err, null);
-          var item = iterator.next();
+          const item = iterator.next();
           assert.strictEqual(item.done, false);
           hosts.push(item.value);
           next();
@@ -58,25 +58,25 @@ describe('RoundRobinPolicy', function () {
   });
   it('should yield host in a round robin manner when consuming', function (done) {
     const policy = new RoundRobinPolicy();
-    var hostList = ['A', 'B', 'C', 'E', 'F'];
+    const hostList = ['A', 'B', 'C', 'E', 'F'];
     const permutations = [];
     // Capture the various permutations of plans.
     for (let i = 0; i < hostList.length; i++) {
       const permutation = [];
-      for(var j = i; j < hostList.length + i; j++) {
+      for (let j = i; j < hostList.length + i; j++) {
         permutation.push(hostList[j % hostList.length]);
       }
       permutations.push(permutation);
     }
-    var originalHosts = createHostMap(hostList);
-    var times = 30;
+    const originalHosts = createHostMap(hostList);
+    const times = 30;
 
     testRoundRobinPlan(times, policy, null, originalHosts, originalHosts, permutations, done);
   });
   it('should yield no more than N host', function (done) {
     const policy = new RoundRobinPolicy();
-    var originalHosts = createHostMap(['A', 'B', 'C']);
-    var times = 10;
+    const originalHosts = createHostMap(['A', 'B', 'C']);
+    const times = 10;
     policy.init(null, originalHosts, function () {
       utils.times(times, function (n, next) {
         policy.newQueryPlan(null, null, function (err, iterator) {
@@ -114,21 +114,21 @@ describe('DCAwareRoundRobinPolicy', function () {
     const policy = new DCAwareRoundRobinPolicy('dc1');
     const options = clientOptions.extend({}, helper.baseOptions, {policies: {loadBalancing: policy}});
     const hosts = [];
-    var originalHosts = new HostMap();
+    const originalHosts = new HostMap();
     for (let i = 0; i < 50; i++) {
-      var h = new Host(i, 2, options);
+      const h = new Host(i, 2, options);
       h.datacenter = (i % 2 === 0) ? 'dc1' : 'dc2';
       originalHosts.set(i.toString(), h);
     }
-    var localLength = originalHosts.length / 2;
-    let times = 1;
+    const localLength = originalHosts.length / 2;
+    const times = 1;
     policy.init(new Client(options), originalHosts, function (err) {
       assert.ifError(err);
       utils.times(times, function (n, next) {
         policy.newQueryPlan(null, null, function (err, iterator) {
           assert.equal(err, null);
           for (let i = 0; i < originalHosts.length; i++) {
-            var item = iterator.next();
+            const item = iterator.next();
             if (i >= localLength) {
               //once the local have ended, it should be "done"
               assert.strictEqual(item.done, true, 'Not done for item ' + i);
@@ -168,23 +168,23 @@ describe('DCAwareRoundRobinPolicy', function () {
   it('should yield local hosts in a round robin manner when consuming.', function (done) {
     const policy = new DCAwareRoundRobinPolicy('dc1');
     const options = clientOptions.extend({}, helper.baseOptions, {policies: {loadBalancing: policy}});
-    var originalHosts = new HostMap();
+    const originalHosts = new HostMap();
     let i;
     for (i = 0; i < 50; i++) {
-      var h = new Host(i, 2, options);
+      const h = new Host(i, 2, options);
       h.datacenter = (i % 2 === 0) ? 'dc1' : 'dc2';
       originalHosts.set(i.toString(), h);
     }
-    var localHosts = originalHosts.values().filter(function(element) {
+    const localHosts = originalHosts.values().filter(function(element) {
       return element.datacenter === 'dc1';
     });
-    var times = 50;
+    const times = 50;
 
     const localPermutations = [];
     // Capture the various permutations of plans.
     for (i = 0; i < localHosts.length; i++) {
       const permutation = [];
-      for(var j = i; j < localHosts.length + i; j++) {
+      for(let j = i; j < localHosts.length + i; j++) {
         permutation.push(localHosts[j % localHosts.length]);
       }
       localPermutations.push(permutation);
@@ -198,9 +198,9 @@ describe('DCAwareRoundRobinPolicy', function () {
     const policy = new DCAwareRoundRobinPolicy(null, 2);
     const options = clientOptions.extend({}, helper.baseOptions, {policies: {loadBalancing: policy}});
     const hosts = [];
-    var originalHosts = new HostMap();
+    const originalHosts = new HostMap();
     for (let i = 0; i < 60; i++) {
-      var h = new Host(i, 2, options);
+      const h = new Host(i, 2, options);
       switch (i % 3) {
         case 0:
           h.datacenter = 'dc1';
@@ -214,10 +214,10 @@ describe('DCAwareRoundRobinPolicy', function () {
       }
       originalHosts.set(i.toString(), h);
     }
-    var localLength = originalHosts.length / 3;
+    const localLength = originalHosts.length / 3;
     //2 nodes per each remote dc
-    var expectedLength = localLength + 2 * 2;
-    let times = 1;
+    const expectedLength = localLength + 2 * 2;
+    const times = 1;
     policy.init(new Client(options), originalHosts, function (err) {
       assert.ifError(err);
       assert.strictEqual(policy.localDc, 'dc1');
@@ -225,7 +225,7 @@ describe('DCAwareRoundRobinPolicy', function () {
         policy.newQueryPlan(null, null, function (err, iterator) {
           assert.equal(err, null);
           for (let i = 0; i < originalHosts.length; i++) {
-            var item = iterator.next();
+            const item = iterator.next();
             if (i >= expectedLength) {
               assert.strictEqual(item.done, true);
               continue;
@@ -264,10 +264,10 @@ describe('DCAwareRoundRobinPolicy', function () {
   it('should yield local + remote hosts in a round robin manner when consuming', function (done) {
     const policy = new DCAwareRoundRobinPolicy(null, 3);
     const options = clientOptions.extend({}, helper.baseOptions, {policies: {loadBalancing: policy}});
-    var originalHosts = new HostMap();
+    const originalHosts = new HostMap();
     let i;
     for (i = 0; i < 60; i++) {
-      var h = new Host(i, 2, options);
+      const h = new Host(i, 2, options);
       switch (i % 3) {
         case 0:
           h.datacenter = 'dc1';
@@ -282,25 +282,25 @@ describe('DCAwareRoundRobinPolicy', function () {
       originalHosts.set(i.toString(), h);
     }
 
-    var localHosts = originalHosts.values().filter(function(element) {
+    const localHosts = originalHosts.values().filter(function(element) {
       return element.datacenter === 'dc1';
     });
 
-    var dc2Hosts = originalHosts.values().filter(function(element) {
+    const dc2Hosts = originalHosts.values().filter(function(element) {
       return element.datacenter === 'dc2';
     });
 
-    var dc3Hosts = originalHosts.values().filter(function(element) {
+    const dc3Hosts = originalHosts.values().filter(function(element) {
       return element.datacenter === 'dc3';
     });
 
-    var times = 60;
+    const times = 60;
 
     const localPermutations = [];
     // Capture the various permutations of plans.
     for (i = 0; i < localHosts.length; i++) {
       const permutation = [];
-      for(var j = i; j < localHosts.length + i; j++) {
+      for(let j = i; j < localHosts.length + i; j++) {
         permutation.push(localHosts[j % localHosts.length]);
       }
       localPermutations.push(permutation);
@@ -315,12 +315,12 @@ describe('DCAwareRoundRobinPolicy', function () {
           const planHosts = [];
           // Iterate through plan local hosts + (remoteHosts * remoteDcs) + 1.
           utils.timesSeries(localHosts.length + (3 * 2) + 1, function (planN, iteratorNext) {
-            var item = iterator.next();
+            const item = iterator.next();
             assert.strictEqual(item.done, (planN >= localHosts.length + (3 * 2)));
             // Wait a random amount of time between executions to ensure
             // sequence of query plan iteration does not impact other
             // query plans.
-            var randomWait = Math.floor((Math.random() * 5) + 1);
+            const randomWait = Math.floor((Math.random() * 5) + 1);
             setTimeout(function () {
               planHosts.push(item.value);
               iteratorNext();
@@ -392,9 +392,9 @@ describe('DCAwareRoundRobinPolicy', function () {
           let length = 0;
           let lastPlan = null;
           plans.forEach(function(item) {
-            var localOnlyPlan = item.plan.slice(0, localHosts.length);
-            var localOnlyPlanDesc = JSON.stringify(localOnlyPlan);
-            var permutationDesc = JSON.stringify(permutation);
+            const localOnlyPlan = item.plan.slice(0, localHosts.length);
+            const localOnlyPlanDesc = JSON.stringify(localOnlyPlan);
+            const permutationDesc = JSON.stringify(permutation);
             length += (localOnlyPlanDesc === permutationDesc ? 1 : 0);
             assert.notEqual(lastPlan, localOnlyPlanDesc, "last encountered" +
               " plan is the same as the previous one.\n" + lastPlan + "\n===\n" + localOnlyPlanDesc);
@@ -406,8 +406,8 @@ describe('DCAwareRoundRobinPolicy', function () {
         // Ensure remote part of query plans is non-repeating among plans.
         let lastPlan = null;
         plans.forEach(function (item){
-          var remoteOnlyPlan = item.plan.slice(localHosts.length);
-          var remoteOnlyPlanDesc = JSON.stringify(remoteOnlyPlan);
+          const remoteOnlyPlan = item.plan.slice(localHosts.length);
+          const remoteOnlyPlanDesc = JSON.stringify(remoteOnlyPlan);
           assert.notEqual(lastPlan, remoteOnlyPlanDesc, "last encountered" +
             " remote plan is the same as the previous one.\n" + lastPlan + "\n==\n" + remoteOnlyPlanDesc);
           lastPlan = remoteOnlyPlanDesc;
@@ -419,7 +419,7 @@ describe('DCAwareRoundRobinPolicy', function () {
   it('should handle cache being cleared and next iterations', function (done) {
     const policy = new DCAwareRoundRobinPolicy('dc1');
     const options = clientOptions.extend({}, helper.baseOptions, {policies: {loadBalancing: policy}});
-    var hosts = new HostMap();
+    const hosts = new HostMap();
     hosts.set('1', createHost('1', options));
     hosts.set('2', createHost('2', options));
     utils.series([
@@ -429,7 +429,7 @@ describe('DCAwareRoundRobinPolicy', function () {
       function checkQueryPlanWithNewNodesBeingAdded(next) {
         policy.newQueryPlan(null, null, function (err, iterator) {
           assert.ifError(err);
-          var item = iterator.next();
+          const item = iterator.next();
           assert.ok(!item.done);
           // Add an item to clear the LBP cache
           hosts.set('3', createHost('2', options));
@@ -495,7 +495,7 @@ describe('DCAwareRoundRobinPolicy', function () {
 describe('TokenAwarePolicy', function () {
   it('should use the childPolicy when no routingKey provided', function (done) {
     const options = clientOptions.extend({}, helper.baseOptions);
-    var childPolicy = createDummyPolicy(options);
+    const childPolicy = createDummyPolicy(options);
     const policy = new TokenAwarePolicy(childPolicy);
     utils.series([
       function (next) {
@@ -515,7 +515,7 @@ describe('TokenAwarePolicy', function () {
   });
   it('should retrieve local replicas plus childPolicy hosts plus remote replicas', function (done) {
     const options = clientOptions.extend({}, helper.baseOptions);
-    var childPolicy = createDummyPolicy(options);
+    const childPolicy = createDummyPolicy(options);
     const policy = new TokenAwarePolicy(childPolicy);
     const client = new Client(options);
     client.getReplicas = toFunc([ 'repl1_remote', 'repl2_local', 'repl3_remote', 'repl4_local' ].map(toHost));
@@ -539,7 +539,7 @@ describe('TokenAwarePolicy', function () {
   });
   it('should retrieve local and remote replicas in a pseudo random order', function (done) {
     const options = clientOptions.extend({}, helper.baseOptions);
-    var childPolicy = createDummyPolicy(options);
+    const childPolicy = createDummyPolicy(options);
     const policy = new TokenAwarePolicy(childPolicy);
     const client = new Client(options);
     client.getReplicas = toFunc(
@@ -569,16 +569,16 @@ describe('TokenAwarePolicy', function () {
   it('should fairly distribute between replicas', function (done) {
     this.timeout(20000);
     const options = clientOptions.extend({}, helper.baseOptions);
-    var childPolicy = createDummyPolicy(options);
+    const childPolicy = createDummyPolicy(options);
     const policy = new TokenAwarePolicy(childPolicy);
     const client = new Client(options);
     client.getReplicas = toFunc([
       'repl1_remote', 'repl2_local', 'repl3_remote', 'repl4_local', 'repl5_remote', 'repl6_local', 'repl7_local'
     ].map(toHost));
     // An array containing the amount of times it host appeared at a determined position
-    var replicaPositions = [ {}, {}, {}, {} ];
+    const replicaPositions = [ {}, {}, {}, {} ];
     const routingKey = types.Uuid.random().buffer;
-    var iterations = 100000;
+    const iterations = 100000;
     utils.series([
       helper.toTask(policy.init, policy, client, new HostMap()),
       function (next) {
@@ -594,13 +594,13 @@ describe('TokenAwarePolicy', function () {
         }, next);
       },
       function checkReplicas(next) {
-        var totalHosts = replicaPositions.length;
+        const totalHosts = replicaPositions.length;
         const expected = iterations / totalHosts;
         for (let i = 0; i < totalHosts; i++) {
-          var hostsAtPosition = replicaPositions[i];
+          const hostsAtPosition = replicaPositions[i];
           // eslint-disable-next-line no-loop-func
           Object.keys(hostsAtPosition).forEach(function (address) {
-            var timesSelected = hostsAtPosition[address];
+            const timesSelected = hostsAtPosition[address];
             // Check that the times that the value is selected is close to the expected
             assert.ok(timesSelected > expected * 0.97);
             assert.ok(timesSelected < expected * 1.03);
@@ -614,7 +614,7 @@ describe('TokenAwarePolicy', function () {
 describe('WhiteListPolicy', function () {
   it('should use the childPolicy to determine the distance', function () {
     let getDistanceCalled = 0;
-    var childPolicy = {
+    const childPolicy = {
       getDistance: function () {
         getDistanceCalled++;
         return types.distance.local;
@@ -630,7 +630,7 @@ describe('WhiteListPolicy', function () {
     assert.strictEqual(getDistanceCalled, 2);
   });
   it('should filter the child policy hosts', function (done) {
-    var childPolicy = {
+    const childPolicy = {
       newQueryPlan: function (ks, o, cb) {
         cb(null, utils.arrayIterator([{ address: '1.1.1.1:9042'}, { address: '1.1.1.2:9042'}, { address: '1.1.1.3:9042'}]));
       }
@@ -661,12 +661,12 @@ function testRoundRobinPlan(times, policy, options, allHosts, expectedHosts, per
           expectedHosts = expectedHosts.values();
         }
         utils.mapSeries(expectedHosts, function (planN, iteratorNext) {
-          var item = iterator.next();
+          const item = iterator.next();
           assert.strictEqual(item.done, false);
           // Wait a random amount of time between executions to ensure
           // sequence of query plan iteration does not impact other
           // query plans.
-          var randomWait = Math.floor((Math.random() * 5) + 1);
+          const randomWait = Math.floor((Math.random() * 5) + 1);
           setTimeout(function () {
             iteratorNext(null, item.value);
           }, randomWait);
@@ -701,8 +701,8 @@ function testRoundRobinPlan(times, policy, options, allHosts, expectedHosts, per
         let length = 0;
         let lastPlan = null;
         plans.forEach(function(item) {
-          var planDesc = JSON.stringify(item.plan);
-          var permutationDesc = JSON.stringify(permutation);
+          const planDesc = JSON.stringify(item.plan);
+          const permutationDesc = JSON.stringify(permutation);
           length += (planDesc === permutationDesc ? 1 : 0);
           assert.notEqual(lastPlan, planDesc, "last encountered plan is the" +
             " same as the previous one.\n" + lastPlan + "\n===\n" + planDesc);
@@ -720,7 +720,7 @@ function testRoundRobinPlan(times, policy, options, allHosts, expectedHosts, per
  * @returns {LoadBalancingPolicy}
  */
 function createDummyPolicy(options) {
-  var childPolicy = new LoadBalancingPolicy();
+  const childPolicy = new LoadBalancingPolicy();
   childPolicy.initCalled = 0;
   childPolicy.newQueryPlanCalled = 0;
   childPolicy.init = function (c, hs, cb) {
@@ -736,7 +736,7 @@ function createDummyPolicy(options) {
   childPolicy.newQueryPlan = function (k, o, cb) {
     childPolicy.newQueryPlanCalled++;
 
-    var hosts = [ new Host('repl2_local', 2, options), new Host('child1', 2, options), new Host('child2', 2, options) ];
+    const hosts = [ new Host('repl2_local', 2, options), new Host('child1', 2, options), new Host('child2', 2, options) ];
     cb(null, utils.arrayIterator(hosts));
   };
   return childPolicy;
@@ -747,7 +747,7 @@ function createDummyPolicy(options) {
  * @returns {HostMap}
  */
 function createHostMap(hosts) {
-  var map = new HostMap();
+  const map = new HostMap();
   for (let i = 0; i < hosts.length; i++) {
     map.set(hosts[i], hosts[i]);
   }
@@ -761,7 +761,7 @@ function createHostMap(hosts) {
  * @param {String} [dc]
  */
 function createHost(address, options, dc) {
-  var h = new Host(address, 4, options);
+  const h = new Host(address, 4, options);
   h.datacenter = dc || 'dc1';
   return h;
 }

--- a/test/unit/load-balancing-tests.js
+++ b/test/unit/load-balancing-tests.js
@@ -450,13 +450,13 @@ describe('DCAwareRoundRobinPolicy', function () {
 
   });
   it('should warn on init when no local DC was configured', function (done) {
-    var policy = new DCAwareRoundRobinPolicy();
-    var client = new Client(helper.baseOptions);
-    var logEvents = [];
+    const policy = new DCAwareRoundRobinPolicy();
+    const client = new Client(helper.baseOptions);
+    const logEvents = [];
     client.on('log', function(level, className, message, furtherInfo) {
       logEvents.push({level: level, className: className, message: message, furtherInfo: furtherInfo});
     });
-    var hosts = new HostMap();
+    const hosts = new HostMap();
     hosts.set('1', createHost('1', client.options));
     utils.series([
       function initPolicy(next) {
@@ -464,7 +464,7 @@ describe('DCAwareRoundRobinPolicy', function () {
       },
       function checkLogs(next) {
         assert.strictEqual(logEvents.length, 1);
-        var event = logEvents[0];
+        const event = logEvents[0];
         assert.strictEqual(event.level, 'warning');
         assert.strictEqual(event.message, 'No local Data Center was provided with DCAwareRoundRobinPolicy.' +
           '  Using discovered DC \'dc1\' from host 1.  Future releases will require local DC to be specified.');
@@ -473,13 +473,13 @@ describe('DCAwareRoundRobinPolicy', function () {
     ], done);
   });
   it('should not warn on init when local DC was configured', function (done) {
-    var policy = new DCAwareRoundRobinPolicy('dc1');
-    var client = new Client(helper.baseOptions);
-    var logEvents = [];
+    const policy = new DCAwareRoundRobinPolicy('dc1');
+    const client = new Client(helper.baseOptions);
+    const logEvents = [];
     client.on('log', function(level, className, message, furtherInfo) {
       logEvents.push({level: level, className: className, message: message, furtherInfo: furtherInfo});
     });
-    var hosts = new HostMap();
+    const hosts = new HostMap();
     hosts.set('1', createHost('1', client.options));
     utils.series([
       function initPolicy(next) {

--- a/test/unit/load-balancing-tests.js
+++ b/test/unit/load-balancing-tests.js
@@ -1,14 +1,14 @@
 'use strict';
-var assert = require('assert');
+const assert = require('assert');
 
-var helper = require('../test-helper.js');
-var Client = require('../../lib/client.js');
-var clientOptions = require('../../lib/client-options.js');
-var Host = require('../../lib/host.js').Host;
-var HostMap = require('../../lib/host.js').HostMap;
-var types = require('../../lib/types');
-var utils = require('../../lib/utils.js');
-var loadBalancing = require('../../lib/policies/load-balancing.js');
+const helper = require('../test-helper.js');
+const Client = require('../../lib/client.js');
+const clientOptions = require('../../lib/client-options.js');
+const Host = require('../../lib/host.js').Host;
+const HostMap = require('../../lib/host.js').HostMap;
+const types = require('../../lib/types');
+const utils = require('../../lib/utils.js');
+const loadBalancing = require('../../lib/policies/load-balancing.js');
 var LoadBalancingPolicy = loadBalancing.LoadBalancingPolicy;
 var TokenAwarePolicy = loadBalancing.TokenAwarePolicy;
 var RoundRobinPolicy = loadBalancing.RoundRobinPolicy;
@@ -17,7 +17,7 @@ var WhiteListPolicy = loadBalancing.WhiteListPolicy;
 
 describe('RoundRobinPolicy', function () {
   it('should yield an error when the hosts are not set', function(done) {
-    var policy = new RoundRobinPolicy();
+    const policy = new RoundRobinPolicy();
     policy.hosts = null;
     policy.newQueryPlan(null, null, function(err) {
       assert(err instanceof Error);
@@ -25,8 +25,8 @@ describe('RoundRobinPolicy', function () {
     });
   });
   it('should yield nodes in a round robin manner even in parallel', function (done) {
-    var policy = new RoundRobinPolicy();
-    var hosts = [];
+    const policy = new RoundRobinPolicy();
+    const hosts = [];
     var originalHosts = createHostMap(['A', 'B', 'C', 'E']);
     var times = 100;
     policy.init(null, originalHosts, function () {
@@ -43,8 +43,8 @@ describe('RoundRobinPolicy', function () {
         assert.strictEqual(hosts.length, times);
         //Count the number of times of each element
         originalHosts.forEach(function (item) {
-          var length = 0;
-          var lastHost = null;
+          let length = 0;
+          let lastHost = null;
           hosts.forEach(function (host) {
             length += (host === item ? 1 : 0);
             assert.notEqual(lastHost, host);
@@ -57,12 +57,12 @@ describe('RoundRobinPolicy', function () {
     });
   });
   it('should yield host in a round robin manner when consuming', function (done) {
-    var policy = new RoundRobinPolicy();
+    const policy = new RoundRobinPolicy();
     var hostList = ['A', 'B', 'C', 'E', 'F'];
-    var permutations = [];
+    const permutations = [];
     // Capture the various permutations of plans.
-    for (var i = 0; i < hostList.length; i++) {
-      var permutation = [];
+    for (let i = 0; i < hostList.length; i++) {
+      const permutation = [];
       for(var j = i; j < hostList.length + i; j++) {
         permutation.push(hostList[j % hostList.length]);
       }
@@ -74,14 +74,14 @@ describe('RoundRobinPolicy', function () {
     testRoundRobinPlan(times, policy, null, originalHosts, originalHosts, permutations, done);
   });
   it('should yield no more than N host', function (done) {
-    var policy = new RoundRobinPolicy();
+    const policy = new RoundRobinPolicy();
     var originalHosts = createHostMap(['A', 'B', 'C']);
     var times = 10;
     policy.init(null, originalHosts, function () {
       utils.times(times, function (n, next) {
         policy.newQueryPlan(null, null, function (err, iterator) {
-          var item;
-          for (var i = 0; i < originalHosts.length; i++) {
+          let item;
+          for (let i = 0; i < originalHosts.length; i++) {
             item = iterator.next();
             assert.strictEqual(item.done, false);
             assert.notEqual(item.value, null);
@@ -101,7 +101,7 @@ describe('RoundRobinPolicy', function () {
 });
 describe('DCAwareRoundRobinPolicy', function () {
   it('should yield an error when the hosts are not set', function(done) {
-    var policy = new DCAwareRoundRobinPolicy('dc1');
+    const policy = new DCAwareRoundRobinPolicy('dc1');
     policy.hosts = null;
     policy.newQueryPlan(null, null, function(err) {
       assert(err instanceof Error);
@@ -111,23 +111,23 @@ describe('DCAwareRoundRobinPolicy', function () {
   it('should yield local nodes in a round robin manner in parallel', function (done) {
     //local datacenter: dc1
     //0 host per remote datacenter
-    var policy = new DCAwareRoundRobinPolicy('dc1');
-    var options = clientOptions.extend({}, helper.baseOptions, {policies: {loadBalancing: policy}});
-    var hosts = [];
+    const policy = new DCAwareRoundRobinPolicy('dc1');
+    const options = clientOptions.extend({}, helper.baseOptions, {policies: {loadBalancing: policy}});
+    const hosts = [];
     var originalHosts = new HostMap();
-    for (var i = 0; i < 50; i++) {
+    for (let i = 0; i < 50; i++) {
       var h = new Host(i, 2, options);
       h.datacenter = (i % 2 === 0) ? 'dc1' : 'dc2';
       originalHosts.set(i.toString(), h);
     }
     var localLength = originalHosts.length / 2;
-    var times = 1;
+    let times = 1;
     policy.init(new Client(options), originalHosts, function (err) {
       assert.ifError(err);
       utils.times(times, function (n, next) {
         policy.newQueryPlan(null, null, function (err, iterator) {
           assert.equal(err, null);
-          for (var i = 0; i < originalHosts.length; i++) {
+          for (let i = 0; i < originalHosts.length; i++) {
             var item = iterator.next();
             if (i >= localLength) {
               //once the local have ended, it should be "done"
@@ -145,8 +145,8 @@ describe('DCAwareRoundRobinPolicy', function () {
         assert.strictEqual(hosts.length, times * localLength);
         //Count the number of times of each element
         originalHosts.forEach(function (item) {
-          var length = 0;
-          var lastHost = null;
+          let length = 0;
+          let lastHost = null;
           hosts.forEach(function (host) {
             length += (host === item ? 1 : 0);
             assert.notEqual(lastHost, host);
@@ -166,10 +166,10 @@ describe('DCAwareRoundRobinPolicy', function () {
     });
   });
   it('should yield local hosts in a round robin manner when consuming.', function (done) {
-    var policy = new DCAwareRoundRobinPolicy('dc1');
-    var options = clientOptions.extend({}, helper.baseOptions, {policies: {loadBalancing: policy}});
+    const policy = new DCAwareRoundRobinPolicy('dc1');
+    const options = clientOptions.extend({}, helper.baseOptions, {policies: {loadBalancing: policy}});
     var originalHosts = new HostMap();
-    var i;
+    let i;
     for (i = 0; i < 50; i++) {
       var h = new Host(i, 2, options);
       h.datacenter = (i % 2 === 0) ? 'dc1' : 'dc2';
@@ -180,10 +180,10 @@ describe('DCAwareRoundRobinPolicy', function () {
     });
     var times = 50;
 
-    var localPermutations = [];
+    const localPermutations = [];
     // Capture the various permutations of plans.
     for (i = 0; i < localHosts.length; i++) {
-      var permutation = [];
+      const permutation = [];
       for(var j = i; j < localHosts.length + i; j++) {
         permutation.push(localHosts[j % localHosts.length]);
       }
@@ -195,11 +195,11 @@ describe('DCAwareRoundRobinPolicy', function () {
   it('should yield the correct amount of remote nodes at the end', function (done) {
     //local datacenter: null (first host's datacenter will be used)
     //2 host per remote datacenter
-    var policy = new DCAwareRoundRobinPolicy(null, 2);
-    var options = clientOptions.extend({}, helper.baseOptions, {policies: {loadBalancing: policy}});
-    var hosts = [];
+    const policy = new DCAwareRoundRobinPolicy(null, 2);
+    const options = clientOptions.extend({}, helper.baseOptions, {policies: {loadBalancing: policy}});
+    const hosts = [];
     var originalHosts = new HostMap();
-    for (var i = 0; i < 60; i++) {
+    for (let i = 0; i < 60; i++) {
       var h = new Host(i, 2, options);
       switch (i % 3) {
         case 0:
@@ -217,14 +217,14 @@ describe('DCAwareRoundRobinPolicy', function () {
     var localLength = originalHosts.length / 3;
     //2 nodes per each remote dc
     var expectedLength = localLength + 2 * 2;
-    var times = 1;
+    let times = 1;
     policy.init(new Client(options), originalHosts, function (err) {
       assert.ifError(err);
       assert.strictEqual(policy.localDc, 'dc1');
       utils.times(times, function (n, next) {
         policy.newQueryPlan(null, null, function (err, iterator) {
           assert.equal(err, null);
-          for (var i = 0; i < originalHosts.length; i++) {
+          for (let i = 0; i < originalHosts.length; i++) {
             var item = iterator.next();
             if (i >= expectedLength) {
               assert.strictEqual(item.done, true);
@@ -246,8 +246,8 @@ describe('DCAwareRoundRobinPolicy', function () {
         //Count the number of times of each element
         originalHosts.forEach(function (item) {
           if (item.datacenter === 'dc1') {
-            var length = 0;
-            var lastHost = null;
+            let length = 0;
+            let lastHost = null;
             hosts.forEach(function (host) {
               length += (host === item ? 1 : 0);
               assert.notEqual(lastHost, host);
@@ -262,10 +262,10 @@ describe('DCAwareRoundRobinPolicy', function () {
     });
   });
   it('should yield local + remote hosts in a round robin manner when consuming', function (done) {
-    var policy = new DCAwareRoundRobinPolicy(null, 3);
-    var options = clientOptions.extend({}, helper.baseOptions, {policies: {loadBalancing: policy}});
+    const policy = new DCAwareRoundRobinPolicy(null, 3);
+    const options = clientOptions.extend({}, helper.baseOptions, {policies: {loadBalancing: policy}});
     var originalHosts = new HostMap();
-    var i;
+    let i;
     for (i = 0; i < 60; i++) {
       var h = new Host(i, 2, options);
       switch (i % 3) {
@@ -296,10 +296,10 @@ describe('DCAwareRoundRobinPolicy', function () {
 
     var times = 60;
 
-    var localPermutations = [];
+    const localPermutations = [];
     // Capture the various permutations of plans.
     for (i = 0; i < localHosts.length; i++) {
-      var permutation = [];
+      const permutation = [];
       for(var j = i; j < localHosts.length + i; j++) {
         permutation.push(localHosts[j % localHosts.length]);
       }
@@ -308,11 +308,11 @@ describe('DCAwareRoundRobinPolicy', function () {
 
     policy.init(new Client(options), originalHosts, function (err) {
       assert.ifError(err);
-      var plans = [];
+      const plans = [];
       utils.times(times, function (n, next) {
         policy.newQueryPlan(null, null, function(err, iterator) {
           assert.ifError(err);
-          var planHosts = [];
+          const planHosts = [];
           // Iterate through plan local hosts + (remoteHosts * remoteDcs) + 1.
           utils.timesSeries(localHosts.length + (3 * 2) + 1, function (planN, iteratorNext) {
             var item = iterator.next();
@@ -331,7 +331,7 @@ describe('DCAwareRoundRobinPolicy', function () {
             // Ensure each host appears only once and at the beginning of the
             // plan.
             localHosts.forEach(function (host) {
-              var length = 0;
+              let length = 0;
               planHosts.slice(0, localHosts.length).forEach(function (planHost) {
                 length += (host === planHost ? 1 : 0);
               });
@@ -340,12 +340,12 @@ describe('DCAwareRoundRobinPolicy', function () {
                 + planHosts + ".  Expected only once.");
             });
 
-            var foundDc2Hosts = [];
-            var foundDc3Hosts = [];
+            const foundDc2Hosts = [];
+            const foundDc3Hosts = [];
             // Ensure that planHosts returned 3 remote hosts from each dc and
             // that they were unique.
             planHosts.slice(localHosts.length, localHosts.length + (3 * 2)).forEach(function (host) {
-              var length = 0;
+              let length = 0;
               dc2Hosts.forEach(function (dc2Host) {
                 length += (host === dc2Host ? 1: 0);
               });
@@ -389,8 +389,8 @@ describe('DCAwareRoundRobinPolicy', function () {
         // Ensure each permutation happened the expected number of times
         // (times / permutations) and never consecutively.
         localPermutations.forEach(function(permutation) {
-          var length = 0;
-          var lastPlan = null;
+          let length = 0;
+          let lastPlan = null;
           plans.forEach(function(item) {
             var localOnlyPlan = item.plan.slice(0, localHosts.length);
             var localOnlyPlanDesc = JSON.stringify(localOnlyPlan);
@@ -404,7 +404,7 @@ describe('DCAwareRoundRobinPolicy', function () {
         });
 
         // Ensure remote part of query plans is non-repeating among plans.
-        var lastPlan = null;
+        let lastPlan = null;
         plans.forEach(function (item){
           var remoteOnlyPlan = item.plan.slice(localHosts.length);
           var remoteOnlyPlanDesc = JSON.stringify(remoteOnlyPlan);
@@ -417,8 +417,8 @@ describe('DCAwareRoundRobinPolicy', function () {
     });
   });
   it('should handle cache being cleared and next iterations', function (done) {
-    var policy = new DCAwareRoundRobinPolicy('dc1');
-    var options = clientOptions.extend({}, helper.baseOptions, {policies: {loadBalancing: policy}});
+    const policy = new DCAwareRoundRobinPolicy('dc1');
+    const options = clientOptions.extend({}, helper.baseOptions, {policies: {loadBalancing: policy}});
     var hosts = new HostMap();
     hosts.set('1', createHost('1', options));
     hosts.set('2', createHost('2', options));
@@ -494,16 +494,16 @@ describe('DCAwareRoundRobinPolicy', function () {
 });
 describe('TokenAwarePolicy', function () {
   it('should use the childPolicy when no routingKey provided', function (done) {
-    var options = clientOptions.extend({}, helper.baseOptions);
+    const options = clientOptions.extend({}, helper.baseOptions);
     var childPolicy = createDummyPolicy(options);
-    var policy = new TokenAwarePolicy(childPolicy);
+    const policy = new TokenAwarePolicy(childPolicy);
     utils.series([
       function (next) {
         policy.init(new Client(options), new HostMap(), next);
       },
       function (next) {
         policy.newQueryPlan(null, null, function (err, iterator) {
-          var hosts = helper.iteratorToArray(iterator);
+          const hosts = helper.iteratorToArray(iterator);
           assert.ok(hosts);
           assert.strictEqual(hosts.length, 3);
           assert.strictEqual(childPolicy.initCalled, 1);
@@ -514,16 +514,16 @@ describe('TokenAwarePolicy', function () {
     ], done);
   });
   it('should retrieve local replicas plus childPolicy hosts plus remote replicas', function (done) {
-    var options = clientOptions.extend({}, helper.baseOptions);
+    const options = clientOptions.extend({}, helper.baseOptions);
     var childPolicy = createDummyPolicy(options);
-    var policy = new TokenAwarePolicy(childPolicy);
-    var client = new Client(options);
+    const policy = new TokenAwarePolicy(childPolicy);
+    const client = new Client(options);
     client.getReplicas = toFunc([ 'repl1_remote', 'repl2_local', 'repl3_remote', 'repl4_local' ].map(toHost));
     utils.series([
       helper.toTask(policy.init, policy, client, new HostMap()),
       function (next) {
         policy.newQueryPlan(null, {routingKey: utils.allocBufferUnsafe(16)}, function (err, iterator) {
-          var hosts = helper.iteratorToArray(iterator);
+          const hosts = helper.iteratorToArray(iterator);
           assert.ok(hosts);
           assert.strictEqual(hosts.length, 4);
           assert.strictEqual(childPolicy.initCalled, 1);
@@ -538,19 +538,19 @@ describe('TokenAwarePolicy', function () {
     ], done);
   });
   it('should retrieve local and remote replicas in a pseudo random order', function (done) {
-    var options = clientOptions.extend({}, helper.baseOptions);
+    const options = clientOptions.extend({}, helper.baseOptions);
     var childPolicy = createDummyPolicy(options);
-    var policy = new TokenAwarePolicy(childPolicy);
-    var client = new Client(options);
+    const policy = new TokenAwarePolicy(childPolicy);
+    const client = new Client(options);
     client.getReplicas = toFunc(
       [ 'repl1_remote', 'repl2_local', 'repl3_remote', 'repl4_local', 'repl5_local'].map(toHost));
-    var localReplicas = {};
+    const localReplicas = {};
     utils.series([
       helper.toTask(policy.init, policy, client, new HostMap()),
       function (next) {
         utils.timesLimit(100, 32, function (n, timesNext) {
           policy.newQueryPlan(null, { routingKey: utils.allocBufferUnsafe(16) }, function (err, iterator) {
-            var hosts = helper.iteratorToArray(iterator);
+            const hosts = helper.iteratorToArray(iterator);
             assert.strictEqual(hosts.length, 5);
             assert.deepEqual(hosts.map(toAddress).slice(0, 3).sort(), ['repl2_local', 'repl4_local', 'repl5_local']);
             localReplicas[hosts[0].address] = true;
@@ -568,23 +568,23 @@ describe('TokenAwarePolicy', function () {
   });
   it('should fairly distribute between replicas', function (done) {
     this.timeout(20000);
-    var options = clientOptions.extend({}, helper.baseOptions);
+    const options = clientOptions.extend({}, helper.baseOptions);
     var childPolicy = createDummyPolicy(options);
-    var policy = new TokenAwarePolicy(childPolicy);
-    var client = new Client(options);
+    const policy = new TokenAwarePolicy(childPolicy);
+    const client = new Client(options);
     client.getReplicas = toFunc([
       'repl1_remote', 'repl2_local', 'repl3_remote', 'repl4_local', 'repl5_remote', 'repl6_local', 'repl7_local'
     ].map(toHost));
     // An array containing the amount of times it host appeared at a determined position
     var replicaPositions = [ {}, {}, {}, {} ];
-    var routingKey = types.Uuid.random().buffer;
+    const routingKey = types.Uuid.random().buffer;
     var iterations = 100000;
     utils.series([
       helper.toTask(policy.init, policy, client, new HostMap()),
       function (next) {
         utils.timesLimit(iterations, 128, function (n, timesNext) {
           policy.newQueryPlan(null, { routingKey: routingKey }, function (err, iterator) {
-            var hosts = helper.iteratorToArray(iterator);
+            const hosts = helper.iteratorToArray(iterator);
             assert.strictEqual(hosts.length, 6);
             hosts.map(toAddress).slice(0, 4).forEach(function (address, i) {
               replicaPositions[i][address] = (replicaPositions[i][address] || 0) + 1;
@@ -595,8 +595,8 @@ describe('TokenAwarePolicy', function () {
       },
       function checkReplicas(next) {
         var totalHosts = replicaPositions.length;
-        var expected = iterations / totalHosts;
-        for (var i = 0; i < totalHosts; i++) {
+        const expected = iterations / totalHosts;
+        for (let i = 0; i < totalHosts; i++) {
           var hostsAtPosition = replicaPositions[i];
           // eslint-disable-next-line no-loop-func
           Object.keys(hostsAtPosition).forEach(function (address) {
@@ -613,14 +613,14 @@ describe('TokenAwarePolicy', function () {
 });
 describe('WhiteListPolicy', function () {
   it('should use the childPolicy to determine the distance', function () {
-    var getDistanceCalled = 0;
+    let getDistanceCalled = 0;
     var childPolicy = {
       getDistance: function () {
         getDistanceCalled++;
         return types.distance.local;
       }
     };
-    var policy = new WhiteListPolicy(childPolicy, ['h1:9042', 'h2:9042']);
+    const policy = new WhiteListPolicy(childPolicy, ['h1:9042', 'h2:9042']);
     assert.strictEqual(policy.getDistance({ address: 'h1:9042'}), types.distance.local);
     assert.strictEqual(getDistanceCalled, 1);
     assert.strictEqual(policy.getDistance({ address: 'h2:9042'}), types.distance.local);
@@ -635,10 +635,10 @@ describe('WhiteListPolicy', function () {
         cb(null, utils.arrayIterator([{ address: '1.1.1.1:9042'}, { address: '1.1.1.2:9042'}, { address: '1.1.1.3:9042'}]));
       }
     };
-    var policy = new WhiteListPolicy(childPolicy, ['1.1.1.3:9042', '1.1.1.1:9042']);
+    const policy = new WhiteListPolicy(childPolicy, ['1.1.1.3:9042', '1.1.1.1:9042']);
     policy.newQueryPlan('ks1', {}, function (err, iterator) {
       assert.ifError(err);
-      var hosts = helper.iteratorToArray(iterator);
+      const hosts = helper.iteratorToArray(iterator);
       assert.strictEqual(hosts.length, 2);
       assert.strictEqual(helper.lastOctetOf(hosts[0]), '1');
       assert.strictEqual(helper.lastOctetOf(hosts[1]), '3');
@@ -648,11 +648,11 @@ describe('WhiteListPolicy', function () {
 });
 
 function testRoundRobinPlan(times, policy, options, allHosts, expectedHosts, permutations, done) {
-  var client = options ? new Client(options) : null;
+  const client = options ? new Client(options) : null;
 
   policy.init(client, allHosts, function (err) {
     assert.ifError(err);
-    var i = 0;
+    let i = 0;
     utils.map(new Array(times), function (n, next) {
       n = i++;
       policy.newQueryPlan(null, null, function(err, iterator) {
@@ -675,7 +675,7 @@ function testRoundRobinPlan(times, policy, options, allHosts, expectedHosts, per
 
           // Ensure each host appears only once.
           expectedHosts.forEach(function(host) {
-            var length = 0;
+            let length = 0;
             planHosts.forEach(function(planHost) {
               length += (host === planHost ? 1 : 0);
             });
@@ -698,8 +698,8 @@ function testRoundRobinPlan(times, policy, options, allHosts, expectedHosts, per
       // Ensure each permutation happened the expected number of times
       // (times / permutations) and never consecutively.
       permutations.forEach(function(permutation) {
-        var length = 0;
-        var lastPlan = null;
+        let length = 0;
+        let lastPlan = null;
         plans.forEach(function(item) {
           var planDesc = JSON.stringify(item.plan);
           var permutationDesc = JSON.stringify(permutation);
@@ -748,7 +748,7 @@ function createDummyPolicy(options) {
  */
 function createHostMap(hosts) {
   var map = new HostMap();
-  for (var i = 0; i < hosts.length; i++) {
+  for (let i = 0; i < hosts.length; i++) {
     map.set(hosts[i], hosts[i]);
   }
   return map;
@@ -779,7 +779,7 @@ function toAddress(h) {
  * @returns {Host}
  */
 function toHost(address) {
-  var options = clientOptions.extend({}, helper.baseOptions);
+  const options = clientOptions.extend({}, helper.baseOptions);
   return new Host(address, 4, options);
 }
 

--- a/test/unit/metadata-tests.js
+++ b/test/unit/metadata-tests.js
@@ -30,7 +30,7 @@ describe('Metadata', function () {
           }]});
         }
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.tokenizer = new tokenizer.Murmur3Tokenizer();
       metadata.ring = [0, 1, 2, 3, 4, 5];
       metadata.primaryReplicas = {'0': '0', '1': '1', '2': '2', '3': '3', '4': '4', '5': '5'};
@@ -38,7 +38,7 @@ describe('Metadata', function () {
       metadata.refreshKeyspaces(function (err) {
         assert.ifError(err);
         assert.ok(metadata.keyspaces);
-        var ks = metadata.keyspaces['ks1'];
+        const ks = metadata.keyspaces['ks1'];
         assert.ok(ks);
         assert.strictEqual(ks.strategy, 'org.apache.cassandra.locator.SimpleStrategy');
         assert.ok(ks.strategyOptions);
@@ -57,7 +57,7 @@ describe('Metadata', function () {
           }]});
         }
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.tokenizer = new tokenizer.Murmur3Tokenizer();
       metadata.ring = [0, 1, 2, 3, 4, 5];
       metadata.primaryReplicas = {'0': '0', '1': '1', '2': '2', '3': '3', '4': '4', '5': '5'};
@@ -65,7 +65,7 @@ describe('Metadata', function () {
       metadata.refreshKeyspaces(function (err) {
         assert.ifError(err);
         assert.ok(metadata.keyspaces);
-        var ks = metadata.keyspaces['ks2'];
+        const ks = metadata.keyspaces['ks2'];
         assert.ok(ks);
         assert.strictEqual(ks.strategy, 'org.apache.cassandra.locator.NetworkTopologyStrategy');
         assert.ok(ks.strategyOptions);
@@ -84,7 +84,7 @@ describe('Metadata', function () {
           }]});
         }
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.tokenizer = new tokenizer.Murmur3Tokenizer();
       metadata.setCassandraVersion([3, 0]);
       metadata.ring = [0, 1, 2, 3, 4, 5];
@@ -93,7 +93,7 @@ describe('Metadata', function () {
       metadata.refreshKeyspaces(function (err) {
         assert.ifError(err);
         assert.ok(metadata.keyspaces);
-        var ks = metadata.keyspaces['ks1'];
+        const ks = metadata.keyspaces['ks1'];
         assert.ok(ks);
         assert.strictEqual(ks.strategy, 'org.apache.cassandra.locator.SimpleStrategy');
         assert.ok(ks.strategyOptions);
@@ -112,7 +112,7 @@ describe('Metadata', function () {
           }]});
         }
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.tokenizer = new tokenizer.Murmur3Tokenizer();
       metadata.setCassandraVersion([3, 0]);
       metadata.ring = [0, 1, 2, 3, 4, 5];
@@ -122,7 +122,7 @@ describe('Metadata', function () {
       metadata.refreshKeyspaces(function (err) {
         assert.ifError(err);
         assert.ok(metadata.keyspaces);
-        var ks = metadata.keyspaces['ks2'];
+        const ks = metadata.keyspaces['ks2'];
         assert.ok(ks);
         assert.strictEqual(ks.strategy, 'org.apache.cassandra.locator.NetworkTopologyStrategy');
         assert.ok(ks.strategyOptions);
@@ -142,7 +142,7 @@ describe('Metadata', function () {
           }]});
         }
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.tokenizer = new tokenizer.Murmur3Tokenizer();
       //Use the value as token
       metadata.tokenizer.hash = function (b) { return b[0];};
@@ -153,7 +153,7 @@ describe('Metadata', function () {
       metadata.primaryReplicas = {'0': '0', '1': '1', '2': '2', '3': '3', '4': '4', '5': '5'};
       metadata.log = helper.noop;
       metadata.refreshKeyspaces();
-      var replicas = metadata.getReplicas('dummy', utils.allocBufferFromArray([0]));
+      let replicas = metadata.getReplicas('dummy', utils.allocBufferFromArray([0]));
       assert.ok(replicas);
       //Primary replica plus the 2 next tokens
       assert.strictEqual(replicas.length, 3);
@@ -175,9 +175,9 @@ describe('Metadata', function () {
         'strategy_options': '{"dc1": "3", "dc2": "1"}'
       }]);
       const options = clientOptions.extend({}, helper.baseOptions);
-      var metadata = new Metadata(options, cc);
+      const metadata = new Metadata(options, cc);
       metadata.tokenizer = getTokenizer();
-      var racks = new utils.HashSet();
+      const racks = new utils.HashSet();
       racks.add('rack1');
       metadata.datacenters = {
         'dc1': { hostLength: 4, racks: racks },
@@ -187,14 +187,14 @@ describe('Metadata', function () {
       //load primary replicas
       metadata.primaryReplicas = {};
       for (let i = 0; i < metadata.ring.length; i ++) {
-        var h = new Host(i.toString(), 2, options);
+        const h = new Host(i.toString(), 2, options);
         h.datacenter = 'dc' + ((i % 2) + 1);
         h.rack = 'rack1';
         metadata.primaryReplicas[i.toString()] = h;
       }
       metadata.log = helper.noop;
       metadata.refreshKeyspaces(function () {
-        var replicas = metadata.getReplicas('dummy', utils.allocBufferFromArray([0]));
+        const replicas = metadata.getReplicas('dummy', utils.allocBufferFromArray([0]));
         assert.ok(replicas);
         //3 replicas from dc1 and 1 replica from dc2
         assert.strictEqual(replicas.length, 4);
@@ -212,12 +212,12 @@ describe('Metadata', function () {
         'strategy_options': '{"dc1": "3", "dc2": "3", "non_existent_dc": "1"}'
       }]);
       const options = clientOptions.extend({}, helper.baseOptions);
-      var metadata = new Metadata(options, cc);
+      const metadata = new Metadata(options, cc);
       metadata.tokenizer = getTokenizer();
-      var racksDc1 = new utils.HashSet();
+      const racksDc1 = new utils.HashSet();
       racksDc1.add('dc1_r1');
       racksDc1.add('dc1_r2');
-      var racksDc2 = new utils.HashSet();
+      const racksDc2 = new utils.HashSet();
       racksDc2.add('dc2_r1');
       racksDc2.add('dc2_r2');
       metadata.datacenters = {
@@ -229,14 +229,14 @@ describe('Metadata', function () {
       metadata.primaryReplicas = {};
       for (let i = 0; i < metadata.ring.length; i ++) {
         // Hosts with in alternate dc and alternate rack
-        var h = new Host(i.toString(), 2, options);
+        const h = new Host(i.toString(), 2, options);
         h.datacenter = 'dc' + ((i % 2) + 1);
         h.rack = h.datacenter + '_r' + ((i % 4) <= 1 ? 1 : 2);
         metadata.primaryReplicas[i.toString()] = h;
       }
       metadata.log = helper.noop;
       metadata.refreshKeyspaces(function () {
-        var replicas = metadata.getReplicas('dummy', utils.allocBufferFromArray([0]));
+        let replicas = metadata.getReplicas('dummy', utils.allocBufferFromArray([0]));
         assert.ok(replicas);
         assert.deepEqual(replicas.map(getAddress), [ '0', '1', '2', '3', '4', '5' ]);
         replicas = metadata.getReplicas('dummy', utils.allocBufferFromArray([1]));
@@ -255,12 +255,12 @@ describe('Metadata', function () {
         'strategy_options': '{"dc1": "3", "dc2": "2"}'
       }]);
       const options = clientOptions.extend({}, helper.baseOptions);
-      var metadata = new Metadata(options, cc);
+      const metadata = new Metadata(options, cc);
       metadata.tokenizer = getTokenizer();
-      var racksDc1 = new utils.HashSet();
+      const racksDc1 = new utils.HashSet();
       racksDc1.add('dc1_r1');
       racksDc1.add('dc1_r2');
-      var racksDc2 = new utils.HashSet();
+      const racksDc2 = new utils.HashSet();
       racksDc2.add('dc2_r1');
       racksDc2.add('dc2_r2');
       metadata.datacenters = {
@@ -272,7 +272,7 @@ describe('Metadata', function () {
       metadata.primaryReplicas = {};
       for (let i = 0; i < metadata.ring.length; i ++) {
         // Hosts with in alternate dc and alternate rack
-        var h = new Host(i.toString(), 2, options);
+        const h = new Host(i.toString(), 2, options);
         h.datacenter = 'dc' + ((i % 2) + 1);
         h.rack = h.datacenter + '_r' + ((i % 4) <= 1 ? 1 : 2);
         metadata.primaryReplicas[i.toString()] = h;
@@ -284,7 +284,7 @@ describe('Metadata', function () {
       metadata.primaryReplicas['6'].rack = 'dc1_rack2';
       metadata.log = helper.noop;
       metadata.refreshKeyspaces(function () {
-        var replicas = metadata.getReplicas('dummy', utils.allocBufferFromArray([0]));
+        const replicas = metadata.getReplicas('dummy', utils.allocBufferFromArray([0]));
         assert.ok(replicas);
         // For DC1, it should skip the replica with the same rack (node2) and add it at the end: 0, 4, 2
         assert.deepEqual(replicas.map(getAddress), [ '0', '1', '3', '4', '2' ]);
@@ -299,11 +299,11 @@ describe('Metadata', function () {
         'strategy_options': '{"dc1": "3", "dc2": "2"}'
       }]);
       const options = clientOptions.extend({}, helper.baseOptions);
-      var metadata = new Metadata(options, cc);
+      const metadata = new Metadata(options, cc);
       metadata.tokenizer = getTokenizer();
-      var racksDc1 = new utils.HashSet();
+      const racksDc1 = new utils.HashSet();
       racksDc1.add('dc1_r1');
-      var racksDc2 = new utils.HashSet();
+      const racksDc2 = new utils.HashSet();
       racksDc2.add('dc2_r1');
       metadata.datacenters = {
         'dc1': {hostLength: 100, racks: racksDc1},
@@ -314,12 +314,12 @@ describe('Metadata', function () {
       // create ring with 100 replicas and 256 vnodes each.  place every replica in DC1.
       metadata.primaryReplicas = {};
       for (let r = 0; r < 100; r++) {
-        var h = new Host(r.toString(), 2, options);
+        const h = new Host(r.toString(), 2, options);
         h.datacenter = 'dc1';
         h.rack = 'dc1_r1';
         // 256 vnodes per replica.
         for (let v = 0; v < 256; v++) {
-          var token = (v * 256) + r;
+          const token = (v * 256) + r;
           metadata.ring.push(token);
           metadata.primaryReplicas[token.toString()] = h;
         }
@@ -335,7 +335,7 @@ describe('Metadata', function () {
       metadata.log = helper.noop;
       // Get the replicas of 5.  Since DC2 has 0 replicas, we only expect 3 replicas (the number of DC1).
       metadata.refreshKeyspaces(function () {
-        var replicas = metadata.getReplicas('dummy', utils.allocBufferFromArray([5]));
+        const replicas = metadata.getReplicas('dummy', utils.allocBufferFromArray([5]));
         assert.ok(replicas);
         assert.deepEqual(replicas.map(getAddress), ['5', '6', '7']);
         done();
@@ -349,11 +349,11 @@ describe('Metadata', function () {
         'strategy_options': '{"dc1": "3", "dc2": "2"}'
       }]);
       const options = clientOptions.extend({}, helper.baseOptions);
-      var metadata = new Metadata(options, cc);
+      const metadata = new Metadata(options, cc);
       metadata.tokenizer = getTokenizer();
-      var racksDc1 = new utils.HashSet();
+      const racksDc1 = new utils.HashSet();
       racksDc1.add('dc1_r1');
-      var racksDc2 = new utils.HashSet();
+      const racksDc2 = new utils.HashSet();
       racksDc2.add('dc2_r1');
       metadata.datacenters = {
         'dc1': {hostLength: 100, racks: racksDc1},
@@ -364,7 +364,7 @@ describe('Metadata', function () {
       // create ring with 100 replicas and 256 vnodes each.  place every replica in DC1 except replica 0.
       metadata.primaryReplicas = {};
       for (let r = 0; r < 100; r++) {
-        var h = new Host(r.toString(), 2, options);
+        const h = new Host(r.toString(), 2, options);
         h.datacenter = 'dc1';
         h.rack = 'dc1_r1';
         // Place replica 0 in DC2.
@@ -374,7 +374,7 @@ describe('Metadata', function () {
         }
         // 256 vnodes per replica.
         for (let v = 0; v < 256; v++) {
-          var token = (v * 256) + r;
+          const token = (v * 256) + r;
           metadata.ring.push(token);
           metadata.primaryReplicas[token.toString()] = h;
         }
@@ -393,7 +393,7 @@ describe('Metadata', function () {
       // Get the replicas of 0.  Since token 0 is a replica in DC2 and DC2 only has 1, it should return 1 replica
       // in addition to the next 3 replicas from DC1.
       metadata.refreshKeyspaces(function () {
-        var replicas = metadata.getReplicas('dummy', utils.allocBufferFromArray([0]));
+        let replicas = metadata.getReplicas('dummy', utils.allocBufferFromArray([0]));
         assert.ok(replicas);
         assert.deepEqual(replicas.map(getAddress), ['0', '1', '2', '3']);
         // Get the replicas for token 51752 which should resolve to primary replica 40 (202nd vnode, 212 * 256 + 40),
@@ -407,11 +407,11 @@ describe('Metadata', function () {
   });
   describe('#clearPrepared()', function () {
     it('should clear the internal state', function () {
-      var metadata = new Metadata(clientOptions.defaultOptions(), null);
-      var info1 = metadata.getPreparedInfo(null, 'QUERY1');
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      const info1 = metadata.getPreparedInfo(null, 'QUERY1');
       // Should be created once
       assert.strictEqual(info1, metadata.getPreparedInfo(null, 'QUERY1'));
-      var info2 = metadata.getPreparedInfo(null, 'QUERY2');
+      const info2 = metadata.getPreparedInfo(null, 'QUERY2');
       metadata.clearPrepared();
       assert.notEqual(info1, metadata.getPreparedInfo(null, 'QUERY1'));
       assert.notEqual(info2, metadata.getPreparedInfo(null, 'QUERY2'));
@@ -419,25 +419,25 @@ describe('Metadata', function () {
   });
   describe('#getPreparedInfo()', function () {
     it('should create a new EventEmitter when the query has not been prepared', function () {
-      var metadata = new Metadata(clientOptions.defaultOptions(), null);
-      var info = metadata.getPreparedInfo(null, 'query1');
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      let info = metadata.getPreparedInfo(null, 'query1');
       helper.assertInstanceOf(info, events.EventEmitter);
       info = metadata.getPreparedInfo(null, 'query2');
       helper.assertInstanceOf(info, events.EventEmitter);
     });
     it('should get the same EventEmitter when the query is the same', function () {
-      var metadata = new Metadata(clientOptions.defaultOptions(), null);
-      var info1 = metadata.getPreparedInfo(null, 'query1');
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      const info1 = metadata.getPreparedInfo(null, 'query1');
       helper.assertInstanceOf(info1, events.EventEmitter);
-      var info2 = metadata.getPreparedInfo(null, 'query1');
+      const info2 = metadata.getPreparedInfo(null, 'query1');
       helper.assertInstanceOf(info2, events.EventEmitter);
       assert.strictEqual(info1, info2);
     });
     it('should create a new EventEmitter when the query is the same but the keyspace is different', function () {
-      var metadata = new Metadata(clientOptions.defaultOptions(), null);
-      var info0 = metadata.getPreparedInfo(null, 'query1');
-      var info1 = metadata.getPreparedInfo('ks1', 'query1');
-      var info2 = metadata.getPreparedInfo('ks2', 'query1');
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      const info0 = metadata.getPreparedInfo(null, 'query1');
+      const info1 = metadata.getPreparedInfo('ks1', 'query1');
+      const info2 = metadata.getPreparedInfo('ks2', 'query1');
       assert.notStrictEqual(info0, info1);
       assert.notStrictEqual(info0, info2);
       assert.notStrictEqual(info1, info2);
@@ -461,7 +461,7 @@ describe('Metadata', function () {
         },
         getEncoder: function () { return new Encoder(1, {});}
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks1: { udts: {}}};
       metadata.getUdt('ks1', 'udt1', function (err, udtInfo) {
         assert.ifError(err);
@@ -481,7 +481,7 @@ describe('Metadata', function () {
         },
         getEncoder: function () { return new Encoder(1, {});}
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks1: { udts: {}}};
       metadata.getUdt('ks1', 'udt1', function (err) {
         helper.assertInstanceOf(err, Error);
@@ -497,7 +497,7 @@ describe('Metadata', function () {
         },
         getEncoder: function () { return new Encoder(1, {});}
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks1: { udts: {}}};
       metadata.getUdt('ks1', 'udt1', function (err, udtInfo) {
         assert.ifError(err);
@@ -519,7 +519,7 @@ describe('Metadata', function () {
         },
         getEncoder: function () { return new Encoder(1, {});}
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       //no keyspace named ks1 in metadata
       metadata.keyspaces = {};
       metadata.getUdt('ks1', 'udt1', function (err, udtInfo) {
@@ -544,7 +544,7 @@ describe('Metadata', function () {
         },
         getEncoder: function () { return new Encoder(1, {});}
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       //no keyspace named ks1 in metadata
       metadata.keyspaces = { ks1: { udts: {}}};
       //Invoke multiple times in parallel
@@ -579,7 +579,7 @@ describe('Metadata', function () {
         },
         getEncoder: function () { return new Encoder(1, {});}
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       //no keyspace named ks1 in metadata
       metadata.keyspaces = { ks1: { udts: {}}};
       //Invoke multiple times in parallel
@@ -607,7 +607,7 @@ describe('Metadata', function () {
         },
         getEncoder: function () { return new Encoder(1, {});}
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks1: { udts: {}}};
       utils.timesSeries(20, function (n, next) {
         metadata.getUdt('ks1', 'udt20', function (err, udtInfo) {
@@ -624,14 +624,14 @@ describe('Metadata', function () {
   });
   describe('#getTrace()', function () {
     it('should return the trace if its already stored', function (done) {
-      var sessionRow = {
+      const sessionRow = {
         request: 'request value',
         coordinator: types.InetAddress.fromString('10.10.10.1'),
         parameters: ['a', 'b'],
         started_at: new Date(),
         duration: 2002
       };
-      var eventRows = [ {
+      const eventRows = [ {
         event_id: types.TimeUuid.now(),
         activity: 'act 1',
         source: types.InetAddress.fromString('10.10.10.2'),
@@ -648,7 +648,7 @@ describe('Metadata', function () {
         },
         getEncoder: function () { return new Encoder(1, {});}
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.getTrace(types.Uuid.random(), types.consistencies.all, function (err, trace) {
         assert.ifError(err);
         assert.ok(trace);
@@ -663,7 +663,7 @@ describe('Metadata', function () {
       });
     });
     it('should parse the new client address column', function (done) {
-      var sessionRow = {
+      const sessionRow = {
         session_id: types.Uuid.fromString('69e37ff0-0475-11e5-9798-f3efee551757'),
         client: types.InetAddress.fromString('127.0.0.2'),
         command: 'QUERY',
@@ -676,7 +676,7 @@ describe('Metadata', function () {
         request: 'Execute CQL3 query',
         started_at: new Date()
       };
-      var eventRows = [ {
+      const eventRows = [ {
         event_id: types.TimeUuid.now(),
         activity: 'act 1',
         source: types.InetAddress.fromString('10.10.10.2'),
@@ -693,7 +693,7 @@ describe('Metadata', function () {
         },
         getEncoder: function () { return new Encoder(1, {});}
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.getTrace(types.Uuid.random(), function (err, trace) {
         assert.ifError(err);
         assert.ok(trace);
@@ -709,14 +709,14 @@ describe('Metadata', function () {
       });
     });
     it('should retry if its not already stored', function (done) {
-      var sessionRow = {
+      const sessionRow = {
         request: 'request value',
         coordinator: types.InetAddress.fromString('10.10.10.1'),
         parameters: ['a', 'b'],
         started_at: new Date(),
         duration: null
       };
-      var eventRows = [ {
+      const eventRows = [ {
         event_id: types.TimeUuid.now(),
         activity: 'act 2',
         source: types.InetAddress.fromString('10.10.10.1'),
@@ -737,7 +737,7 @@ describe('Metadata', function () {
         },
         getEncoder: function () { return new Encoder(1, {});}
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.getTrace(types.Uuid.random(), function (err, trace) {
         assert.ifError(err);
         assert.ok(trace);
@@ -753,7 +753,7 @@ describe('Metadata', function () {
       });
     });
     it('should stop retrying after a few attempts', function (done) {
-      var sessionRow = {
+      const sessionRow = {
         request: 'request value',
         coordinator: types.InetAddress.fromString('10.10.10.1'),
         parameters: ['a', 'b'],
@@ -774,7 +774,7 @@ describe('Metadata', function () {
         },
         getEncoder: function () { return new Encoder(1, {});}
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.getTrace(types.Uuid.random(), function (err, trace) {
         assert.ok(err);
         assert.ok(!trace);
@@ -784,7 +784,7 @@ describe('Metadata', function () {
       });
     });
     it('should callback in error if there was an error retrieving the trace', function (done) {
-      var err = new Error('dummy err');
+      const err = new Error('dummy err');
       const cc = {
         query: function (r, cb) {
           setImmediate(function () {
@@ -792,7 +792,7 @@ describe('Metadata', function () {
           });
         }
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.getTrace(types.Uuid.random(), function (receivedErr, trace) {
         assert.ok(err);
         assert.strictEqual(receivedErr, err);
@@ -814,7 +814,7 @@ describe('Metadata', function () {
         },
         getEncoder: function () { return new Encoder(1, {}); }
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
       metadata.getTable('ks_tbl_meta', 'tbl_does_not_exists', function (err, table) {
         assert.ifError(err);
@@ -823,7 +823,7 @@ describe('Metadata', function () {
       });
     });
     it('should be null when keyspace does not exists', function (done) {
-      var metadata = new Metadata(clientOptions.defaultOptions(), {});
+      const metadata = new Metadata(clientOptions.defaultOptions(), {});
       metadata.keyspaces = { };
       metadata.getTable('ks_does_not_exists', 'tbl1', function (err, table) {
         assert.ifError(err);
@@ -832,11 +832,11 @@ describe('Metadata', function () {
       });
     });
     it('should query once when called in parallel', function (done) {
-      var tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', bloom_filter_fp_chance: 0.02, caching: 'KEYS_ONLY',
+      const tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', bloom_filter_fp_chance: 0.02, caching: 'KEYS_ONLY',
         column_aliases: '["ck"]', comment: '', compaction_strategy_class: 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', compaction_strategy_options: '{}',
         comparator: 'org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.TimeUUIDType,org.apache.cassandra.db.marshal.UTF8Type)', compression_parameters: '{"sstable_compression":"org.apache.cassandra.io.compress.LZ4Compressor"}', default_time_to_live: 0, default_validator: 'org.apache.cassandra.db.marshal.BytesType', dropped_columns: null, gc_grace_seconds: 864000, index_interval: 128, is_dense: false,
         key_aliases: '["pk1","apk2"]', key_validator: 'org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UUIDType,org.apache.cassandra.db.marshal.UTF8Type)', local_read_repair_chance: 0.1, max_compaction_threshold: 32, memtable_flush_period_in_ms: 0, min_compaction_threshold: 4, populate_io_cache_on_flush: false, read_repair_chance: 0, replicate_on_write: true, speculative_retry: '99.0PERCENTILE', subcomparator: null, type: 'Standard', value_alias: null };
-      var columnRows = [
+      const columnRows = [
         { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'apk2', component_index: 1, index_name: null, index_options: null, index_type: null, type: 'partition_key', validator: 'org.apache.cassandra.db.marshal.UTF8Type' },
         { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'ck', component_index: 0, index_name: null, index_options: null, index_type: null, type: 'clustering_key', validator: 'org.apache.cassandra.db.marshal.TimeUUIDType' },
         { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'pk1', component_index: 0, index_name: null, index_options: null, index_type: null, type: 'partition_key', validator: 'org.apache.cassandra.db.marshal.UUIDType' }
@@ -856,7 +856,7 @@ describe('Metadata', function () {
         },
         getEncoder: function () { return new Encoder(1, {}); }
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
       utils.map(new Array(100), function (n, next) {
         metadata.getTable('ks_tbl_meta', 'tbl1', next);
@@ -872,11 +872,11 @@ describe('Metadata', function () {
       });
     });
     it('should query once if query the same table serially', function (done) {
-      var tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', bloom_filter_fp_chance: 0.02, caching: 'KEYS_ONLY',
+      const tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', bloom_filter_fp_chance: 0.02, caching: 'KEYS_ONLY',
         column_aliases: '["ck"]', comment: '', compaction_strategy_class: 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', compaction_strategy_options: '{}',
         comparator: 'org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.TimeUUIDType,org.apache.cassandra.db.marshal.UTF8Type)', compression_parameters: '{"sstable_compression":"org.apache.cassandra.io.compress.LZ4Compressor"}', default_time_to_live: 0, default_validator: 'org.apache.cassandra.db.marshal.BytesType', dropped_columns: null, gc_grace_seconds: 864000, index_interval: 128, is_dense: false,
         key_aliases: '["pk1","apk2"]', key_validator: 'org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UUIDType,org.apache.cassandra.db.marshal.UTF8Type)', local_read_repair_chance: 0.1, max_compaction_threshold: 32, memtable_flush_period_in_ms: 0, min_compaction_threshold: 4, populate_io_cache_on_flush: false, read_repair_chance: 0, replicate_on_write: true, speculative_retry: '99.0PERCENTILE', subcomparator: null, type: 'Standard', value_alias: null };
-      var columnRows = [
+      const columnRows = [
         { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'apk2', component_index: 1, index_name: null, index_options: null, index_type: null, type: 'partition_key', validator: 'org.apache.cassandra.db.marshal.UTF8Type' },
         { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'ck', component_index: 0, index_name: null, index_options: null, index_type: null, type: 'clustering_key', validator: 'org.apache.cassandra.db.marshal.TimeUUIDType' },
         { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'pk1', component_index: 0, index_name: null, index_options: null, index_type: null, type: 'partition_key', validator: 'org.apache.cassandra.db.marshal.UUIDType' }
@@ -896,7 +896,7 @@ describe('Metadata', function () {
         },
         getEncoder: function () { return new Encoder(1, {}); }
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
       utils.mapSeries(new Array(100), function (n, next) {
         metadata.getTable('ks_tbl_meta', 'tbl1', next);
@@ -927,7 +927,7 @@ describe('Metadata', function () {
         },
         getEncoder: function () { return new Encoder(1, {}); }
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
       utils.mapSeries(new Array(100), function (n, next) {
         metadata.getTable('ks_tbl_meta', 'tbl1', next);
@@ -943,15 +943,15 @@ describe('Metadata', function () {
       });
     });
     it('should query each time if metadata retrieval flag is false', function (done) {
-      var tableRow = {"keyspace_name":"ks_tbl_meta","table_name":"tbl1","bloom_filter_fp_chance":0.01,"caching":{"keys":"ALL","rows_per_partition":"NONE"},"comment":"","compaction":{"min_threshold":"4","max_threshold":"32","class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy"},"compression":{"chunk_length_in_kb":"64","class":"org.apache.cassandra.io.compress.LZ4Compressor"},"dclocal_read_repair_chance":0.1,"default_time_to_live":0,"extensions":{},"flags":["compound"],"gc_grace_seconds":864000,"id":"7e0e8bf0-5862-11e5-84f8-c7d0c38d1d8d","max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99PERCENTILE"};
-      var columnRows = [
+      const tableRow = {"keyspace_name":"ks_tbl_meta","table_name":"tbl1","bloom_filter_fp_chance":0.01,"caching":{"keys":"ALL","rows_per_partition":"NONE"},"comment":"","compaction":{"min_threshold":"4","max_threshold":"32","class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy"},"compression":{"chunk_length_in_kb":"64","class":"org.apache.cassandra.io.compress.LZ4Compressor"},"dclocal_read_repair_chance":0.1,"default_time_to_live":0,"extensions":{},"flags":["compound"],"gc_grace_seconds":864000,"id":"7e0e8bf0-5862-11e5-84f8-c7d0c38d1d8d","max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99PERCENTILE"};
+      const columnRows = [
         {"keyspace_name": "ks_tbl_meta", "table_name": "tbl1", "column_name": "id", "clustering_order": "none", "column_name_bytes": "0x6964", "kind": "partition_key", "position": -1, "type": "uuid"},
         {"keyspace_name": "ks_tbl_meta", "table_name": "tbl1", "column_name": "text_sample", "clustering_order": "none", "column_name_bytes": "0x746578745f73616d706c65", "kind": "regular", "position": -1, "type": "text"}
       ];
       const options = utils.extend({}, clientOptions.defaultOptions());
       options.isMetadataSyncEnabled = false;
       const cc = getControlConnectionForTable(tableRow, columnRows);
-      var metadata = new Metadata(options, cc);
+      const metadata = new Metadata(options, cc);
       metadata.keyspaces = { };
       metadata.setCassandraVersion([3, 0]);
       utils.mapSeries(new Array(100), function (n, next) {
@@ -969,12 +969,12 @@ describe('Metadata', function () {
     });
     describe('with C*2.0 metadata rows', function () {
       it('should parse partition and clustering keys', function (done) {
-        var customType ="org.apache.cassandra.db.marshal.DynamicCompositeType(s=>org.apache.cassandra.db.marshal.UTF8Type, i=>org.apache.cassandra.db.marshal.Int32Type)";
-        var tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', bloom_filter_fp_chance: 0.02, caching: 'KEYS_ONLY',
+        const customType ="org.apache.cassandra.db.marshal.DynamicCompositeType(s=>org.apache.cassandra.db.marshal.UTF8Type, i=>org.apache.cassandra.db.marshal.Int32Type)";
+        const tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', bloom_filter_fp_chance: 0.02, caching: 'KEYS_ONLY',
           column_aliases: '["ck"]', comment: '', compaction_strategy_class: 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', compaction_strategy_options: '{}',
           comparator: 'org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.TimeUUIDType,org.apache.cassandra.db.marshal.UTF8Type)', compression_parameters: '{"sstable_compression":"org.apache.cassandra.io.compress.LZ4Compressor"}', default_time_to_live: 0, default_validator: 'org.apache.cassandra.db.marshal.BytesType', dropped_columns: null, gc_grace_seconds: 864000, index_interval: 128, is_dense: false,
           key_aliases: '["pk1","apk2"]', key_validator: 'org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UUIDType,org.apache.cassandra.db.marshal.UTF8Type)', local_read_repair_chance: 0.1, max_compaction_threshold: 32, memtable_flush_period_in_ms: 3000, min_compaction_threshold: 4, populate_io_cache_on_flush: false, read_repair_chance: 0, replicate_on_write: true, speculative_retry: '99.0PERCENTILE', subcomparator: null, type: 'Standard', value_alias: null };
-        var columnRows = [
+        const columnRows = [
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'apk2', component_index: 1, index_name: null, index_options: null, index_type: null, type: 'partition_key', validator: 'org.apache.cassandra.db.marshal.UTF8Type' },
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'ck', component_index: 0, index_name: null, index_options: null, index_type: null, type: 'clustering_key', validator: 'org.apache.cassandra.db.marshal.TimeUUIDType' },
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'pk1', component_index: 0, index_name: null, index_options: null, index_type: null, type: 'partition_key', validator: 'org.apache.cassandra.db.marshal.UUIDType' },
@@ -982,7 +982,7 @@ describe('Metadata', function () {
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'val2', component_index: 1, index_name: null, index_options: null, index_type: null, type: 'regular', validator: 'org.apache.cassandra.db.marshal.BytesType' },
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'valcus3', component_index: 1, index_name: null, index_options: null, index_type: null, type: 'regular', validator: customType }
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
           assert.ifError(err);
@@ -1025,15 +1025,15 @@ describe('Metadata', function () {
         });
       });
       it('should parse table with compact storage with clustering key', function (done) {
-        var tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', bloom_filter_fp_chance: 0.01, caching: '{"keys":"ALL", "rows_per_partition":"NONE"}', cf_id: types.Uuid.fromString('96c86920-ed84-11e4-8991-199e66562428'),
+        const tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', bloom_filter_fp_chance: 0.01, caching: '{"keys":"ALL", "rows_per_partition":"NONE"}', cf_id: types.Uuid.fromString('96c86920-ed84-11e4-8991-199e66562428'),
           column_aliases: '["id2"]', comment: '', compaction_strategy_class: 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', compaction_strategy_options: '{}',
           comparator: 'org.apache.cassandra.db.marshal.TimeUUIDType', compression_parameters: '{"sstable_compression":"org.apache.cassandra.io.compress.LZ4Compressor"}', default_time_to_live: 0, default_validator: 'org.apache.cassandra.db.marshal.UTF8Type', dropped_columns: null, gc_grace_seconds: 864000, index_interval: null, is_dense: true, key_aliases: '["id1"]', key_validator: 'org.apache.cassandra.db.marshal.UUIDType', local_read_repair_chance: 0.1, max_compaction_threshold: 32, max_index_interval: 2048, memtable_flush_period_in_ms: 0, min_compaction_threshold: 4, min_index_interval: 128, read_repair_chance: 0, speculative_retry: '99.0PERCENTILE', subcomparator: null, type: 'Standard', value_alias: 'text1' };
-        var columnRows = [
+        const columnRows = [
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'id1', component_index: null, index_name: null, index_options: 'null', index_type: null, type: 'partition_key', validator: 'org.apache.cassandra.db.marshal.UUIDType' },
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'id2', component_index: null, index_name: null, index_options: 'null', index_type: null, type: 'clustering_key', validator: 'org.apache.cassandra.db.marshal.TimeUUIDType' },
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'text1', component_index: null, index_name: null, index_options: 'null', index_type: null, type: 'compact_value', validator: 'org.apache.cassandra.db.marshal.UTF8Type' }
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
           assert.ifError(err);
@@ -1052,13 +1052,13 @@ describe('Metadata', function () {
         });
       });
       it('should parse table with compact storage', function (done) {
-        var tableRow = {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","bloom_filter_fp_chance":0.01,"caching":"{\"keys\":\"ALL\", \"rows_per_partition\":\"NONE\"}","cf_id":"609f53a0-038b-11e5-be48-0d419bfb85c8","column_aliases":"[]","comment":"","compaction_strategy_class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy","compaction_strategy_options":"{}","comparator":"org.apache.cassandra.db.marshal.UTF8Type","compression_parameters":"{\"sstable_compression\":\"org.apache.cassandra.io.compress.LZ4Compressor\"}","default_time_to_live":0,"default_validator":"org.apache.cassandra.db.marshal.BytesType","dropped_columns":null,"gc_grace_seconds":864000,"index_interval":null,"is_dense":false,"key_aliases":"[\"id\"]","key_validator":"org.apache.cassandra.db.marshal.UUIDType","local_read_repair_chance":0.1,"max_compaction_threshold":32,"max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_compaction_threshold":4,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99.0PERCENTILE","subcomparator":null,"type":"Standard","value_alias":null};
-        var columnRows = [
+        const tableRow = {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","bloom_filter_fp_chance":0.01,"caching":"{\"keys\":\"ALL\", \"rows_per_partition\":\"NONE\"}","cf_id":"609f53a0-038b-11e5-be48-0d419bfb85c8","column_aliases":"[]","comment":"","compaction_strategy_class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy","compaction_strategy_options":"{}","comparator":"org.apache.cassandra.db.marshal.UTF8Type","compression_parameters":"{\"sstable_compression\":\"org.apache.cassandra.io.compress.LZ4Compressor\"}","default_time_to_live":0,"default_validator":"org.apache.cassandra.db.marshal.BytesType","dropped_columns":null,"gc_grace_seconds":864000,"index_interval":null,"is_dense":false,"key_aliases":"[\"id\"]","key_validator":"org.apache.cassandra.db.marshal.UUIDType","local_read_repair_chance":0.1,"max_compaction_threshold":32,"max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_compaction_threshold":4,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99.0PERCENTILE","subcomparator":null,"type":"Standard","value_alias":null};
+        const columnRows = [
           {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"id","component_index":null,"index_name":null,"index_options":"null","index_type":null,"type":"partition_key","validator":"org.apache.cassandra.db.marshal.UUIDType"},
           {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"text1","component_index":null,"index_name":null,"index_options":"null","index_type":null,"type":"regular","validator":"org.apache.cassandra.db.marshal.UTF8Type"},
           {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"text2","component_index":null,"index_name":null,"index_options":"null","index_type":null,"type":"regular","validator":"org.apache.cassandra.db.marshal.UTF8Type"}
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
           assert.ifError(err);
@@ -1076,19 +1076,19 @@ describe('Metadata', function () {
         });
       });
       it('should parse custom index (legacy)', function (done) {
-        var tableRow = {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","bloom_filter_fp_chance":0.01,"caching":"{\"keys\":\"ALL\", \"rows_per_partition\":\"NONE\"}","cf_id":"609f53a0-038b-11e5-be48-0d419bfb85c8","column_aliases":"[]","comment":"","compaction_strategy_class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy","compaction_strategy_options":"{}","comparator":"org.apache.cassandra.db.marshal.UTF8Type","compression_parameters":"{\"sstable_compression\":\"org.apache.cassandra.io.compress.LZ4Compressor\"}","default_time_to_live":0,"default_validator":"org.apache.cassandra.db.marshal.BytesType","dropped_columns":null,"gc_grace_seconds":864000,"index_interval":null,"is_dense":false,"key_aliases":"[\"id\"]","key_validator":"org.apache.cassandra.db.marshal.UUIDType","local_read_repair_chance":0.1,"max_compaction_threshold":32,"max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_compaction_threshold":4,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99.0PERCENTILE","subcomparator":null,"type":"Standard","value_alias":null};
-        var columnRows = [
+        const tableRow = {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","bloom_filter_fp_chance":0.01,"caching":"{\"keys\":\"ALL\", \"rows_per_partition\":\"NONE\"}","cf_id":"609f53a0-038b-11e5-be48-0d419bfb85c8","column_aliases":"[]","comment":"","compaction_strategy_class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy","compaction_strategy_options":"{}","comparator":"org.apache.cassandra.db.marshal.UTF8Type","compression_parameters":"{\"sstable_compression\":\"org.apache.cassandra.io.compress.LZ4Compressor\"}","default_time_to_live":0,"default_validator":"org.apache.cassandra.db.marshal.BytesType","dropped_columns":null,"gc_grace_seconds":864000,"index_interval":null,"is_dense":false,"key_aliases":"[\"id\"]","key_validator":"org.apache.cassandra.db.marshal.UUIDType","local_read_repair_chance":0.1,"max_compaction_threshold":32,"max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_compaction_threshold":4,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99.0PERCENTILE","subcomparator":null,"type":"Standard","value_alias":null};
+        const columnRows = [
           {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"id","component_index":null,"index_name":null,"index_options":"null","index_type":null,"type":"partition_key","validator":"org.apache.cassandra.db.marshal.UUIDType"},
           {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"text1","component_index":null,"index_name":"custom_index","index_options":'{"foo":"bar", "class_name":"dummy.DummyIndex"}',"index_type":"CUSTOM","type":"regular","validator":"org.apache.cassandra.db.marshal.UTF8Type"}
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
           assert.ifError(err);
           assert.ok(table);
           assert.ok(table.indexes);
           assert.ok(table.indexes.length === 1);
-          var index = table.indexes[0];
+          const index = table.indexes[0];
           assert.ok(index, 'Index not found');
           assert.strictEqual(index.name, 'custom_index');
           assert.strictEqual(index.target, 'text1');
@@ -1102,19 +1102,19 @@ describe('Metadata', function () {
         });
       });
       it('should parse keys index (legacy)', function (done) {
-        var tableRow = {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","bloom_filter_fp_chance":0.01,"caching":"{\"keys\":\"ALL\", \"rows_per_partition\":\"NONE\"}","cf_id":"609f53a0-038b-11e5-be48-0d419bfb85c8","column_aliases":"[]","comment":"","compaction_strategy_class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy","compaction_strategy_options":"{}","comparator":"org.apache.cassandra.db.marshal.UTF8Type","compression_parameters":"{\"sstable_compression\":\"org.apache.cassandra.io.compress.LZ4Compressor\"}","default_time_to_live":0,"default_validator":"org.apache.cassandra.db.marshal.BytesType","dropped_columns":null,"gc_grace_seconds":864000,"index_interval":null,"is_dense":false,"key_aliases":"[\"id\"]","key_validator":"org.apache.cassandra.db.marshal.UUIDType","local_read_repair_chance":0.1,"max_compaction_threshold":32,"max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_compaction_threshold":4,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99.0PERCENTILE","subcomparator":null,"type":"Standard","value_alias":null};
-        var columnRows = [
+        const tableRow = {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","bloom_filter_fp_chance":0.01,"caching":"{\"keys\":\"ALL\", \"rows_per_partition\":\"NONE\"}","cf_id":"609f53a0-038b-11e5-be48-0d419bfb85c8","column_aliases":"[]","comment":"","compaction_strategy_class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy","compaction_strategy_options":"{}","comparator":"org.apache.cassandra.db.marshal.UTF8Type","compression_parameters":"{\"sstable_compression\":\"org.apache.cassandra.io.compress.LZ4Compressor\"}","default_time_to_live":0,"default_validator":"org.apache.cassandra.db.marshal.BytesType","dropped_columns":null,"gc_grace_seconds":864000,"index_interval":null,"is_dense":false,"key_aliases":"[\"id\"]","key_validator":"org.apache.cassandra.db.marshal.UUIDType","local_read_repair_chance":0.1,"max_compaction_threshold":32,"max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_compaction_threshold":4,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99.0PERCENTILE","subcomparator":null,"type":"Standard","value_alias":null};
+        const columnRows = [
           {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"id","component_index":null,"index_name":null,"index_options":"null","index_type":null,"type":"partition_key","validator":"org.apache.cassandra.db.marshal.UUIDType"},
           {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"text1","component_index":null,"index_name":"custom_index","index_options":'{"index_keys": ""}',"index_type":"KEYS","type":"regular","validator":"org.apache.cassandra.db.marshal.UTF8Type"}
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'b@706172656e745f70617468', function (err, table) {
           assert.ifError(err);
           assert.ok(table);
           assert.ok(table.indexes);
           assert.ok(table.indexes.length === 1);
-          var index = table.indexes[0];
+          const index = table.indexes[0];
           assert.ok(index, 'Index not found');
           assert.strictEqual(index.name, 'custom_index');
           // target should be column name since we weren't able to parse index_keys from index_options.
@@ -1131,19 +1131,19 @@ describe('Metadata', function () {
         // lacks index_options, however the index_options value is a 'null' string rather than a null value.
         // DSE Analytics at some point did this with its cfs tables.
 
-        var tableRow = {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","bloom_filter_fp_chance":0.01,"caching":"{\"keys\":\"ALL\", \"rows_per_partition\":\"NONE\"}","cf_id":"609f53a0-038b-11e5-be48-0d419bfb85c8","column_aliases":"[]","comment":"","compaction_strategy_class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy","compaction_strategy_options":"{}","comparator":"org.apache.cassandra.db.marshal.UTF8Type","compression_parameters":"{\"sstable_compression\":\"org.apache.cassandra.io.compress.LZ4Compressor\"}","default_time_to_live":0,"default_validator":"org.apache.cassandra.db.marshal.BytesType","dropped_columns":null,"gc_grace_seconds":864000,"index_interval":null,"is_dense":false,"key_aliases":"[\"id\"]","key_validator":"org.apache.cassandra.db.marshal.UUIDType","local_read_repair_chance":0.1,"max_compaction_threshold":32,"max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_compaction_threshold":4,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99.0PERCENTILE","subcomparator":null,"type":"Standard","value_alias":null};
-        var columnRows = [
+        const tableRow = {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","bloom_filter_fp_chance":0.01,"caching":"{\"keys\":\"ALL\", \"rows_per_partition\":\"NONE\"}","cf_id":"609f53a0-038b-11e5-be48-0d419bfb85c8","column_aliases":"[]","comment":"","compaction_strategy_class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy","compaction_strategy_options":"{}","comparator":"org.apache.cassandra.db.marshal.UTF8Type","compression_parameters":"{\"sstable_compression\":\"org.apache.cassandra.io.compress.LZ4Compressor\"}","default_time_to_live":0,"default_validator":"org.apache.cassandra.db.marshal.BytesType","dropped_columns":null,"gc_grace_seconds":864000,"index_interval":null,"is_dense":false,"key_aliases":"[\"id\"]","key_validator":"org.apache.cassandra.db.marshal.UUIDType","local_read_repair_chance":0.1,"max_compaction_threshold":32,"max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_compaction_threshold":4,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99.0PERCENTILE","subcomparator":null,"type":"Standard","value_alias":null};
+        const columnRows = [
           {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"id","component_index":null,"index_name":null,"index_options":"null","index_type":null,"type":"partition_key","validator":"org.apache.cassandra.db.marshal.UUIDType"},
           {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"b@706172656e745f70617468","component_index":null,"index_name":"cfs_archive_parent_path","index_options":"\"null\"","index_type":"KEYS","type":"regular","validator":"org.apache.cassandra.db.marshal.UTF8Type"}
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'b@706172656e745f70617468', function (err, table) {
           assert.ifError(err);
           assert.ok(table);
           assert.ok(table.indexes);
           assert.ok(table.indexes.length === 1);
-          var index = table.indexes[0];
+          const index = table.indexes[0];
           assert.ok(index, 'Index not found');
           assert.strictEqual(index.name, 'cfs_archive_parent_path');
           // target should be column name since we weren't able to parse index_keys from index_options.
@@ -1158,17 +1158,17 @@ describe('Metadata', function () {
     });
     describe('with C*1.2 metadata rows', function () {
       it('should parse partition and clustering keys', function (done) {
-        var customType ="org.apache.cassandra.db.marshal.DynamicCompositeType(s=>org.apache.cassandra.db.marshal.UTF8Type, i=>org.apache.cassandra.db.marshal.Int32Type)";
-        var tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', bloom_filter_fp_chance: 0.01, caching: 'KEYS_ONLY',
+        const customType ="org.apache.cassandra.db.marshal.DynamicCompositeType(s=>org.apache.cassandra.db.marshal.UTF8Type, i=>org.apache.cassandra.db.marshal.Int32Type)";
+        const tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', bloom_filter_fp_chance: 0.01, caching: 'KEYS_ONLY',
           column_aliases: '["zck"]', comment: '', compaction_strategy_class: 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', compaction_strategy_options: '{}',
           comparator: 'org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.TimeUUIDType,org.apache.cassandra.db.marshal.UTF8Type)', compression_parameters: '{"sstable_compression":"org.apache.cassandra.io.compress.SnappyCompressor"}', default_validator: 'org.apache.cassandra.db.marshal.BytesType', gc_grace_seconds: 864000, id: null, key_alias: null,
           key_aliases: '["pk1","apk2"]', key_validator: 'org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UUIDType,org.apache.cassandra.db.marshal.UTF8Type)', local_read_repair_chance: 0, max_compaction_threshold: 32, min_compaction_threshold: 4, populate_io_cache_on_flush: true, read_repair_chance: 0.1, replicate_on_write: true, subcomparator: null, type: 'Standard', value_alias: null };
-        var columnRows = [
+        const columnRows = [
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'val2', component_index: 1, index_name: null, index_options: null, index_type: null, validator: 'org.apache.cassandra.db.marshal.BytesType' },
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'valz1', component_index: 1, index_name: null, index_options: null, index_type: null, validator: 'org.apache.cassandra.db.marshal.Int32Type' },
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'valcus3', component_index: 1, index_name: null, index_options: null, index_type: null, validator: customType }
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
           assert.ifError(err);
@@ -1196,11 +1196,11 @@ describe('Metadata', function () {
         });
       });
       it('should parse with no clustering keys', function (done) {
-        var tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', bloom_filter_fp_chance: 0.01, caching: 'KEYS_ONLY',
+        const tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', bloom_filter_fp_chance: 0.01, caching: 'KEYS_ONLY',
           column_aliases: '[]', comment: '', compaction_strategy_class: 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', compaction_strategy_options: '{}', comparator: 'org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type)', compression_parameters: '{"sstable_compression":"org.apache.cassandra.io.compress.SnappyCompressor"}', default_validator: 'org.apache.cassandra.db.marshal.BytesType', gc_grace_seconds: 864000, id: null, key_alias: null,
           key_aliases: '["id"]', key_validator: 'org.apache.cassandra.db.marshal.UUIDType', local_read_repair_chance: 0, max_compaction_threshold: 32, min_compaction_threshold: 4, populate_io_cache_on_flush: false, read_repair_chance: 0.1, replicate_on_write: true, subcomparator: null, type: 'Standard', value_alias: null };
-        var columnRows = [ { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'text_sample', component_index: 0, index_name: null, index_options: null, index_type: null, validator: 'org.apache.cassandra.db.marshal.UTF8Type' } ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        const columnRows = [ { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'text_sample', component_index: 0, index_name: null, index_options: null, index_type: null, validator: 'org.apache.cassandra.db.marshal.UTF8Type' } ];
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
           assert.ifError(err);
@@ -1215,13 +1215,13 @@ describe('Metadata', function () {
       });
       it('should parse with compact storage', function (done) {
         //1 pk, 1 ck and 1 val
-        var tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl5', bloom_filter_fp_chance: 0.01, caching: 'KEYS_ONLY',
+        const tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl5', bloom_filter_fp_chance: 0.01, caching: 'KEYS_ONLY',
           column_aliases: '["id2"]', comment: '', compaction_strategy_class: 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', compaction_strategy_options: '{}',
           comparator: 'org.apache.cassandra.db.marshal.TimeUUIDType', compression_parameters: '{"sstable_compression":"org.apache.cassandra.io.compress.SnappyCompressor"}',
           default_validator: 'org.apache.cassandra.db.marshal.UTF8Type', gc_grace_seconds: 864000, id: null, key_alias: null, key_aliases: '["id1"]', key_validator: 'org.apache.cassandra.db.marshal.UUIDType', local_read_repair_chance: 0, max_compaction_threshold: 32, min_compaction_threshold: 4, populate_io_cache_on_flush: false, read_repair_chance: 0.1, replicate_on_write: true, subcomparator: null, type: 'Standard',
           value_alias: 'text1' };
         const columnRows = [];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
           assert.ifError(err);
@@ -1237,14 +1237,14 @@ describe('Metadata', function () {
       });
       it('should parse with compact storage with pk', function (done) {
         //1 pk, 2 val
-        var tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', bloom_filter_fp_chance: 0.01, caching: 'KEYS_ONLY',
+        const tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', bloom_filter_fp_chance: 0.01, caching: 'KEYS_ONLY',
           column_aliases: '[]', comment: '', compaction_strategy_class: 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', compaction_strategy_options: '{}',
           comparator: 'org.apache.cassandra.db.marshal.UTF8Type', compression_parameters: '{"sstable_compression":"org.apache.cassandra.io.compress.SnappyCompressor"}', default_validator: 'org.apache.cassandra.db.marshal.BytesType', gc_grace_seconds: 864000, id: null, key_alias: null, key_aliases: '["id"]', key_validator: 'org.apache.cassandra.db.marshal.UUIDType', local_read_repair_chance: 0, max_compaction_threshold: 32, min_compaction_threshold: 4, populate_io_cache_on_flush: false, read_repair_chance: 0.1, replicate_on_write: true, subcomparator: null, type: 'Standard', value_alias: null };
-        var columnRows = [
+        const columnRows = [
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'text1', component_index: null, index_name: null, index_options: null, index_type: null, validator: 'org.apache.cassandra.db.marshal.UTF8Type' },
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'text2', component_index: null, index_name: null, index_options: null, index_type: null, validator: 'org.apache.cassandra.db.marshal.UTF8Type' }
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
           assert.ifError(err);
@@ -1258,11 +1258,11 @@ describe('Metadata', function () {
       });
       it('should parse with compact storage and all columns as clustering keys', function (done) {
         //1 pk, 2 ck
-        var tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', bloom_filter_fp_chance: 0.01, caching: 'KEYS_ONLY',
+        const tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', bloom_filter_fp_chance: 0.01, caching: 'KEYS_ONLY',
           column_aliases: '["id2","text1"]', comment: '', compaction_strategy_class: 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', compaction_strategy_options: '{}',
           comparator: 'org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.TimeUUIDType,org.apache.cassandra.db.marshal.UTF8Type)', compression_parameters: '{"sstable_compression":"org.apache.cassandra.io.compress.SnappyCompressor"}', default_validator: 'org.apache.cassandra.db.marshal.BytesType', gc_grace_seconds: 864000, id: null, key_alias: null, key_aliases: '["id1"]', key_validator: 'org.apache.cassandra.db.marshal.UUIDType', local_read_repair_chance: 0, max_compaction_threshold: 32, min_compaction_threshold: 4, populate_io_cache_on_flush: false, read_repair_chance: 0.1, replicate_on_write: true, subcomparator: null, type: 'Standard', value_alias: '' };
         const columnRows = [];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
           assert.ifError(err);
@@ -1279,11 +1279,11 @@ describe('Metadata', function () {
     });
     describe('with C*2.2 metadata rows', function () {
       it('should parse new 2.2 types', function (done) {
-        var customType ="org.apache.cassandra.db.marshal.DynamicCompositeType(s=>org.apache.cassandra.db.marshal.UTF8Type, i=>org.apache.cassandra.db.marshal.Int32Type)";
-        var tableRow = {
+        const customType ="org.apache.cassandra.db.marshal.DynamicCompositeType(s=>org.apache.cassandra.db.marshal.UTF8Type, i=>org.apache.cassandra.db.marshal.Int32Type)";
+        const tableRow = {
           keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl_c22', bloom_filter_fp_chance: 0.03, caching: '{"keys":"ALL", "rows_per_partition":"NONE"}',
           cf_id: types.Uuid.fromString('c05f4c40-fe05-11e4-8481-277ff03b5030'), comment: '', compaction_strategy_class: 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', compaction_strategy_options: '{}', comparator: 'org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type)', compression_parameters: '{"sstable_compression":"org.apache.cassandra.io.compress.LZ4Compressor"}', default_time_to_live: 0, default_validator: 'org.apache.cassandra.db.marshal.BytesType', dropped_columns: null, gc_grace_seconds: 864000, is_dense: false, key_validator: 'org.apache.cassandra.db.marshal.UUIDType', local_read_repair_chance: 0.1, max_compaction_threshold: 32, max_index_interval: 2048, memtable_flush_period_in_ms: 0, min_compaction_threshold: 4, min_index_interval: 128, read_repair_chance: 0, speculative_retry: '99.0PERCENTILE', subcomparator: null, type: 'Standard' };
-        var columnRows = [
+        const columnRows = [
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl_c22', column_name: 'date_sample', component_index: 0, index_name: null, index_options: 'null', index_type: null, type: 'regular', validator: 'org.apache.cassandra.db.marshal.SimpleDateType' },
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl_c22', column_name: 'id', component_index: null, index_name: null, index_options: 'null', index_type: null, type: 'partition_key', validator: 'org.apache.cassandra.db.marshal.UUIDType' },
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl_c22', column_name: 'smallint_sample', component_index: 0, index_name: null, index_options: 'null', index_type: null, type: 'regular', validator: 'org.apache.cassandra.db.marshal.ShortType' },
@@ -1291,7 +1291,7 @@ describe('Metadata', function () {
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl_c22', column_name: 'tinyint_sample', component_index: 0, index_name: null, index_options: 'null', index_type: null, type: 'regular', validator: 'org.apache.cassandra.db.marshal.ByteType' },
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl_c22', column_name: 'custom_sample', component_index: 0, index_name: null, index_options: 'null', index_type: null, type: 'regular', validator: customType }
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl_c22', function (err, table) {
           assert.ifError(err);
@@ -1322,7 +1322,7 @@ describe('Metadata', function () {
     });
     describe('with C*3.0+ metadata rows', function () {
       it('should parse partition and clustering keys', function (done) {
-        var tableRow = {
+        const tableRow = {
           "keyspace_name":"ks_tbl_meta",
           "table_name":"tbl4",
           "bloom_filter_fp_chance":0.01,
@@ -1339,8 +1339,8 @@ describe('Metadata', function () {
           "max_index_interval":1024,
           "crc_check_chance": 0.8,
           "memtable_flush_period_in_ms":0,"min_index_interval":64,"read_repair_chance":0,"speculative_retry":"99PERCENTILE"};
-        var customType ="org.apache.cassandra.db.marshal.DynamicCompositeType(s=>org.apache.cassandra.db.marshal.UTF8Type, i=>org.apache.cassandra.db.marshal.Int32Type)";
-        var columnRows = [
+        const customType ="org.apache.cassandra.db.marshal.DynamicCompositeType(s=>org.apache.cassandra.db.marshal.UTF8Type, i=>org.apache.cassandra.db.marshal.Int32Type)";
+        const columnRows = [
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl4", "column_name": "apk2", "clustering_order": "none", "column_name_bytes": "0x61706b32", "kind": "partition_key", "position": 1, "type": "text"},
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl4", "column_name": "pk1", "clustering_order": "none", "column_name_bytes": "0x706b31", "kind": "partition_key", "position": 0, "type": "uuid"},
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl4", "column_name": "val2", "clustering_order": "none", "column_name_bytes": "0x76616c32", "kind": "regular", "position": -1, "type": "blob"},
@@ -1348,7 +1348,7 @@ describe('Metadata', function () {
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl4", "column_name": "valcus3", "clustering_order": "none", "column_name_bytes": "0x76611663757333", "kind": "regular", "position": -1, "type": "'" + customType + "'"},
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl4", "column_name": "zck", "clustering_order": "asc", "column_name_bytes": "0x7a636b", "kind": "clustering", "position": 0, "type": "timeuuid"}
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.setCassandraVersion([3, 0]);
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl4', function (err, table) {
@@ -1378,12 +1378,12 @@ describe('Metadata', function () {
         });
       });
       it('should parse with no clustering keys', function (done) {
-        var tableRow = {"keyspace_name":"ks_tbl_meta","table_name":"tbl1","bloom_filter_fp_chance":0.01,"caching":{"keys":"ALL","rows_per_partition":"NONE"},"comment":"","compaction":{"min_threshold":"4","max_threshold":"32","class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy"},"compression":{"chunk_length_in_kb":"64","class":"org.apache.cassandra.io.compress.LZ4Compressor"},"dclocal_read_repair_chance":0.1,"default_time_to_live":0,"extensions":{},"flags":["compound"],"gc_grace_seconds":864000,"id":"7e0e8bf0-5862-11e5-84f8-c7d0c38d1d8d","max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99PERCENTILE"};
-        var columnRows = [
+        const tableRow = {"keyspace_name":"ks_tbl_meta","table_name":"tbl1","bloom_filter_fp_chance":0.01,"caching":{"keys":"ALL","rows_per_partition":"NONE"},"comment":"","compaction":{"min_threshold":"4","max_threshold":"32","class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy"},"compression":{"chunk_length_in_kb":"64","class":"org.apache.cassandra.io.compress.LZ4Compressor"},"dclocal_read_repair_chance":0.1,"default_time_to_live":0,"extensions":{},"flags":["compound"],"gc_grace_seconds":864000,"id":"7e0e8bf0-5862-11e5-84f8-c7d0c38d1d8d","max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99PERCENTILE"};
+        const columnRows = [
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl1", "column_name": "id", "clustering_order": "none", "column_name_bytes": "0x6964", "kind": "partition_key", "position": -1, "type": "uuid"},
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl1", "column_name": "text_sample", "clustering_order": "none", "column_name_bytes": "0x746578745f73616d706c65", "kind": "regular", "position": -1, "type": "text"}
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.setCassandraVersion([3, 0]);
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
@@ -1399,15 +1399,15 @@ describe('Metadata', function () {
       });
       it('should parse with compact storage', function (done) {
         //1 pk, 1 ck and 1 val
-        var tableRow = {
+        const tableRow = {
           "keyspace_name":"ks_tbl_meta","table_name":"tbl5","bloom_filter_fp_chance":0.01,"caching":{"keys":"ALL","rows_per_partition":"NONE"},"comment":"","compaction":{"min_threshold":"4","max_threshold":"32","class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy"},"compression":{"chunk_length_in_kb":"64","class":"org.apache.cassandra.io.compress.LZ4Compressor"},"dclocal_read_repair_chance":0.1,"default_time_to_live":0,"extensions":{},
           "flags":["dense"],"gc_grace_seconds":864000,"id":"80fd9590-5862-11e5-84f8-c7d0c38d1d8d","max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99PERCENTILE"};
-        var columnRows = [
+        const columnRows = [
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "id1", "clustering_order": "none", "column_name_bytes": "0x696431", "kind": "partition_key", "position": -1, "type": "uuid"},
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "id2", "clustering_order": "asc", "column_name_bytes": "0x696432", "kind": "clustering", "position": 0, "type": "timeuuid"},
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "text1", "clustering_order": "none", "column_name_bytes": "0x7465787431", "kind": "regular", "position": -1, "type": "text"}
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.setCassandraVersion([3, 0]);
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl5', function (err, table) {
@@ -1424,18 +1424,18 @@ describe('Metadata', function () {
       });
       it('should parse with custom index', function (done) {
         //1 pk, 1 ck and 1 val
-        var tableRow = {
+        const tableRow = {
           "keyspace_name":"ks_tbl_meta","table_name":"tbl5","bloom_filter_fp_chance":0.01,"caching":{"keys":"ALL","rows_per_partition":"NONE"},"comment":"","compaction":{"min_threshold":"4","max_threshold":"32","class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy"},"compression":{"chunk_length_in_kb":"64","class":"org.apache.cassandra.io.compress.LZ4Compressor"},"dclocal_read_repair_chance":0.1,"default_time_to_live":0,"extensions":{},
           "flags":["dense"],"gc_grace_seconds":864000,"id":"80fd9590-5862-11e5-84f8-c7d0c38d1d8d","max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99PERCENTILE"};
-        var columnRows = [
+        const columnRows = [
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "id1", "clustering_order": "none", "column_name_bytes": "0x696431", "kind": "partition_key", "position": -1, "type": "uuid"},
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "id2", "clustering_order": "asc", "column_name_bytes": "0x696432", "kind": "clustering", "position": 0, "type": "timeuuid"},
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "text1", "clustering_order": "none", "column_name_bytes": "0x7465787431", "kind": "regular", "position": -1, "type": "text"}
         ];
-        var indexRows = [
+        const indexRows = [
           {"index_name": "custom_index", "kind": "CUSTOM", "options": {"foo":"bar","class_name":"dummy.DummyIndex","target":"a, b, keys(c)"}}
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows,indexRows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows,indexRows));
         metadata.setCassandraVersion([3, 0]);
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl5', function (err, table) {
@@ -1443,7 +1443,7 @@ describe('Metadata', function () {
           assert.ok(table);
           assert.ok(table.indexes);
           assert.ok(table.indexes.length === 1);
-          var index = table.indexes[0];
+          const index = table.indexes[0];
           assert.ok(index, 'Index not found');
           assert.strictEqual(index.name, 'custom_index');
           assert.strictEqual(index.target, 'a, b, keys(c)');
@@ -1458,17 +1458,17 @@ describe('Metadata', function () {
       });
       it('should parse with compact storage with pk', function (done) {
         //1 pk, 2 val
-        var tableRow = {
+        const tableRow = {
           "keyspace_name":"ks_tbl_meta","table_name":"tbl6","bloom_filter_fp_chance":0.01,"caching":{"keys":"ALL","rows_per_partition":"NONE"},"comment":"","compaction":{"min_threshold":"4","max_threshold":"32","class":"org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy"},"compression":{"chunk_length_in_kb":"64","class":"org.apache.cassandra.io.compress.LZ4Compressor"},"dclocal_read_repair_chance":0.1,"default_time_to_live":0,"extensions":{},
           "flags":[],"gc_grace_seconds":864000,"id":"81a32460-5862-11e5-b0ce-c7d0c38d1d8d","max_index_interval":2048,"memtable_flush_period_in_ms":0,"min_index_interval":128,"read_repair_chance":0,"speculative_retry":"99PERCENTILE"};
-        var columnRows = [
+        const columnRows = [
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl6", "column_name": "column1", "clustering_order": "asc", "column_name_bytes": "0x636f6c756d6e31", "kind": "clustering", "position": 0, "type": "text"},
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl6", "column_name": "id", "clustering_order": "none", "column_name_bytes": "0x6964", "kind": "partition_key", "position": -1, "type": "uuid"},
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl6", "column_name": "text1", "clustering_order": "none", "column_name_bytes": "0x7465787431", "kind": "static", "position": -1, "type": "text"},
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl6", "column_name": "text2", "clustering_order": "none", "column_name_bytes": "0x7465787432", "kind": "static", "position": -1, "type": "text"},
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl6", "column_name": "value", "clustering_order": "none", "column_name_bytes": "0x76616c7565", "kind": "regular", "position": -1, "type": "blob"}
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.setCassandraVersion([3, 0]);
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl6', function (err, table) {
@@ -1484,16 +1484,16 @@ describe('Metadata', function () {
       });
       it('should parse with compact storage and all columns as clustering keys', function (done) {
         //1 pk, 2 ck. similar to tbl5 but with id2 and text1 as ck
-        var tableRow = {
+        const tableRow = {
           "keyspace_name": "ks1", "table_name": "tbl10", "bloom_filter_fp_chance": 0.01, "caching": {"keys": "ALL", "rows_per_partition": "NONE"}, "comment": "", "compaction": {"min_threshold": "4", "max_threshold": "32", "class": "org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy"}, "compression": {"chunk_length_in_kb": "64", "class": "org.apache.cassandra.io.compress.LZ4Compressor"}, "dclocal_read_repair_chance": 0.1, "default_time_to_live": 0, "extensions": {},
           "flags": ["compound", "dense"], "gc_grace_seconds": 864000, "id": "b4d56ea0-5881-11e5-8326-c7d0c38d1d8d", "max_index_interval": 2048, "memtable_flush_period_in_ms": 0, "min_index_interval": 128, "read_repair_chance": 0.0, "speculative_retry": "99PERCENTILE"};
-        var columnRows = [
+        const columnRows = [
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl10", "column_name": "id1", "clustering_order": "none", "column_name_bytes": "0x696431", "kind": "partition_key", "position": -1, "type": "uuid"},
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl10", "column_name": "id2", "clustering_order": "asc", "column_name_bytes": "0x696432", "kind": "clustering", "position": 0, "type": "timeuuid"},
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl10", "column_name": "text1", "clustering_order": "asc", "column_name_bytes": "0x7465787431", "kind": "clustering", "position": 1, "type": "text"},
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl10", "column_name": "value", "clustering_order": "none", "column_name_bytes": "0x76616c7565", "kind": "regular", "position": -1, "type": "empty"}
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.setCassandraVersion([3, 0]);
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
@@ -1511,7 +1511,7 @@ describe('Metadata', function () {
     });
     describe('with Thrift secondary index', function () {
       it('should parse tables from Thrift with secondary indexes', function (done) {
-        var tableRow = {
+        const tableRow = {
           keyspace_name: 'ks1', columnfamily_name: 'ThriftSecondaryIndexTest', bloom_filter_fp_chance: null,
           caching: {"keys":"ALL", "rows_per_partition":"NONE"}, cf_id: "121d4950-41fd-11e7-ac8d-e1535f74c6ee",
           column_aliases: [], comparator: 'org.apache.cassandra.db.marshal.UTF8Type',
@@ -1519,7 +1519,7 @@ describe('Metadata', function () {
           compression_parameters: '{"sstable_compression":"org.apache.cassandra.io.compress.LZ4Compressor"}',
           default_validator: 'org.apache.cassandra.db.marshal.BytesType', key_aliases: '["key"]',
           key_validator: 'org.apache.cassandra.db.marshal.UTF8Type', type: 'Standard' };
-        var columnRows = [
+        const columnRows = [
           { keyspace_name: 'ks1', columnfamily_name: 'ThriftSecondaryIndexTest', column_name: 'ACCOUNT',
             component_index: null, index_name: 'ACCOUNT1', index_options: 'null', index_type: 'KEYS', type: 'regular',
             validator: 'org.apache.cassandra.db.marshal.UTF8Type' },
@@ -1530,7 +1530,7 @@ describe('Metadata', function () {
             component_index: null, index_name: null, index_options: 'null', index_type: null, type: 'partition_key',
             validator: 'org.apache.cassandra.db.marshal.UTF8Type' }
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.setCassandraVersion([2, 1]);
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'ThriftSecondaryIndexTest', function (err, table) {
@@ -1552,7 +1552,7 @@ describe('Metadata', function () {
   });
   describe('#getFunctions()', function () {
     it('should return an empty array when not found', function (done) {
-      var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
+      const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
       metadata.keyspaces['ks_udf'] = { functions: {}};
       metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
         assert.ifError(err);
@@ -1564,7 +1564,7 @@ describe('Metadata', function () {
     describe('with C* 2.2 metadata rows', function () {
       it('should query once when called in parallel', function (done) {
         let called = 0;
-        var rows = [
+        const rows = [
           {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
         ];
         const cc = {
@@ -1576,7 +1576,7 @@ describe('Metadata', function () {
           },
           getEncoder: function () { return new Encoder(4, {}); }
         };
-        var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { functions: {}};
         utils.times(10, function (n, next) {
           metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
@@ -1592,7 +1592,7 @@ describe('Metadata', function () {
       });
       it('should query once when called serially', function (done) {
         let called = 0;
-        var rows = [
+        const rows = [
           {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
         ];
         const cc = {
@@ -1604,7 +1604,7 @@ describe('Metadata', function () {
           },
           getEncoder: function () { return new Encoder(4, {}); }
         };
-        var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { functions: {}};
         utils.timesSeries(10, function (n, next) {
           metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
@@ -1621,7 +1621,7 @@ describe('Metadata', function () {
       });
       it('should query the following times if was previously not found', function (done) {
         let called = 0;
-        var rows = [
+        const rows = [
           {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
         ];
         const cc = {
@@ -1637,7 +1637,7 @@ describe('Metadata', function () {
           },
           getEncoder: function () { return new Encoder(4, {}); }
         };
-        var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { functions: {}};
         utils.timesSeries(10, function (n, next) {
           metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
@@ -1660,7 +1660,7 @@ describe('Metadata', function () {
       });
       it('should query the following times if there was an error previously', function (done) {
         let called = 0;
-        var rows = [
+        const rows = [
           {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
         ];
         const cc = {
@@ -1676,7 +1676,7 @@ describe('Metadata', function () {
           },
           getEncoder: function () { return new Encoder(4, {}); }
         };
-        var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { functions: {}};
         utils.timesSeries(10, function (n, next) {
           metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
@@ -1698,11 +1698,11 @@ describe('Metadata', function () {
         });
       });
       it('should parse function metadata with 2 parameters', function (done) {
-        var rows = [
+        const rows = [
           {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"},
           {"keyspace_name":"ks_udf","function_name":"plus","signature":["int","int"],"argument_names":["arg1","arg2"],"argument_types":["org.apache.cassandra.db.marshal.Int32Type","org.apache.cassandra.db.marshal.Int32Type"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.Int32Type"}
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
         metadata.keyspaces['ks_udf'] = { functions: {}};
         metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
           assert.ifError(err);
@@ -1735,10 +1735,10 @@ describe('Metadata', function () {
         });
       });
       it('should parse a function metadata with no parameters', function (done) {
-        var rows = [
+        const rows = [
           {"keyspace_name":"ks_udf","function_name":"return_one","signature":[],"argument_names":null,"argument_types":null,"body":"return 1;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.Int32Type"}
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
         metadata.keyspaces['ks_udf'] = { functions: {}};
         metadata.getFunctions('ks_udf', 'return_one', function (err, funcArray) {
           assert.ifError(err);
@@ -1757,10 +1757,10 @@ describe('Metadata', function () {
     });
     describe('with C* 3.0+ metadata rows', function () {
       it('should parse function metadata with 2 parameters', function (done) {
-        var rows = [
+        const rows = [
           {"keyspace_name": "ks_udf", "function_name": "plus", "argument_types": ["int", "int"], "argument_names": ["s", "v"], "body": "return s+v;", "called_on_null_input": false, "language": "java", "return_type": "int"}
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
         metadata.setCassandraVersion([3, 0]);
         metadata.keyspaces['ks_udf'] = { functions: {}};
         metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
@@ -1787,12 +1787,12 @@ describe('Metadata', function () {
     context('with no callback specified', function () {
       it('should return a Promise', function () {
         const metadata = newInstance();
-        var p = metadata.getFunction('ks1', 'fn1', []);
+        const p = metadata.getFunction('ks1', 'fn1', []);
         helper.assertInstanceOf(p, Promise);
       });
     });
     it('should callback in error if keyspace or name are not provided', function (done) {
-      var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
+      const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
       metadata.keyspaces['ks_udf'] = { functions: {}};
       metadata.getFunction('ks_udf', null, [], function (err) {
         helper.assertInstanceOf(err, errors.ArgumentError);
@@ -1800,7 +1800,7 @@ describe('Metadata', function () {
       });
     });
     it('should callback in error if signature is not an array', function (done) {
-      var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
+      const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
       metadata.keyspaces['ks_udf'] = { functions: {}};
       metadata.getFunction('ks_udf', 'func1', {}, function (err) {
         helper.assertInstanceOf(err, errors.ArgumentError);
@@ -1808,7 +1808,7 @@ describe('Metadata', function () {
       });
     });
     it('should callback in error if signature types are not found', function (done) {
-      var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
+      const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
       metadata.keyspaces['ks_udf'] = { functions: {}};
       metadata.getFunction('ks_udf', 'func1', [{code: 0x1000}], function (err) {
         helper.assertInstanceOf(err, errors.ArgumentError);
@@ -1817,7 +1817,7 @@ describe('Metadata', function () {
     });
     it('should query once when called in parallel', function (done) {
       let called = 0;
-      var rows = [
+      const rows = [
         {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
       ];
       const cc = {
@@ -1829,7 +1829,7 @@ describe('Metadata', function () {
         },
         getEncoder: function () { return new Encoder(4, {}); }
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces['ks_udf'] = { functions: {}};
       utils.times(10, function (n, next) {
         metadata.getFunction('ks_udf', 'plus', ['bigint', 'bigint'], function (err, func) {
@@ -1845,7 +1845,7 @@ describe('Metadata', function () {
     });
     it('should query once when called serially', function (done) {
       let called = 0;
-      var rows = [
+      const rows = [
         {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
       ];
       const cc = {
@@ -1858,7 +1858,7 @@ describe('Metadata', function () {
         },
         getEncoder: function () { return new Encoder(4, {}); }
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces['ks_udf'] = { functions: {}};
       utils.timesSeries(10, function (n, next) {
         metadata.getFunction('ks_udf', 'plus', ['bigint', 'bigint'], function (err, func) {
@@ -1874,7 +1874,7 @@ describe('Metadata', function () {
       });
     });
     it('should return null when not found', function (done) {
-      var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
+      const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
       metadata.keyspaces['ks_udf'] = { functions: {}};
       metadata.getFunction('ks_udf', 'plus', [], function (err, func) {
         assert.ifError(err);
@@ -1883,11 +1883,11 @@ describe('Metadata', function () {
       });
     });
     it('should parse function metadata with 2 parameters', function (done) {
-      var rows = [
+      const rows = [
         {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"},
         {"keyspace_name":"ks_udf","function_name":"plus","signature":["int","int"],"argument_names":["arg1","arg2"],"argument_types":["org.apache.cassandra.db.marshal.Int32Type","org.apache.cassandra.db.marshal.Int32Type"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.Int32Type"}
       ];
-      var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+      const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
       metadata.keyspaces['ks_udf'] = { functions: {}};
       metadata.getFunction('ks_udf', 'plus', ['int', 'int'], function (err, func) {
         assert.ifError(err);
@@ -1906,10 +1906,10 @@ describe('Metadata', function () {
       });
     });
     it('should parse a function metadata with no parameters', function (done) {
-      var rows = [
+      const rows = [
         {"keyspace_name":"ks_udf","function_name":"return_one","signature":[],"argument_names":null,"argument_types":null,"body":"return 1;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.Int32Type"}
       ];
-      var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+      const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
       metadata.keyspaces['ks_udf'] = { functions: {}};
       metadata.getFunction('ks_udf', 'return_one', [], function (err, func) {
         assert.ifError(err);
@@ -1927,7 +1927,7 @@ describe('Metadata', function () {
   });
   describe('#getAggregates()', function () {
     it('should return an empty array when not found', function (done) {
-      var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
+      const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
       metadata.keyspaces['ks_udf'] = { aggregates: {}};
       metadata.getAggregates('ks_udf', 'plus', function (err, funcArray) {
         assert.ifError(err);
@@ -1939,7 +1939,7 @@ describe('Metadata', function () {
     describe('with C* 2.2 metadata rows', function () {
       it('should query once when called in parallel', function (done) {
         let called = 0;
-        var rows = [
+        const rows = [
           {"keyspace_name":"ks_udf","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":utils.allocBufferFromArray([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"}
         ];
         const cc = {
@@ -1952,7 +1952,7 @@ describe('Metadata', function () {
           },
           getEncoder: function () { return new Encoder(4, {}); }
         };
-        var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { aggregates: {}};
         utils.times(10, function (n, next) {
           metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
@@ -1968,7 +1968,7 @@ describe('Metadata', function () {
       });
       it('should query once when called serially', function (done) {
         let called = 0;
-        var rows = [
+        const rows = [
           {"keyspace_name":"ks_udf","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":utils.allocBufferFromArray([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"}
         ];
         const cc = {
@@ -1980,7 +1980,7 @@ describe('Metadata', function () {
           },
           getEncoder: function () { return new Encoder(4, {}); }
         };
-        var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { aggregates: {}};
         utils.timesSeries(10, function (n, next) {
           metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
@@ -1997,7 +1997,7 @@ describe('Metadata', function () {
       });
       it('should query the following times if was previously not found', function (done) {
         let called = 0;
-        var rows = [
+        const rows = [
           {"keyspace_name":"ks_udf","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":utils.allocBufferFromArray([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"}
         ];
         const cc = {
@@ -2013,7 +2013,7 @@ describe('Metadata', function () {
           },
           getEncoder: function () { return new Encoder(4, {}); }
         };
-        var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { aggregates: {}};
         utils.timesSeries(10, function (n, next) {
           metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
@@ -2036,7 +2036,7 @@ describe('Metadata', function () {
       });
       it('should query the following times if there was an error previously', function (done) {
         let called = 0;
-        var rows = [
+        const rows = [
           {"keyspace_name":"ks_udf","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":utils.allocBufferFromArray([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"}
         ];
         const cc = {
@@ -2053,7 +2053,7 @@ describe('Metadata', function () {
           },
           getEncoder: function () { return new Encoder(4, {}); }
         };
-        var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { aggregates: {}};
         utils.timesSeries(10, function (n, next) {
           metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
@@ -2075,11 +2075,11 @@ describe('Metadata', function () {
         });
       });
       it('should parse aggregate metadata with 1 parameter', function (done) {
-        var rows = [
+        const rows = [
           {"keyspace_name":"ks_udf1","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":utils.allocBufferFromArray([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"},
           {"keyspace_name":"ks_udf1","aggregate_name":"sum","signature":["int"],"argument_types":["org.apache.cassandra.db.marshal.Int32Type"],"final_func":null,"initcond":utils.allocBufferFromArray([0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.Int32Type","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.Int32Type"}
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
         metadata.keyspaces['ks_udf1'] = { aggregates: {}};
         metadata.getAggregates('ks_udf1', 'sum', function (err, aggregatesArray) {
           assert.ifError(err);
@@ -2118,11 +2118,11 @@ describe('Metadata', function () {
     });
     describe('with C* 3.0+ metadata rows', function () {
       it('should parse aggregate metadata with 1 parameter', function (done) {
-        var rows = [
+        const rows = [
           {"keyspace_name": "ks_udf1", "aggregate_name": "sum", "argument_types": ["bigint"], "final_func": null, "initcond": '2', "return_type": "bigint", "state_func": "plus", "state_type": "bigint"},
           {"keyspace_name": "ks_udf1", "aggregate_name": "sum", "argument_types": ["int"], "final_func": null, "initcond": '1', "return_type": "int", "state_func": "plus", "state_type": "int"}
         ];
-        var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+        const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
         metadata.setCassandraVersion([3, 0]);
         metadata.keyspaces['ks_udf1'] = { aggregates: {}};
         metadata.getAggregates('ks_udf1', 'sum', function (err, aggregatesArray) {
@@ -2163,7 +2163,7 @@ describe('Metadata', function () {
     });
   });
   describe('#getMaterializedView()', function () {
-    var scoresTableMetadata = new TableMetadata('scores');
+    const scoresTableMetadata = new TableMetadata('scores');
     scoresTableMetadata.columnsByName = {
       'score': { type: { code: types.dataTypes.int}, name: 'score' },
       'user': { type: { code: types.dataTypes.text}, name: 'user' },
@@ -2182,7 +2182,7 @@ describe('Metadata', function () {
         },
         getEncoder: function () { return new Encoder(4, {}); }
       };
-      var metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.setCassandraVersion([3, 0]);
       metadata.keyspaces['ks_mv'] = { views: {}};
       metadata.getMaterializedView('ks_mv', 'not_found', function (err, view) {
@@ -2192,7 +2192,7 @@ describe('Metadata', function () {
       });
     });
     it('should callback in error when cassandra version is lower than 3.0', function (done) {
-      var metadata = new Metadata(clientOptions.defaultOptions(), {});
+      const metadata = new Metadata(clientOptions.defaultOptions(), {});
       metadata.setCassandraVersion([2, 1]);
       metadata.keyspaces['ks_mv'] = { views: {}};
       metadata.getTable = function (ksName, name, cb) {
@@ -2206,15 +2206,15 @@ describe('Metadata', function () {
   });
   describe('#buildTokens', function() {
     it('should set sorted tokens from a single host', function (done) {
-      var metadata = new Metadata(clientOptions.defaultOptions(), null);
-      var tokenizer = getTokenizer();
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      const tokenizer = getTokenizer();
       metadata.tokenizer = tokenizer;
-      var hosts = new HostMap();
-      var h1 = new Host('127.0.0.1', 2, clientOptions.defaultOptions());
+      const hosts = new HostMap();
+      const h1 = new Host('127.0.0.1', 2, clientOptions.defaultOptions());
       h1.tokens = ['10', '20', '400', '15', '25', '5'];
       hosts.push(h1.address, h1);
       metadata.buildTokens(hosts);
-      var sortedTokens = ['5', '10', '15', '20', '25', '400'];
+      const sortedTokens = ['5', '10', '15', '20', '25', '400'];
       const sortedParsedTokens = [];
       sortedTokens.forEach(function (token) {
         sortedParsedTokens.push(tokenizer.parse(token));
@@ -2224,18 +2224,18 @@ describe('Metadata', function () {
       done();
     });
     it('should set sorted tokens from multiple hosts', function (done) {
-      var metadata = new Metadata(clientOptions.defaultOptions(), null);
-      var tokenizer = getTokenizer();
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      const tokenizer = getTokenizer();
       metadata.tokenizer = tokenizer;
-      var hosts = new HostMap();
-      var h1 = new Host('127.0.0.1', 2, clientOptions.defaultOptions());
+      const hosts = new HostMap();
+      const h1 = new Host('127.0.0.1', 2, clientOptions.defaultOptions());
       h1.tokens = ['10', '400', '25', '5'];
       hosts.push(h1.address, h1);
-      var h2 = new Host('127.0.0.2', 2, clientOptions.defaultOptions());
+      const h2 = new Host('127.0.0.2', 2, clientOptions.defaultOptions());
       h2.tokens = ['13', '203', '18', '8'];
       hosts.push(h2.address, h2);
       metadata.buildTokens(hosts);
-      var sortedTokens = ['5', '8', '10', '13', '18', '25', '203', '400'];
+      const sortedTokens = ['5', '8', '10', '13', '18', '25', '203', '400'];
       const sortedParsedTokens = [];
       sortedTokens.forEach(function (token) {
         sortedParsedTokens.push(tokenizer.parse(token));
@@ -2248,29 +2248,29 @@ describe('Metadata', function () {
 
 });
 describe('SchemaParser', function () {
-  var isDoneForToken = rewire('../../lib/metadata/schema-parser')['__get__']('isDoneForToken');
+  const isDoneForToken = rewire('../../lib/metadata/schema-parser')['__get__']('isDoneForToken');
   describe('isDoneForToken()', function () {
     it('should skip if dc not included in topology', function () {
-      var replicationFactors = { 'dc1': 3, 'dc2': 1 };
+      const replicationFactors = { 'dc1': 3, 'dc2': 1 };
       //dc2 does not exist
-      var datacenters = {
+      const datacenters = {
         'dc1': { hostLength: 6 }
       };
       assert.strictEqual(false, isDoneForToken(replicationFactors, datacenters, {}));
     });
     it('should skip if rf equals to 0', function () {
       //rf 0 for dc2
-      var replicationFactors = { 'dc1': 4, 'dc2': 0 };
-      var datacenters = {
+      const replicationFactors = { 'dc1': 4, 'dc2': 0 };
+      const datacenters = {
         'dc1': { hostLength: 6 },
         'dc2': { hostLength: 6 }
       };
       assert.strictEqual(true, isDoneForToken(replicationFactors, datacenters, { 'dc1': 4 }));
     });
     it('should return false for undefined replicasByDc[dcName]', function () {
-      var replicationFactors = { 'dc1': 3, 'dc2': 1 };
+      const replicationFactors = { 'dc1': 3, 'dc2': 1 };
       //dc2 does not exist
-      var datacenters = {
+      const datacenters = {
         'dc1': { hostLength: 6 }
       };
       assert.strictEqual(false, isDoneForToken(replicationFactors, datacenters, {}));
@@ -2325,7 +2325,7 @@ function getAddress(h) {
  * @returns {Murmur3Tokenizer}
  */
 function getTokenizer() {
-  var t = new tokenizer.Murmur3Tokenizer();
+  const t = new tokenizer.Murmur3Tokenizer();
   //Use the first byte as token
   t.hash = function (b) { return b[0];};
   t.compare = function (a, b) { return a - b; };

--- a/test/unit/metadata-tests.js
+++ b/test/unit/metadata-tests.js
@@ -1,26 +1,26 @@
 "use strict";
-var assert = require('assert');
-var util = require('util');
-var events = require('events');
-var rewire = require('rewire');
+const assert = require('assert');
+const util = require('util');
+const events = require('events');
+const rewire = require('rewire');
 
-var helper = require('../test-helper.js');
-var clientOptions = require('../../lib/client-options.js');
-var Host = require('../../lib/host.js').Host;
-var HostMap = require('../../lib/host').HostMap;
-var Metadata = require('../../lib/metadata');
-var TableMetadata = require('../../lib/metadata/table-metadata');
-var tokenizer = require('../../lib/tokenizer');
-var types = require('../../lib/types');
-var dataTypes = types.dataTypes;
-var utils = require('../../lib/utils');
-var errors = require('../../lib/errors');
-var Encoder = require('../../lib/encoder');
+const helper = require('../test-helper.js');
+const clientOptions = require('../../lib/client-options.js');
+const Host = require('../../lib/host.js').Host;
+const HostMap = require('../../lib/host').HostMap;
+const Metadata = require('../../lib/metadata');
+const TableMetadata = require('../../lib/metadata/table-metadata');
+const tokenizer = require('../../lib/tokenizer');
+const types = require('../../lib/types');
+const dataTypes = types.dataTypes;
+const utils = require('../../lib/utils');
+const errors = require('../../lib/errors');
+const Encoder = require('../../lib/encoder');
 
 describe('Metadata', function () {
   describe('#refreshKeyspaces()', function () {
     it('should parse C*2 keyspace metadata for simple strategy', function (done) {
-      var cc = {
+      const cc = {
         query: function (q, w, cb) {
           cb(null, { rows: [{
             'keyspace_name': 'ks1',
@@ -30,7 +30,6 @@ describe('Metadata', function () {
           }]});
         }
       };
-      //noinspection JSCheckFunctionSignatures
       var metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.tokenizer = new tokenizer.Murmur3Tokenizer();
       metadata.ring = [0, 1, 2, 3, 4, 5];
@@ -49,7 +48,7 @@ describe('Metadata', function () {
       });
     });
     it('should parse C*2 keyspace metadata for network strategy', function (done) {
-      var cc = {
+      const cc = {
         query: function (q, w, cb) {
           cb(null, { rows: [{
             'keyspace_name': 'ks2',
@@ -76,7 +75,7 @@ describe('Metadata', function () {
       });
     });
     it('should parse C*3 keyspace metadata for simple strategy', function (done) {
-      var cc = {
+      const cc = {
         query: function (q, w, cb) {
           cb(null, { rows: [{
             'keyspace_name': 'ks1',
@@ -104,7 +103,7 @@ describe('Metadata', function () {
       });
     });
     it('should parse C*3 keyspace metadata for network strategy', function (done) {
-      var cc = {
+      const cc = {
         query: function (q, w, cb) {
           cb(null, { rows: [{
             'keyspace_name': 'ks2',
@@ -134,7 +133,7 @@ describe('Metadata', function () {
   });
   describe('#getReplicas()', function () {
     it('should return depending on the rf and ring size with simple strategy', function () {
-      var cc = {
+      const cc = {
         query: function (q, w, cb) {
           cb(null, { rows: [{
             'keyspace_name': 'dummy',
@@ -170,12 +169,12 @@ describe('Metadata', function () {
       assert.strictEqual(replicas[2], '1');
     });
     it('should return depending on the dc rf with network topology', function (done) {
-      var cc = getControlConnectionForRows([{
+      const cc = getControlConnectionForRows([{
         'keyspace_name': 'dummy',
         'strategy_class': 'NetworkTopologyStrategy',
         'strategy_options': '{"dc1": "3", "dc2": "1"}'
       }]);
-      var options = clientOptions.extend({}, helper.baseOptions);
+      const options = clientOptions.extend({}, helper.baseOptions);
       var metadata = new Metadata(options, cc);
       metadata.tokenizer = getTokenizer();
       var racks = new utils.HashSet();
@@ -187,7 +186,7 @@ describe('Metadata', function () {
       metadata.ringTokensAsStrings = ['0', '1', '2', '3', '4', '5', '6', '7'];
       //load primary replicas
       metadata.primaryReplicas = {};
-      for (var i = 0; i < metadata.ring.length; i ++) {
+      for (let i = 0; i < metadata.ring.length; i ++) {
         var h = new Host(i.toString(), 2, options);
         h.datacenter = 'dc' + ((i % 2) + 1);
         h.rack = 'rack1';
@@ -207,12 +206,12 @@ describe('Metadata', function () {
       });
     });
     it('should return depending on the dc rf and rack with network topology', function (done) {
-      var cc = getControlConnectionForRows([{
+      const cc = getControlConnectionForRows([{
         'keyspace_name': 'dummy',
         'strategy_class': 'NetworkTopologyStrategy',
         'strategy_options': '{"dc1": "3", "dc2": "3", "non_existent_dc": "1"}'
       }]);
-      var options = clientOptions.extend({}, helper.baseOptions);
+      const options = clientOptions.extend({}, helper.baseOptions);
       var metadata = new Metadata(options, cc);
       metadata.tokenizer = getTokenizer();
       var racksDc1 = new utils.HashSet();
@@ -228,7 +227,7 @@ describe('Metadata', function () {
       metadata.ringTokensAsStrings = ['0', '1', '2', '3', '4', '5', '6', '7'];
       //load primary replicas
       metadata.primaryReplicas = {};
-      for (var i = 0; i < metadata.ring.length; i ++) {
+      for (let i = 0; i < metadata.ring.length; i ++) {
         // Hosts with in alternate dc and alternate rack
         var h = new Host(i.toString(), 2, options);
         h.datacenter = 'dc' + ((i % 2) + 1);
@@ -250,12 +249,12 @@ describe('Metadata', function () {
       });
     });
     it('should return depending on the dc rf and rack with network topology and skipping hosts', function (done) {
-      var cc = getControlConnectionForRows([{
+      const cc = getControlConnectionForRows([{
         'keyspace_name': 'dummy',
         'strategy_class': 'NetworkTopologyStrategy',
         'strategy_options': '{"dc1": "3", "dc2": "2"}'
       }]);
-      var options = clientOptions.extend({}, helper.baseOptions);
+      const options = clientOptions.extend({}, helper.baseOptions);
       var metadata = new Metadata(options, cc);
       metadata.tokenizer = getTokenizer();
       var racksDc1 = new utils.HashSet();
@@ -271,7 +270,7 @@ describe('Metadata', function () {
       metadata.ringTokensAsStrings = ['0', '1', '2', '3', '4', '5', '6', '7'];
       //load primary replicas
       metadata.primaryReplicas = {};
-      for (var i = 0; i < metadata.ring.length; i ++) {
+      for (let i = 0; i < metadata.ring.length; i ++) {
         // Hosts with in alternate dc and alternate rack
         var h = new Host(i.toString(), 2, options);
         h.datacenter = 'dc' + ((i % 2) + 1);
@@ -294,12 +293,12 @@ describe('Metadata', function () {
     });
     it('should return quickly with many replicas and 0 nodes in one DC.', function (done) {
       this.timeout(2000);
-      var cc = getControlConnectionForRows([{
+      const cc = getControlConnectionForRows([{
         'keyspace_name': 'dummy',
         'strategy_class': 'NetworkTopologyStrategy',
         'strategy_options': '{"dc1": "3", "dc2": "2"}'
       }]);
-      var options = clientOptions.extend({}, helper.baseOptions);
+      const options = clientOptions.extend({}, helper.baseOptions);
       var metadata = new Metadata(options, cc);
       metadata.tokenizer = getTokenizer();
       var racksDc1 = new utils.HashSet();
@@ -314,12 +313,12 @@ describe('Metadata', function () {
       metadata.ring = [];
       // create ring with 100 replicas and 256 vnodes each.  place every replica in DC1.
       metadata.primaryReplicas = {};
-      for (var r = 0; r < 100; r++) {
+      for (let r = 0; r < 100; r++) {
         var h = new Host(r.toString(), 2, options);
         h.datacenter = 'dc1';
         h.rack = 'dc1_r1';
         // 256 vnodes per replica.
-        for (var v = 0; v < 256; v++) {
+        for (let v = 0; v < 256; v++) {
           var token = (v * 256) + r;
           metadata.ring.push(token);
           metadata.primaryReplicas[token.toString()] = h;
@@ -329,7 +328,7 @@ describe('Metadata', function () {
         return a - b;
       });
       metadata.ringTokensAsStrings = [];
-      for (var i = 0; i < metadata.ring.length; i++) {
+      for (let i = 0; i < metadata.ring.length; i++) {
         metadata.ringTokensAsStrings.push(metadata.ring[i].toString());
       }
 
@@ -344,12 +343,12 @@ describe('Metadata', function () {
     });
     it('should return quickly with many replicas and not enough nodes in a DC to satisfy RF.', function (done) {
       this.timeout(2000);
-      var cc = getControlConnectionForRows([{
+      const cc = getControlConnectionForRows([{
         'keyspace_name': 'dummy',
         'strategy_class': 'NetworkTopologyStrategy',
         'strategy_options': '{"dc1": "3", "dc2": "2"}'
       }]);
-      var options = clientOptions.extend({}, helper.baseOptions);
+      const options = clientOptions.extend({}, helper.baseOptions);
       var metadata = new Metadata(options, cc);
       metadata.tokenizer = getTokenizer();
       var racksDc1 = new utils.HashSet();
@@ -364,7 +363,7 @@ describe('Metadata', function () {
       metadata.ring = [];
       // create ring with 100 replicas and 256 vnodes each.  place every replica in DC1 except replica 0.
       metadata.primaryReplicas = {};
-      for (var r = 0; r < 100; r++) {
+      for (let r = 0; r < 100; r++) {
         var h = new Host(r.toString(), 2, options);
         h.datacenter = 'dc1';
         h.rack = 'dc1_r1';
@@ -374,7 +373,7 @@ describe('Metadata', function () {
           h.rack = 'dc2_r1';
         }
         // 256 vnodes per replica.
-        for (var v = 0; v < 256; v++) {
+        for (let v = 0; v < 256; v++) {
           var token = (v * 256) + r;
           metadata.ring.push(token);
           metadata.primaryReplicas[token.toString()] = h;
@@ -386,7 +385,7 @@ describe('Metadata', function () {
         return a - b;
       });
       metadata.ringTokensAsStrings = [];
-      for (var i = 0; i < metadata.ring.length; i++) {
+      for (let i = 0; i < metadata.ring.length; i++) {
         metadata.ringTokensAsStrings.push(metadata.ring[i].toString());
       }
 
@@ -446,7 +445,7 @@ describe('Metadata', function () {
   });
   describe('#getUdt()', function () {
     it('should retrieve the udt information', function (done) {
-      var cc = {
+      const cc = {
         query: function (q, cb) {
           setImmediate(function () {
             cb(null, new types.ResultSet({
@@ -474,7 +473,7 @@ describe('Metadata', function () {
       });
     });
     it('should callback in err when there is an error', function (done) {
-      var cc = {
+      const cc = {
         query: function (q, cb) {
           setImmediate(function () {
             cb(new Error('Test error'));
@@ -490,7 +489,7 @@ describe('Metadata', function () {
       });
     });
     it('should be null when it is not found', function (done) {
-      var cc = {
+      const cc = {
         query: function (q, cb) {
           setImmediate(function () {
             cb(null, new types.ResultSet({ rows: [], flags: utils.emptyObject}));
@@ -507,7 +506,7 @@ describe('Metadata', function () {
       });
     });
     it('should be null when keyspace does not exists', function (done) {
-      var cc = {
+      const cc = {
         query: function (q, cb) {
           setImmediate(function () {
             cb(null, new types.ResultSet({
@@ -530,8 +529,8 @@ describe('Metadata', function () {
       });
     });
     it('should query once when called in parallel', function (done) {
-      var queried = 0;
-      var cc = {
+      let queried = 0;
+      const cc = {
         query: function (q, cb) {
           setImmediate(function () {
             queried++;
@@ -565,8 +564,8 @@ describe('Metadata', function () {
       });
     });
     it('should query once and cache when called serially', function (done) {
-      var queried = 0;
-      var cc = {
+      let queried = 0;
+      const cc = {
         query: function (q, cb) {
           setImmediate(function () {
             queried++;
@@ -598,8 +597,8 @@ describe('Metadata', function () {
       });
     });
     it('should query the following times if it was null', function (done) {
-      var queried = 0;
-      var cc = {
+      let queried = 0;
+      const cc = {
         query: function (q, cb) {
           queried++;
           setImmediate(function () {
@@ -638,7 +637,7 @@ describe('Metadata', function () {
         source: types.InetAddress.fromString('10.10.10.2'),
         source_elapsed: 101
       }];
-      var cc = {
+      const cc = {
         query: function (r, cb) {
           setImmediate(function () {
             if (r.query.indexOf('system_traces.sessions') >= 0) {
@@ -683,7 +682,7 @@ describe('Metadata', function () {
         source: types.InetAddress.fromString('10.10.10.2'),
         source_elapsed: 101
       }];
-      var cc = {
+      const cc = {
         query: function (r, cb) {
           setImmediate(function () {
             if (r.query.indexOf('system_traces.sessions') >= 0) {
@@ -723,8 +722,8 @@ describe('Metadata', function () {
         source: types.InetAddress.fromString('10.10.10.1'),
         source_elapsed: 102
       }];
-      var calls = 0;
-      var cc = {
+      let calls = 0;
+      const cc = {
         query: function (r, cb) {
           setImmediate(function () {
             if (r.query.indexOf('system_traces.sessions') >= 0) {
@@ -761,12 +760,12 @@ describe('Metadata', function () {
         started_at: new Date(),
         duration: null //duration null means that trace is not fully flushed
       };
-      var calls = 0;
-      var cc = {
+      let calls = 0;
+      const cc = {
         query: function (r, cb) {
           setImmediate(function () {
             //try with empty result and null duration
-            var rows = [];
+            let rows = [];
             if (++calls > 1) {
               rows = [ sessionRow ];
             }
@@ -786,7 +785,7 @@ describe('Metadata', function () {
     });
     it('should callback in error if there was an error retrieving the trace', function (done) {
       var err = new Error('dummy err');
-      var cc = {
+      const cc = {
         query: function (r, cb) {
           setImmediate(function () {
             cb(err);
@@ -804,7 +803,7 @@ describe('Metadata', function () {
   });
   describe('#getTable()', function () {
     it('should be null when it is not found', function (done) {
-      var cc = {
+      const cc = {
         query: function (q, cb) {
           setImmediate(function () {
             if (q.indexOf('system.schema_columnfamilies') >= 0) {
@@ -842,9 +841,9 @@ describe('Metadata', function () {
         { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'ck', component_index: 0, index_name: null, index_options: null, index_type: null, type: 'clustering_key', validator: 'org.apache.cassandra.db.marshal.TimeUUIDType' },
         { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'pk1', component_index: 0, index_name: null, index_options: null, index_type: null, type: 'partition_key', validator: 'org.apache.cassandra.db.marshal.UUIDType' }
       ];
-      var calledTable = 0;
-      var calledRows = 0;
-      var cc = {
+      let calledTable = 0;
+      let calledRows = 0;
+      const cc = {
         query: function (q, cb) {
           setImmediate(function () {
             if (q.indexOf('system.schema_columnfamilies') >= 0) {
@@ -882,9 +881,9 @@ describe('Metadata', function () {
         { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'ck', component_index: 0, index_name: null, index_options: null, index_type: null, type: 'clustering_key', validator: 'org.apache.cassandra.db.marshal.TimeUUIDType' },
         { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'pk1', component_index: 0, index_name: null, index_options: null, index_type: null, type: 'partition_key', validator: 'org.apache.cassandra.db.marshal.UUIDType' }
       ];
-      var calledTable = 0;
-      var calledRows = 0;
-      var cc = {
+      let calledTable = 0;
+      let calledRows = 0;
+      const cc = {
         query: function (q, cb) {
           setImmediate(function () {
             if (q.indexOf('system.schema_columnfamilies') >= 0) {
@@ -913,9 +912,9 @@ describe('Metadata', function () {
       });
     });
     it('should query the following times if it was not found', function (done) {
-      var calledTable = 0;
-      var calledRows = 0;
-      var cc = {
+      let calledTable = 0;
+      let calledRows = 0;
+      const cc = {
         query: function (q, cb) {
           setImmediate(function () {
             if (q.indexOf('system.schema_columnfamilies') >= 0) {
@@ -949,9 +948,9 @@ describe('Metadata', function () {
         {"keyspace_name": "ks_tbl_meta", "table_name": "tbl1", "column_name": "id", "clustering_order": "none", "column_name_bytes": "0x6964", "kind": "partition_key", "position": -1, "type": "uuid"},
         {"keyspace_name": "ks_tbl_meta", "table_name": "tbl1", "column_name": "text_sample", "clustering_order": "none", "column_name_bytes": "0x746578745f73616d706c65", "kind": "regular", "position": -1, "type": "text"}
       ];
-      var options = utils.extend({}, clientOptions.defaultOptions());
+      const options = utils.extend({}, clientOptions.defaultOptions());
       options.isMetadataSyncEnabled = false;
-      var cc = getControlConnectionForTable(tableRow, columnRows);
+      const cc = getControlConnectionForTable(tableRow, columnRows);
       var metadata = new Metadata(options, cc);
       metadata.keyspaces = { };
       metadata.setCassandraVersion([3, 0]);
@@ -1221,7 +1220,7 @@ describe('Metadata', function () {
           comparator: 'org.apache.cassandra.db.marshal.TimeUUIDType', compression_parameters: '{"sstable_compression":"org.apache.cassandra.io.compress.SnappyCompressor"}',
           default_validator: 'org.apache.cassandra.db.marshal.UTF8Type', gc_grace_seconds: 864000, id: null, key_alias: null, key_aliases: '["id1"]', key_validator: 'org.apache.cassandra.db.marshal.UUIDType', local_read_repair_chance: 0, max_compaction_threshold: 32, min_compaction_threshold: 4, populate_io_cache_on_flush: false, read_repair_chance: 0.1, replicate_on_write: true, subcomparator: null, type: 'Standard',
           value_alias: 'text1' };
-        var columnRows = [];
+        const columnRows = [];
         var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
@@ -1262,7 +1261,7 @@ describe('Metadata', function () {
         var tableRow = { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', bloom_filter_fp_chance: 0.01, caching: 'KEYS_ONLY',
           column_aliases: '["id2","text1"]', comment: '', compaction_strategy_class: 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', compaction_strategy_options: '{}',
           comparator: 'org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.TimeUUIDType,org.apache.cassandra.db.marshal.UTF8Type)', compression_parameters: '{"sstable_compression":"org.apache.cassandra.io.compress.SnappyCompressor"}', default_validator: 'org.apache.cassandra.db.marshal.BytesType', gc_grace_seconds: 864000, id: null, key_alias: null, key_aliases: '["id1"]', key_validator: 'org.apache.cassandra.db.marshal.UUIDType', local_read_repair_chance: 0, max_compaction_threshold: 32, min_compaction_threshold: 4, populate_io_cache_on_flush: false, read_repair_chance: 0.1, replicate_on_write: true, subcomparator: null, type: 'Standard', value_alias: '' };
-        var columnRows = [];
+        const columnRows = [];
         var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
@@ -1564,11 +1563,11 @@ describe('Metadata', function () {
     });
     describe('with C* 2.2 metadata rows', function () {
       it('should query once when called in parallel', function (done) {
-        var called = 0;
+        let called = 0;
         var rows = [
           {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
         ];
-        var cc = {
+        const cc = {
           query: function (q, cb) {
             called++;
             setImmediate(function () {
@@ -1592,11 +1591,11 @@ describe('Metadata', function () {
         });
       });
       it('should query once when called serially', function (done) {
-        var called = 0;
+        let called = 0;
         var rows = [
           {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
         ];
-        var cc = {
+        const cc = {
           query: function (q, cb) {
             called++;
             setImmediate(function () {
@@ -1621,11 +1620,11 @@ describe('Metadata', function () {
         });
       });
       it('should query the following times if was previously not found', function (done) {
-        var called = 0;
+        let called = 0;
         var rows = [
           {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
         ];
-        var cc = {
+        const cc = {
           query: function (q, cb) {
             if (called++ < 5) {
               return setImmediate(function () {
@@ -1660,11 +1659,11 @@ describe('Metadata', function () {
         });
       });
       it('should query the following times if there was an error previously', function (done) {
-        var called = 0;
+        let called = 0;
         var rows = [
           {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
         ];
-        var cc = {
+        const cc = {
           query: function (q, cb) {
             if (called++ < 5) {
               return setImmediate(function () {
@@ -1787,7 +1786,7 @@ describe('Metadata', function () {
   describe('#getFunction()', function () {
     context('with no callback specified', function () {
       it('should return a Promise', function () {
-        var metadata = newInstance();
+        const metadata = newInstance();
         var p = metadata.getFunction('ks1', 'fn1', []);
         helper.assertInstanceOf(p, Promise);
       });
@@ -1803,7 +1802,6 @@ describe('Metadata', function () {
     it('should callback in error if signature is not an array', function (done) {
       var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
       metadata.keyspaces['ks_udf'] = { functions: {}};
-      //noinspection JSCheckFunctionSignatures
       metadata.getFunction('ks_udf', 'func1', {}, function (err) {
         helper.assertInstanceOf(err, errors.ArgumentError);
         done();
@@ -1812,18 +1810,17 @@ describe('Metadata', function () {
     it('should callback in error if signature types are not found', function (done) {
       var metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
       metadata.keyspaces['ks_udf'] = { functions: {}};
-      //noinspection JSCheckFunctionSignatures
       metadata.getFunction('ks_udf', 'func1', [{code: 0x1000}], function (err) {
         helper.assertInstanceOf(err, errors.ArgumentError);
         done();
       });
     });
     it('should query once when called in parallel', function (done) {
-      var called = 0;
+      let called = 0;
       var rows = [
         {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
       ];
-      var cc = {
+      const cc = {
         query: function (q, cb) {
           called++;
           setImmediate(function () {
@@ -1847,11 +1844,11 @@ describe('Metadata', function () {
       });
     });
     it('should query once when called serially', function (done) {
-      var called = 0;
+      let called = 0;
       var rows = [
         {"keyspace_name":"ks_udf","function_name":"plus","signature":["bigint","bigint"],"argument_names":["s","v"],"argument_types":["org.apache.cassandra.db.marshal.LongType","org.apache.cassandra.db.marshal.LongType"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.LongType"}
       ];
-      var cc = {
+      const cc = {
         query: function (q, cb) {
           called++;
           helper.assertContains(q, 'system.schema_functions');
@@ -1941,11 +1938,11 @@ describe('Metadata', function () {
     });
     describe('with C* 2.2 metadata rows', function () {
       it('should query once when called in parallel', function (done) {
-        var called = 0;
+        let called = 0;
         var rows = [
           {"keyspace_name":"ks_udf","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":utils.allocBufferFromArray([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"}
         ];
-        var cc = {
+        const cc = {
           query: function (q, cb) {
             called++;
             helper.assertContains(q, 'system.schema_aggregates');
@@ -1970,11 +1967,11 @@ describe('Metadata', function () {
         });
       });
       it('should query once when called serially', function (done) {
-        var called = 0;
+        let called = 0;
         var rows = [
           {"keyspace_name":"ks_udf","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":utils.allocBufferFromArray([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"}
         ];
-        var cc = {
+        const cc = {
           query: function (q, cb) {
             called++;
             setImmediate(function () {
@@ -1999,11 +1996,11 @@ describe('Metadata', function () {
         });
       });
       it('should query the following times if was previously not found', function (done) {
-        var called = 0;
+        let called = 0;
         var rows = [
           {"keyspace_name":"ks_udf","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":utils.allocBufferFromArray([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"}
         ];
-        var cc = {
+        const cc = {
           query: function (q, cb) {
             if (called++ < 5) {
               return setImmediate(function () {
@@ -2038,11 +2035,11 @@ describe('Metadata', function () {
         });
       });
       it('should query the following times if there was an error previously', function (done) {
-        var called = 0;
+        let called = 0;
         var rows = [
           {"keyspace_name":"ks_udf","aggregate_name":"sum","signature":["bigint"],"argument_types":["org.apache.cassandra.db.marshal.LongType"],"final_func":null,"initcond":utils.allocBufferFromArray([0,0,0,0,0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.LongType","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.LongType"}
         ];
-        var cc = {
+        const cc = {
           query: function (q, cb) {
             helper.assertContains(q, 'system.schema_aggregates');
             if (called++ < 5) {
@@ -2176,7 +2173,7 @@ describe('Metadata', function () {
       'day': { type: { code: types.dataTypes.int}, name: 'day'}
     };
     it('should return null when the view is not found', function (done) {
-      var cc = {
+      const cc = {
         query: function (q, cb) {
           setImmediate(function () {
             //return an empty array
@@ -2218,7 +2215,7 @@ describe('Metadata', function () {
       hosts.push(h1.address, h1);
       metadata.buildTokens(hosts);
       var sortedTokens = ['5', '10', '15', '20', '25', '400'];
-      var sortedParsedTokens = [];
+      const sortedParsedTokens = [];
       sortedTokens.forEach(function (token) {
         sortedParsedTokens.push(tokenizer.parse(token));
       });
@@ -2239,7 +2236,7 @@ describe('Metadata', function () {
       hosts.push(h2.address, h2);
       metadata.buildTokens(hosts);
       var sortedTokens = ['5', '8', '10', '13', '18', '25', '203', '400'];
-      var sortedParsedTokens = [];
+      const sortedParsedTokens = [];
       sortedTokens.forEach(function (token) {
         sortedParsedTokens.push(tokenizer.parse(token));
       });
@@ -2287,7 +2284,7 @@ function getControlConnectionForTable(tableRow, columnRows, indexRows) {
     queriedRows: 0,
     queriedIndexes: 0,
     query: function (q, cb) {
-      var self = this;
+      const self = this;
       setImmediate(function () {
         if (q.indexOf('system.schema_columnfamilies') >= 0 || q.indexOf('system_schema.tables') >= 0) {
           self.queriedTable++;

--- a/test/unit/mutable-long-tests.js
+++ b/test/unit/mutable-long-tests.js
@@ -1,9 +1,9 @@
 "use strict";
 
-var assert = require('assert');
-var format = require('util').format;
-var Long = require('long');
-var MutableLong = require('../../lib/types/mutable-long');
+const assert = require('assert');
+const format = require('util').format;
+const Long = require('long');
+const MutableLong = require('../../lib/types/mutable-long');
 
 describe('MutableLong', function () {
   describe('fromNumber() and #toNumber()', function () {
@@ -27,7 +27,7 @@ describe('MutableLong', function () {
         [ '-6989252372825142799', [ 0x89f1, 0x6033, 0x2fff, 0x9f01 ]],
         [ '-8142173877431989775', [ 0x89f1, 0x6033, 0x2fff, 0x8f01 ]],
       ].forEach(function (item) {
-        var expected = new MutableLong(item[1][0], item[1][1], item[1][2], item[1][3]);
+        const expected = new MutableLong(item[1][0], item[1][1], item[1][2], item[1][3]);
         assert.ok(MutableLong.fromString(item[0]).equals(expected));
       });
     });
@@ -43,7 +43,7 @@ describe('MutableLong', function () {
         [ 22631153906384 * 199 ],
         [ -1, Math.pow(2, 43) ]
       ].forEach(function (item) {
-        var expected = item[0] * item[1];
+        const expected = item[0] * item[1];
         var a = MutableLong.fromNumber(item[0]);
         var b = MutableLong.fromNumber(item[1]);
         assert.ok(a.multiply(b).equals(MutableLong.fromNumber(expected)), format('failed for value %d*%d',
@@ -70,7 +70,7 @@ describe('MutableLong', function () {
   });
   describe('#shiftRightUnsigned()', function () {
     it('should shift across int16 blocks', function () {
-      for (var i = 1; i < 64; i++) {
+      for (let i = 1; i < 64; i++) {
         var l = MutableLong.fromBits(0xffffffff, 0xffffffff).shiftRightUnsigned(i);
 
         var expectedHigh = 0xffffffff;
@@ -91,10 +91,10 @@ describe('MutableLong', function () {
   });
   describe('#shiftLeft()', function () {
     it('should shift across int16 blocks', function () {
-      for (var i = 1; i < 64; i++) {
+      for (let i = 1; i < 64; i++) {
         var l = MutableLong.fromBits(1, 0).shiftLeft(i);
-        var expectedHigh = 0;
-        var expectedLow = 0;
+        let expectedHigh = 0;
+        let expectedLow = 0;
         if (i < 32) {
           expectedLow = 1 << i;
         }
@@ -126,11 +126,11 @@ describe('MutableLong', function () {
     it('should compare random numbers', function () {
       var max = Math.pow(2, 52);
       var length = 100;
-      var i;
-      var arr1 = new Array(length);
-      var arr2 = new Array(length);
+      let i;
+      const arr1 = new Array(length);
+      const arr2 = new Array(length);
       for (i = 0; i < length; i++) {
-        var n = 0;
+        let n = 0;
         if (i !== 0) {
           n = Math.floor(Math.random() * max);
           if (i%2 === 1) {
@@ -147,7 +147,7 @@ describe('MutableLong', function () {
         return a.compare(b);
       });
       for (i = 0; i < length; i++) {
-        var expected = MutableLong.fromNumber(arr1[i]);
+        const expected = MutableLong.fromNumber(arr1[i]);
         assert.ok(arr2[i].equals(expected));
       }
     });

--- a/test/unit/mutable-long-tests.js
+++ b/test/unit/mutable-long-tests.js
@@ -8,9 +8,9 @@ const MutableLong = require('../../lib/types/mutable-long');
 describe('MutableLong', function () {
   describe('fromNumber() and #toNumber()', function () {
     it('should convert from and to a Number', function () {
-      var values = [ 1, 2, -1, -999999, 256, 1024 * 1024, 1024 * 1025 + 13, Math.pow(2, 52), -1 * Math.pow(2, 52) ];
+      const values = [ 1, 2, -1, -999999, 256, 1024 * 1024, 1024 * 1025 + 13, Math.pow(2, 52), -1 * Math.pow(2, 52) ];
       values.forEach(function (value) {
-        var ml = MutableLong.fromNumber(value);
+        const ml = MutableLong.fromNumber(value);
         assert.strictEqual(ml.toNumber(), value);
       });
     });
@@ -44,8 +44,8 @@ describe('MutableLong', function () {
         [ -1, Math.pow(2, 43) ]
       ].forEach(function (item) {
         const expected = item[0] * item[1];
-        var a = MutableLong.fromNumber(item[0]);
-        var b = MutableLong.fromNumber(item[1]);
+        const a = MutableLong.fromNumber(item[0]);
+        const b = MutableLong.fromNumber(item[1]);
         assert.ok(a.multiply(b).equals(MutableLong.fromNumber(expected)), format('failed for value %d*%d',
           item[0], item[1]));
       });
@@ -60,9 +60,9 @@ describe('MutableLong', function () {
         [ MutableLong.fromBits(0xe084bca4, 0x28b1), MutableLong.fromBits(0xed558ccd, 0xff51afd7),
           MutableLong.fromBits(0xd7e8bf54, 0x9e9ed5ab)]
       ].forEach(function (item) {
-        var a = Long.fromBits(item[0].getLowBitsUnsigned(), item[0].getHighBitsUnsigned(), false);
-        var b = Long.fromBits(item[1].getLowBitsUnsigned(), item[1].getHighBitsUnsigned(), false);
-        var c = Long.fromBits(item[2].getLowBitsUnsigned(), item[2].getHighBitsUnsigned(), false);
+        const a = Long.fromBits(item[0].getLowBitsUnsigned(), item[0].getHighBitsUnsigned(), false);
+        const b = Long.fromBits(item[1].getLowBitsUnsigned(), item[1].getHighBitsUnsigned(), false);
+        const c = Long.fromBits(item[2].getLowBitsUnsigned(), item[2].getHighBitsUnsigned(), false);
         assert.ok(a.multiply(b).equals(c));
         assert.ok(item[0].multiply(item[1]).equals(item[2]));
       });
@@ -71,10 +71,10 @@ describe('MutableLong', function () {
   describe('#shiftRightUnsigned()', function () {
     it('should shift across int16 blocks', function () {
       for (let i = 1; i < 64; i++) {
-        var l = MutableLong.fromBits(0xffffffff, 0xffffffff).shiftRightUnsigned(i);
+        const l = MutableLong.fromBits(0xffffffff, 0xffffffff).shiftRightUnsigned(i);
 
-        var expectedHigh = 0xffffffff;
-        var expectedLow = 0xffffffff;
+        let expectedHigh = 0xffffffff;
+        let expectedLow = 0xffffffff;
         if (i < 32) {
           expectedLow = (expectedLow >>> i) | (expectedHigh << (32 - i));
           expectedHigh = expectedHigh >>> i;
@@ -92,7 +92,7 @@ describe('MutableLong', function () {
   describe('#shiftLeft()', function () {
     it('should shift across int16 blocks', function () {
       for (let i = 1; i < 64; i++) {
-        var l = MutableLong.fromBits(1, 0).shiftLeft(i);
+        const l = MutableLong.fromBits(1, 0).shiftLeft(i);
         let expectedHigh = 0;
         let expectedLow = 0;
         if (i < 32) {
@@ -124,8 +124,8 @@ describe('MutableLong', function () {
       });
     });
     it('should compare random numbers', function () {
-      var max = Math.pow(2, 52);
-      var length = 100;
+      const max = Math.pow(2, 52);
+      const length = 100;
       let i;
       const arr1 = new Array(length);
       const arr2 = new Array(length);

--- a/test/unit/parser-tests.js
+++ b/test/unit/parser-tests.js
@@ -1122,11 +1122,8 @@ function getEventData(eventType, value) {
 }
 
 function buildParserAndExpect(validationFn) {
-  var parser = newInstance();
-  parser.on('readable', function () {
-    var item = parser.read();
-    validationFn(item);
-  });
+  const parser = newInstance();
+  parser.on('readable', () => validationFn(parser.read()));
   return parser;
 }
 

--- a/test/unit/parser-tests.js
+++ b/test/unit/parser-tests.js
@@ -16,7 +16,7 @@ describe('Parser', function () {
     it('should read a READY opcode', function (done) {
       const parser = newInstance();
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.bodyLength, 0);
         assert.strictEqual(item.header.opcode, types.opcodes.ready);
         done();
@@ -26,7 +26,7 @@ describe('Parser', function () {
     it('should read a AUTHENTICATE response', function (done) {
       const parser = newInstance();
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.authenticate);
         assert.ok(item.mustAuthenticate, 'it should return a mustAuthenticate return flag');
         done();
@@ -36,14 +36,14 @@ describe('Parser', function () {
     it('should buffer a AUTHENTICATE response until complete', function (done) {
       const parser = newInstance();
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.authenticate);
         assert.ok(item.mustAuthenticate, 'it should return a mustAuthenticate return flag');
         assert.strictEqual(item.authenticatorName, 'abc');
         //mocha will fail if done is called multiple times
         done();
       });
-      var header = getFrameHeader(5, types.opcodes.authenticate);
+      const header = getFrameHeader(5, types.opcodes.authenticate);
       parser._transform({ header: header, chunk: utils.allocBufferFromArray([0, 3]), offset: 0}, null, doneIfError(done));
       parser._transform({ header: header, chunk: utils.allocBufferFromString('a'), offset: 0}, null, doneIfError(done));
       parser._transform({ header: header, chunk: utils.allocBufferFromString('bc'), offset: 0}, null, doneIfError(done));
@@ -51,7 +51,7 @@ describe('Parser', function () {
     it('should read a VOID result', function (done) {
       const parser = newInstance();
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.bodyLength, 4);
         assert.strictEqual(item.header.opcode, types.opcodes.result);
         done();
@@ -64,7 +64,7 @@ describe('Parser', function () {
     it('should read a VOID result with trace id', function (done) {
       const parser = newInstance();
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.bodyLength, 4);
         assert.strictEqual(item.header.opcode, types.opcodes.result);
         helper.assertInstanceOf(item.flags.traceId, types.Uuid);
@@ -82,12 +82,12 @@ describe('Parser', function () {
       const parser = newInstance();
       let responseCounter = 0;
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.result);
         responseCounter++;
       });
 
-      var body = Buffer.concat([
+      const body = Buffer.concat([
         utils.allocBufferUnsafe(16), //uuid
         utils.allocBufferFromArray([0, 0, 0, types.resultKind.voidResult])
       ]);
@@ -111,12 +111,12 @@ describe('Parser', function () {
       const parser = newInstance();
       let responseCounter = 0;
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.result);
         responseCounter++;
       });
 
-      var body = Buffer.concat([
+      const body = Buffer.concat([
         utils.allocBufferUnsafe(16), //uuid
         getBodyChunks(3, 1, 0, undefined, null).chunk
       ]);
@@ -140,7 +140,7 @@ describe('Parser', function () {
     it('should read a VOID result with warnings and custom payload', function (done) {
       const parser = newInstance();
 
-      var body = Buffer.concat([
+      const body = Buffer.concat([
         // 2 string list of warnings containing 'Hello', 'World'
         utils.allocBufferFromString('0002000548656c6c6f0005576f726c64', 'hex'),
         // Custom payload byte map of {a: 1, b: 2}
@@ -150,7 +150,7 @@ describe('Parser', function () {
       ]);
 
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.ok(!item.error);
         assert.strictEqual(item.header.bodyLength, body.length);
         assert.strictEqual(item.header.opcode, types.opcodes.result);
@@ -162,7 +162,7 @@ describe('Parser', function () {
         done();
       });
 
-      var header = getFrameHeader(body.length, types.opcodes.result, 4, false, 12, true, true);
+      const header = getFrameHeader(body.length, types.opcodes.result, 4, false, 12, true, true);
       parser._transform({
         header: header,
         chunk: body,
@@ -172,13 +172,13 @@ describe('Parser', function () {
     it('should read a SET_KEYSPACE result', function (done) {
       const parser = newInstance();
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.result);
         assert.strictEqual(item.keyspaceSet, 'ks1');
         done();
       });
       //kind + stringLength + string
-      var bodyLength = 4 + 2 + 3;
+      const bodyLength = 4 + 2 + 3;
       parser._transform({
         header: getFrameHeader(bodyLength, types.opcodes.result),
         chunk: utils.allocBufferFromArray([0, 0, 0, types.resultKind.setKeyspace]),
@@ -199,7 +199,7 @@ describe('Parser', function () {
       const parser = newInstance();
       const id = types.Uuid.random();
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.ifError(item.error);
         assert.strictEqual(item.header.opcode, types.opcodes.result);
         helper.assertInstanceOf(item.id, Buffer);
@@ -210,14 +210,14 @@ describe('Parser', function () {
       // id length + id
       // metadata (flags + columnLength + ksname + tblname + column name + column type) +
       // result metadata (flags + columnLength + ksname + tblname + column name + column type)
-      var body = Buffer.concat([
+      const body = Buffer.concat([
         utils.allocBufferFromArray([0, 0, 0, types.resultKind.prepared]),
         utils.allocBufferFromArray([0, 16]),
         id.getBuffer(),
         utils.allocBufferFromArray([0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 62, 0, 1, 63, 0, 1, 61, 0, types.dataTypes.text]),
         utils.allocBufferFromArray([0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 62, 0, 1, 63, 0, 1, 61, 0, types.dataTypes.text])
       ]);
-      var bodyLength = body.length;
+      const bodyLength = body.length;
       parser._transform({
         header: getFrameHeader(bodyLength, types.opcodes.result),
         chunk: body.slice(0, 22),
@@ -237,49 +237,49 @@ describe('Parser', function () {
     it('should read a STATUS_CHANGE UP EVENT response', function (done) {
       const parser = newInstance();
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.event);
         assert.ok(item.event, 'it should return the details of the event');
         assert.strictEqual(item.event.up, true);
         done();
       });
 
-      var eventData = getEventData('STATUS_CHANGE', 'UP');
+      const eventData = getEventData('STATUS_CHANGE', 'UP');
       parser._transform(eventData, null, doneIfError(done));
     });
     it('should read a STATUS_CHANGE DOWN EVENT response', function (done) {
       const parser = newInstance();
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.event);
         assert.ok(item.event, 'it should return the details of the event');
         assert.strictEqual(item.event.up, false);
         done();
       });
 
-      var eventData = getEventData('STATUS_CHANGE', 'DOWN');
+      const eventData = getEventData('STATUS_CHANGE', 'DOWN');
       parser._transform(eventData, null, doneIfError(done));
     });
     it('should read a STATUS_CHANGE DOWN EVENT response chunked', function (done) {
       const parser = newInstance();
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.event);
         assert.ok(item.event, 'it should return the details of the event');
         assert.strictEqual(item.event.up, false);
         done();
       });
 
-      var eventData = getEventData('STATUS_CHANGE', 'DOWN');
-      var chunk1 = eventData.chunk.slice(0, 5);
-      var chunk2 = eventData.chunk.slice(5);
+      const eventData = getEventData('STATUS_CHANGE', 'DOWN');
+      const chunk1 = eventData.chunk.slice(0, 5);
+      const chunk2 = eventData.chunk.slice(5);
       parser._transform({header: eventData.header, chunk: chunk1, offset: 0}, null, doneIfError(done));
       parser._transform({header: eventData.header, chunk: chunk2, offset: 0}, null, doneIfError(done));
     });
     it('should read an ERROR response that includes warnings', function (done) {
       const parser = newInstance();
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.error);
         assert.ok(item.error);
         helper.assertInstanceOf(item.error, errors.ResponseError);
@@ -288,12 +288,12 @@ describe('Parser', function () {
         done();
       });
 
-      var body = Buffer.concat([
+      const body = Buffer.concat([
         utils.allocBufferFromString('0002000548656c6c6f0005576f726c64', 'hex'), // 2 string list of warnings containing 'Hello', 'World'
         utils.allocBufferFromString('0000000000044661696c', 'hex') // Server Error Code (0x0000) with 4 length message 'Fail'
       ]);
-      var bodyLength = body.length;
-      var header = getFrameHeader(bodyLength, types.opcodes.error, 4, false, 12, true);
+      const bodyLength = body.length;
+      const header = getFrameHeader(bodyLength, types.opcodes.error, 4, false, 12, true);
       parser._transform({
         header: header,
         chunk: body.slice(0, 4),
@@ -696,7 +696,7 @@ describe('Parser', function () {
     it('should read a buffer until there is enough data', function (done) {
       const parser = newInstance();
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.bodyLength, 4);
         assert.strictEqual(item.header.opcode, types.opcodes.result);
         done();
@@ -715,7 +715,7 @@ describe('Parser', function () {
     it('should emit empty result one column no rows', function (done) {
       const parser = newInstance();
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.result);
         assert.ok(item.result && item.result.rows && item.result.rows.length === 0);
         done();
@@ -730,7 +730,7 @@ describe('Parser', function () {
     it('should emit empty result two columns no rows', function (done) {
       const parser = newInstance();
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.result);
         assert.ok(item.result && item.result.rows && item.result.rows.length === 0);
         done();
@@ -740,10 +740,10 @@ describe('Parser', function () {
     });
     it('should emit row when rows present', function (done) {
       const parser = newInstance();
-      var rowLength = 2;
+      const rowLength = 2;
       let rowCounter = 0;
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.result);
         assert.ok(item.row);
         if ((++rowCounter) === rowLength) {
@@ -782,23 +782,23 @@ describe('Parser', function () {
             { columnLength: 6, rowLength: 5 },
             { columnLength: 1, rowLength: 20 }
           ];
-          var items = expected.map(function (item, index) {
+          const items = expected.map(function (item, index) {
             parser.setOptions(index, { byRow: true });
             return getBodyChunks(item.columnLength, item.rowLength, 0, null, null, index);
           });
           function transformChunkedItem(i) {
-            var item = items[i];
-            var chunkedItem = {
+            const item = items[i];
+            const chunkedItem = {
               header: item.header,
               offset: 0
             };
             for (let j = 0; j < item.chunk.length; j = j + chunkLength) {
-              var end = j + chunkLength;
+              let end = j + chunkLength;
               if (end >= item.chunk.length) {
                 end = item.chunk.length;
                 chunkedItem.frameEnded = true;
               }
-              var start = j;
+              const start = j;
               if (start === 0) {
                 //sum a few bytes
                 chunkedItem.chunk = Buffer.concat([ utils.allocBufferUnsafe(9), item.chunk.slice(start, end) ]);
@@ -823,7 +823,7 @@ describe('Parser', function () {
       });
     });
     describe('with multiple chunk lengths piped', function () {
-      var protocol = new streams.Protocol({ objectMode: true });
+      const protocol = new streams.Protocol({ objectMode: true });
       const parser = newInstance();
       protocol.pipe(parser);
       let result;
@@ -851,12 +851,12 @@ describe('Parser', function () {
           result = {};
           const buffer = Buffer.concat(expected.map(function (expectedItem, index) {
             parser.setOptions(index, { byRow: true });
-            var item = getBodyChunks(expectedItem.columnLength, expectedItem.rowLength, 0, null, null, index);
+            const item = getBodyChunks(expectedItem.columnLength, expectedItem.rowLength, 0, null, null, index);
             return Buffer.concat([ item.header.toBuffer(), item.chunk ]);
           }));
 
           for (let j = 0; j < buffer.length; j = j + chunkLength) {
-            var end = j + chunkLength;
+            let end = j + chunkLength;
             if (end >= buffer.length) {
               end = buffer.length;
             }
@@ -882,7 +882,7 @@ describe('Parser', function () {
         const parser = newInstance();
         let rowCounter = 0;
         parser.on('readable', function () {
-          var item = parser.read();
+          const item = parser.read();
           assert.strictEqual(item.header.opcode, types.opcodes.result);
           assert.ok(item.row);
           if ((++rowCounter) === rowLength) {
@@ -895,7 +895,7 @@ describe('Parser', function () {
         const parser = newInstance();
         let rowCounter = 0;
         parser.on('readable', function () {
-          var item = parser.read();
+          const item = parser.read();
           assert.strictEqual(item.header.opcode, types.opcodes.result);
           assert.ok(item.row);
           if ((++rowCounter) === rowLength) {
@@ -909,7 +909,7 @@ describe('Parser', function () {
         const parser = newInstance();
         let rowCounter = 0;
         parser.on('readable', function () {
-          var item = parser.read();
+          const item = parser.read();
           assert.strictEqual(item.header.opcode, types.opcodes.result);
           assert.ok(item.row);
           if ((++rowCounter) === rowLength) {
@@ -930,7 +930,7 @@ describe('Parser', function () {
         const parser = newInstance();
         let rowCounter = 0;
         parser.on('readable', function () {
-          var item = parser.read();
+          const item = parser.read();
           assert.strictEqual(item.header.opcode, types.opcodes.result);
           assert.ok(item.row);
           if ((++rowCounter) === rowLength) {
@@ -944,13 +944,13 @@ describe('Parser', function () {
         parser._transform(getBodyChunks(1, rowLength, 150, 200, cellValue), null, doneIfError(done));
         parser._transform(getBodyChunks(1, rowLength, 200, null, cellValue), null, doneIfError(done));
       }, function (next) {
-        const cellValue = helper.fillArray(256, 74);
+        let cellValue = helper.fillArray(256, 74);
         //Add the length 256 of the value
         cellValue = [0, 0, 1, 0].concat(cellValue);
         const parser = newInstance();
         let rowCounter = 0;
         parser.on('readable', function () {
-          var item = parser.read();
+          const item = parser.read();
           assert.strictEqual(item.header.opcode, types.opcodes.result);
           assert.ok(item.row);
           if ((++rowCounter) === rowLength) {
@@ -967,14 +967,14 @@ describe('Parser', function () {
     it('should read a AUTH_CHALLENGE response', function (done) {
       const parser = newInstance();
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.authChallenge);
         helper.assertValueEqual(item.token, utils.allocBufferFromArray([100, 100]));
         assert.strictEqual(item.authChallenge, true);
         done();
       });
       //Length + buffer
-      var bodyLength = 4 + 2;
+      const bodyLength = 4 + 2;
       parser._transform({
         header: getFrameHeader(bodyLength, types.opcodes.authChallenge),
         chunk: utils.allocBufferFromArray([255, 254, 0, 0, 0, 2]),
@@ -989,7 +989,7 @@ describe('Parser', function () {
     it('should buffer ERROR response until complete', function (done) {
       const parser = newInstance();
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.error);
         helper.assertInstanceOf(item.error, errors.ResponseError);
         assert.strictEqual(item.error.message, 'ERR');
@@ -998,7 +998,7 @@ describe('Parser', function () {
         done();
       });
       //streamId 33
-      var header = new types.FrameHeader(4, 0, 33, types.opcodes.error, 9);
+      const header = new types.FrameHeader(4, 0, 33, types.opcodes.error, 9);
       parser.setOptions(33, { byRow: true });
       assert.strictEqual(parser.frameState({ header: header}).byRow, true);
       parser._transform({ header: header, chunk: utils.allocBufferFromArray([255, 0, 0, 0, 0]), offset: 1}, null, doneIfError(done));
@@ -1007,10 +1007,10 @@ describe('Parser', function () {
     });
     it('should not buffer RESULT ROWS response when byRow is enabled', function (done) {
       const parser = newInstance();
-      var rowLength = 2;
+      const rowLength = 2;
       let rowCounter = 0;
       parser.on('readable', function () {
-        var item = parser.read();
+        const item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.result);
         assert.ok(item.row);
         rowCounter++;
@@ -1060,7 +1060,7 @@ function getFrameHeader(bodyLength, opcode, version, trace, streamId, warnings, 
  */
 function getBodyChunks(columnLength, rowLength, fromIndex, toIndex, cellValue, streamId) {
   let i;
-  var fullChunk = [
+  let fullChunk = [
     //kind
     0, 0, 0, types.resultKind.rows,
     //flags and column count
@@ -1116,8 +1116,8 @@ function getEventData(eventType, value) {
   //Port
   bodyArray.push(utils.allocBufferFromArray([0, 0, 0, 200]));
 
-  var body = Buffer.concat(bodyArray);
-  var header = new types.FrameHeader(2, 0, -1, types.opcodes.event, body.length);
+  const body = Buffer.concat(bodyArray);
+  const header = new types.FrameHeader(2, 0, -1, types.opcodes.event, body.length);
   return {header: header, chunk: body};
 }
 

--- a/test/unit/parser-tests.js
+++ b/test/unit/parser-tests.js
@@ -1,12 +1,12 @@
 'use strict';
-var assert = require('assert');
+const assert = require('assert');
 
-var Encoder = require('../../lib/encoder');
-var streams = require('../../lib/streams');
-var errors = require('../../lib/errors');
-var types = require('../../lib/types');
-var utils = require('../../lib/utils');
-var helper = require('../test-helper');
+const Encoder = require('../../lib/encoder');
+const streams = require('../../lib/streams');
+const errors = require('../../lib/errors');
+const types = require('../../lib/types');
+const utils = require('../../lib/utils');
+const helper = require('../test-helper');
 
 /**
  * Tests for the transform streams that are involved in the reading of a response
@@ -14,7 +14,7 @@ var helper = require('../test-helper');
 describe('Parser', function () {
   describe('#_transform()', function () {
     it('should read a READY opcode', function (done) {
-      var parser = newInstance();
+      const parser = newInstance();
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.bodyLength, 0);
@@ -24,7 +24,7 @@ describe('Parser', function () {
       parser._transform({header: getFrameHeader(0, types.opcodes.ready), chunk: utils.allocBufferFromArray([])}, null, doneIfError(done));
     });
     it('should read a AUTHENTICATE response', function (done) {
-      var parser = newInstance();
+      const parser = newInstance();
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.authenticate);
@@ -34,7 +34,7 @@ describe('Parser', function () {
       parser._transform({ header: getFrameHeader(2, types.opcodes.authenticate), chunk: utils.allocBufferFromArray([0, 0])}, null, doneIfError(done));
     });
     it('should buffer a AUTHENTICATE response until complete', function (done) {
-      var parser = newInstance();
+      const parser = newInstance();
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.authenticate);
@@ -49,7 +49,7 @@ describe('Parser', function () {
       parser._transform({ header: header, chunk: utils.allocBufferFromString('bc'), offset: 0}, null, doneIfError(done));
     });
     it('should read a VOID result', function (done) {
-      var parser = newInstance();
+      const parser = newInstance();
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.bodyLength, 4);
@@ -62,7 +62,7 @@ describe('Parser', function () {
       }, null, doneIfError(done));
     });
     it('should read a VOID result with trace id', function (done) {
-      var parser = newInstance();
+      const parser = newInstance();
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.bodyLength, 4);
@@ -79,8 +79,8 @@ describe('Parser', function () {
       }, null, doneIfError(done));
     });
     it('should read a VOID result with trace id chunked', function (done) {
-      var parser = newInstance();
-      var responseCounter = 0;
+      const parser = newInstance();
+      let responseCounter = 0;
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.result);
@@ -97,7 +97,7 @@ describe('Parser', function () {
       }, null, doneIfError(done));
       assert.strictEqual(responseCounter, 1);
       parser.setOptions(88, { byRow: true });
-      for (var i = 0; i < body.length; i++) {
+      for (let i = 0; i < body.length; i++) {
         parser._transform({
           header: getFrameHeader(4, types.opcodes.result, 2, true, 88),
           chunk: body.slice(i, i + 1),
@@ -108,8 +108,8 @@ describe('Parser', function () {
       done();
     });
     it('should read a RESULT result with trace id chunked', function (done) {
-      var parser = newInstance();
-      var responseCounter = 0;
+      const parser = newInstance();
+      let responseCounter = 0;
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.result);
@@ -127,7 +127,7 @@ describe('Parser', function () {
       }, null, doneIfError(done));
       assert.strictEqual(responseCounter, 1);
       parser.setOptions(88, { byRow: true });
-      for (var i = 0; i < body.length; i++) {
+      for (let i = 0; i < body.length; i++) {
         parser._transform({
           header: getFrameHeader(4, types.opcodes.result, 2, true, 88),
           chunk: body.slice(i, i + 1),
@@ -138,7 +138,7 @@ describe('Parser', function () {
       done();
     });
     it('should read a VOID result with warnings and custom payload', function (done) {
-      var parser = newInstance();
+      const parser = newInstance();
 
       var body = Buffer.concat([
         // 2 string list of warnings containing 'Hello', 'World'
@@ -170,7 +170,7 @@ describe('Parser', function () {
       }, null, doneIfError(done));
     });
     it('should read a SET_KEYSPACE result', function (done) {
-      var parser = newInstance();
+      const parser = newInstance();
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.result);
@@ -196,8 +196,8 @@ describe('Parser', function () {
       }, null, doneIfError(done));
     });
     it('should read a PREPARE result', function (done) {
-      var parser = newInstance();
-      var id = types.Uuid.random();
+      const parser = newInstance();
+      const id = types.Uuid.random();
       parser.on('readable', function () {
         var item = parser.read();
         assert.ifError(item.error);
@@ -235,7 +235,7 @@ describe('Parser', function () {
       }, null, doneIfError(done));
     });
     it('should read a STATUS_CHANGE UP EVENT response', function (done) {
-      var parser = newInstance();
+      const parser = newInstance();
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.event);
@@ -248,7 +248,7 @@ describe('Parser', function () {
       parser._transform(eventData, null, doneIfError(done));
     });
     it('should read a STATUS_CHANGE DOWN EVENT response', function (done) {
-      var parser = newInstance();
+      const parser = newInstance();
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.event);
@@ -261,7 +261,7 @@ describe('Parser', function () {
       parser._transform(eventData, null, doneIfError(done));
     });
     it('should read a STATUS_CHANGE DOWN EVENT response chunked', function (done) {
-      var parser = newInstance();
+      const parser = newInstance();
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.event);
@@ -277,7 +277,7 @@ describe('Parser', function () {
       parser._transform({header: eventData.header, chunk: chunk2, offset: 0}, null, doneIfError(done));
     });
     it('should read an ERROR response that includes warnings', function (done) {
-      var parser = newInstance();
+      const parser = newInstance();
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.error);
@@ -694,7 +694,7 @@ describe('Parser', function () {
       }, null, doneIfError(done));
     });
     it('should read a buffer until there is enough data', function (done) {
-      var parser = newInstance();
+      const parser = newInstance();
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.bodyLength, 4);
@@ -713,7 +713,7 @@ describe('Parser', function () {
       }, null, doneIfError(done));
     });
     it('should emit empty result one column no rows', function (done) {
-      var parser = newInstance();
+      const parser = newInstance();
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.result);
@@ -728,7 +728,7 @@ describe('Parser', function () {
       parser._transform(getBodyChunks(1, 0, 12, null), null, doneIfError(done));
     });
     it('should emit empty result two columns no rows', function (done) {
-      var parser = newInstance();
+      const parser = newInstance();
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.result);
@@ -739,9 +739,9 @@ describe('Parser', function () {
       parser._transform(getBodyChunks(2, 0, 0, null), null, doneIfError(done));
     });
     it('should emit row when rows present', function (done) {
-      var parser = newInstance();
+      const parser = newInstance();
       var rowLength = 2;
-      var rowCounter = 0;
+      let rowCounter = 0;
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.result);
@@ -758,10 +758,10 @@ describe('Parser', function () {
       parser._transform(getBodyChunks(3, rowLength, 37, null), null, doneIfError(done));
     });
     describe('with multiple chunk lengths', function () {
-      var parser = newInstance();
-      var result;
+      const parser = newInstance();
+      let result;
       parser.on('readable', function () {
-        var item;
+        let item;
         while ((item = parser.read())) {
           if (!item.row && item.frameEnded) {
             continue;
@@ -775,7 +775,7 @@ describe('Parser', function () {
       [1, 3, 5, 13].forEach(function (chunkLength) {
         it('should emit rows chunked with chunk length of ' + chunkLength, function () {
           result = {};
-          var expected = [
+          const expected = [
             { columnLength: 3, rowLength: 10 },
             { columnLength: 5, rowLength: 5 },
             { columnLength: 6, rowLength: 15 },
@@ -792,7 +792,7 @@ describe('Parser', function () {
               header: item.header,
               offset: 0
             };
-            for (var j = 0; j < item.chunk.length; j = j + chunkLength) {
+            for (let j = 0; j < item.chunk.length; j = j + chunkLength) {
               var end = j + chunkLength;
               if (end >= item.chunk.length) {
                 end = item.chunk.length;
@@ -811,7 +811,7 @@ describe('Parser', function () {
               parser._transform(chunkedItem, null, helper.throwop);
             }
           }
-          for (var i = 0; i < items.length; i++) {
+          for (let i = 0; i < items.length; i++) {
             transformChunkedItem(i);
           }
           //assert result
@@ -824,11 +824,11 @@ describe('Parser', function () {
     });
     describe('with multiple chunk lengths piped', function () {
       var protocol = new streams.Protocol({ objectMode: true });
-      var parser = newInstance();
+      const parser = newInstance();
       protocol.pipe(parser);
-      var result;
+      let result;
       parser.on('readable', function () {
-        var item;
+        let item;
         while ((item = parser.read())) {
           if (!item.row && item.frameEnded) {
             continue;
@@ -839,7 +839,7 @@ describe('Parser', function () {
           result[item.header.streamId].push(item.row);
         }
       });
-      var expected = [
+      const expected = [
         { columnLength: 3, rowLength: 10 },
         { columnLength: 5, rowLength: 5 },
         { columnLength: 6, rowLength: 15 },
@@ -849,13 +849,13 @@ describe('Parser', function () {
       [1, 2, 7, 11].forEach(function (chunkLength) {
         it('should emit rows chunked with chunk length of ' + chunkLength, function () {
           result = {};
-          var buffer = Buffer.concat(expected.map(function (expectedItem, index) {
+          const buffer = Buffer.concat(expected.map(function (expectedItem, index) {
             parser.setOptions(index, { byRow: true });
             var item = getBodyChunks(expectedItem.columnLength, expectedItem.rowLength, 0, null, null, index);
             return Buffer.concat([ item.header.toBuffer(), item.chunk ]);
           }));
 
-          for (var j = 0; j < buffer.length; j = j + chunkLength) {
+          for (let j = 0; j < buffer.length; j = j + chunkLength) {
             var end = j + chunkLength;
             if (end >= buffer.length) {
               end = buffer.length;
@@ -874,13 +874,13 @@ describe('Parser', function () {
     it('should emit row with large row values', function (done) {
       this.timeout(20000);
       //3mb value
-      var cellValue = helper.fillArray(3 * 1024 * 1024, 74);
+      let cellValue = helper.fillArray(3 * 1024 * 1024, 74);
       //Add the length 0x00300000 of the value
       cellValue = [0, 30, 0, 0].concat(cellValue);
-      var rowLength = 1;
+      const rowLength = 1;
       utils.series([function (next) {
-        var parser = newInstance();
-        var rowCounter = 0;
+        const parser = newInstance();
+        let rowCounter = 0;
         parser.on('readable', function () {
           var item = parser.read();
           assert.strictEqual(item.header.opcode, types.opcodes.result);
@@ -892,8 +892,8 @@ describe('Parser', function () {
         //1 columns, 1 row, 1 chunk
         parser._transform(getBodyChunks(1, rowLength, 0, null, cellValue), null, doneIfError(done));
       }, function (next) {
-        var parser = newInstance();
-        var rowCounter = 0;
+        const parser = newInstance();
+        let rowCounter = 0;
         parser.on('readable', function () {
           var item = parser.read();
           assert.strictEqual(item.header.opcode, types.opcodes.result);
@@ -906,8 +906,8 @@ describe('Parser', function () {
         parser._transform(getBodyChunks(1, rowLength, 0, 50, cellValue), null, doneIfError(done));
         parser._transform(getBodyChunks(1, rowLength, 50, null, cellValue), null, doneIfError(done));
       }, function (next) {
-        var parser = newInstance();
-        var rowCounter = 0;
+        const parser = newInstance();
+        let rowCounter = 0;
         parser.on('readable', function () {
           var item = parser.read();
           assert.strictEqual(item.header.opcode, types.opcodes.result);
@@ -924,11 +924,11 @@ describe('Parser', function () {
         parser._transform(getBodyChunks(1, rowLength, 195, 1501, cellValue), null, doneIfError(done));
         parser._transform(getBodyChunks(1, rowLength, 1501, null, cellValue), null, doneIfError(done));
       }, function (next) {
-        var cellValue = helper.fillArray(256, 74);
+        let cellValue = helper.fillArray(256, 74);
         //Add the length 256 of the value
         cellValue = [0, 0, 1, 0].concat(cellValue);
-        var parser = newInstance();
-        var rowCounter = 0;
+        const parser = newInstance();
+        let rowCounter = 0;
         parser.on('readable', function () {
           var item = parser.read();
           assert.strictEqual(item.header.opcode, types.opcodes.result);
@@ -944,11 +944,11 @@ describe('Parser', function () {
         parser._transform(getBodyChunks(1, rowLength, 150, 200, cellValue), null, doneIfError(done));
         parser._transform(getBodyChunks(1, rowLength, 200, null, cellValue), null, doneIfError(done));
       }, function (next) {
-        var cellValue = helper.fillArray(256, 74);
+        const cellValue = helper.fillArray(256, 74);
         //Add the length 256 of the value
         cellValue = [0, 0, 1, 0].concat(cellValue);
-        var parser = newInstance();
-        var rowCounter = 0;
+        const parser = newInstance();
+        let rowCounter = 0;
         parser.on('readable', function () {
           var item = parser.read();
           assert.strictEqual(item.header.opcode, types.opcodes.result);
@@ -965,7 +965,7 @@ describe('Parser', function () {
       }], done);
     });
     it('should read a AUTH_CHALLENGE response', function (done) {
-      var parser = newInstance();
+      const parser = newInstance();
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.authChallenge);
@@ -987,7 +987,7 @@ describe('Parser', function () {
       }, null, doneIfError(done));
     });
     it('should buffer ERROR response until complete', function (done) {
-      var parser = newInstance();
+      const parser = newInstance();
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.error);
@@ -1006,9 +1006,9 @@ describe('Parser', function () {
       parser._transform({ header: header, chunk: utils.allocBufferFromString('ERR'), offset: 0}, null, doneIfError(done));
     });
     it('should not buffer RESULT ROWS response when byRow is enabled', function (done) {
-      var parser = newInstance();
+      const parser = newInstance();
       var rowLength = 2;
-      var rowCounter = 0;
+      let rowCounter = 0;
       parser.on('readable', function () {
         var item = parser.read();
         assert.strictEqual(item.header.opcode, types.opcodes.result);
@@ -1048,7 +1048,7 @@ function getFrameHeader(bodyLength, opcode, version, trace, streamId, warnings, 
   if (typeof streamId === 'undefined') {
     streamId = 12;
   }
-  var flags = 0;
+  let flags = 0;
   flags += (trace ? 0x2 : 0x0);
   flags += (customPayload ? 0x4 : 0x0);
   flags += (warnings ? 0x8 : 0x0);
@@ -1059,7 +1059,7 @@ function getFrameHeader(bodyLength, opcode, version, trace, streamId, warnings, 
  * @returns {{header: FrameHeader, chunk: Buffer, offset: number}}
  */
 function getBodyChunks(columnLength, rowLength, fromIndex, toIndex, cellValue, streamId) {
-  var i;
+  let i;
   var fullChunk = [
     //kind
     0, 0, 0, types.resultKind.rows,
@@ -1078,8 +1078,8 @@ function getBodyChunks(columnLength, rowLength, fromIndex, toIndex, cellValue, s
   //rows length
   fullChunk = fullChunk.concat([0, 0, 0, rowLength || 0]);
   for (i = 0; i < rowLength; i++) {
-    var rowChunk = [];
-    for (var j = 0; j < columnLength; j++) {
+    let rowChunk = [];
+    for (let j = 0; j < columnLength; j++) {
       //4 bytes length + bytes of each column value
       if (!cellValue) {
         rowChunk.push(0);
@@ -1104,7 +1104,7 @@ function getBodyChunks(columnLength, rowLength, fromIndex, toIndex, cellValue, s
 }
 
 function getEventData(eventType, value) {
-  var bodyArray = [];
+  const bodyArray = [];
   //EVENT TYPE
   bodyArray.push(utils.allocBufferFromArray([0, eventType.length]));
   bodyArray.push(utils.allocBufferFromString(eventType));

--- a/test/unit/prepare-handler-tests.js
+++ b/test/unit/prepare-handler-tests.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var assert = require('assert');
-var events = require('events');
-var helper = require('../test-helper');
-var PrepareHandler = require('../../lib/prepare-handler');
-var defaultOptions = require('../../lib/client-options').defaultOptions;
-var types = require('../../lib/types');
-var utils = require('../../lib/utils');
+const assert = require('assert');
+const events = require('events');
+const helper = require('../test-helper');
+const PrepareHandler = require('../../lib/prepare-handler');
+const defaultOptions = require('../../lib/client-options').defaultOptions;
+const types = require('../../lib/types');
+const utils = require('../../lib/utils');
 
 describe('PrepareHandler', function () {
   describe('getPrepared()', function () {
     it('should make request when not already prepared', function (done) {
-      var client = getClient({ prepareOnAllHosts: false });
-      var lbp = helper.getLoadBalancingPolicyFake([ { isUp: false }, { ignored: true }, {}, {} ]);
+      const client = getClient({ prepareOnAllHosts: false });
+      const lbp = helper.getLoadBalancingPolicyFake([ { isUp: false }, { ignored: true }, {}, {} ]);
       PrepareHandler.getPrepared(client, lbp, 'SELECT QUERY', null, function (err) {
         assert.ifError(err);
         var hosts = lbp.getFixedQueryPlan();
@@ -22,8 +22,8 @@ describe('PrepareHandler', function () {
       });
     });
     it('should make the same prepare request once and queue the rest', function (done) {
-      var client = getClient();
-      var lbp = helper.getLoadBalancingPolicyFake([ { } ]);
+      const client = getClient();
+      const lbp = helper.getLoadBalancingPolicyFake([ { } ]);
       utils.times(100, function (n, next) {
         PrepareHandler.getPrepared(client, lbp, 'SELECT QUERY', null, next);
       }, function (err) {
@@ -34,8 +34,8 @@ describe('PrepareHandler', function () {
       });
     });
     it('should callback in error if request send fails', function (done) {
-      var client = getClient();
-      var lbp = helper.getLoadBalancingPolicyFake([ {} ], function (q, h, cb) {
+      const client = getClient();
+      const lbp = helper.getLoadBalancingPolicyFake([ {} ], function (q, h, cb) {
         cb(new Error('Test prepare error'));
       });
       PrepareHandler.getPrepared(client, lbp, 'SELECT QUERY', null, function (err) {
@@ -46,8 +46,8 @@ describe('PrepareHandler', function () {
       });
     });
     it('should retry on next host if request send fails due to socket error', function (done) {
-      var client = getClient();
-      var lbp = helper.getLoadBalancingPolicyFake([ {}, {} ], function (q, h, cb) {
+      const client = getClient();
+      const lbp = helper.getLoadBalancingPolicyFake([ {}, {} ], function (q, h, cb) {
         if (h.address === '0') {
           var err = new Error('Test prepare error');
           err.isSocketError = true;
@@ -64,8 +64,8 @@ describe('PrepareHandler', function () {
       });
     });
     it('should prepare on all UP hosts not ignored', function (done) {
-      var client = getClient({ prepareOnAllHosts: true });
-      var lbp = helper.getLoadBalancingPolicyFake([ { isUp: false }, {}, {}, { ignored: true }, {} ]);
+      const client = getClient({ prepareOnAllHosts: true });
+      const lbp = helper.getLoadBalancingPolicyFake([ { isUp: false }, {}, {}, { ignored: true }, {} ]);
       PrepareHandler.getPrepared(client, lbp, 'SELECT QUERY', null, function (err) {
         assert.ifError(err);
         var hosts = lbp.getFixedQueryPlan();
@@ -80,7 +80,7 @@ describe('PrepareHandler', function () {
   });
   describe('prepareAllQueries', function () {
     it('should switch keyspace per each keyspace and execute', function (done) {
-      var host = helper.getHostsMock([ {} ])[0];
+      const host = helper.getHostsMock([ {} ])[0];
       var preparedInfoArray = [
         { keyspace: 'system', query: 'query1' },
         { keyspace: 'system_schema', query: 'query2' },
@@ -99,7 +99,7 @@ describe('PrepareHandler', function () {
       PrepareHandler.prepareAllQueries({}, [], done);
     });
     it('should callback in error when there is an error borrowing a connection', function (done) {
-      var host = helper.getHostsMock([ {} ])[0];
+      const host = helper.getHostsMock([ {} ])[0];
       host.borrowConnection = function (cb) {
         cb(new Error('Test error'));
       };
@@ -115,7 +115,7 @@ describe('PrepareHandler', function () {
         }
         cb();
       }
-      var host = helper.getHostsMock([ {} ], prepareOnce)[0];
+      const host = helper.getHostsMock([ {} ], prepareOnce)[0];
       var preparedInfoArray = [
         { keyspace: 'system', query: 'query1' },
         { keyspace: null, query: 'query2' },

--- a/test/unit/prepare-handler-tests.js
+++ b/test/unit/prepare-handler-tests.js
@@ -15,7 +15,7 @@ describe('PrepareHandler', function () {
       const lbp = helper.getLoadBalancingPolicyFake([ { isUp: false }, { ignored: true }, {}, {} ]);
       PrepareHandler.getPrepared(client, lbp, 'SELECT QUERY', null, function (err) {
         assert.ifError(err);
-        var hosts = lbp.getFixedQueryPlan();
+        const hosts = lbp.getFixedQueryPlan();
         assert.strictEqual(hosts[2].prepareCalled, 1);
         assert.strictEqual(hosts[3].prepareCalled, 0);
         done();
@@ -28,7 +28,7 @@ describe('PrepareHandler', function () {
         PrepareHandler.getPrepared(client, lbp, 'SELECT QUERY', null, next);
       }, function (err) {
         assert.ifError(err);
-        var hosts = lbp.getFixedQueryPlan();
+        const hosts = lbp.getFixedQueryPlan();
         assert.strictEqual(hosts[0].prepareCalled, 1);
         done();
       });
@@ -40,7 +40,7 @@ describe('PrepareHandler', function () {
       });
       PrepareHandler.getPrepared(client, lbp, 'SELECT QUERY', null, function (err) {
         assert.ok(err);
-        var host = lbp.getFixedQueryPlan()[0];
+        const host = lbp.getFixedQueryPlan()[0];
         assert.strictEqual(host.prepareCalled, 1);
         done();
       });
@@ -49,7 +49,7 @@ describe('PrepareHandler', function () {
       const client = getClient();
       const lbp = helper.getLoadBalancingPolicyFake([ {}, {} ], function (q, h, cb) {
         if (h.address === '0') {
-          var err = new Error('Test prepare error');
+          const err = new Error('Test prepare error');
           err.isSocketError = true;
           return cb(err);
         }
@@ -57,7 +57,7 @@ describe('PrepareHandler', function () {
       });
       PrepareHandler.getPrepared(client, lbp, 'SELECT QUERY', null, function (err) {
         assert.ifError(err);
-        var hosts = lbp.getFixedQueryPlan();
+        const hosts = lbp.getFixedQueryPlan();
         assert.strictEqual(hosts[0].prepareCalled, 1);
         assert.strictEqual(hosts[1].prepareCalled, 1);
         done();
@@ -68,7 +68,7 @@ describe('PrepareHandler', function () {
       const lbp = helper.getLoadBalancingPolicyFake([ { isUp: false }, {}, {}, { ignored: true }, {} ]);
       PrepareHandler.getPrepared(client, lbp, 'SELECT QUERY', null, function (err) {
         assert.ifError(err);
-        var hosts = lbp.getFixedQueryPlan();
+        const hosts = lbp.getFixedQueryPlan();
         assert.strictEqual(hosts[1].prepareCalled, 1);
         assert.strictEqual(hosts[2].prepareCalled, 1);
         assert.strictEqual(hosts[4].prepareCalled, 1);
@@ -81,7 +81,7 @@ describe('PrepareHandler', function () {
   describe('prepareAllQueries', function () {
     it('should switch keyspace per each keyspace and execute', function (done) {
       const host = helper.getHostsMock([ {} ])[0];
-      var preparedInfoArray = [
+      const preparedInfoArray = [
         { keyspace: 'system', query: 'query1' },
         { keyspace: 'system_schema', query: 'query2' },
         { keyspace: null, query: 'query3' },
@@ -116,7 +116,7 @@ describe('PrepareHandler', function () {
         cb();
       }
       const host = helper.getHostsMock([ {} ], prepareOnce)[0];
-      var preparedInfoArray = [
+      const preparedInfoArray = [
         { keyspace: 'system', query: 'query1' },
         { keyspace: null, query: 'query2' },
         { keyspace: 'system', query: 'query3' }
@@ -136,7 +136,7 @@ function getClient(options) {
     metadata: {
       _infos: {},
       getPreparedInfo: function (ks, q) {
-        var info = this._infos[ks + '.' + q];
+        let info = this._infos[ks + '.' + q];
         if (!info) {
           info = this._infos[ks + '.' + q] = new events.EventEmitter();
         }

--- a/test/unit/protocol-stream-tests.js
+++ b/test/unit/protocol-stream-tests.js
@@ -44,7 +44,7 @@ describe('Protocol', function () {
         items.push(item);
       }
     });
-    var bodyLengths = [ 0, 10, 0, 20, 30, 0];
+    const bodyLengths = [ 0, 10, 0, 20, 30, 0];
     const buffer = generateBuffer(4, bodyLengths);
     p.readItems(buffer);
     assert.strictEqual(items.length, bodyLengths.length);
@@ -62,7 +62,7 @@ describe('Protocol', function () {
         items[item.header.streamId].push(item);
       }
     });
-    var bodyLengths = [ 0, 10, 0, 20, 30, 0];
+    const bodyLengths = [ 0, 10, 0, 20, 30, 0];
     const buffer = generateBuffer(4, bodyLengths);
     p.readItems(buffer.slice(0, 9));
     p.readItems(buffer.slice(9, 31));
@@ -71,10 +71,10 @@ describe('Protocol', function () {
     p.readItems(buffer.slice(45, 65));
     p.readItems(buffer.slice(65));
     bodyLengths.forEach(function (length, index) {
-      var item = items[index];
+      const item = items[index];
       assert.ok(item);
       assert.ok(item.length);
-      var sumLength = item.reduce(function (previousValue, subItem) {
+      const sumLength = item.reduce(function (previousValue, subItem) {
         return previousValue + subItem.chunk.length - subItem.offset;
       }, 0);
       assert.ok(sumLength >= length, sumLength + ' >= ' + length + ' failed');
@@ -90,7 +90,7 @@ describe('Protocol', function () {
         items[item.header.streamId].push(item);
       }
     });
-    var bodyLengths = [ 0, 10, 15, 15, 20, 12, 0, 6];
+    const bodyLengths = [ 0, 10, 15, 15, 20, 12, 0, 6];
     const buffer = generateBuffer(4, bodyLengths);
     for (let i = 0; i < buffer.length; i = i + 2) {
       if (i + 2 > buffer.length) {
@@ -100,10 +100,10 @@ describe('Protocol', function () {
       p.readItems(buffer.slice(i, i + 2));
     }
     bodyLengths.forEach(function (length, index) {
-      var item = items[index];
+      const item = items[index];
       assert.ok(item);
       assert.ok(item.length);
-      var sumLength = item.reduce(function (previousValue, subItem) {
+      const sumLength = item.reduce(function (previousValue, subItem) {
         return previousValue + subItem.chunk.length - subItem.offset;
       }, 0);
       assert.ok(sumLength >= length, sumLength + ' >= ' + length + ' failed');
@@ -117,8 +117,8 @@ describe('Protocol', function () {
  * @returns {Buffer}
  */
 function generateBuffer(version, frameBodyLengths) {
-  var buffers = frameBodyLengths.map(function (bodyLength, index) {
-    var header = new types.FrameHeader(version, 0, index, 0, bodyLength);
+  const buffers = frameBodyLengths.map(function (bodyLength, index) {
+    const header = new types.FrameHeader(version, 0, index, 0, bodyLength);
     return Buffer.concat([ header.toBuffer(), utils.allocBuffer(bodyLength) ]);
   });
   return Buffer.concat(buffers);

--- a/test/unit/protocol-stream-tests.js
+++ b/test/unit/protocol-stream-tests.js
@@ -1,51 +1,51 @@
 'use strict';
-var assert = require('assert');
+const assert = require('assert');
 
-var Protocol = require('../../lib/streams').Protocol;
-var types = require('../../lib/types');
-var utils = require('../../lib/utils');
+const Protocol = require('../../lib/streams').Protocol;
+const types = require('../../lib/types');
+const utils = require('../../lib/utils');
 
 describe('Protocol', function () {
   it('should emit a single frame with 0-length body', function () {
-    var p = newInstance();
-    var items = [];
+    const p = newInstance();
+    const items = [];
     p.on('readable', function () {
-      var item;
+      let item;
       while ((item = p.read())) {
         items.push(item);
       }
     });
-    var buffer = generateBuffer(4, [ 0 ]);
+    const buffer = generateBuffer(4, [ 0 ]);
     p.readItems(buffer);
     assert.strictEqual(items.length, 1);
     assert.strictEqual(items[0].header.bodyLength, 0);
   });
   it('should emit a single frame with 0-length body chunked', function () {
-    var p = newInstance();
-    var items = [];
+    const p = newInstance();
+    const items = [];
     p.on('readable', function () {
-      var item;
+      let item;
       while ((item = p.read())) {
         items.push(item);
       }
     });
-    var buffer = generateBuffer(4, [ 0 ]);
+    const buffer = generateBuffer(4, [ 0 ]);
     p.readItems(buffer.slice(0, 2));
     p.readItems(buffer.slice(2));
     assert.strictEqual(items.length, 1);
     assert.strictEqual(items[0].header.bodyLength, 0);
   });
   it('should emit multiple frames from a single chunk', function () {
-    var p = newInstance();
-    var items = [];
+    const p = newInstance();
+    const items = [];
     p.on('readable', function () {
-      var item;
+      let item;
       while ((item = p.read())) {
         items.push(item);
       }
     });
     var bodyLengths = [ 0, 10, 0, 20, 30, 0];
-    var buffer = generateBuffer(4, bodyLengths);
+    const buffer = generateBuffer(4, bodyLengths);
     p.readItems(buffer);
     assert.strictEqual(items.length, bodyLengths.length);
     bodyLengths.forEach(function (length, index) {
@@ -53,17 +53,17 @@ describe('Protocol', function () {
     });
   });
   it('should emit multiple frames from multiples chunks', function () {
-    var p = newInstance();
-    var items = {};
+    const p = newInstance();
+    const items = {};
     p.on('readable', function () {
-      var item;
+      let item;
       while ((item = p.read())) {
         items[item.header.streamId] = items[item.header.streamId] || [];
         items[item.header.streamId].push(item);
       }
     });
     var bodyLengths = [ 0, 10, 0, 20, 30, 0];
-    var buffer = generateBuffer(4, bodyLengths);
+    const buffer = generateBuffer(4, bodyLengths);
     p.readItems(buffer.slice(0, 9));
     p.readItems(buffer.slice(9, 31));
     p.readItems(buffer.slice(31, 33));
@@ -81,18 +81,18 @@ describe('Protocol', function () {
     });
   });
   it('should emit multiple frames from multiples small chunks', function () {
-    var p = newInstance();
-    var items = {};
+    const p = newInstance();
+    const items = {};
     p.on('readable', function () {
-      var item;
+      let item;
       while ((item = p.read())) {
         items[item.header.streamId] = items[item.header.streamId] || [];
         items[item.header.streamId].push(item);
       }
     });
     var bodyLengths = [ 0, 10, 15, 15, 20, 12, 0, 6];
-    var buffer = generateBuffer(4, bodyLengths);
-    for (var i = 0; i < buffer.length; i = i + 2) {
+    const buffer = generateBuffer(4, bodyLengths);
+    for (let i = 0; i < buffer.length; i = i + 2) {
       if (i + 2 > buffer.length) {
         p.readItems(buffer.slice(i));
         break;

--- a/test/unit/reconnection-test.js
+++ b/test/unit/reconnection-test.js
@@ -1,16 +1,16 @@
 'use strict';
-var assert = require('assert');
+const assert = require('assert');
 //project modules
-var utils = require('../../lib/utils');
-var reconnection = require('../../lib/policies/reconnection');
+const utils = require('../../lib/utils');
+const reconnection = require('../../lib/policies/reconnection');
 
 describe('ConstantReconnectionPolicy', function () {
   it('should yield the same wait time', function (done) {
     var delay = 2000;
-    var policy = new reconnection.ConstantReconnectionPolicy(delay);
+    const policy = new reconnection.ConstantReconnectionPolicy(delay);
     utils.times(100, function (n, next) {
       var schedule = policy.newSchedule();
-      for (var i = 0; i < 5; i++) {
+      for (let i = 0; i < 5; i++) {
         assert.strictEqual(schedule.next().value, delay);
       }
       next();
@@ -23,10 +23,10 @@ describe('ExponentialReconnectionPolicy', function () {
   it('should exponentially grow the wait time', function (done) {
     var baseDelay = 1000;
     var maxDelay = 256000;
-    var policy = new reconnection.ExponentialReconnectionPolicy(baseDelay, maxDelay, false);
+    const policy = new reconnection.ExponentialReconnectionPolicy(baseDelay, maxDelay, false);
     utils.times(1, function (n, next) {
       var schedule = policy.newSchedule();
-      for (var i = 0; i < 8; i++) {
+      for (let i = 0; i < 8; i++) {
         assert.strictEqual(schedule.next().value, Math.pow(2, i + 1) * baseDelay);
       }
       for (var j = 8; j < 30; j++) {

--- a/test/unit/reconnection-test.js
+++ b/test/unit/reconnection-test.js
@@ -6,10 +6,10 @@ const reconnection = require('../../lib/policies/reconnection');
 
 describe('ConstantReconnectionPolicy', function () {
   it('should yield the same wait time', function (done) {
-    var delay = 2000;
+    const delay = 2000;
     const policy = new reconnection.ConstantReconnectionPolicy(delay);
     utils.times(100, function (n, next) {
-      var schedule = policy.newSchedule();
+      const schedule = policy.newSchedule();
       for (let i = 0; i < 5; i++) {
         assert.strictEqual(schedule.next().value, delay);
       }
@@ -21,15 +21,15 @@ describe('ConstantReconnectionPolicy', function () {
 
 describe('ExponentialReconnectionPolicy', function () {
   it('should exponentially grow the wait time', function (done) {
-    var baseDelay = 1000;
-    var maxDelay = 256000;
+    const baseDelay = 1000;
+    const maxDelay = 256000;
     const policy = new reconnection.ExponentialReconnectionPolicy(baseDelay, maxDelay, false);
     utils.times(1, function (n, next) {
-      var schedule = policy.newSchedule();
+      const schedule = policy.newSchedule();
       for (let i = 0; i < 8; i++) {
         assert.strictEqual(schedule.next().value, Math.pow(2, i + 1) * baseDelay);
       }
-      for (var j = 8; j < 30; j++) {
+      for (let j = 8; j < 30; j++) {
         assert.strictEqual(schedule.next().value, maxDelay);
       }
       next();

--- a/test/unit/request-handler-tests.js
+++ b/test/unit/request-handler-tests.js
@@ -15,11 +15,11 @@ const OperationState = require('../../lib/operation-state');
 const defaultOptions = require('../../lib/client-options').defaultOptions;
 
 describe('RequestHandler', function () {
-  var queryRequest = new requests.QueryRequest('QUERY1');
+  const queryRequest = new requests.QueryRequest('QUERY1');
   describe('#send()', function () {
     it('should return a ResultSet', function (done) {
       const lbp = helper.getLoadBalancingPolicyFake([ {}, {} ]);
-      var handler = newInstance(queryRequest, null, lbp);
+      const handler = newInstance(queryRequest, null, lbp);
       handler.send(function (err, result) {
         assert.ifError(err);
         helper.assertInstanceOf(result, types.ResultSet);
@@ -33,10 +33,10 @@ describe('RequestHandler', function () {
         }
         cb(null, {});
       });
-      var handler = newInstance(queryRequest, null, lbp, new TestRetryPolicy());
+      const handler = newInstance(queryRequest, null, lbp, new TestRetryPolicy());
       handler.send(function (err) {
         helper.assertInstanceOf(err, Error);
-        var hosts = lbp.getFixedQueryPlan();
+        const hosts = lbp.getFixedQueryPlan();
         assert.strictEqual(hosts[0].sendStreamCalled, 1);
         assert.strictEqual(hosts[1].sendStreamCalled, 0);
         done();
@@ -49,12 +49,12 @@ describe('RequestHandler', function () {
         }
         cb(null, {});
       });
-      var retryPolicy = new TestRetryPolicy();
-      var handler = newInstance(queryRequest, null, lbp, retryPolicy);
+      const retryPolicy = new TestRetryPolicy();
+      const handler = newInstance(queryRequest, null, lbp, retryPolicy);
       handler.send(function (err, result) {
         assert.ifError(err);
         helper.assertInstanceOf(result, types.ResultSet);
-        var hosts = lbp.getFixedQueryPlan();
+        const hosts = lbp.getFixedQueryPlan();
         assert.strictEqual(hosts[0].sendStreamCalled, 1);
         assert.strictEqual(hosts[1].sendStreamCalled, 1);
         assert.strictEqual(retryPolicy.writeTimeoutErrors.length, 1);
@@ -68,11 +68,11 @@ describe('RequestHandler', function () {
         }
         cb(null, {});
       });
-      var retryPolicy = new TestRetryPolicy(false);
-      var handler = newInstance(queryRequest, null, lbp, retryPolicy);
+      const retryPolicy = new TestRetryPolicy(false);
+      const handler = newInstance(queryRequest, null, lbp, retryPolicy);
       handler.send(function (err) {
         helper.assertInstanceOf(err, errors.OperationTimedOutError);
-        var hosts = lbp.getFixedQueryPlan();
+        const hosts = lbp.getFixedQueryPlan();
         assert.strictEqual(hosts[0].sendStreamCalled, 1);
         assert.strictEqual(hosts[1].sendStreamCalled, 0);
         assert.strictEqual(retryPolicy.requestErrors.length, 1);
@@ -81,24 +81,24 @@ describe('RequestHandler', function () {
     });
     context('when an UNPREPARED response is obtained', function () {
       it('should send a prepare request on the same connection', function (done) {
-        var queryId = utils.allocBufferFromString('123');
+        const queryId = utils.allocBufferFromString('123');
         const lbp = helper.getLoadBalancingPolicyFake([ {}, {} ], undefined, function sendCallback(r, h, cb) {
           if (h.sendStreamCalled === 1) {
             // Its the first request, send an error
-            var err = new errors.ResponseError(types.responseErrorCodes.unprepared, 'Test error');
+            const err = new errors.ResponseError(types.responseErrorCodes.unprepared, 'Test error');
             err.queryId = queryId;
             return cb(err);
           }
           cb(null, { });
         });
-        var hosts = lbp.getFixedQueryPlan();
+        const hosts = lbp.getFixedQueryPlan();
         const client = newClient({
           getPreparedById: function (id) {
             return { query: 'QUERY1', id: id };
           }
         }, lbp);
-        var request = new requests.ExecuteRequest('QUERY1', queryId, [], {});
-        var handler = newInstance(request, client, lbp);
+        const request = new requests.ExecuteRequest('QUERY1', queryId, [], {});
+        const handler = newInstance(request, client, lbp);
         handler.send(function (err, response) {
           assert.ifError(err);
           assert.ok(response);
@@ -110,7 +110,7 @@ describe('RequestHandler', function () {
         });
       });
       it('should move to next host when PREPARE response is an error', function (done) {
-        var queryId = utils.allocBufferFromString('123');
+        const queryId = utils.allocBufferFromString('123');
         const lbp = helper.getLoadBalancingPolicyFake([ {}, {} ], function prepareCallback(q, h, cb) {
           if (h.address === '0') {
             return cb(new Error('Test error'));
@@ -119,20 +119,20 @@ describe('RequestHandler', function () {
         }, function sendFake(r, h, cb) {
           if (h.sendStreamCalled === 1) {
             // Its the first request, send an error
-            var err = new errors.ResponseError(types.responseErrorCodes.unprepared, 'Test error');
+            const err = new errors.ResponseError(types.responseErrorCodes.unprepared, 'Test error');
             err.queryId = queryId;
             return cb(err);
           }
           cb(null, { });
         });
-        var hosts = lbp.getFixedQueryPlan();
+        const hosts = lbp.getFixedQueryPlan();
         const client = newClient({
           getPreparedById: function (id) {
             return { query: 'QUERY1', id: id };
           }
         }, lbp);
-        var request = new requests.ExecuteRequest('QUERY1', queryId, [], {});
-        var handler = newInstance(request, client, lbp);
+        const request = new requests.ExecuteRequest('QUERY1', queryId, [], {});
+        const handler = newInstance(request, client, lbp);
         handler.send(function (err, response) {
           assert.ifError(err);
           assert.ok(response);
@@ -147,7 +147,7 @@ describe('RequestHandler', function () {
     context('with speculative executions', function () {
       it('should use the query plan to use next hosts as coordinators', function (done) {
         const lbp = helper.getLoadBalancingPolicyFake([ {}, {}, {}], undefined, function sendStreamCb(r, h, cb) {
-          var op = new OperationState(r, null, cb);
+          const op = new OperationState(r, null, cb);
           if (h.address !== '2') {
             setTimeout(function () {
               op.setResult(null, {});
@@ -160,14 +160,14 @@ describe('RequestHandler', function () {
         const client = newClient(null, lbp);
         client.options.policies.speculativeExecution =
           new speculativeExecution.ConstantSpeculativeExecutionPolicy(20, 2);
-        var handler = newInstance(queryRequest, client, lbp, null, true);
+        const handler = newInstance(queryRequest, client, lbp, null, true);
         handler.send(function (err, result) {
           assert.ifError(err);
           helper.assertInstanceOf(result, types.ResultSet);
           // Used the third host to get the response
           assert.strictEqual(result.info.queriedHost, '2');
           assert.deepEqual(Object.keys(result.info.triedHosts), [ '0', '1', '2' ]);
-          var hosts = lbp.getFixedQueryPlan();
+          const hosts = lbp.getFixedQueryPlan();
           assert.strictEqual(hosts[0].sendStreamCalled, 1);
           assert.strictEqual(hosts[1].sendStreamCalled, 1);
           assert.strictEqual(hosts[2].sendStreamCalled, 1);
@@ -176,7 +176,7 @@ describe('RequestHandler', function () {
       });
       it('should use the query plan to use next hosts as coordinators with zero delay', function (done) {
         const lbp = helper.getLoadBalancingPolicyFake([ {}, {} ], undefined, function sendStreamCb(r, h, cb) {
-          var op = new OperationState(r, null, cb);
+          const op = new OperationState(r, null, cb);
           if (h.address !== '1') {
             setTimeout(function () {
               op.setResult(null, {});
@@ -189,14 +189,14 @@ describe('RequestHandler', function () {
         const client = newClient(null, lbp);
         client.options.policies.speculativeExecution =
           new speculativeExecution.ConstantSpeculativeExecutionPolicy(0, 2);
-        var handler = newInstance(queryRequest, client, lbp, null, true);
+        const handler = newInstance(queryRequest, client, lbp, null, true);
         handler.send(function (err, result) {
           assert.ifError(err);
           helper.assertInstanceOf(result, types.ResultSet);
           // Used the second host to get the response
           assert.strictEqual(result.info.queriedHost, '1');
           assert.deepEqual(Object.keys(result.info.triedHosts), [ '0', '1' ]);
-          var hosts = lbp.getFixedQueryPlan();
+          const hosts = lbp.getFixedQueryPlan();
           assert.strictEqual(hosts[0].sendStreamCalled, 1);
           assert.strictEqual(hosts[1].sendStreamCalled, 1);
           done();
@@ -204,7 +204,7 @@ describe('RequestHandler', function () {
       });
       it('should callback in error when any of execution responses is an error that cant be retried', function (done) {
         const lbp = helper.getLoadBalancingPolicyFake([ {}, {}, {}], undefined, function sendStreamCb(r, h, cb) {
-          var op = new OperationState(r, null, cb);
+          const op = new OperationState(r, null, cb);
           if (h.address !== '0') {
             setTimeout(function () {
               op.setResult(null, {});
@@ -220,10 +220,10 @@ describe('RequestHandler', function () {
         const client = newClient(null, lbp);
         client.options.policies.speculativeExecution =
           new speculativeExecution.ConstantSpeculativeExecutionPolicy(20, 2);
-        var handler = newInstance(queryRequest, client, lbp, null, true);
+        const handler = newInstance(queryRequest, client, lbp, null, true);
         handler.send(function (err) {
           helper.assertInstanceOf(err, Error);
-          var hosts = lbp.getFixedQueryPlan();
+          const hosts = lbp.getFixedQueryPlan();
           // 3 hosts were queried but the first responded with an error
           assert.strictEqual(hosts[0].sendStreamCalled, 1);
           assert.strictEqual(hosts[1].sendStreamCalled, 1);

--- a/test/unit/requests-test.js
+++ b/test/unit/requests-test.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var assert = require('assert');
-var requests = require('../../lib/requests');
-var Encoder = require('../../lib/encoder');
-var types = require('../../lib/types');
-var utils = require('../../lib/utils');
+const assert = require('assert');
+const requests = require('../../lib/requests');
+const Encoder = require('../../lib/encoder');
+const types = require('../../lib/types');
+const utils = require('../../lib/utils');
 var QueryRequest = requests.QueryRequest;
 var ExecuteRequest = requests.ExecuteRequest;
 var BatchRequest = requests.BatchRequest;
-var encoder = new Encoder(types.protocolVersion.maxSupported, {});
+const encoder = new Encoder(types.protocolVersion.maxSupported, {});
 
 describe('QueryRequest', function () {
   describe('#clone()', function () {

--- a/test/unit/requests-test.js
+++ b/test/unit/requests-test.js
@@ -5,28 +5,28 @@ const requests = require('../../lib/requests');
 const Encoder = require('../../lib/encoder');
 const types = require('../../lib/types');
 const utils = require('../../lib/utils');
-var QueryRequest = requests.QueryRequest;
-var ExecuteRequest = requests.ExecuteRequest;
-var BatchRequest = requests.BatchRequest;
+const QueryRequest = requests.QueryRequest;
+const ExecuteRequest = requests.ExecuteRequest;
+const BatchRequest = requests.BatchRequest;
 const encoder = new Encoder(types.protocolVersion.maxSupported, {});
 
 describe('QueryRequest', function () {
   describe('#clone()', function () {
-    var request = new QueryRequest('Q1', [ 1, 2 ], { consistency: 1, hints: [] });
+    const request = new QueryRequest('Q1', [ 1, 2 ], { consistency: 1, hints: [] });
     testClone(request);
   });
 });
 
 describe('ExecuteRequest', function () {
   describe('#clone()', function () {
-    var request = new ExecuteRequest('Q1', utils.allocBufferFromString('Q1'), [ 1, 2], { });
+    const request = new ExecuteRequest('Q1', utils.allocBufferFromString('Q1'), [ 1, 2], { });
     testClone(request);
   });
 });
 
 describe('BatchRequest', function () {
   describe('#clone()', function () {
-    var request = new BatchRequest([
+    const request = new BatchRequest([
       { query: 'Q1', params: [] },
       { query: 'Q2', params: [] }
     ], { logged: false, consistency: 1 });
@@ -36,14 +36,14 @@ describe('BatchRequest', function () {
 
 function testClone(request) {
   it('should return a new instance with the same properties', function () {
-    var cloned = request.clone();
+    const cloned = request.clone();
     assert.notStrictEqual(request, cloned);
     Object.keys(request).forEach(function (key) {
       assert.strictEqual(request[key], cloned[key]);
     });
   });
   it('should generate the same buffer', function () {
-    var cloned = request.clone();
+    const cloned = request.clone();
     assert.strictEqual(
       request.write(encoder, 1).toString(),
       cloned.write(encoder, 1).toString()

--- a/test/unit/result-set-tests.js
+++ b/test/unit/result-set-tests.js
@@ -1,8 +1,8 @@
 "use strict";
 
-var assert = require('assert');
-var types = require('../../lib/types');
-var ResultSet = types.ResultSet;
+const assert = require('assert');
+const types = require('../../lib/types');
+const ResultSet = types.ResultSet;
 
 describe('ResultSet', function () {
   describe('constructor', function () {

--- a/test/unit/result-set-tests.js
+++ b/test/unit/result-set-tests.js
@@ -7,8 +7,8 @@ const ResultSet = types.ResultSet;
 describe('ResultSet', function () {
   describe('constructor', function () {
     it('should set the properties', function () {
-      var response = { rows: [ 0, 1, 2 ] };
-      var result = new ResultSet(response, '192.168.1.100', {}, 1, types.consistencies.three);
+      const response = { rows: [ 0, 1, 2 ] };
+      const result = new ResultSet(response, '192.168.1.100', {}, 1, types.consistencies.three);
       assert.strictEqual(result.rowLength, 3);
       assert.ok(result.info);
       assert.strictEqual(result.info.queriedHost, '192.168.1.100');
@@ -20,20 +20,20 @@ describe('ResultSet', function () {
   });
   describe('#first()', function () {
     it('should return the first row', function () {
-      var result = new ResultSet({ rows: [ 400, 420 ] }, null);
+      const result = new ResultSet({ rows: [ 400, 420 ] }, null);
       assert.strictEqual(result.first(), 400);
     });
     it('should return null when rows is not defined', function () {
-      var result = new ResultSet({ }, null);
+      const result = new ResultSet({ }, null);
       assert.strictEqual(result.first(), null);
     });
   });
   describe('#[@@iterator]()', function () {
     it('should return the rows iterator', function () {
-      var result = new ResultSet({ rows: [ 100, 200, 300] }, null);
+      const result = new ResultSet({ rows: [ 100, 200, 300] }, null);
       // Equivalent of for..of result
-      var iterator = result[Symbol.iterator]();
-      var item = iterator.next();
+      const iterator = result[Symbol.iterator]();
+      let item = iterator.next();
       assert.strictEqual(item.done, false);
       assert.strictEqual(item.value, 100);
       item = iterator.next();
@@ -45,10 +45,10 @@ describe('ResultSet', function () {
       assert.strictEqual(iterator.next().done, true);
     });
     it('should return an empty iterator when rows is not defined', function () {
-      var result = new ResultSet({ }, null);
+      const result = new ResultSet({ }, null);
       // Equivalent of for..of result
-      var iterator = result[Symbol.iterator]();
-      var item = iterator.next();
+      const iterator = result[Symbol.iterator]();
+      const item = iterator.next();
       assert.ok(item);
       assert.strictEqual(item.done, true);
       assert.strictEqual(item.value, undefined);

--- a/test/unit/retry-policy-tests.js
+++ b/test/unit/retry-policy-tests.js
@@ -1,22 +1,22 @@
 "use strict";
-var assert = require('assert');
+const assert = require('assert');
 
-var types = require('../../lib/types');
-var policies = require('../../lib/policies');
+const types = require('../../lib/types');
+const policies = require('../../lib/policies');
 var RetryPolicy = policies.retry.RetryPolicy;
 var IdempotenceAwareRetryPolicy = policies.retry.IdempotenceAwareRetryPolicy;
 
 describe('RetryPolicy', function () {
   describe('#onUnavailable()', function () {
     it('should retry on the next host the first time', function () {
-      var policy = new RetryPolicy();
+      const policy = new RetryPolicy();
       var result = policy.onUnavailable(getRequestInfo(0), types.consistencies.one, 3, 3);
       assert.strictEqual(result.consistency, undefined);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
       assert.strictEqual(result.useCurrentHost, false);
     });
     it('should rethrow the following times', function () {
-      var policy = new RetryPolicy();
+      const policy = new RetryPolicy();
       var result = policy.onUnavailable(getRequestInfo(1), types.consistencies.one, 3, 3);
       assert.strictEqual(result.consistency, undefined);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
@@ -24,43 +24,43 @@ describe('RetryPolicy', function () {
   });
   describe('#onWriteTimeout()', function () {
     it('should retry on the same host the first time when writeType is BATCH_LOG', function () {
-      var policy = new RetryPolicy();
+      const policy = new RetryPolicy();
       var result = policy.onWriteTimeout(getRequestInfo(0), types.consistencies.one, 1, 1, 'BATCH_LOG');
       assert.strictEqual(result.consistency, undefined);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
       assert.strictEqual(result.useCurrentHost, true);
     });
     it('should rethrow the following times', function () {
-      var policy = new RetryPolicy();
+      const policy = new RetryPolicy();
       var result = policy.onWriteTimeout(getRequestInfo(1), types.consistencies.one, 1, 1, 'BATCH_LOG');
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
     });
     it('should rethrow when the writeType is not SIMPLE', function () {
-      var policy = new RetryPolicy();
+      const policy = new RetryPolicy();
       var result = policy.onWriteTimeout(getRequestInfo(0), types.consistencies.one, 3, 2, 'SIMPLE');
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
     });
     it('should rethrow when the writeType is not COUNTER', function () {
-      var policy = new RetryPolicy();
+      const policy = new RetryPolicy();
       var result = policy.onWriteTimeout(getRequestInfo(0), types.consistencies.one, 3, 3, 'COUNTER');
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
     });
   });
   describe('#onReadTimeout()', function () {
     it('should retry on the same host the first time when received is greater or equal than blockFor', function () {
-      var policy = new RetryPolicy();
+      const policy = new RetryPolicy();
       var result = policy.onReadTimeout(getRequestInfo(0), types.consistencies.one, 2, 2, false);
       assert.strictEqual(result.consistency, undefined);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
       assert.strictEqual(result.useCurrentHost, true);
     });
     it('should rethrow the following times', function () {
-      var policy = new RetryPolicy();
+      const policy = new RetryPolicy();
       var result = policy.onReadTimeout(getRequestInfo(1), types.consistencies.one, 2, 2, false);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
     });
     it('should rethrow when the received is less than blockFor', function () {
-      var policy = new RetryPolicy();
+      const policy = new RetryPolicy();
       var result = policy.onReadTimeout(getRequestInfo(0), types.consistencies.one, 2, 3, false);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
     });
@@ -69,7 +69,7 @@ describe('RetryPolicy', function () {
 describe('IdempotenceAwareRetryPolicy', function () {
   describe('#onReadTimeout()', function () {
     it('should rely on the child policy to decide', function () {
-      var actual = null;
+      let actual = null;
       var childPolicy = {
         onReadTimeout: function (info, consistency, received, blockFor, isDataPresent) {
           actual = {
@@ -78,14 +78,14 @@ describe('IdempotenceAwareRetryPolicy', function () {
           return { decision: RetryPolicy.retryDecision.retry };
         }
       };
-      var policy = new IdempotenceAwareRetryPolicy(childPolicy);
+      const policy = new IdempotenceAwareRetryPolicy(childPolicy);
       var result = policy.onReadTimeout(1, 2, 3, 4, 5);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
       assert.deepEqual(actual, { info: 1, consistency: 2, received: 3, blockFor: 4, isDataPresent: 5 });
     });
   });
   describe('#onRequestError()', function () {
-    var actual;
+    let actual;
     var childPolicy = {
       onRequestError: function (info, consistency, err) {
         actual = { info: info, consistency: consistency, err: err };
@@ -94,21 +94,21 @@ describe('IdempotenceAwareRetryPolicy', function () {
     };
     it('should rethrow for non-idempotent queries', function () {
       actual = null;
-      var policy = new IdempotenceAwareRetryPolicy(childPolicy);
+      const policy = new IdempotenceAwareRetryPolicy(childPolicy);
       var result = policy.onRequestError({ options: { isIdempotent: false } }, 2, 3);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
       assert.strictEqual(actual, null);
     });
     it('should rely on the child policy when query is idempotent', function () {
       actual = null;
-      var policy = new IdempotenceAwareRetryPolicy(childPolicy);
+      const policy = new IdempotenceAwareRetryPolicy(childPolicy);
       var result = policy.onRequestError({ options: { isIdempotent: true } }, 2, 3);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
       assert.deepEqual(actual, { info: { options: { isIdempotent: true } }, consistency: 2, err: 3 });
     });
   });
   describe('#onWriteTimeout()', function () {
-    var actual;
+    let actual;
     var childPolicy = {
       onWriteTimeout: function (info, consistency, received, blockFor, writeType) {
         actual = { info: info, consistency: consistency, received: received, blockFor: blockFor, writeType: writeType };
@@ -117,14 +117,14 @@ describe('IdempotenceAwareRetryPolicy', function () {
     };
     it('should rethrow for non-idempotent queries', function () {
       actual = null;
-      var policy = new IdempotenceAwareRetryPolicy(childPolicy);
+      const policy = new IdempotenceAwareRetryPolicy(childPolicy);
       var result = policy.onWriteTimeout({ options: { isIdempotent: false } }, 2, 3, 4, 5);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
       assert.strictEqual(actual, null);
     });
     it('should rely on the child policy when query is idempotent', function () {
       actual = null;
-      var policy = new IdempotenceAwareRetryPolicy(childPolicy);
+      const policy = new IdempotenceAwareRetryPolicy(childPolicy);
       var result = policy.onWriteTimeout({ options: { isIdempotent: true } }, 2, 3, 4, 5);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
       assert.deepEqual(actual, {
@@ -134,14 +134,14 @@ describe('IdempotenceAwareRetryPolicy', function () {
   });
   describe('#onUnavailable()', function () {
     it('should rely on the child policy to decide', function () {
-      var actual = null;
+      let actual = null;
       var childPolicy = {
         onUnavailable: function (info, consistency, required, alive) {
           actual = { info: info, consistency: consistency, required: required, alive: alive };
           return { decision: RetryPolicy.retryDecision.retry };
         }
       };
-      var policy = new IdempotenceAwareRetryPolicy(childPolicy);
+      const policy = new IdempotenceAwareRetryPolicy(childPolicy);
       var result = policy.onUnavailable(10, 20, 30, 40);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
       assert.deepEqual(actual, { info: 10, consistency: 20, required: 30, alive: 40 });

--- a/test/unit/retry-policy-tests.js
+++ b/test/unit/retry-policy-tests.js
@@ -3,21 +3,21 @@ const assert = require('assert');
 
 const types = require('../../lib/types');
 const policies = require('../../lib/policies');
-var RetryPolicy = policies.retry.RetryPolicy;
-var IdempotenceAwareRetryPolicy = policies.retry.IdempotenceAwareRetryPolicy;
+const RetryPolicy = policies.retry.RetryPolicy;
+const IdempotenceAwareRetryPolicy = policies.retry.IdempotenceAwareRetryPolicy;
 
 describe('RetryPolicy', function () {
   describe('#onUnavailable()', function () {
     it('should retry on the next host the first time', function () {
       const policy = new RetryPolicy();
-      var result = policy.onUnavailable(getRequestInfo(0), types.consistencies.one, 3, 3);
+      const result = policy.onUnavailable(getRequestInfo(0), types.consistencies.one, 3, 3);
       assert.strictEqual(result.consistency, undefined);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
       assert.strictEqual(result.useCurrentHost, false);
     });
     it('should rethrow the following times', function () {
       const policy = new RetryPolicy();
-      var result = policy.onUnavailable(getRequestInfo(1), types.consistencies.one, 3, 3);
+      const result = policy.onUnavailable(getRequestInfo(1), types.consistencies.one, 3, 3);
       assert.strictEqual(result.consistency, undefined);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
     });
@@ -25,43 +25,43 @@ describe('RetryPolicy', function () {
   describe('#onWriteTimeout()', function () {
     it('should retry on the same host the first time when writeType is BATCH_LOG', function () {
       const policy = new RetryPolicy();
-      var result = policy.onWriteTimeout(getRequestInfo(0), types.consistencies.one, 1, 1, 'BATCH_LOG');
+      const result = policy.onWriteTimeout(getRequestInfo(0), types.consistencies.one, 1, 1, 'BATCH_LOG');
       assert.strictEqual(result.consistency, undefined);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
       assert.strictEqual(result.useCurrentHost, true);
     });
     it('should rethrow the following times', function () {
       const policy = new RetryPolicy();
-      var result = policy.onWriteTimeout(getRequestInfo(1), types.consistencies.one, 1, 1, 'BATCH_LOG');
+      const result = policy.onWriteTimeout(getRequestInfo(1), types.consistencies.one, 1, 1, 'BATCH_LOG');
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
     });
     it('should rethrow when the writeType is not SIMPLE', function () {
       const policy = new RetryPolicy();
-      var result = policy.onWriteTimeout(getRequestInfo(0), types.consistencies.one, 3, 2, 'SIMPLE');
+      const result = policy.onWriteTimeout(getRequestInfo(0), types.consistencies.one, 3, 2, 'SIMPLE');
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
     });
     it('should rethrow when the writeType is not COUNTER', function () {
       const policy = new RetryPolicy();
-      var result = policy.onWriteTimeout(getRequestInfo(0), types.consistencies.one, 3, 3, 'COUNTER');
+      const result = policy.onWriteTimeout(getRequestInfo(0), types.consistencies.one, 3, 3, 'COUNTER');
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
     });
   });
   describe('#onReadTimeout()', function () {
     it('should retry on the same host the first time when received is greater or equal than blockFor', function () {
       const policy = new RetryPolicy();
-      var result = policy.onReadTimeout(getRequestInfo(0), types.consistencies.one, 2, 2, false);
+      const result = policy.onReadTimeout(getRequestInfo(0), types.consistencies.one, 2, 2, false);
       assert.strictEqual(result.consistency, undefined);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
       assert.strictEqual(result.useCurrentHost, true);
     });
     it('should rethrow the following times', function () {
       const policy = new RetryPolicy();
-      var result = policy.onReadTimeout(getRequestInfo(1), types.consistencies.one, 2, 2, false);
+      const result = policy.onReadTimeout(getRequestInfo(1), types.consistencies.one, 2, 2, false);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
     });
     it('should rethrow when the received is less than blockFor', function () {
       const policy = new RetryPolicy();
-      var result = policy.onReadTimeout(getRequestInfo(0), types.consistencies.one, 2, 3, false);
+      const result = policy.onReadTimeout(getRequestInfo(0), types.consistencies.one, 2, 3, false);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
     });
   });
@@ -70,7 +70,7 @@ describe('IdempotenceAwareRetryPolicy', function () {
   describe('#onReadTimeout()', function () {
     it('should rely on the child policy to decide', function () {
       let actual = null;
-      var childPolicy = {
+      const childPolicy = {
         onReadTimeout: function (info, consistency, received, blockFor, isDataPresent) {
           actual = {
             info: info, consistency: consistency, received: received, blockFor: blockFor, isDataPresent: isDataPresent
@@ -79,14 +79,14 @@ describe('IdempotenceAwareRetryPolicy', function () {
         }
       };
       const policy = new IdempotenceAwareRetryPolicy(childPolicy);
-      var result = policy.onReadTimeout(1, 2, 3, 4, 5);
+      const result = policy.onReadTimeout(1, 2, 3, 4, 5);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
       assert.deepEqual(actual, { info: 1, consistency: 2, received: 3, blockFor: 4, isDataPresent: 5 });
     });
   });
   describe('#onRequestError()', function () {
     let actual;
-    var childPolicy = {
+    const childPolicy = {
       onRequestError: function (info, consistency, err) {
         actual = { info: info, consistency: consistency, err: err };
         return { decision: RetryPolicy.retryDecision.retry };
@@ -95,21 +95,21 @@ describe('IdempotenceAwareRetryPolicy', function () {
     it('should rethrow for non-idempotent queries', function () {
       actual = null;
       const policy = new IdempotenceAwareRetryPolicy(childPolicy);
-      var result = policy.onRequestError({ options: { isIdempotent: false } }, 2, 3);
+      const result = policy.onRequestError({ options: { isIdempotent: false } }, 2, 3);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
       assert.strictEqual(actual, null);
     });
     it('should rely on the child policy when query is idempotent', function () {
       actual = null;
       const policy = new IdempotenceAwareRetryPolicy(childPolicy);
-      var result = policy.onRequestError({ options: { isIdempotent: true } }, 2, 3);
+      const result = policy.onRequestError({ options: { isIdempotent: true } }, 2, 3);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
       assert.deepEqual(actual, { info: { options: { isIdempotent: true } }, consistency: 2, err: 3 });
     });
   });
   describe('#onWriteTimeout()', function () {
     let actual;
-    var childPolicy = {
+    const childPolicy = {
       onWriteTimeout: function (info, consistency, received, blockFor, writeType) {
         actual = { info: info, consistency: consistency, received: received, blockFor: blockFor, writeType: writeType };
         return { decision: RetryPolicy.retryDecision.retry };
@@ -118,14 +118,14 @@ describe('IdempotenceAwareRetryPolicy', function () {
     it('should rethrow for non-idempotent queries', function () {
       actual = null;
       const policy = new IdempotenceAwareRetryPolicy(childPolicy);
-      var result = policy.onWriteTimeout({ options: { isIdempotent: false } }, 2, 3, 4, 5);
+      const result = policy.onWriteTimeout({ options: { isIdempotent: false } }, 2, 3, 4, 5);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
       assert.strictEqual(actual, null);
     });
     it('should rely on the child policy when query is idempotent', function () {
       actual = null;
       const policy = new IdempotenceAwareRetryPolicy(childPolicy);
-      var result = policy.onWriteTimeout({ options: { isIdempotent: true } }, 2, 3, 4, 5);
+      const result = policy.onWriteTimeout({ options: { isIdempotent: true } }, 2, 3, 4, 5);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
       assert.deepEqual(actual, {
         info: { options: { isIdempotent: true } }, consistency: 2, received: 3, blockFor: 4, writeType: 5
@@ -135,14 +135,14 @@ describe('IdempotenceAwareRetryPolicy', function () {
   describe('#onUnavailable()', function () {
     it('should rely on the child policy to decide', function () {
       let actual = null;
-      var childPolicy = {
+      const childPolicy = {
         onUnavailable: function (info, consistency, required, alive) {
           actual = { info: info, consistency: consistency, required: required, alive: alive };
           return { decision: RetryPolicy.retryDecision.retry };
         }
       };
       const policy = new IdempotenceAwareRetryPolicy(childPolicy);
-      var result = policy.onUnavailable(10, 20, 30, 40);
+      const result = policy.onUnavailable(10, 20, 30, 40);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
       assert.deepEqual(actual, { info: 10, consistency: 20, required: 30, alive: 40 });
     });

--- a/test/unit/stream-id-stack-tests.js
+++ b/test/unit/stream-id-stack-tests.js
@@ -5,7 +5,7 @@ const rewire = require('rewire');
 
 describe('StreamIdStack', function () {
   this.timeout(2000);
-  var osPrecision = 30;
+  const osPrecision = 30;
   it('should pop and push', function () {
     const stack = newInstance();
     assert.strictEqual(stack.pop(), 0);
@@ -24,10 +24,10 @@ describe('StreamIdStack', function () {
       [2, 128],
       [3, Math.pow(2, 15)]
     ].forEach(function (value) {
-      var version = value[0];
-      var maxSize = value[1];
-      var stack = newInstance(version);
-      var ids = pop(stack, maxSize + 20);
+      const version = value[0];
+      const maxSize = value[1];
+      const stack = newInstance(version);
+      const ids = pop(stack, maxSize + 20);
       assert.strictEqual(ids.length, maxSize + 20);
       for (let i = 0; i < maxSize + 20; i++) {
         if (i < maxSize) {
@@ -43,8 +43,8 @@ describe('StreamIdStack', function () {
     });
   });
   it('should yield the lowest available id', function () {
-    var stack = newInstance(3);
-    var ids = pop(stack, 128 * 3 - 1);
+    const stack = newInstance(3);
+    const ids = pop(stack, 128 * 3 - 1);
     assert.strictEqual(ids.length, 128 * 3 - 1);
     for (let i = 0; i < ids.length; i++) {
       assert.strictEqual(ids[i], i);
@@ -63,8 +63,8 @@ describe('StreamIdStack', function () {
     stack.clear();
   });
   it('should release unused groups', function (done) {
-    var releaseDelay = 100;
-    var stack = newInstance(3, releaseDelay);
+    const releaseDelay = 100;
+    const stack = newInstance(3, releaseDelay);
     //6 groups,
     pop(stack, 128 * 5 + 2);
     //return just 1 to the last group
@@ -83,8 +83,8 @@ describe('StreamIdStack', function () {
     }, releaseDelay + osPrecision);
   });
   it('should not release the current group', function (done) {
-    var releaseDelay = 100;
-    var stack = newInstance(3, releaseDelay);
+    const releaseDelay = 100;
+    const stack = newInstance(3, releaseDelay);
     //6 groups,
     pop(stack, 128 * 5 + 2);
     //return just 1 to the last group
@@ -101,8 +101,8 @@ describe('StreamIdStack', function () {
     }, releaseDelay + osPrecision);
   });
   it('should not release more than release size per time', function (done) {
-    var releaseDelay = 100;
-    var stack = newInstance(3, releaseDelay);
+    const releaseDelay = 100;
+    const stack = newInstance(3, releaseDelay);
     //12 groups,
     pop(stack, 128 * 11 + 2);
     assert.strictEqual(stack.groups.length, 12);
@@ -128,7 +128,7 @@ describe('StreamIdStack', function () {
 
 /** @returns {StreamIdStack}  */
 function newInstance(version, releaseDelay) {
-  var StreamIdStack = rewire('../../lib/stream-id-stack');
+  const StreamIdStack = rewire('../../lib/stream-id-stack');
   StreamIdStack.__set__("releaseDelay", releaseDelay || 100);
   return new StreamIdStack(version || 3);
 }

--- a/test/unit/stream-id-stack-tests.js
+++ b/test/unit/stream-id-stack-tests.js
@@ -1,13 +1,13 @@
 "use strict";
-var assert = require('assert');
-var util = require('util');
-var rewire = require('rewire');
+const assert = require('assert');
+const util = require('util');
+const rewire = require('rewire');
 
 describe('StreamIdStack', function () {
   this.timeout(2000);
   var osPrecision = 30;
   it('should pop and push', function () {
-    var stack = newInstance();
+    const stack = newInstance();
     assert.strictEqual(stack.pop(), 0);
     assert.strictEqual(stack.pop(), 1);
     assert.strictEqual(stack.pop(), 2);
@@ -29,7 +29,7 @@ describe('StreamIdStack', function () {
       var stack = newInstance(version);
       var ids = pop(stack, maxSize + 20);
       assert.strictEqual(ids.length, maxSize + 20);
-      for (var i = 0; i < maxSize + 20; i++) {
+      for (let i = 0; i < maxSize + 20; i++) {
         if (i < maxSize) {
           assert.strictEqual(ids[i], i);
         }
@@ -46,7 +46,7 @@ describe('StreamIdStack', function () {
     var stack = newInstance(3);
     var ids = pop(stack, 128 * 3 - 1);
     assert.strictEqual(ids.length, 128 * 3 - 1);
-    for (var i = 0; i < ids.length; i++) {
+    for (let i = 0; i < ids.length; i++) {
       assert.strictEqual(ids[i], i);
     }
     //popped all from the first 3 groups
@@ -134,8 +134,8 @@ function newInstance(version, releaseDelay) {
 }
 
 function pop(stack, n) {
-  var arr = [];
-  for (var i = 0; i < n; i++) {
+  const arr = [];
+  for (let i = 0; i < n; i++) {
     arr.push(stack.pop());
   }
   return arr;
@@ -146,7 +146,7 @@ function push(stack, initialValue, length) {
     initialValue.forEach(stack.push.bind(stack));
     return;
   }
-  for (var i = 0; i < length; i++) {
+  for (let i = 0; i < length; i++) {
     stack.push(initialValue + i);
   }
 }

--- a/test/unit/timestamp-tests.js
+++ b/test/unit/timestamp-tests.js
@@ -8,23 +8,23 @@ const helper = require('../test-helper');
 describe('MonotonicTimestampGenerator', function () {
   describe('#next()', function () {
     it('should return a Number when the current date is before Jun 06 2255', function () {
-      var g = new MonotonicTimestampGenerator();
+      const g = new MonotonicTimestampGenerator();
       g.getDate = function () {
         return 9007199254739;
       };
-      var value = g.next();
+      const value = g.next();
       assert.strictEqual(typeof value, 'number');
     });
     it('should return a Long when the current date is after Jun 06 2255', function () {
-      var g = new MonotonicTimestampGenerator();
+      const g = new MonotonicTimestampGenerator();
       g.getDate = function () {
         return 9007199254740;
       };
-      var value = g.next();
+      const value = g.next();
       helper.assertInstanceOf(value, Long);
     });
     it('should log a warning once when it drifted into the future', function (done) {
-      var g = new MonotonicTimestampGenerator(null, 50);
+      const g = new MonotonicTimestampGenerator(null, 50);
       let counter = 0;
       g.getDate = function () {
         if (counter++ === 0) {
@@ -39,7 +39,7 @@ describe('MonotonicTimestampGenerator', function () {
         }
       };
       for (let i = 0; i < 200; i++) {
-        var value = g.next(client);
+        const value = g.next(client);
         assert.strictEqual(value, 1000000 + i);
       }
       assert.strictEqual(logs.length, 1);
@@ -54,23 +54,23 @@ describe('MonotonicTimestampGenerator', function () {
       }, 100);
     });
     it('should use the current date', function () {
-      var g = new MonotonicTimestampGenerator();
-      var longThousand = Long.fromInt(1000);
-      var startDate = Long.fromNumber(Date.now()).multiply(longThousand);
-      var value = g.next();
-      var endDate = Long.fromNumber(Date.now()).multiply(longThousand);
-      var longValue = value instanceof Long ? value : Long.fromNumber(value);
+      const g = new MonotonicTimestampGenerator();
+      const longThousand = Long.fromInt(1000);
+      const startDate = Long.fromNumber(Date.now()).multiply(longThousand);
+      const value = g.next();
+      const endDate = Long.fromNumber(Date.now()).multiply(longThousand);
+      const longValue = value instanceof Long ? value : Long.fromNumber(value);
       assert.ok(longValue.greaterThanOrEqual(startDate));
       assert.ok(longValue.lessThanOrEqual(endDate));
     });
     it('should increment the microseconds portion for the same date', function () {
-      var g = new MonotonicTimestampGenerator();
+      const g = new MonotonicTimestampGenerator();
       g.getDate = function () {
         // Use a fixed date
         return 1;
       };
       for (let i = 0; i < 1000; i++) {
-        var value = g.next();
+        const value = g.next();
         assert.strictEqual(value, 1000 + i);
       }
       // Should drift into the future

--- a/test/unit/timestamp-tests.js
+++ b/test/unit/timestamp-tests.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var assert = require('assert');
-var MonotonicTimestampGenerator = require('../../lib/policies/timestamp-generation').MonotonicTimestampGenerator;
-var Long = require('../../lib/types').Long;
-var helper = require('../test-helper');
+const assert = require('assert');
+const MonotonicTimestampGenerator = require('../../lib/policies/timestamp-generation').MonotonicTimestampGenerator;
+const Long = require('../../lib/types').Long;
+const helper = require('../test-helper');
 
 describe('MonotonicTimestampGenerator', function () {
   describe('#next()', function () {
@@ -25,20 +25,20 @@ describe('MonotonicTimestampGenerator', function () {
     });
     it('should log a warning once when it drifted into the future', function (done) {
       var g = new MonotonicTimestampGenerator(null, 50);
-      var counter = 0;
+      let counter = 0;
       g.getDate = function () {
         if (counter++ === 0) {
           return 1000;
         }
         return 0;
       };
-      var logs = [];
-      var client = {
+      const logs = [];
+      const client = {
         log: function (level, message) {
           logs.push({ level: level, message: message });
         }
       };
-      for (var i = 0; i < 200; i++) {
+      for (let i = 0; i < 200; i++) {
         var value = g.next(client);
         assert.strictEqual(value, 1000000 + i);
       }
@@ -69,7 +69,7 @@ describe('MonotonicTimestampGenerator', function () {
         // Use a fixed date
         return 1;
       };
-      for (var i = 0; i < 1000; i++) {
+      for (let i = 0; i < 1000; i++) {
         var value = g.next();
         assert.strictEqual(value, 1000 + i);
       }

--- a/test/unit/tokenizer-tests.js
+++ b/test/unit/tokenizer-tests.js
@@ -1,13 +1,13 @@
 'use strict';
-var assert = require('assert');
+const assert = require('assert');
 
-var tokenizer = require('../../lib/tokenizer');
+const tokenizer = require('../../lib/tokenizer');
 var Murmur3Tokenizer = tokenizer.Murmur3Tokenizer;
 var RandomTokenizer = tokenizer.RandomTokenizer;
-var types = require('../../lib/types');
-var utils = require('../../lib/utils');
-var MutableLong = require('../../lib/types/mutable-long');
-var helper = require('../test-helper');
+const types = require('../../lib/types');
+const utils = require('../../lib/utils');
+const MutableLong = require('../../lib/types/mutable-long');
+const helper = require('../test-helper');
 
 describe('Murmur3Tokenizer', function () {
   describe('#rotl64()', function () {

--- a/test/unit/tokenizer-tests.js
+++ b/test/unit/tokenizer-tests.js
@@ -2,8 +2,8 @@
 const assert = require('assert');
 
 const tokenizer = require('../../lib/tokenizer');
-var Murmur3Tokenizer = tokenizer.Murmur3Tokenizer;
-var RandomTokenizer = tokenizer.RandomTokenizer;
+const Murmur3Tokenizer = tokenizer.Murmur3Tokenizer;
+const RandomTokenizer = tokenizer.RandomTokenizer;
 const types = require('../../lib/types');
 const utils = require('../../lib/utils');
 const MutableLong = require('../../lib/types/mutable-long');
@@ -12,14 +12,14 @@ const helper = require('../test-helper');
 describe('Murmur3Tokenizer', function () {
   describe('#rotl64()', function () {
     it('should return expected results', function () {
-      var t = new Murmur3Tokenizer();
+      const t = new Murmur3Tokenizer();
       [
         ['12002002', 4, '192032032'],
         ['120020021112229', 27, '4806971846970835817'],
         ['44444441112229', 31, '256695637490275382'],
         ['44744441112828', 31, '-1134251256001325992']
       ].forEach(function (item) {
-        var v = MutableLong.fromString(item[0]);
+        const v = MutableLong.fromString(item[0]);
         t.rotl64(v, item[1]);
         assert.ok(v.equals(MutableLong.fromString(item[2])));
       });
@@ -27,7 +27,7 @@ describe('Murmur3Tokenizer', function () {
   });
   describe('#fmix()', function () {
     it('should return expected results', function () {
-      var t = new Murmur3Tokenizer();
+      const t = new Murmur3Tokenizer();
       [
         [44744441112828, 0x709d544d, 0x9bbee13c],
         [9090, 0x2355d910, 0x97d95964],
@@ -35,7 +35,7 @@ describe('Murmur3Tokenizer', function () {
         [1, 0x34c2cb2c, 0xb456bcfc],
         [-1, 0x4b825f21, 0x64b5720b]
       ].forEach(function (item) {
-        var input = MutableLong.fromNumber(item[0]);
+        const input = MutableLong.fromNumber(item[0]);
         t.fmix(input);
         assert.strictEqual(input.getLowBitsUnsigned(), item[1]);
         assert.strictEqual(input.getHighBitsUnsigned(), item[2]);
@@ -44,7 +44,7 @@ describe('Murmur3Tokenizer', function () {
   });
   describe('#getBlock()', function () {
     it('should return expected results', function () {
-      var t = new Murmur3Tokenizer();
+      const t = new Murmur3Tokenizer();
       [
         [[1, 2, 3, 4, 5, 6, 7, 8], 0x4030201, 0x8070605],
         [[1, 254, 3, 4, 5, 6, 7, 248], 0x403fe01, 0xf8070605],
@@ -52,14 +52,14 @@ describe('Murmur3Tokenizer', function () {
         [[100, 254, 3, 4, 5, 250, 7, 122], 0x403fe64, 0x7a07fa05],
         [[100, 254, 3, 4, 154, 250, 7, 122], 0x403fe64, 0x7a07fa9a]
       ].forEach(function (item) {
-        var result = t.getBlock(item[0], 0, 0);
+        const result = t.getBlock(item[0], 0, 0);
         assert.ok(result.equals(MutableLong.fromBits(item[1], item[2])));
       });
     });
   });
   describe('#hash()', function () {
     it('should hash the according results', function () {
-      var t = new Murmur3Tokenizer();
+      const t = new Murmur3Tokenizer();
       [
         [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], '-5563837382979743776'],
         [[2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17], '-1513403162740402161'],
@@ -71,13 +71,13 @@ describe('Murmur3Tokenizer', function () {
         [[0, 1, 127, 127], '6573459401642635627'],
         [[226, 231, 226, 231, 226, 231, 1], '2222373981930033306']
       ].forEach(function (item) {
-        var v = t.hash(item[0]);
+        const v = t.hash(item[0]);
         assert.ok(v.equals(MutableLong.fromString(item[1])));
       });
     });
   });
   describe('RandomTokenizer', function () {
-    var t = new RandomTokenizer();
+    const t = new RandomTokenizer();
     describe('#hash', function () {
       it('should return expected results', function () {
         [
@@ -92,7 +92,7 @@ describe('Murmur3Tokenizer', function () {
     });
     describe('#parse()', function () {
       it('should return the Integer representation', function () {
-        var val = t.parse('141904934057871337334287797400233978956');
+        const val = t.parse('141904934057871337334287797400233978956');
         helper.assertInstanceOf(val, types.Integer);
         assert.ok(val.equals(types.Integer.fromString('141904934057871337334287797400233978956')));
       });

--- a/test/unit/utils-tests.js
+++ b/test/unit/utils-tests.js
@@ -16,7 +16,7 @@ describe('utils', function () {
   });
   describe('allocBuffer', function () {
     it('should return a buffer filled with zeros', function () {
-      var b = utils.allocBuffer(256);
+      const b = utils.allocBuffer(256);
       helper.assertInstanceOf(b, Buffer);
       assert.strictEqual(b.length, 256);
       for (let i = 0; i < b.length; i++) {
@@ -26,7 +26,7 @@ describe('utils', function () {
   });
   describe('allocBufferUnsafe', function () {
     it('should return a Buffer with the correct length', function () {
-      var b = utils.allocBuffer(256);
+      const b = utils.allocBuffer(256);
       helper.assertInstanceOf(b, Buffer);
       assert.strictEqual(b.length, 256);
     });
@@ -50,8 +50,8 @@ describe('utils', function () {
       }, TypeError);
     });
     it('should return a Buffer representing the string value', function () {
-      var text = 'Hello safe buffer';
-      var b = utils.allocBufferFromString(text);
+      const text = 'Hello safe buffer';
+      const b = utils.allocBufferFromString(text);
       helper.assertInstanceOf(b, Buffer);
       assert.strictEqual(b.toString(), text);
     });
@@ -75,8 +75,8 @@ describe('utils', function () {
       }, TypeError);
     });
     it('should return a Buffer representing the string value', function () {
-      var arr = [ 0xff, 0, 0x1a ];
-      var b = utils.allocBufferFromArray(arr);
+      const arr = [ 0xff, 0, 0x1a ];
+      const b = utils.allocBufferFromArray(arr);
       helper.assertInstanceOf(b, Buffer);
       assert.strictEqual(b.length, arr.length);
       for (let i = 0; i < b.length; i++) {

--- a/test/unit/utils-tests.js
+++ b/test/unit/utils-tests.js
@@ -1,7 +1,7 @@
 "use strict";
-var assert = require('assert');
-var utils = require('../../lib/utils');
-var helper = require('../test-helper');
+const assert = require('assert');
+const utils = require('../../lib/utils');
+const helper = require('../test-helper');
 
 describe('utils', function () {
   describe('timesLimit()', function () {
@@ -19,7 +19,7 @@ describe('utils', function () {
       var b = utils.allocBuffer(256);
       helper.assertInstanceOf(b, Buffer);
       assert.strictEqual(b.length, 256);
-      for (var i = 0; i < b.length; i++) {
+      for (let i = 0; i < b.length; i++) {
         assert.strictEqual(b[i], 0);
       }
     });
@@ -79,7 +79,7 @@ describe('utils', function () {
       var b = utils.allocBufferFromArray(arr);
       helper.assertInstanceOf(b, Buffer);
       assert.strictEqual(b.length, arr.length);
-      for (var i = 0; i < b.length; i++) {
+      for (let i = 0; i < b.length; i++) {
         assert.strictEqual(b[i], arr[i]);
       }
     });

--- a/test/unit/uuid-tests.js
+++ b/test/unit/uuid-tests.js
@@ -36,8 +36,8 @@ describe('Uuid', function () {
   describe('#equals', function () {
     it('should return true only when the values are equal', function () {
       const val = new Uuid(utils.allocBufferFromString('aabbccddeeff00112233445566778899', 'hex'));
-      var val2 = new Uuid(utils.allocBufferFromString('ffffffffffff00000000000000000000', 'hex'));
-      var val3 = new Uuid(utils.allocBufferFromString('ffffffffffff00000000000000000001', 'hex'));
+      const val2 = new Uuid(utils.allocBufferFromString('ffffffffffff00000000000000000000', 'hex'));
+      const val3 = new Uuid(utils.allocBufferFromString('ffffffffffff00000000000000000001', 'hex'));
       assert.strictEqual(val.equals(val), true);
       assert.strictEqual(val.equals(new Uuid(utils.allocBufferFromString('aabbccddeeff00112233445566778899', 'hex'))), true);
       assert.strictEqual(val.equals(val2), false);
@@ -48,8 +48,8 @@ describe('Uuid', function () {
   });
   describe('#getBuffer()', function () {
     it('should return the Buffer representation', function () {
-      var buf = utils.allocBufferUnsafe(16);
-      var val = new Uuid(buf);
+      let buf = utils.allocBufferUnsafe(16);
+      let val = new Uuid(buf);
       assert.strictEqual(val.getBuffer().toString('hex'), buf.toString('hex'));
       buf = utils.allocBufferFromString('ffffccddeeff00222233445566778813', 'hex');
       val = new Uuid(buf);
@@ -75,7 +75,7 @@ describe('Uuid', function () {
       });
     });
     it('should contain a valid internal representation', function () {
-      var val = Uuid.fromString('acb1ccdd-eeff-0011-2233-445566778813');
+      let val = Uuid.fromString('acb1ccdd-eeff-0011-2233-445566778813');
       assert.strictEqual(val.buffer.toString('hex'), 'acb1ccddeeff00112233445566778813');
       val = Uuid.fromString('ffffccdd-eeff-0022-2233-445566778813');
       assert.strictEqual(val.buffer.toString('hex'), 'ffffccddeeff00222233445566778813');
@@ -87,7 +87,7 @@ describe('Uuid', function () {
       helper.assertInstanceOf(Uuid.random(), Uuid);
     });
     it('should contain the version bits and IETF variant', function () {
-      var val = Uuid.random();
+      let val = Uuid.random();
       assert.strictEqual(val.toString().charAt(14), '4');
       assert.ok(['8', '9', 'a', 'b'].indexOf(val.toString().charAt(19)) >= 0);
       val = Uuid.random();
@@ -99,7 +99,7 @@ describe('Uuid', function () {
     });
     it('should generate v4 uuids that do not collide', function () {
       const values = {};
-      var length = 100000;
+      const length = 100000;
       for (let i = 0; i < length; i++) {
         values[Uuid.random().toString()] = true;
       }
@@ -133,7 +133,7 @@ describe('Uuid', function () {
     });
     it('should generate v4 uuids that do not collide', function (done) {
       const values = {};
-      var length = 100000;
+      const length = 100000;
       
       utils.times(length, function eachTime(n, next) {
         Uuid.random(function (err, val) {
@@ -155,7 +155,7 @@ describe('TimeUuid', function () {
   describe('constructor()', function () {
     it('should generate based on the parameters', function () {
       //Gregorian calendar epoch
-      var val = new TimeUuid(new Date(-12219292800000), 0, utils.allocBufferFromArray([0,0,0,0,0,0]), utils.allocBufferFromArray([0,0]));
+      let val = new TimeUuid(new Date(-12219292800000), 0, utils.allocBufferFromArray([0,0,0,0,0,0]), utils.allocBufferFromArray([0,0]));
       assert.strictEqual(val.toString(), '00000000-0000-1000-8000-000000000000');
       val = new TimeUuid(new Date(-12219292800000 + 1000), 0, utils.allocBufferFromArray([0,0,0,0,0,0]), utils.allocBufferFromArray([0,0]));
       assert.strictEqual(val.toString(), '00989680-0000-1000-8000-000000000000');
@@ -173,8 +173,8 @@ describe('TimeUuid', function () {
   });
   describe('#getDatePrecision()', function () {
     it('should get the Date and ticks of the Uuid representation', function () {
-      var date = new Date();
-      var val = new TimeUuid(date, 1);
+      let date = new Date();
+      let val = new TimeUuid(date, 1);
       assert.strictEqual(val.getDatePrecision().ticks, 1);
       assert.strictEqual(val.getDatePrecision().date.getTime(), date.getTime());
 
@@ -187,7 +187,7 @@ describe('TimeUuid', function () {
   });
   describe('#getNodeId()', function () {
     it('should get the node id of the Uuid representation', function () {
-      var val = new TimeUuid(new Date(), 0, utils.allocBufferFromArray([1, 2, 3, 4, 5, 6]));
+      let val = new TimeUuid(new Date(), 0, utils.allocBufferFromArray([1, 2, 3, 4, 5, 6]));
       helper.assertInstanceOf(val.getNodeId(), Buffer);
       assert.strictEqual(val.getNodeId().toString('hex'), '010203040506');
       val = new TimeUuid(new Date(), 0, 'host01');
@@ -200,8 +200,8 @@ describe('TimeUuid', function () {
     this.timeout(5000);
     it('should generate v1 uuids that do not collide', function () {
       const values = {};
-      var length = 50000;
-      var date = new Date();
+      const length = 50000;
+      const date = new Date();
       for (let i = 0; i < length; i++) {
         values[TimeUuid.fromDate(date).toString()] = true;
       }
@@ -209,8 +209,8 @@ describe('TimeUuid', function () {
     });
     it('should collide exactly at 10001 if date but not the ticks are specified', function () {
       const values = {};
-      var length = 10000;
-      var date = new Date();
+      const length = 10000;
+      const date = new Date();
       for (let i = 0; i < length; i++) {
         values[TimeUuid.fromDate(date, null, 'host01', 'AA').toString()] = true;
       }
@@ -221,8 +221,8 @@ describe('TimeUuid', function () {
   });
   describe('fromString()', function () {
     it('should parse the string representation', function () {
-      var text = '3d555680-9886-11e4-8101-010101010101';
-      var val = TimeUuid.fromString(text);
+      const text = '3d555680-9886-11e4-8101-010101010101';
+      const val = TimeUuid.fromString(text);
       helper.assertInstanceOf(val, TimeUuid);
       assert.strictEqual(val.toString(), text);
       assert.strictEqual(val.getDate().getTime(), new Date('2015-01-10 5:05:05 GMT+0000').getTime());
@@ -230,19 +230,19 @@ describe('TimeUuid', function () {
   });
   describe('now()', function () {
     it('should pass the nodeId when provided', function () {
-      var val = TimeUuid.now('h12345');
+      const val = TimeUuid.now('h12345');
       assert.strictEqual(val.getNodeIdString(), 'h12345');
     });
     it('should use current date', function () {
-      var startDate = new Date().getTime();
-      var val = TimeUuid.now().getDate().getTime();
-      var endDate = new Date().getTime();
+      const startDate = new Date().getTime();
+      const val = TimeUuid.now().getDate().getTime();
+      const endDate = new Date().getTime();
       assert.ok(val >= startDate);
       assert.ok(val <= endDate);
     });
     it('should reset the ticks portion of the TimeUuid to zero when the time progresses', function () {
-      var firstTimeUuid = TimeUuid.now();
-      var secondTimeUuid = TimeUuid.now();
+      const firstTimeUuid = TimeUuid.now();
+      let secondTimeUuid = TimeUuid.now();
       while(firstTimeUuid.getDate().getTime() === secondTimeUuid.getDate().getTime()) {
         secondTimeUuid = TimeUuid.now();
       }
@@ -251,13 +251,13 @@ describe('TimeUuid', function () {
   });
   describe('min()', function () {
     it('should generate uuid with the minimum node and clock id values', function () {
-      var val = TimeUuid.min(new Date());
+      const val = TimeUuid.min(new Date());
       assert.strictEqual(val.getNodeId().toString('hex'), '808080808080');
     });
   });
   describe('max()', function () {
     it('should generate uuid with the maximum node and clock id values', function () {
-      var val = TimeUuid.max(new Date());
+      const val = TimeUuid.max(new Date());
       assert.strictEqual(val.getNodeId().toString('hex'), '7f7f7f7f7f7f');
     });
   });

--- a/test/unit/uuid-tests.js
+++ b/test/unit/uuid-tests.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var assert = require('assert');
-var helper = require('../test-helper');
-var utils = require('../../lib/utils');
-var Uuid = require('../../lib/types').Uuid;
-var TimeUuid = require('../../lib/types').TimeUuid;
+const assert = require('assert');
+const helper = require('../test-helper');
+const utils = require('../../lib/utils');
+const Uuid = require('../../lib/types').Uuid;
+const TimeUuid = require('../../lib/types').TimeUuid;
 
 describe('Uuid', function () {
   describe('constructor', function () {
@@ -25,7 +25,7 @@ describe('Uuid', function () {
   });
   describe('#toString()', function () {
     it('should convert to string representation', function () {
-      var val = new Uuid(utils.allocBufferFromString('aabbccddeeff00112233445566778899', 'hex'));
+      let val = new Uuid(utils.allocBufferFromString('aabbccddeeff00112233445566778899', 'hex'));
       assert.strictEqual(val.toString(), 'aabbccdd-eeff-0011-2233-445566778899');
       val = new Uuid(utils.allocBufferFromString('a1b1ccddeeff00112233445566778899', 'hex'));
       assert.strictEqual(val.toString(), 'a1b1ccdd-eeff-0011-2233-445566778899');
@@ -35,7 +35,7 @@ describe('Uuid', function () {
   });
   describe('#equals', function () {
     it('should return true only when the values are equal', function () {
-      var val = new Uuid(utils.allocBufferFromString('aabbccddeeff00112233445566778899', 'hex'));
+      const val = new Uuid(utils.allocBufferFromString('aabbccddeeff00112233445566778899', 'hex'));
       var val2 = new Uuid(utils.allocBufferFromString('ffffffffffff00000000000000000000', 'hex'));
       var val3 = new Uuid(utils.allocBufferFromString('ffffffffffff00000000000000000001', 'hex'));
       assert.strictEqual(val.equals(val), true);
@@ -98,9 +98,9 @@ describe('Uuid', function () {
       assert.ok(['8', '9', 'a', 'b'].indexOf(val.toString().charAt(19)) >= 0);
     });
     it('should generate v4 uuids that do not collide', function () {
-      var values = {};
+      const values = {};
       var length = 100000;
-      for (var i = 0; i < length; i++) {
+      for (let i = 0; i < length; i++) {
         values[Uuid.random().toString()] = true;
       }
       assert.strictEqual(Object.keys(values).length, length);
@@ -132,7 +132,7 @@ describe('Uuid', function () {
       });
     });
     it('should generate v4 uuids that do not collide', function (done) {
-      var values = {};
+      const values = {};
       var length = 100000;
       
       utils.times(length, function eachTime(n, next) {
@@ -199,19 +199,19 @@ describe('TimeUuid', function () {
   describe('fromDate()', function () {
     this.timeout(5000);
     it('should generate v1 uuids that do not collide', function () {
-      var values = {};
+      const values = {};
       var length = 50000;
       var date = new Date();
-      for (var i = 0; i < length; i++) {
+      for (let i = 0; i < length; i++) {
         values[TimeUuid.fromDate(date).toString()] = true;
       }
       assert.strictEqual(Object.keys(values).length, length);
     });
     it('should collide exactly at 10001 if date but not the ticks are specified', function () {
-      var values = {};
+      const values = {};
       var length = 10000;
       var date = new Date();
-      for (var i = 0; i < length; i++) {
+      for (let i = 0; i < length; i++) {
         values[TimeUuid.fromDate(date, null, 'host01', 'AA').toString()] = true;
       }
       assert.strictEqual(Object.keys(values).length, length);


### PR DESCRIPTION
Part of NODEJS-406, its a large change set replacing occurrences of `var` with `const/let`.

Includes 2 new eslint rules: `no-var` and `prefer-const`.

I would like to have this pr open for the least amount of time, to avoid rebasing with other changes.
I'll do some quick benchmark tomorrow morning with Node.js 6 to see if it has any significant impact.