### PR TITLE
Use class syntax and use arrow functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -98,7 +98,6 @@ module.exports = {
     "arrow-body-style": ["error", "as-needed"],
     "arrow-spacing": "error",
     "no-confusing-arrow": ["error", { "allowParens": true }],
-    "class-methods-use-this": "error",
     "yoda": "error",
     "constructor-super": "error"
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -94,7 +94,13 @@ module.exports = {
     "no-buffer-constructor": "error",
     radix: "error",
     "no-var": "error",
-    "prefer-const": "error"
+    "prefer-const": "error",
+    "arrow-body-style": ["error", "as-needed"],
+    "arrow-spacing": "error",
+    "no-confusing-arrow": ["error", { "allowParens": true }],
+    "class-methods-use-this": "error",
+    "yoda": "error",
+    "constructor-super": "error"
   },
   "globals": {
     "Buffer": false,

--- a/lib/client.js
+++ b/lib/client.js
@@ -644,9 +644,7 @@ Client.prototype._batchCb = function (queries, options, callback) {
   }
 
   utils.series([
-    function connect(next) {
-      self.connect(next);
-    },
+    next => this.connect(next),
     function adaptQueries(next) {
       if (options.prepare) {
         return PrepareHandler.getPreparedMultiple(
@@ -726,9 +724,7 @@ Client.prototype._shutdownCb = function (callback) {
     self.controlConnection.shutdown();
     self.options.policies.speculativeExecution.shutdown();
     // go through all the host and shut down their pools
-    utils.each(hosts, function (h, next) {
-      h.shutdown(false, next);
-    }, callback);
+    utils.each(hosts, (h, next) => h.shutdown(false, next), callback);
   }
   this.log('info', 'Shutting down');
   callback = callback || utils.noop;
@@ -761,9 +757,7 @@ Client.prototype._waitForSchemaAgreement = function (connection, callback) {
   this.log('info', 'Waiting for schema agreement');
   let versionsMatch;
   let peerVersions;
-  utils.whilst(function condition() {
-    return !versionsMatch && (new Date() - start) < maxWaitTime;
-  }, function fn(next) {
+  utils.whilst(() => !versionsMatch && (new Date() - start) < maxWaitTime, function fn(next) {
     utils.series([
       function (next) {
         self.metadata.getPeersSchemaVersions(connection, function (err, result) {
@@ -837,9 +831,7 @@ Client.prototype._innerExecute = function (query, params, options, callback) {
   }
   const self = this;
   utils.series([
-    function connecting(next) {
-      self.connect(next);
-    },
+    next => this.connect(next),
     function settingOptions(next) {
       self._setQueryOptions(options, params, null, function setOptionsCallback(err, p) {
         params = p;
@@ -870,9 +862,7 @@ Client.prototype._executeAsPrepared = function (query, params, options, callback
   let meta;
   const self = this;
   utils.series([
-    function connecting(next) {
-      self.connect(next);
-    },
+    next => this.connect(next),
     function preparing(next) {
       const lbp = options.executionProfile.loadBalancing;
       PrepareHandler.getPrepared(self, lbp, query, self.keyspace, function (err, id, m) {
@@ -1009,9 +999,7 @@ Client.prototype._setQueryOptions = function (options, params, meta, callback) {
           //The data is not there, maybe it is being recreated
           return next();
         }
-        options.routingIndexes = tableInfo.partitionKeys.map(function (c) {
-          return meta.columnsByName[c.name];
-        });
+        options.routingIndexes = tableInfo.partitionKeys.map(c => meta.columnsByName[c.name]);
         //Skip parsing metadata next time
         meta.partitionKeys = options.routingIndexes;
         next();

--- a/lib/client.js
+++ b/lib/client.js
@@ -895,17 +895,13 @@ Client.prototype._executeAsPrepared = function (query, params, options, callback
  * @private
  */
 Client.prototype._setHostListeners = function () {
-  const self = this;
   function getHostUpListener(emitter, h) {
-    return (function hostUpListener() {
-      emitter.emit('hostUp', h);
-    });
+    return () => emitter.emit('hostUp', h);
   }
   function getHostDownListener(emitter, h) {
-    return (function hostDownListener() {
-      emitter.emit('hostDown', h);
-    });
+    return () => emitter.emit('hostDown', h);
   }
+  const self = this;
   //Add status listeners when new nodes are added and emit hostAdd
   this.hosts.on('add', function hostAddedListener(h) {
     h.on('up', getHostUpListener(self, h));

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -466,9 +466,7 @@ Connection.prototype._setIdleTimeout = function () {
   // Scheduling the new timeout before de-scheduling the previous performs significantly better
   // than de-scheduling first, see nodejs implementation: https://github.com/nodejs/node/blob/master/lib/timers.js
   const previousTimeout = this._idleTimeout;
-  self._idleTimeout = setTimeout(function () {
-    self._idleTimeoutHandler();
-  }, self.options.pooling.heartBeatInterval);
+  self._idleTimeout = setTimeout(() => self._idleTimeoutHandler(), self.options.pooling.heartBeatInterval);
   if (previousTimeout) {
     //remove the previous timeout for the idle request
     clearTimeout(previousTimeout);

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -415,9 +415,7 @@ ControlConnection.prototype.noOpenConnectionHandler = function () {
   const delay = this.reconnectionSchedule.next().value;
   this.log('warning', f('ControlConnection could not reconnect, scheduling reconnection in %dms', delay));
   const self = this;
-  setTimeout(function controlConnectionReconnection() {
-    self.refresh();
-  }, delay);
+  setTimeout(() => self.refresh(), delay);
 };
 
 /**
@@ -437,9 +435,7 @@ ControlConnection.prototype.nodeTopologyChangeHandler = function (event) {
   clearTimeout(this.topologyChangeTimeout);
   // Use an additional timer to make sure that the refresh hosts is executed only AFTER the delay
   // In this case, the event debouncer doesn't help because it could not honor the sliding delay (ie: processNow)
-  this.topologyChangeTimeout = setTimeout(function nodeTopologyDelayedHandler() {
-    self.scheduleRefreshHosts();
-  }, newNodeDelay);
+  this.topologyChangeTimeout = setTimeout(() => self.scheduleRefreshHosts(), newNodeDelay);
 };
 
 /**
@@ -462,9 +458,7 @@ ControlConnection.prototype.nodeStatusChangeHandler = function (event) {
       }
       clearTimeout(self.nodeStatusChangeTimeout);
       // Waits a couple of seconds before marking it as UP
-      self.nodeStatusChangeTimeout = setTimeout(function delayCheckIsUp() {
-        host.checkIsUp();
-      }, newNodeDelay);
+      self.nodeStatusChangeTimeout = setTimeout(() => host.checkIsUp(), newNodeDelay);
       return;
     }
     // marked as down

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -261,9 +261,7 @@ ControlConnection.prototype.refreshHosts = function (newNodesUp, callback) {
   }
   const self = this;
   if (!this.host.protocolVersion) {
-    this.hosts.forEach(function (h) {
-      h.setProtocolVersion(self.protocolVersion);
-    });
+    this.hosts.forEach(h => h.setProtocolVersion(self.protocolVersion));
   }
   this.log('info', 'Refreshing local and peers info');
   const c = this.connection;
@@ -543,10 +541,7 @@ ControlConnection.prototype.handleSchemaChange = function (event, processNow, ca
  * @param {Function} [callback]
  */
 ControlConnection.prototype.scheduleObjectRefresh = function (handler, keyspaceName, cqlObject, processNow, callback) {
-  this.debouncer.eventReceived(
-    { handler: handler, keyspace: keyspaceName, cqlObject: cqlObject, callback: callback },
-    processNow
-  );
+  this.debouncer.eventReceived({ handler, keyspace: keyspaceName, cqlObject: cqlObject, callback }, processNow);
 };
 
 /**
@@ -555,22 +550,22 @@ ControlConnection.prototype.scheduleObjectRefresh = function (handler, keyspaceN
  * @param {Function} [callback]
  */
 ControlConnection.prototype.scheduleKeyspaceRefresh = function (keyspaceName, processNow, callback) {
-  const self = this;
-  const handler = function keyspaceRefreshHandler(cb) {
-    self.metadata.refreshKeyspace(keyspaceName, cb);
-  };
-  this.debouncer.eventReceived({ handler: handler, keyspace: keyspaceName, callback: callback}, processNow);
+  this.debouncer.eventReceived({
+    handler: cb => this.metadata.refreshKeyspace(keyspaceName, cb),
+    keyspace: keyspaceName,
+    callback
+  }, processNow);
 };
 
 /**
  * @param {Function} [callback]
  */
 ControlConnection.prototype.scheduleRefreshHosts = function (callback) {
-  const self = this;
-  const handler = function hostsRefreshHandler(cb) {
-    self.refreshHosts(false, cb);
-  };
-  this.debouncer.eventReceived({ handler: handler, all: true, callback: callback }, false);
+  this.debouncer.eventReceived({
+    handler: cb => this.refreshHosts(false, cb),
+    all: true,
+    callback
+  }, false);
 };
 
 ControlConnection.prototype.setLocalInfo = function (endPoint, result) {
@@ -755,12 +750,8 @@ ControlConnection.prototype.reset = function (callback) {
   // Set the shutting down flag temporarily to avoid reconnects.
   this.isShuttingDown = true;
   const self = this;
-  utils.each(currentHosts, function forEachHost(h, next) {
-    h.shutdown(false, function () {
-      // Ignore any shutdown error
-      next();
-    });
-  }, function shuttingDownFinished() {
+  // Ignore any shutdown error
+  utils.each(currentHosts, (h, next) => h.shutdown(false, () => next()), function shuttingDownFinished() {
     self.initialized = false;
     self.isShuttingDown = false;
     callback();

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -1041,9 +1041,7 @@ function defineInstanceMembers() {
         throw new TypeError('Not a valid type ' + typeName);
       }
       dataType.code = dataTypes.tuple;
-      dataType.info = innerTypes.map(function (x) {
-        return this.parseFqTypeName(x);
-      }, this);
+      dataType.info = innerTypes.map(x => this.parseFqTypeName(x));
       return dataType;
     }
 
@@ -1110,9 +1108,7 @@ function defineInstanceMembers() {
       types.push(typesString.substring(startIndex, length));
     }
     return {
-      types: types.map(function (name) {
-        return this.parseFqTypeName(name);
-      }, this),
+      types: types.map(name => this.parseFqTypeName(name)),
       hasCollections: hasCollections,
       isComposite: isComposite
     };

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -1150,66 +1150,63 @@ function defineInstanceMembers() {
  * @private
  */
 function setEncoders() {
-  //decoders
-  const d = {};
-  d[dataTypes.custom] = this.decodeCustom;
-  d[dataTypes.ascii] = this.decodeAsciiString;
-  d[dataTypes.bigint] = this.decodeLong;
-  d[dataTypes.blob] = this.decodeBlob;
-  d[dataTypes.boolean] = this.decodeBoolean;
-  d[dataTypes.counter] = this.decodeLong;
-  d[dataTypes.decimal] = this.decodeDecimal;
-  d[dataTypes.double] = this.decodeDouble;
-  d[dataTypes.float] = this.decodeFloat;
-  d[dataTypes.int] = this.decodeInt;
-  d[dataTypes.text] = this.decodeUtf8String;
-  d[dataTypes.timestamp] = this.decodeTimestamp;
-  d[dataTypes.uuid] = this.decodeUuid;
-  d[dataTypes.varchar] = this.decodeUtf8String;
-  d[dataTypes.varint] = this.decodeVarint;
-  d[dataTypes.timeuuid] = this.decodeTimeUuid;
-  d[dataTypes.inet] = this.decodeInet;
-  d[dataTypes.date] = this.decodeDate;
-  d[dataTypes.time] = this.decodeTime;
-  d[dataTypes.smallint] = this.decodeSmallint;
-  d[dataTypes.tinyint] = this.decodeTinyint;
-  d[dataTypes.list] = this.decodeList;
-  d[dataTypes.map] = this.decodeMap;
-  d[dataTypes.set] = this.decodeSet;
-  d[dataTypes.udt] = this.decodeUdt;
-  d[dataTypes.tuple] = this.decodeTuple;
+  this.decoders = {
+    [dataTypes.custom]: this.decodeCustom,
+    [dataTypes.ascii]: this.decodeAsciiString,
+    [dataTypes.bigint]: this.decodeLong,
+    [dataTypes.blob]: this.decodeBlob,
+    [dataTypes.boolean]: this.decodeBoolean,
+    [dataTypes.counter]: this.decodeLong,
+    [dataTypes.decimal]: this.decodeDecimal,
+    [dataTypes.double]: this.decodeDouble,
+    [dataTypes.float]: this.decodeFloat,
+    [dataTypes.int]: this.decodeInt,
+    [dataTypes.text]: this.decodeUtf8String,
+    [dataTypes.timestamp]: this.decodeTimestamp,
+    [dataTypes.uuid]: this.decodeUuid,
+    [dataTypes.varchar]: this.decodeUtf8String,
+    [dataTypes.varint]: this.decodeVarint,
+    [dataTypes.timeuuid]: this.decodeTimeUuid,
+    [dataTypes.inet]: this.decodeInet,
+    [dataTypes.date]: this.decodeDate,
+    [dataTypes.time]: this.decodeTime,
+    [dataTypes.smallint]: this.decodeSmallint,
+    [dataTypes.tinyint]: this.decodeTinyint,
+    [dataTypes.list]: this.decodeList,
+    [dataTypes.map]: this.decodeMap,
+    [dataTypes.set]: this.decodeSet,
+    [dataTypes.udt]: this.decodeUdt,
+    [dataTypes.tuple]: this.decodeTuple
+  };
 
-  //encoders
-  const e = {};
-  e[dataTypes.custom] = this.encodeCustom;
-  e[dataTypes.ascii] = this.encodeAsciiString;
-  e[dataTypes.bigint] = this.encodeLong;
-  e[dataTypes.blob] = this.encodeBlob;
-  e[dataTypes.boolean] = this.encodeBoolean;
-  e[dataTypes.counter] = this.encodeLong;
-  e[dataTypes.decimal] = this.encodeDecimal;
-  e[dataTypes.double] = this.encodeDouble;
-  e[dataTypes.float] = this.encodeFloat;
-  e[dataTypes.int] = this.encodeInt;
-  e[dataTypes.text] = this.encodeUtf8String;
-  e[dataTypes.timestamp] = this.encodeTimestamp;
-  e[dataTypes.uuid] = this.encodeUuid;
-  e[dataTypes.varchar] = this.encodeUtf8String;
-  e[dataTypes.varint] = this.encodeVarint;
-  e[dataTypes.timeuuid] = this.encodeUuid;
-  e[dataTypes.inet] = this.encodeInet;
-  e[dataTypes.date] = this.encodeDate;
-  e[dataTypes.time] = this.encodeTime;
-  e[dataTypes.smallint] = this.encodeSmallint;
-  e[dataTypes.tinyint] = this.encodeTinyint;
-  e[dataTypes.list] = this.encodeList;
-  e[dataTypes.map] = this.encodeMap;
-  e[dataTypes.set] = this.encodeSet;
-  e[dataTypes.udt] = this.encodeUdt;
-  e[dataTypes.tuple] = this.encodeTuple;
-
-  this.decoders = d;
-  this.encoders = e;
+  this.encoders = {
+    [dataTypes.custom]: this.encodeCustom,
+    [dataTypes.ascii]: this.encodeAsciiString,
+    [dataTypes.bigint]: this.encodeLong,
+    [dataTypes.blob]: this.encodeBlob,
+    [dataTypes.boolean]: this.encodeBoolean,
+    [dataTypes.counter]: this.encodeLong,
+    [dataTypes.decimal]: this.encodeDecimal,
+    [dataTypes.double]: this.encodeDouble,
+    [dataTypes.float]: this.encodeFloat,
+    [dataTypes.int]: this.encodeInt,
+    [dataTypes.text]: this.encodeUtf8String,
+    [dataTypes.timestamp]: this.encodeTimestamp,
+    [dataTypes.uuid]: this.encodeUuid,
+    [dataTypes.varchar]: this.encodeUtf8String,
+    [dataTypes.varint]: this.encodeVarint,
+    [dataTypes.timeuuid]: this.encodeUuid,
+    [dataTypes.inet]: this.encodeInet,
+    [dataTypes.date]: this.encodeDate,
+    [dataTypes.time]: this.encodeTime,
+    [dataTypes.smallint]: this.encodeSmallint,
+    [dataTypes.tinyint]: this.encodeTinyint,
+    [dataTypes.list]: this.encodeList,
+    [dataTypes.map]: this.encodeMap,
+    [dataTypes.set]: this.encodeSet,
+    [dataTypes.udt]: this.encodeUdt,
+    [dataTypes.tuple]: this.encodeTuple
+  };
 }
 
 /**

--- a/lib/host-connection-pool.js
+++ b/lib/host-connection-pool.js
@@ -34,387 +34,388 @@ const state = {
 
 /**
  * Represents a pool of connections to a host
- * @param {Host} host
- * @param {Number} protocolVersion Initial protocol version
- * @extends EventEmitter
- * @constructor
  */
-function HostConnectionPool(host, protocolVersion) {
-  events.EventEmitter.call(this);
-  this._address = host.address;
-  this._newConnectionTimeout = null;
-  this._creating = false;
-  this._state = state.initial;
-  this.options = host.options;
-  this.protocolVersion = protocolVersion;
-  this.coreConnectionsLength = 1;
+class HostConnectionPool extends events.EventEmitter {
   /**
-   * An immutable array of connections
-   * @type {Array.<Connection>}
+   * Creates a new instance of HostConnectionPool.
+   * @param {Host} host
+   * @param {Number} protocolVersion Initial protocol version
+   * @extends EventEmitter
    */
-  this.connections = utils.emptyArray;
-  this.setMaxListeners(0);
-}
+  constructor(host, protocolVersion) {
+    super();
+    this._address = host.address;
+    this._newConnectionTimeout = null;
+    this._creating = false;
+    this._state = state.initial;
+    this.options = host.options;
+    this.protocolVersion = protocolVersion;
+    this.coreConnectionsLength = 1;
+    /**
+     * An immutable array of connections
+     * @type {Array.<Connection>}
+     */
+    this.connections = utils.emptyArray;
+    this.setMaxListeners(0);
+    this.log = utils.log;
+  }
 
-util.inherits(HostConnectionPool, events.EventEmitter);
-
-/**
- * @param {Function} callback
- */
-HostConnectionPool.prototype.borrowConnection = function (callback) {
-  const self = this;
-  this.create(false, function afterCreating(err) {
-    if (err) {
-      return callback(err);
-    }
-    if (self.connections.length === 0) {
-      // Normally it should have callback in error, but better to handle this possibility
-      return callback(new Error('No connection available'));
-    }
-    const c = HostConnectionPool.minInFlight(self.connections);
-    callback(null, c);
-  });
-};
-
-/**
- * Gets the connection with the minimum number of in-flight requests.
- * Only checks for index + 1 and index, to avoid a loop through all the connections.
- * @param {Array.<Connection>} connections
- * @returns {Connection}
- */
-HostConnectionPool.minInFlight = function(connections) {
-  const length = connections.length;
-  if (length === 1) {
-    return connections[0];
-  }
-  const index = ++connectionIndex;
-  if (connectionIndex >= connectionIndexOverflow) {
-    connectionIndex = 0;
-  }
-  const current = connections[index % length];
-  const previous = connections[(index - 1) % length];
-  if (previous.getInFlight() < current.getInFlight()) {
-    return previous;
-  }
-  return current;
-};
-
-/**
- * Create the min amount of connections, if the pool is empty.
- * @param {Boolean} warmup Determines if all connections must be created before invoking the callback
- * @param {Function} callback
- */
-HostConnectionPool.prototype.create = function (warmup, callback) {
-  if (this.isClosing()) {
-    return callback(new Error('Pool is being closed when calling create'));
-  }
-  // The value of this.coreConnectionsLength can change over time
-  // when an existing pool is being resized (by setting the distance).
-  if (this.connections.length >= this.coreConnectionsLength) {
-    return callback();
-  }
-  if (!warmup && this.connections.length > 0) {
-    // we already have a valid connection
-    // let the connection grow continue in the background
-    this.increaseSize();
-    return callback();
-  }
-  this.once('creation', callback);
-  if (this._creating) {
-    // wait for the pool to be creating
-    return;
-  }
-  this._creating = true;
-  let connectionsToCreate = this.coreConnectionsLength;
-  if (!warmup) {
-    connectionsToCreate = 1;
-  }
-  const self = this;
-  utils.whilst(
-    function condition() {
-      return self.connections.length < connectionsToCreate;
-    },
-    function iterator(next) {
-      self._attemptNewConnection(next);
-    }, function whilstEnded(err) {
-      self._creating = false;
+  /**
+   * @param {Function} callback
+   */
+  borrowConnection(callback) {
+    const self = this;
+    this.create(false, function afterCreating(err) {
       if (err) {
-        if (self.isClosing()) {
-          self.log('info', 'Connection pool created but it was being closed');
-          self._closeAllConnections();
-          err = new Error('Pool is being closed');
-        }
-        else {
-          // there was an error and no connections could be successfully opened
-          self.log('warning', util.format('Connection pool to host %s could not be created', self._address), err);
-        }
-        return self.emit('creation', err);
+        return callback(err);
       }
-      self.log('info', util.format('Connection pool to host %s created with %d connection(s)',
-        self._address, self.connections.length));
-      self.emit('creation');
-      self.increaseSize();
+      if (self.connections.length === 0) {
+        // Normally it should have callback in error, but better to handle this possibility
+        return callback(new Error('No connection available'));
+      }
+      const c = HostConnectionPool.minInFlight(self.connections);
+      callback(null, c);
     });
-};
-
-/** @returns {Connection} */
-HostConnectionPool.prototype._createConnection = function () {
-  const c = new Connection(this._address, this.protocolVersion, this.options);
-  const self = this;
-  function connectionErrorCallback() {
-    // The socket is not fully open / can not send heartbeat
-    self.remove(c);
   }
-  c.on('idleRequestError', connectionErrorCallback);
-  c.on('socketClose', connectionErrorCallback);
-  return c;
-};
 
-/**
- * Prevents reconnection timeout from triggering
- */
-HostConnectionPool.prototype.clearNewConnectionAttempt = function () {
-  if (!this._newConnectionTimeout) {
-    return;
-  }
-  clearTimeout(this._newConnectionTimeout);
-  this._newConnectionTimeout = null;
-};
-
-/**
- * @param {Function} callback
- */
-HostConnectionPool.prototype._attemptNewConnection = function (callback) {
-  const c = this._createConnection();
-  const self = this;
-  this.once('open', callback);
-  if (this._opening) {
-    // wait for the event to fire
-    return;
-  }
-  this._opening = true;
-  c.open(function attemptOpenCallback(err) {
-    self._opening = false;
-    if (err) {
-      self.log('warning', util.format('Connection to %s could not be created: %s', self._address, err), err);
-      c.close();
-      return self.emit('open', err);
+  /**
+   * Gets the connection with the minimum number of in-flight requests.
+   * Only checks for index + 1 and index, to avoid a loop through all the connections.
+   * @param {Array.<Connection>} connections
+   * @returns {Connection}
+   */
+  static minInFlight(connections) {
+    const length = connections.length;
+    if (length === 1) {
+      return connections[0];
     }
-    if (self.isClosing()) {
-      self.log('info', util.format('Connection to %s opened successfully but pool was being closed', self._address));
-      c.close();
-      return self.emit('open', new Error('Connection closed'));
+    const index = ++connectionIndex;
+    if (connectionIndex >= connectionIndexOverflow) {
+      connectionIndex = 0;
     }
-    // use a copy of the connections array
-    const newConnections = self.connections.slice(0);
-    newConnections.push(c);
-    self.connections = newConnections;
-    self.log('info', util.format('Connection to %s opened successfully', self._address));
-    self.emit('open', null, c);
-  });
-};
+    const current = connections[index % length];
+    const previous = connections[(index - 1) % length];
+    if (previous.getInFlight() < current.getInFlight()) {
+      return previous;
+    }
+    return current;
+  }
 
-HostConnectionPool.prototype.attemptNewConnectionImmediate = function () {
-  const self = this;
-  function openConnection() {
-    self.clearNewConnectionAttempt();
-    self.scheduleNewConnectionAttempt(0);
-  }
-  if (this._state === state.initial) {
-    return openConnection();
-  }
-  if (this._state === state.closing) {
-    return this.once('close', openConnection);
-  }
-  // In the case the pool its being / has been shutdown for good
-  // Do not attempt to create a new connection.
-};
-
-/**
- * Closes the connection and removes a connection from the pool.
- * @param {Connection} connection
- */
-HostConnectionPool.prototype.remove = function (connection) {
-  // locating an object by position in the array is O(n), but normally there should be between 1 to 8 connections.
-  const index = this.connections.indexOf(connection);
-  if (index < 0) {
-    // it was already removed from the connections and it's closing
-    return;
-  }
-  // remove the connection from the pool, using an pool copy
-  const newConnections = this.connections.slice(0);
-  newConnections.splice(index, 1);
-  this.connections = newConnections;
-  // close the connection
-  setImmediate(function removeClose() {
-    connection.close();
-  });
-  this.emit('remove');
-};
-
-/**
- * @param {Number} delay
- */
-HostConnectionPool.prototype.scheduleNewConnectionAttempt = function (delay) {
-  if (this.isClosing()) {
-    return;
-  }
-  const self = this;
-  this._newConnectionTimeout = setTimeout(function newConnectionTimeoutExpired() {
-    self._newConnectionTimeout = null;
-    if (self.connections.length >= self.coreConnectionsLength) {
-      // new connection can be scheduled while a new connection is being opened
-      // the pool has the appropriate size
+  /**
+   * Create the min amount of connections, if the pool is empty.
+   * @param {Boolean} warmup Determines if all connections must be created before invoking the callback
+   * @param {Function} callback
+   */
+  create(warmup, callback) {
+    if (this.isClosing()) {
+      return callback(new Error('Pool is being closed when calling create'));
+    }
+    // The value of this.coreConnectionsLength can change over time
+    // when an existing pool is being resized (by setting the distance).
+    if (this.connections.length >= this.coreConnectionsLength) {
+      return callback();
+    }
+    if (!warmup && this.connections.length > 0) {
+      // we already have a valid connection
+      // let the connection grow continue in the background
+      this.increaseSize();
+      return callback();
+    }
+    this.once('creation', callback);
+    if (this._creating) {
+      // wait for the pool to be creating
       return;
     }
-    self._attemptNewConnection(utils.noop);
-  }, delay);
-};
-
-HostConnectionPool.prototype.hasScheduledNewConnection = function () {
-  return !!this._newConnectionTimeout || this._opening;
-};
-
-/**
- * Increases the size of the connection pool in the background, if needed.
- */
-HostConnectionPool.prototype.increaseSize = function () {
-  if (this.connections.length < this.coreConnectionsLength && !this.hasScheduledNewConnection()) {
-    // schedule the next connection in the background
-    this.scheduleNewConnectionAttempt(0);
-  }
-};
-
-/**
- * Gets a boolean indicating if the pool is being closed / shutting down or has been shutdown.
- */
-HostConnectionPool.prototype.isClosing = function () {
-  return this._state !== state.initial;
-};
-
-/**
- * Gracefully waits for all in-flight requests to finish and closes the pool.
- */
-HostConnectionPool.prototype.drainAndShutdown = function () {
-  if (this.isClosing()) {
-    // Its already closing / shutting down
-    return;
-  }
-  this._state = state.closing;
-  this.clearNewConnectionAttempt();
-  const self = this;
-  if (this.connections.length === 0) {
-    return this._afterClosing();
-  }
-  const connections = this.connections;
-  this.connections = utils.emptyArray;
-  let closedConnections = 0;
-  this.log('info', util.format('Draining and closing %d connections to %s', connections.length, this._address));
-  let wasClosed = false;
-  // eslint-disable-next-line prefer-const
-  let checkShutdownTimeout;
-  for (let i = 0; i < connections.length; i++) {
-    const c = connections[i];
-    if (c.getInFlight() === 0) {
-      getDelayedClose(c)();
-      continue;
+    this._creating = true;
+    let connectionsToCreate = this.coreConnectionsLength;
+    if (!warmup) {
+      connectionsToCreate = 1;
     }
-    c.emitDrain = true;
-    c.once('drain', getDelayedClose(c));
+    const self = this;
+    utils.whilst(
+      function condition() {
+        return self.connections.length < connectionsToCreate;
+      },
+      function iterator(next) {
+        self._attemptNewConnection(next);
+      }, function whilstEnded(err) {
+        self._creating = false;
+        if (err) {
+          if (self.isClosing()) {
+            self.log('info', 'Connection pool created but it was being closed');
+            self._closeAllConnections();
+            err = new Error('Pool is being closed');
+          }
+          else {
+            // there was an error and no connections could be successfully opened
+            self.log('warning', util.format('Connection pool to host %s could not be created', self._address), err);
+          }
+          return self.emit('creation', err);
+        }
+        self.log('info', util.format('Connection pool to host %s created with %d connection(s)',
+          self._address, self.connections.length));
+        self.emit('creation');
+        self.increaseSize();
+      });
   }
-  function getDelayedClose(connection) {
-    return (function delayedClose() {
+
+  /** @returns {Connection} */
+  _createConnection() {
+    const c = new Connection(this._address, this.protocolVersion, this.options);
+    const self = this;
+    function connectionErrorCallback() {
+      // The socket is not fully open / can not send heartbeat
+      self.remove(c);
+    }
+    c.on('idleRequestError', connectionErrorCallback);
+    c.on('socketClose', connectionErrorCallback);
+    return c;
+  }
+
+  /**
+   * Prevents reconnection timeout from triggering
+   */
+  clearNewConnectionAttempt() {
+    if (!this._newConnectionTimeout) {
+      return;
+    }
+    clearTimeout(this._newConnectionTimeout);
+    this._newConnectionTimeout = null;
+  }
+
+  /**
+   * @param {Function} callback
+   */
+  _attemptNewConnection(callback) {
+    const c = this._createConnection();
+    const self = this;
+    this.once('open', callback);
+    if (this._opening) {
+      // wait for the event to fire
+      return;
+    }
+    this._opening = true;
+    c.open(function attemptOpenCallback(err) {
+      self._opening = false;
+      if (err) {
+        self.log('warning', util.format('Connection to %s could not be created: %s', self._address, err), err);
+        c.close();
+        return self.emit('open', err);
+      }
+      if (self.isClosing()) {
+        self.log('info', util.format('Connection to %s opened successfully but pool was being closed', self._address));
+        c.close();
+        return self.emit('open', new Error('Connection closed'));
+      }
+      // use a copy of the connections array
+      const newConnections = self.connections.slice(0);
+      newConnections.push(c);
+      self.connections = newConnections;
+      self.log('info', util.format('Connection to %s opened successfully', self._address));
+      self.emit('open', null, c);
+    });
+  }
+
+  attemptNewConnectionImmediate() {
+    const self = this;
+    function openConnection() {
+      self.clearNewConnectionAttempt();
+      self.scheduleNewConnectionAttempt(0);
+    }
+    if (this._state === state.initial) {
+      return openConnection();
+    }
+    if (this._state === state.closing) {
+      return this.once('close', openConnection);
+    }
+    // In the case the pool its being / has been shutdown for good
+    // Do not attempt to create a new connection.
+  }
+
+  /**
+   * Closes the connection and removes a connection from the pool.
+   * @param {Connection} connection
+   */
+  remove(connection) {
+    // locating an object by position in the array is O(n), but normally there should be between 1 to 8 connections.
+    const index = this.connections.indexOf(connection);
+    if (index < 0) {
+      // it was already removed from the connections and it's closing
+      return;
+    }
+    // remove the connection from the pool, using an pool copy
+    const newConnections = this.connections.slice(0);
+    newConnections.splice(index, 1);
+    this.connections = newConnections;
+    // close the connection
+    setImmediate(function removeClose() {
       connection.close();
-      if (++closedConnections < connections.length) {
+    });
+    this.emit('remove');
+  }
+
+  /**
+   * @param {Number} delay
+   */
+  scheduleNewConnectionAttempt(delay) {
+    if (this.isClosing()) {
+      return;
+    }
+    const self = this;
+    this._newConnectionTimeout = setTimeout(function newConnectionTimeoutExpired() {
+      self._newConnectionTimeout = null;
+      if (self.connections.length >= self.coreConnectionsLength) {
+        // new connection can be scheduled while a new connection is being opened
+        // the pool has the appropriate size
         return;
       }
-      if (wasClosed) {
-        return;
+      self._attemptNewConnection(utils.noop);
+    }, delay);
+  }
+
+  hasScheduledNewConnection() {
+    return !!this._newConnectionTimeout || this._opening;
+  }
+
+  /**
+   * Increases the size of the connection pool in the background, if needed.
+   */
+  increaseSize() {
+    if (this.connections.length < this.coreConnectionsLength && !this.hasScheduledNewConnection()) {
+      // schedule the next connection in the background
+      this.scheduleNewConnectionAttempt(0);
+    }
+  }
+
+  /**
+   * Gets a boolean indicating if the pool is being closed / shutting down or has been shutdown.
+   */
+  isClosing() {
+    return this._state !== state.initial;
+  }
+
+  /**
+   * Gracefully waits for all in-flight requests to finish and closes the pool.
+   */
+  drainAndShutdown() {
+    if (this.isClosing()) {
+      // Its already closing / shutting down
+      return;
+    }
+    this._state = state.closing;
+    this.clearNewConnectionAttempt();
+    const self = this;
+    if (this.connections.length === 0) {
+      return this._afterClosing();
+    }
+    const connections = this.connections;
+    this.connections = utils.emptyArray;
+    let closedConnections = 0;
+    this.log('info', util.format('Draining and closing %d connections to %s', connections.length, this._address));
+    let wasClosed = false;
+    // eslint-disable-next-line prefer-const
+    let checkShutdownTimeout;
+    for (let i = 0; i < connections.length; i++) {
+      const c = connections[i];
+      if (c.getInFlight() === 0) {
+        getDelayedClose(c)();
+        continue;
       }
+      c.emitDrain = true;
+      c.once('drain', getDelayedClose(c));
+    }
+    function getDelayedClose(connection) {
+      return (function delayedClose() {
+        connection.close();
+        if (++closedConnections < connections.length) {
+          return;
+        }
+        if (wasClosed) {
+          return;
+        }
+        wasClosed = true;
+        if (checkShutdownTimeout) {
+          clearTimeout(checkShutdownTimeout);
+        }
+        self._afterClosing();
+      });
+    }
+    // Check that after sometime (readTimeout + 100ms) the connections have been drained
+    const delay = (this.options.socketOptions.readTimeout || defaultOptions.socketOptions.readTimeout) + 100;
+    checkShutdownTimeout = setTimeout(function checkShutdown() {
       wasClosed = true;
-      if (checkShutdownTimeout) {
-        clearTimeout(checkShutdownTimeout);
-      }
+      connections.forEach(function connectionEach(c) {
+        c.close();
+      });
       self._afterClosing();
-    });
+    }, delay);
   }
-  // Check that after sometime (readTimeout + 100ms) the connections have been drained
-  const delay = (this.options.socketOptions.readTimeout || defaultOptions.socketOptions.readTimeout) + 100;
-  checkShutdownTimeout = setTimeout(function checkShutdown() {
-    wasClosed = true;
-    connections.forEach(function connectionEach(c) {
-      c.close();
-    });
-    self._afterClosing();
-  }, delay);
-};
 
-HostConnectionPool.prototype._afterClosing = function () {
-  const self = this;
-  function resetState() {
-    if (self._state === state.shuttingDown) {
+  _afterClosing() {
+    const self = this;
+    function resetState() {
+      if (self._state === state.shuttingDown) {
+        self._state = state.shutDown;
+      }
+      else {
+        self._state = state.initial;
+      }
+      self.emit('close');
+    }
+    if (this._creating) {
+      // The pool is being created, reset the state back to init once the creation finished (without any new connection)
+      return this.once('creation', resetState);
+    }
+    if (this._opening) {
+      // The pool is growing, reset the state back to init once the open finished (without any new connection)
+      return this.once('open', resetState);
+    }
+    resetState();
+  }
+
+  /**
+   * @param {Function} callback
+   */
+  shutdown(callback) {
+    this.clearNewConnectionAttempt();
+    if (!this.connections.length) {
+      this._state = state.shutDown;
+      return callback();
+    }
+    const previousState = this._state;
+    this._state = state.shuttingDown;
+    if (previousState === state.closing) {
+      return this.once('close', callback);
+    }
+    this.once('shutdown', callback);
+    if (previousState === state.shuttingDown) {
+      // Its going to be emitted
+      return;
+    }
+    const self = this;
+    this._closeAllConnections(function closeAllCallback() {
       self._state = state.shutDown;
-    }
-    else {
-      self._state = state.initial;
-    }
-    self.emit('close');
-  }
-  if (this._creating) {
-    // The pool is being created, reset the state back to init once the creation finished (without any new connection)
-    return this.once('creation', resetState);
-  }
-  if (this._opening) {
-    // The pool is growing, reset the state back to init once the open finished (without any new connection)
-    return this.once('open', resetState);
-  }
-  resetState();
-};
-
-/**
- * @param {Function} callback
- */
-HostConnectionPool.prototype.shutdown = function (callback) {
-  this.clearNewConnectionAttempt();
-  if (!this.connections.length) {
-    this._state = state.shutDown;
-    return callback();
-  }
-  const previousState = this._state;
-  this._state = state.shuttingDown;
-  if (previousState === state.closing) {
-    return this.once('close', callback);
-  }
-  this.once('shutdown', callback);
-  if (previousState === state.shuttingDown) {
-    // Its going to be emitted
-    return;
-  }
-  const self = this;
-  this._closeAllConnections(function closeAllCallback() {
-    self._state = state.shutDown;
-    self.emit('shutdown');
-  });
-};
-
-/** @param {Function} [callback] */
-HostConnectionPool.prototype._closeAllConnections = function (callback) {
-  callback = callback || utils.noop;
-  const connections = this.connections;
-  // point to an empty array
-  this.connections = utils.emptyArray;
-  if (connections.length === 0) {
-    return callback();
-  }
-  this.log('info', util.format('Closing %d connections to %s', connections.length, this._address));
-  utils.each(connections, function closeEach(c, next) {
-    c.close(function closedCallback() {
-      //ignore errors
-      next();
+      self.emit('shutdown');
     });
-  }, callback);
-};
+  }
 
-HostConnectionPool.prototype.log = utils.log;
+  /** @param {Function} [callback] */
+  _closeAllConnections(callback) {
+    callback = callback || utils.noop;
+    const connections = this.connections;
+    // point to an empty array
+    this.connections = utils.emptyArray;
+    if (connections.length === 0) {
+      return callback();
+    }
+    this.log('info', util.format('Closing %d connections to %s', connections.length, this._address));
+    utils.each(connections, function closeEach(c, next) {
+      c.close(function closedCallback() {
+        //ignore errors
+        next();
+      });
+    }, callback);
+  }
+}
 
 module.exports = HostConnectionPool;

--- a/lib/host.js
+++ b/lib/host.js
@@ -314,9 +314,7 @@ Host.prototype.getCassandraVersion = function () {
   if (!this.cassandraVersion) {
     return utils.emptyArray;
   }
-  return this.cassandraVersion.split('-')[0].split('.').map(function eachMap(x) {
-    return parseInt(x, 10);
-  });
+  return this.cassandraVersion.split('-')[0].split('.').map(x => parseInt(x, 10));
 };
 
 Host.prototype.log = utils.log;

--- a/lib/operation-state.js
+++ b/lib/operation-state.js
@@ -16,122 +16,127 @@ const state = {
 
 /**
  * Maintains the state information of a request inside a Connection.
- * @param {Request} request
- * @param {QueryOptions} options
- * @param {Function} callback
  */
-function OperationState(request, options, callback) {
-  this.request = request;
-  this._options = options;
-  this._rowCallback = options && options.rowCallback;
-  this._callback = callback;
-  this._timeout = null;
-  this._state = state.init;
-  this._rowIndex = 0;
+class OperationState {
   /**
-   * Stream id that is set right before being written.
-   * @type {number}
+   * Creates a new instance of OperationState.
+   * @param {Request} request
+   * @param {QueryOptions} options
+   * @param {Function} callback
    */
-  this.streamId = -1;
+  constructor(request, options, callback) {
+    this.request = request;
+    this._options = options;
+    this._rowCallback = options && options.rowCallback;
+    this._callback = callback;
+    this._timeout = null;
+    this._state = state.init;
+    this._rowIndex = 0;
+    /**
+     * Stream id that is set right before being written.
+     * @type {number}
+     */
+    this.streamId = -1;
+  }
+
+  /**
+   * Marks the operation as cancelled, clearing all callbacks and timeouts.
+   */
+  cancel() {
+    if (this._state !== state.init) {
+      return;
+    }
+    if (this._timeout !== null) {
+      clearTimeout(this._timeout);
+    }
+    this._state = state.cancelled;
+    this._callback = utils.noop;
+  }
+
+  /**
+   * Determines if the response is going to be yielded by row.
+   * @return {boolean}
+   */
+  isByRow() {
+    return this._rowCallback && (this.request instanceof ExecuteRequest || this.request instanceof QueryRequest);
+  }
+
+  /**
+   * Creates the timeout for the request.
+   * @param {Number} defaultReadTimeout
+   * @param {String} address
+   * @param {Function} onTimeout The callback to be invoked when it times out.
+   * @param {Function} onResponse The callback to be invoked if a response is obtained after it timed out.
+   */
+  setRequestTimeout(defaultReadTimeout, address, onTimeout, onResponse) {
+    if (this._state !== state.init) {
+      // No need to set the timeout
+      return;
+    }
+    const millis = (this._options && this._options.readTimeout !== undefined) ?
+      this._options.readTimeout : defaultReadTimeout;
+    if (!(millis > 0)) {
+      // Read timeout disabled
+      return;
+    }
+    const self = this;
+    this._timeout = setTimeout(function requestTimedOut() {
+      onTimeout();
+      const message = util.format('The host %s did not reply before timeout %d ms', address, millis);
+      self._markAsTimedOut(new errors.OperationTimedOutError(message), onResponse);
+    }, millis);
+  }
+
+  setResultRow(row, meta, rowLength, flags) {
+    this._markAsCompleted();
+    if (!this._rowCallback) {
+      return this.setResult(new errors.DriverInternalError('RowCallback not found for streaming frame handler'));
+    }
+    this._rowCallback(this._rowIndex++, row, rowLength);
+    if (this._rowIndex === rowLength) {
+      this._swapCallbackAndInvoke(null, { rowLength: rowLength, meta: meta, flags: flags });
+    }
+  }
+
+  /**
+   * Marks the current operation as timed out.
+   * @param {Error} err
+   * @param {Function} onResponse
+   * @private
+   */
+  _markAsTimedOut(err, onResponse) {
+    if (this._state !== state.init) {
+      return;
+    }
+    this._state = state.timedOut;
+    this._swapCallbackAndInvoke(err, null, onResponse);
+  }
+
+  _markAsCompleted() {
+    if (this._state !== state.init) {
+      return;
+    }
+    if (this._timeout !== null) {
+      clearTimeout(this._timeout);
+    }
+    this._state = state.completed;
+  }
+
+  /**
+   * Sets the result of this operation, declaring that no further input will be processed for this operation.
+   * @param {Error} err
+   * @param {Object} [result]
+   */
+  setResult(err, result) {
+    this._markAsCompleted();
+    this._swapCallbackAndInvoke(err, result);
+  }
+
+  _swapCallbackAndInvoke(err, result, newCallback) {
+    const callback = this._callback;
+    this._callback = newCallback || utils.noop;
+    callback(err, result);
+  }
 }
-
-/**
- * Marks the operation as cancelled, clearing all callbacks and timeouts.
- */
-OperationState.prototype.cancel = function () {
-  if (this._state !== state.init) {
-    return;
-  }
-  if (this._timeout !== null) {
-    clearTimeout(this._timeout);
-  }
-  this._state = state.cancelled;
-  this._callback = utils.noop;
-};
-
-/**
- * Determines if the response is going to be yielded by row.
- * @return {boolean}
- */
-OperationState.prototype.isByRow = function () {
-  return this._rowCallback && (this.request instanceof ExecuteRequest || this.request instanceof QueryRequest);
-};
-
-/**
- * Creates the timeout for the request.
- * @param {Number} defaultReadTimeout
- * @param {String} address
- * @param {Function} onTimeout The callback to be invoked when it times out.
- * @param {Function} onResponse The callback to be invoked if a response is obtained after it timed out.
- */
-OperationState.prototype.setRequestTimeout = function (defaultReadTimeout, address, onTimeout, onResponse) {
-  if (this._state !== state.init) {
-    // No need to set the timeout
-    return;
-  }
-  const millis = (this._options && this._options.readTimeout !== undefined) ?
-    this._options.readTimeout : defaultReadTimeout;
-  if (!(millis > 0)) {
-    // Read timeout disabled
-    return;
-  }
-  const self = this;
-  this._timeout = setTimeout(function requestTimedOut() {
-    onTimeout();
-    const message = util.format('The host %s did not reply before timeout %d ms', address, millis);
-    self._markAsTimedOut(new errors.OperationTimedOutError(message), onResponse);
-  }, millis);
-};
-
-OperationState.prototype.setResultRow = function (row, meta, rowLength, flags) {
-  this._markAsCompleted();
-  if (!this._rowCallback) {
-    return this.setResult(new errors.DriverInternalError('RowCallback not found for streaming frame handler'));
-  }
-  this._rowCallback(this._rowIndex++, row, rowLength);
-  if (this._rowIndex === rowLength) {
-    this._swapCallbackAndInvoke(null, { rowLength: rowLength, meta: meta, flags: flags });
-  }
-};
-
-/**
- * Marks the current operation as timed out.
- * @param {Error} err
- * @param {Function} onResponse
- * @private
- */
-OperationState.prototype._markAsTimedOut = function (err, onResponse) {
-  if (this._state !== state.init) {
-    return;
-  }
-  this._state = state.timedOut;
-  this._swapCallbackAndInvoke(err, null, onResponse);
-};
-
-OperationState.prototype._markAsCompleted = function () {
-  if (this._state !== state.init) {
-    return;
-  }
-  if (this._timeout !== null) {
-    clearTimeout(this._timeout);
-  }
-  this._state = state.completed;
-};
-
-/**
- * Sets the result of this operation, declaring that no further input will be processed for this operation.
- * @param {Error} err
- * @param {Object} [result]
- */
-OperationState.prototype.setResult = function (err, result) {
-  this._markAsCompleted();
-  this._swapCallbackAndInvoke(err, result);
-};
-
-OperationState.prototype._swapCallbackAndInvoke = function (err, result, newCallback) {
-  const callback = this._callback;
-  this._callback = newCallback || utils.noop;
-  callback(err, result);
-};
 
 module.exports = OperationState;

--- a/lib/prepare-handler.js
+++ b/lib/prepare-handler.js
@@ -8,221 +8,224 @@ const RequestHandler = require('./request-handler');
 /**
  * Encapsulates the logic for dealing with the different prepare request and response flows, including failover when
  * trying to prepare a query.
- * @param {Client} client
- * @param {LoadBalancingPolicy} loadBalancing
- * @constructor
  */
-function PrepareHandler(client, loadBalancing) {
-  this._client = client;
-  this.logEmitter = client.options.logEmitter;
-  this._loadBalancing = loadBalancing;
-}
-
-/**
- * @param {Client} client
- * @param {LoadBalancingPolicy} loadBalancing
- * @param {String} query
- * @param {String} keyspace
- * @param {Function} callback
- * @static
- */
-PrepareHandler.getPrepared = function (client, loadBalancing, query, keyspace, callback) {
-  const info = client.metadata.getPreparedInfo(keyspace, query);
-  if (info.queryId) {
-    return callback(null, info.queryId, info.meta);
+class PrepareHandler {
+  /**
+   * Creates a new instance of PrepareHandler
+   * @param {Client} client
+   * @param {LoadBalancingPolicy} loadBalancing
+   */
+  constructor(client, loadBalancing) {
+    this._client = client;
+    this._loadBalancing = loadBalancing;
+    this.logEmitter = client.options.logEmitter;
+    this.log = utils.log;
   }
-  info.once('prepared', callback);
-  if (info.preparing) {
-    // It's already being prepared
-    return;
+
+  /**
+   * @param {Client} client
+   * @param {LoadBalancingPolicy} loadBalancing
+   * @param {String} query
+   * @param {String} keyspace
+   * @param {Function} callback
+   * @static
+   */
+  static getPrepared(client, loadBalancing, query, keyspace, callback) {
+    const info = client.metadata.getPreparedInfo(keyspace, query);
+    if (info.queryId) {
+      return callback(null, info.queryId, info.meta);
+    }
+    info.once('prepared', callback);
+    if (info.preparing) {
+      // It's already being prepared
+      return;
+    }
+    const instance = new PrepareHandler(client, loadBalancing);
+    instance._prepare(info, query, keyspace);
   }
-  const instance = new PrepareHandler(client, loadBalancing);
-  instance._prepare(info, query, keyspace);
-};
 
-/**
- * @param {Client} client
- * @param {LoadBalancingPolicy} loadBalancing
- * @param {Array} queries
- * @param {String} keyspace
- * @param {Function} callback
- * @static
- */
-PrepareHandler.getPreparedMultiple = function (client, loadBalancing, queries, keyspace, callback) {
-  const result = new Array(queries.length);
-  utils.forEachOf(queries, function eachQuery(item, index, next) {
-    let query;
-    if (item) {
-      query = typeof item === 'string' ? item : item.query;
-    }
-    if (typeof query !== 'string') {
-      return next(new errors.ArgumentError('Query item should be a string'));
-    }
-    PrepareHandler.getPrepared(client, loadBalancing, query, keyspace, function getPrepareCb(err, id, meta) {
-      result[index] = {
-        query: query,
-        params: item.params,
-        queryId: id,
-        meta: meta
-      };
-      next();
-    });
-  }, function eachEnded(err) {
-    if (err) {
-      return callback(err);
-    }
-    callback(null, result);
-  });
-};
-
-/**
- * Prepares the query on a single host or on all hosts depending on the options.
- * Uses the info 'prepared' event to emit the result.
- * @param {Object} info
- * @param {String} query
- * @param {String} keyspace
- */
-PrepareHandler.prototype._prepare = function (info, query, keyspace) {
-  info.preparing = true;
-  const self = this;
-  this._loadBalancing.newQueryPlan(keyspace, null, function (err, iterator) {
-    if (err) {
-      info.preparing = false;
-      return info.emit('prepared', err);
-    }
-    self._prepareWithQueryPlan(info, iterator, null, query, keyspace);
-  });
-};
-
-/**
- * @param {Object} info
- * @param {Iterator} iterator
- * @param {Object|null} triedHosts
- * @param {String} query
- * @param {String} keyspace
- * @private
- */
-PrepareHandler.prototype._prepareWithQueryPlan = function (info, iterator, triedHosts, query, keyspace) {
-  triedHosts = triedHosts || {};
-  const self = this;
-  RequestHandler.borrowNextConnection(iterator, triedHosts, this._client.profileManager, keyspace,
-    function borrowCallback(err, connection, host) {
-      if (err) {
-        return self._onPrepareError(err, host, triedHosts, info, iterator, query, keyspace);
+  /**
+   * @param {Client} client
+   * @param {LoadBalancingPolicy} loadBalancing
+   * @param {Array} queries
+   * @param {String} keyspace
+   * @param {Function} callback
+   * @static
+   */
+  static getPreparedMultiple(client, loadBalancing, queries, keyspace, callback) {
+    const result = new Array(queries.length);
+    utils.forEachOf(queries, function eachQuery(item, index, next) {
+      let query;
+      if (item) {
+        query = typeof item === 'string' ? item : item.query;
       }
-      connection.prepareOnce(query, function prepareOnceCallback(err, response) {
+      if (typeof query !== 'string') {
+        return next(new errors.ArgumentError('Query item should be a string'));
+      }
+      PrepareHandler.getPrepared(client, loadBalancing, query, keyspace, function getPrepareCb(err, id, meta) {
+        result[index] = {
+          query: query,
+          params: item.params,
+          queryId: id,
+          meta: meta
+        };
+        next();
+      });
+    }, function eachEnded(err) {
+      if (err) {
+        return callback(err);
+      }
+      callback(null, result);
+    });
+  }
+
+  /**
+   * Prepares the query on a single host or on all hosts depending on the options.
+   * Uses the info 'prepared' event to emit the result.
+   * @param {Object} info
+   * @param {String} query
+   * @param {String} keyspace
+   */
+  _prepare(info, query, keyspace) {
+    info.preparing = true;
+    const self = this;
+    this._loadBalancing.newQueryPlan(keyspace, null, function (err, iterator) {
+      if (err) {
+        info.preparing = false;
+        return info.emit('prepared', err);
+      }
+      self._prepareWithQueryPlan(info, iterator, null, query, keyspace);
+    });
+  }
+
+  /**
+   * @param {Object} info
+   * @param {Iterator} iterator
+   * @param {Object|null} triedHosts
+   * @param {String} query
+   * @param {String} keyspace
+   * @private
+   */
+  _prepareWithQueryPlan(info, iterator, triedHosts, query, keyspace) {
+    triedHosts = triedHosts || {};
+    const self = this;
+    RequestHandler.borrowNextConnection(iterator, triedHosts, this._client.profileManager, keyspace,
+      function borrowCallback(err, connection, host) {
         if (err) {
           return self._onPrepareError(err, host, triedHosts, info, iterator, query, keyspace);
         }
-        if (self._client.options.prepareOnAllHosts) {
-          return self._prepareOnAllHosts(info, response, host, iterator, query, keyspace);
-        }
-        self._onPrepareSuccess(info, response);
+        connection.prepareOnce(query, function prepareOnceCallback(err, response) {
+          if (err) {
+            return self._onPrepareError(err, host, triedHosts, info, iterator, query, keyspace);
+          }
+          if (self._client.options.prepareOnAllHosts) {
+            return self._prepareOnAllHosts(info, response, host, iterator, query, keyspace);
+          }
+          self._onPrepareSuccess(info, response);
+        });
       });
+  }
+
+  _onPrepareSuccess(info, response) {
+    info.preparing = false;
+    info.queryId = response.id;
+    info.meta = response.meta;
+    this._client.metadata.setPreparedById(info);
+    info.emit('prepared', null, info.queryId, info.meta);
+  }
+
+  _onPrepareError(err, host, triedHosts, info, iterator, query, keyspace) {
+    if (err.isSocketError || err instanceof errors.OperationTimedOutError) {
+      const self = this;
+      triedHosts[host.address] = err;
+      return self._prepareWithQueryPlan(info, iterator, triedHosts, query, keyspace);
+    }
+    info.preparing = false;
+    err.query = query;
+    return info.emit('prepared', err);
+  }
+
+  /**
+   * Prepares all queries on a single host.
+   * @param {Host} host
+   * @param {Array} allPrepared
+   * @param {Function} callback
+   */
+  static prepareAllQueries(host, allPrepared, callback) {
+    const anyKeyspaceQueries = [];
+    const queriesByKeyspace = {};
+    allPrepared.forEach(function (info) {
+      let arr = anyKeyspaceQueries;
+      if (info.keyspace) {
+        arr = queriesByKeyspace[info.keyspace] = (queriesByKeyspace[info.keyspace] || []);
+      }
+      arr.push(info.query);
     });
-};
-
-PrepareHandler.prototype._onPrepareSuccess = function (info, response) {
-  info.preparing = false;
-  info.queryId = response.id;
-  info.meta = response.meta;
-  this._client.metadata.setPreparedById(info);
-  info.emit('prepared', null, info.queryId, info.meta);
-};
-
-PrepareHandler.prototype._onPrepareError = function (err, host, triedHosts, info, iterator, query, keyspace) {
-  if (err.isSocketError || err instanceof errors.OperationTimedOutError) {
-    const self = this;
-    triedHosts[host.address] = err;
-    return self._prepareWithQueryPlan(info, iterator, triedHosts, query, keyspace);
+    utils.eachSeries(Object.keys(queriesByKeyspace), function eachKeyspace(keyspace, next) {
+      PrepareHandler._borrowAndPrepare(host, keyspace, queriesByKeyspace[keyspace], next);
+    }, function (err) {
+      if (err) {
+        return callback(err);
+      }
+      PrepareHandler._borrowAndPrepare(host, null, anyKeyspaceQueries, callback);
+    });
   }
-  info.preparing = false;
-  err.query = query;
-  return info.emit('prepared', err);
-};
 
-/**
- * Prepares all queries on a single host.
- * @param {Host} host
- * @param {Array} allPrepared
- * @param {Function} callback
- */
-PrepareHandler.prepareAllQueries = function (host, allPrepared, callback) {
-  const anyKeyspaceQueries = [];
-  const queriesByKeyspace = {};
-  allPrepared.forEach(function (info) {
-    let arr = anyKeyspaceQueries;
-    if (info.keyspace) {
-      arr = queriesByKeyspace[info.keyspace] = (queriesByKeyspace[info.keyspace] || []);
-    }
-    arr.push(info.query);
-  });
-  utils.eachSeries(Object.keys(queriesByKeyspace), function eachKeyspace(keyspace, next) {
-    PrepareHandler._borrowAndPrepare(host, keyspace, queriesByKeyspace[keyspace], next);
-  }, function (err) {
-    if (err) {
-      return callback(err);
-    }
-    PrepareHandler._borrowAndPrepare(host, null, anyKeyspaceQueries, callback);
-  });
-};
-
-/**
- * Borrows a connection from the host and prepares the queries provided.
- * @param {Host} host
- * @param {String} keyspace
- * @param {Array} queries
- * @param {Function} callback
- * @private
- */
-PrepareHandler._borrowAndPrepare = function (host, keyspace, queries, callback) {
-  if (queries.length === 0) {
-    return callback();
-  }
-  RequestHandler.borrowFromHost(host, keyspace, function borrowCallback(err, connection) {
-    if (err) {
-      return callback(err);
-    }
-    utils.each(queries, function prepareEach(query, next) {
-      connection.prepareOnce(query, next);
-    }, callback);
-  });
-};
-
-PrepareHandler.prototype.log = utils.log;
-
-/**
- * Prepares the provided query on all hosts, except the host provided.
- * @param {Object} info
- * @param {Object} response
- * @param {Host} hostToAvoid
- * @param {Iterator} iterator
- * @param {String} query
- * @param {String} keyspace
- * @private
- */
-PrepareHandler.prototype._prepareOnAllHosts = function (info, response, hostToAvoid, iterator, query, keyspace) {
-  const self = this;
-  utils.each(utils.iteratorToArray(iterator), function (host, next) {
-    if (host.address === hostToAvoid.address) {
-      return next();
+  /**
+   * Borrows a connection from the host and prepares the queries provided.
+   * @param {Host} host
+   * @param {String} keyspace
+   * @param {Array} queries
+   * @param {Function} callback
+   * @private
+   */
+  static _borrowAndPrepare(host, keyspace, queries, callback) {
+    if (queries.length === 0) {
+      return callback();
     }
     RequestHandler.borrowFromHost(host, keyspace, function borrowCallback(err, connection) {
       if (err) {
-        // Don't mind about issues with the pool in this case
+        return callback(err);
+      }
+      utils.each(queries, function prepareEach(query, next) {
+        connection.prepareOnce(query, next);
+      }, callback);
+    });
+  }
+
+  /**
+   * Prepares the provided query on all hosts, except the host provided.
+   * @param {Object} info
+   * @param {Object} response
+   * @param {Host} hostToAvoid
+   * @param {Iterator} iterator
+   * @param {String} query
+   * @param {String} keyspace
+   * @private
+   */
+  _prepareOnAllHosts(info, response, hostToAvoid, iterator, query, keyspace) {
+    const self = this;
+    utils.each(utils.iteratorToArray(iterator), function (host, next) {
+      if (host.address === hostToAvoid.address) {
         return next();
       }
-      connection.prepareOnce(query, function (err) {
+      RequestHandler.borrowFromHost(host, keyspace, function borrowCallback(err, connection) {
         if (err) {
-          // There has been error
-          self.log('verbose', util.format('Unexpected error while preparing query (%s) on %s', query, host.address));
+          // Don't mind about issues with the pool in this case
+          return next();
         }
-        return next();
+        connection.prepareOnce(query, function (err) {
+          if (err) {
+            // There has been error
+            self.log('verbose', util.format('Unexpected error while preparing query (%s) on %s', query, host.address));
+          }
+          return next();
+        });
       });
+    }, function eachEnded() {
+      self._onPrepareSuccess(info, response);
     });
-  }, function eachEnded() {
-    self._onPrepareSuccess(info, response);
-  });
-};
+  }
+}
 
 module.exports = PrepareHandler;

--- a/lib/request-execution.js
+++ b/lib/request-execution.js
@@ -13,233 +13,234 @@ const retryOnNextHostDecision = Object.freeze({
   consistency: undefined
 });
 
-/**
- * Encapsulates a single flow of execution against a coordinator, handling individual retries and failover.
- * @param {RequestHandler} parent
- * @constructor
- */
-function RequestExecution(parent) {
-  this._parent = parent;
-  /** @type {OperationState} */
-  this._operation = null;
-  this._host = null;
-  this._cancelled = false;
-  this._retryCount = 0;
-  // The streamId information is not included in the request.
-  // A pointer to the parent request can be used, except when changing the consistency level from the retry policy
-  this._request = this._parent.request;
-}
+class RequestExecution {
+  /**
+   * Encapsulates a single flow of execution against a coordinator, handling individual retries and failover.
+   * @param {RequestHandler} parent
+   */
+  constructor(parent) {
+    this._parent = parent;
+    /** @type {OperationState} */
+    this._operation = null;
+    this._host = null;
+    this._cancelled = false;
+    this._retryCount = 0;
+    // The streamId information is not included in the request.
+    // A pointer to the parent request can be used, except when changing the consistency level from the retry policy
+    this._request = this._parent.request;
+  }
 
-/**
- * Starts the execution by borrowing the next connection available using the query plan.
- * It invokes the callback when a connection is acquired, if any.
- * @param {Function} [getHostCallback] Callback to be invoked when a connection to a host was successfully acquired.
- */
-RequestExecution.prototype.start = function (getHostCallback) {
-  const self = this;
-  getHostCallback = getHostCallback || utils.noop;
-  this._parent.getNextConnection(function nextConnectionCallback(err, connection, host) {
-    if (self._cancelled) {
-      // No need to send the request or invoke any callback
-      return;
-    }
-    if (err) {
-      return self._parent.handleNoHostAvailable(err, self);
-    }
-    self._connection = connection;
-    self._host = host;
-    getHostCallback(host);
-    if (self._retryCount === 0) {
-      self._parent.speculativeExecutions++;
-    }
-    self._sendOnConnection();
-  });
-};
-
-RequestExecution.prototype._sendOnConnection = function () {
-  const self = this;
-  this._operation =
-    this._connection.sendStream(this._request, this._parent.requestOptions, function responseCb(err, response) {
+  /**
+   * Starts the execution by borrowing the next connection available using the query plan.
+   * It invokes the callback when a connection is acquired, if any.
+   * @param {Function} [getHostCallback] Callback to be invoked when a connection to a host was successfully acquired.
+   */
+  start(getHostCallback) {
+    const self = this;
+    getHostCallback = getHostCallback || utils.noop;
+    this._parent.getNextConnection(function nextConnectionCallback(err, connection, host) {
       if (self._cancelled) {
-        // Avoid handling the response / err
+        // No need to send the request or invoke any callback
         return;
       }
       if (err) {
-        return self._handleError(err);
+        return self._parent.handleNoHostAvailable(err, self);
       }
-      const result = self._getResultSet(response);
-      if (response.schemaChange) {
-        return self._parent.client.handleSchemaAgreementAndRefresh(
-          self._connection, response.schemaChange, function schemaCb(){
-            if (self._cancelled) {
-              // After the schema agreement method was started, this execution was cancelled
-              return;
-            }
-            self._parent.setCompleted(null, result);
-          });
+      self._connection = connection;
+      self._host = host;
+      getHostCallback(host);
+      if (self._retryCount === 0) {
+        self._parent.speculativeExecutions++;
       }
-      if (response.keyspaceSet) {
-        self._parent.client.keyspace = response.keyspaceSet;
-      }
-      self._parent.setCompleted(null, result);
+      self._sendOnConnection();
     });
-};
-
-RequestExecution.prototype._getResultSet = function (response) {
-  return new types.ResultSet(response, this._host.address, this._parent.triedHosts, this._parent.speculativeExecutions,
-    this._request.consistency);
-};
-
-/**
- * Allows the handler to cancel the current request.
- * When the request has been already written, we can unset the callback and forget about it.
- */
-RequestExecution.prototype.cancel = function () {
-  this._cancelled = true;
-  if (this._operation === null) {
-    return;
   }
-  this._operation.cancel();
-};
 
-/**
- * Determines if the current execution was cancelled.
- */
-RequestExecution.prototype.wasCancelled = function () {
-  return this._cancelled;
-};
+  _sendOnConnection() {
+    const self = this;
+    this._operation =
+      this._connection.sendStream(this._request, this._parent.requestOptions, function responseCb(err, response) {
+        if (self._cancelled) {
+          // Avoid handling the response / err
+          return;
+        }
+        if (err) {
+          return self._handleError(err);
+        }
+        const result = self._getResultSet(response);
+        if (response.schemaChange) {
+          return self._parent.client.handleSchemaAgreementAndRefresh(
+            self._connection, response.schemaChange, function schemaCb(){
+              if (self._cancelled) {
+                // After the schema agreement method was started, this execution was cancelled
+                return;
+              }
+              self._parent.setCompleted(null, result);
+            });
+        }
+        if (response.keyspaceSet) {
+          self._parent.client.keyspace = response.keyspaceSet;
+        }
+        self._parent.setCompleted(null, result);
+      });
+  }
 
-RequestExecution.prototype._handleError = function (err) {
-  this._parent.triedHosts[this._host.address] = err;
-  err['coordinator'] = this._host.address;
-  if (err.code === types.responseErrorCodes.unprepared && (err instanceof errors.ResponseError)) {
-    return this._prepareAndRetry(err.queryId);
+  _getResultSet(response) {
+    return new types.ResultSet(response, this._host.address, this._parent.triedHosts, this._parent.speculativeExecutions,
+      this._request.consistency);
   }
-  const decisionInfo = this._getDecision(err);
-  if (err.isSocketError) {
-    this._host.removeFromPool(this._connection);
-  }
-  if (!decisionInfo || decisionInfo.decision === retry.RetryPolicy.retryDecision.rethrow) {
-    if (this._request instanceof requests.QueryRequest || this._request instanceof requests.ExecuteRequest) {
-      err['query'] = this._request.query;
+
+  /**
+   * Allows the handler to cancel the current request.
+   * When the request has been already written, we can unset the callback and forget about it.
+   */
+  cancel() {
+    this._cancelled = true;
+    if (this._operation === null) {
+      return;
     }
-    return this._parent.setCompleted(err);
+    this._operation.cancel();
   }
-  if (decisionInfo.decision === retry.RetryPolicy.retryDecision.ignore) {
-    // Return an empty ResultSet
-    return this._parent.setCompleted(null, this._getResultSet(utils.emptyObject));
-  }
-  return this._retry(decisionInfo.consistency, decisionInfo.useCurrentHost);
-};
 
-/**
- * Gets a decision whether or not to retry based on the error information.
- * @param {Error} err
- * @returns {{decision, useCurrentHost, consistency}}
- */
-RequestExecution.prototype._getDecision = function (err) {
-  const operationInfo = {
-    query: this._request && this._request.query,
-    options: this._parent.requestOptions,
-    nbRetry: this._retryCount,
-    // handler, request and retryOnTimeout properties are deprecated and should be removed in the next major version
-    handler: this,
-    request: this._request,
-    retryOnTimeout: false
-  };
-  const self = this;
-  function onRequestError() {
-    return self._parent.retryPolicy.onRequestError(operationInfo, self._request.consistency, err);
+  /**
+   * Determines if the current execution was cancelled.
+   */
+  wasCancelled() {
+    return this._cancelled;
   }
-  if (err.isSocketError) {
-    if (err.requestNotWritten) {
-      // The request was definitely not applied, it's safe to retry
-      return retryOnNextHostDecision;
+
+  _handleError(err) {
+    this._parent.triedHosts[this._host.address] = err;
+    err['coordinator'] = this._host.address;
+    if (err.code === types.responseErrorCodes.unprepared && (err instanceof errors.ResponseError)) {
+      return this._prepareAndRetry(err.queryId);
     }
-    return onRequestError();
-  }
-  if (err instanceof errors.OperationTimedOutError) {
-    this._parent.log('warning', err.message);
-    this._host.checkHealth(this._connection);
-    operationInfo.retryOnTimeout = this._parent.requestOptions.retryOnTimeout !== false;
-    return onRequestError();
-  }
-  if (err instanceof errors.ResponseError) {
-    switch (err.code) {
-      case types.responseErrorCodes.overloaded:
-      case types.responseErrorCodes.isBootstrapping:
-      case types.responseErrorCodes.truncateError:
-        return onRequestError();
-      case types.responseErrorCodes.unavailableException:
-        return this._parent.retryPolicy.onUnavailable(operationInfo, err.consistencies, err.required, err.alive);
-      case types.responseErrorCodes.readTimeout:
-        return this._parent.retryPolicy.onReadTimeout(
-          operationInfo, err.consistencies, err.received, err.blockFor, err.isDataPresent);
-      case types.responseErrorCodes.writeTimeout:
-        return this._parent.retryPolicy.onWriteTimeout(
-          operationInfo, err.consistencies, err.received, err.blockFor, err.writeType);
+    const decisionInfo = this._getDecision(err);
+    if (err.isSocketError) {
+      this._host.removeFromPool(this._connection);
     }
-  }
-  return { decision: retry.RetryPolicy.retryDecision.rethrow };
-};
-
-/**
- * @param {Number|undefined} consistency
- * @param {Boolean} useCurrentHost
- * @private
- */
-RequestExecution.prototype._retry = function (consistency, useCurrentHost) {
-  if (this._cancelled) {
-    // No point in retrying
-    return;
-  }
-  this._parent.log('info', 'Retrying request');
-  this._retryCount++;
-  if (typeof consistency === 'number' && this._request.consistency !== consistency) {
-    this._request = this._request.clone();
-    this._request.consistency = consistency;
-  }
-  if (useCurrentHost !== false) {
-    // Use existing host (default)
-    return this._sendOnConnection();
-  }
-  // Use the next host in the query plan to send the request
-  this.start();
-};
-
-
-
-/**
- * Issues a PREPARE request on the current connection.
- * If there's a socket or timeout issue, it moves to next host and executes the original request.
- * @param {Buffer} queryId
- * @private
- */
-RequestExecution.prototype._prepareAndRetry = function (queryId) {
-  this._parent.log('info', util.format('Query 0x%s not prepared on host %s, preparing and retrying',
-    queryId.toString('hex'), this._host.address));
-  const info = this._parent.client.metadata.getPreparedById(queryId);
-  if (!info) {
-    return this._parent.setCompleted(
-      new errors.DriverInternalError(util.format('Unprepared response invalid, id: %s', queryId.toString('hex'))));
-  }
-  if (info.keyspace && info.keyspace !== this._connection.keyspace) {
-    return this._parent.setCompleted(
-      new Error(util.format('Query was prepared on keyspace %s, can\'t execute it on %s (%s)',
-        info.keyspace, this._connection.keyspace, info.query)));
-  }
-  const self = this;
-  this._connection.prepareOnce(info.query, function (err) {
-    if (err) {
-      if (!err.isSocketError && err instanceof errors.OperationTimedOutError) {
-        self._parent.log('warning', util.format('Unexpected error when re-preparing query on host %s'));
+    if (!decisionInfo || decisionInfo.decision === retry.RetryPolicy.retryDecision.rethrow) {
+      if (this._request instanceof requests.QueryRequest || this._request instanceof requests.ExecuteRequest) {
+        err['query'] = this._request.query;
       }
-      // There was a failure re-preparing on this connection.
-      // Execute the original request on the next connection and forget about the PREPARE-UNPREPARE flow.
-      return self._retry(undefined, false);
+      return this._parent.setCompleted(err);
     }
-    self._retry(undefined, true);
-  });
-};
+    if (decisionInfo.decision === retry.RetryPolicy.retryDecision.ignore) {
+      // Return an empty ResultSet
+      return this._parent.setCompleted(null, this._getResultSet(utils.emptyObject));
+    }
+    return this._retry(decisionInfo.consistency, decisionInfo.useCurrentHost);
+  }
+
+  /**
+   * Gets a decision whether or not to retry based on the error information.
+   * @param {Error} err
+   * @returns {{decision, useCurrentHost, consistency}}
+   */
+  _getDecision(err) {
+    const operationInfo = {
+      query: this._request && this._request.query,
+      options: this._parent.requestOptions,
+      nbRetry: this._retryCount,
+      // handler, request and retryOnTimeout properties are deprecated and should be removed in the next major version
+      handler: this,
+      request: this._request,
+      retryOnTimeout: false
+    };
+    const self = this;
+    function onRequestError() {
+      return self._parent.retryPolicy.onRequestError(operationInfo, self._request.consistency, err);
+    }
+    if (err.isSocketError) {
+      if (err.requestNotWritten) {
+        // The request was definitely not applied, it's safe to retry
+        return retryOnNextHostDecision;
+      }
+      return onRequestError();
+    }
+    if (err instanceof errors.OperationTimedOutError) {
+      this._parent.log('warning', err.message);
+      this._host.checkHealth(this._connection);
+      operationInfo.retryOnTimeout = this._parent.requestOptions.retryOnTimeout !== false;
+      return onRequestError();
+    }
+    if (err instanceof errors.ResponseError) {
+      switch (err.code) {
+        case types.responseErrorCodes.overloaded:
+        case types.responseErrorCodes.isBootstrapping:
+        case types.responseErrorCodes.truncateError:
+          return onRequestError();
+        case types.responseErrorCodes.unavailableException:
+          return this._parent.retryPolicy.onUnavailable(operationInfo, err.consistencies, err.required, err.alive);
+        case types.responseErrorCodes.readTimeout:
+          return this._parent.retryPolicy.onReadTimeout(
+            operationInfo, err.consistencies, err.received, err.blockFor, err.isDataPresent);
+        case types.responseErrorCodes.writeTimeout:
+          return this._parent.retryPolicy.onWriteTimeout(
+            operationInfo, err.consistencies, err.received, err.blockFor, err.writeType);
+      }
+    }
+    return { decision: retry.RetryPolicy.retryDecision.rethrow };
+  }
+
+  /**
+   * @param {Number|undefined} consistency
+   * @param {Boolean} useCurrentHost
+   * @private
+   */
+  _retry(consistency, useCurrentHost) {
+    if (this._cancelled) {
+      // No point in retrying
+      return;
+    }
+    this._parent.log('info', 'Retrying request');
+    this._retryCount++;
+    if (typeof consistency === 'number' && this._request.consistency !== consistency) {
+      this._request = this._request.clone();
+      this._request.consistency = consistency;
+    }
+    if (useCurrentHost !== false) {
+      // Use existing host (default)
+      return this._sendOnConnection();
+    }
+    // Use the next host in the query plan to send the request
+    this.start();
+  }
+
+
+
+  /**
+   * Issues a PREPARE request on the current connection.
+   * If there's a socket or timeout issue, it moves to next host and executes the original request.
+   * @param {Buffer} queryId
+   * @private
+   */
+  _prepareAndRetry(queryId) {
+    this._parent.log('info', util.format('Query 0x%s not prepared on host %s, preparing and retrying',
+      queryId.toString('hex'), this._host.address));
+    const info = this._parent.client.metadata.getPreparedById(queryId);
+    if (!info) {
+      return this._parent.setCompleted(
+        new errors.DriverInternalError(util.format('Unprepared response invalid, id: %s', queryId.toString('hex'))));
+    }
+    if (info.keyspace && info.keyspace !== this._connection.keyspace) {
+      return this._parent.setCompleted(
+        new Error(util.format('Query was prepared on keyspace %s, can\'t execute it on %s (%s)',
+          info.keyspace, this._connection.keyspace, info.query)));
+    }
+    const self = this;
+    this._connection.prepareOnce(info.query, function (err) {
+      if (err) {
+        if (!err.isSocketError && err instanceof errors.OperationTimedOutError) {
+          self._parent.log('warning', util.format('Unexpected error when re-preparing query on host %s'));
+        }
+        // There was a failure re-preparing on this connection.
+        // Execute the original request on the next connection and forget about the PREPARE-UNPREPARE flow.
+        return self._retry(undefined, false);
+      }
+      self._retry(undefined, true);
+    });
+  }
+}
 
 module.exports = RequestExecution;

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -7,245 +7,246 @@ const utils = require('./utils');
 const RequestExecution = require('./request-execution');
 
 /**
- * Handles a request to Cassandra, dealing with host fail-over and retries on error
- * @param {Request} request
- * @param {QueryOptions} options
- * @param {Client} client Client instance used to retrieve and set the keyspace.
- * @constructor
+ * Handles a request to the server, dealing with host fail-over and retries on error
  */
-function RequestHandler(request, options, client) {
-  this.client = client;
-  this.loadBalancingPolicy = options.executionProfile.loadBalancing;
-  this.retryPolicy = options.retry;
-  this._speculativeExecutionPlan = client.options.policies.speculativeExecution.newPlan(
-    client.keyspace, request.query || request.queries);
-  this.logEmitter = client.options.logEmitter;
-  this.request = request;
-  this.requestOptions = options;
-  this.stackContainer = null;
-  this.triedHosts = {};
-  // start at -1 as first request does not count.
-  this.speculativeExecutions = -1;
-  this._hostIterator = null;
-  this._callback = null;
-  this._newExecutionTimeout = null;
-  this._executions = [];
-}
-
-/**
- * Borrows a connection iterating from the query plan one or more times, until finding an open connection with the
- * keyspace set.
- * It invokes the callback with the err, connection and host as parameters.
- * The error can only be a NoHostAvailableError instance.
- * @param {Iterator} iterator
- * @param {Object} triedHosts
- * @param {ProfileManager} profileManager
- * @param {String} keyspace
- * @param {Function} callback
- */
-RequestHandler.borrowNextConnection = function(iterator, triedHosts, profileManager, keyspace, callback) {
-  triedHosts = triedHosts || {};
-  const host = getNextHost(iterator, profileManager, triedHosts);
-  if (host === null) {
-    return callback(new errors.NoHostAvailableError(triedHosts));
+class RequestHandler {
+  /**
+   * Creates a new instance of RequestHandler.
+   * @param {Request} request
+   * @param {QueryOptions} options
+   * @param {Client} client Client instance used to retrieve and set the keyspace.
+   */
+  constructor(request, options, client) {
+    this.client = client;
+    this.loadBalancingPolicy = options.executionProfile.loadBalancing;
+    this.retryPolicy = options.retry;
+    this._speculativeExecutionPlan = client.options.policies.speculativeExecution.newPlan(
+      client.keyspace, request.query || request.queries);
+    this.logEmitter = client.options.logEmitter;
+    this.log = utils.log;
+    this.request = request;
+    this.requestOptions = options;
+    this.stackContainer = null;
+    this.triedHosts = {};
+    // start at -1 as first request does not count.
+    this.speculativeExecutions = -1;
+    this._hostIterator = null;
+    this._callback = null;
+    this._newExecutionTimeout = null;
+    this._executions = [];
   }
 
-  RequestHandler.borrowFromHost(host, keyspace, function borrowFromHostCallback(err, connection) {
-    if (err) {
-      triedHosts[host.address] = err;
-      if (connection) {
-        host.removeFromPool(connection);
-      }
-      // The error occurred on a different tick, so there is no risk of issuing a large number sync recursive calls
-      return RequestHandler.borrowNextConnection(iterator, triedHosts, profileManager, keyspace, callback);
+  /**
+   * Borrows a connection iterating from the query plan one or more times, until finding an open connection with the
+   * keyspace set.
+   * It invokes the callback with the err, connection and host as parameters.
+   * The error can only be a NoHostAvailableError instance.
+   * @param {Iterator} iterator
+   * @param {Object} triedHosts
+   * @param {ProfileManager} profileManager
+   * @param {String} keyspace
+   * @param {Function} callback
+   */
+  static borrowNextConnection(iterator, triedHosts, profileManager, keyspace, callback) {
+    triedHosts = triedHosts || {};
+    const host = RequestHandler._getNextHost(iterator, profileManager, triedHosts);
+    if (host === null) {
+      return callback(new errors.NoHostAvailableError(triedHosts));
     }
-    triedHosts[host.address] = null;
-    callback(null, connection, host);
-  });
-};
 
-/**
- * Borrows a connection from the provided host, changing the current keyspace, if necessary.
- * @param {Host} host
- * @param {String} keyspace
- * @param {Function} callback
- */
-RequestHandler.borrowFromHost = function (host, keyspace, callback) {
-  host.borrowConnection(function (err, connection) {
-    if (err) {
-      return callback(err);
-    }
-    if (!keyspace || keyspace === connection.keyspace) {
-      // Connection is ready to be used
-      return callback(null, connection);
-    }
-    connection.changeKeyspace(keyspace, function (err) {
+    RequestHandler.borrowFromHost(host, keyspace, function borrowFromHostCallback(err, connection) {
       if (err) {
-        return callback(err, connection);
-      }
-      callback(null, connection);
-    });
-  });
-};
-
-/**
- * Gets the next host from the query plan.
- * @param {Iterator} iterator
- * @param {ProfileManager} profileManager
- * @param {Object} triedHosts
- * @return {Host|null}
- * @private
- */
-function getNextHost(iterator, profileManager, triedHosts) {
-  let host;
-  // Get a host that is UP in a sync loop
-  while (true) {
-    const item = iterator.next();
-    if (item.done) {
-      return null;
-    }
-    host = item.value;
-    // set the distance relative to the client first
-    const distance = profileManager.getDistance(host);
-    if (distance === types.distance.ignored) {
-      //If its marked as ignore by the load balancing policy, move on.
-      continue;
-    }
-    if (host.isUp()) {
-      break;
-    }
-    triedHosts[host.address] = 'Host considered as DOWN';
-  }
-  return host;
-}
-
-/**
- * Gets a connection from the next host according to the query plan or a NoHostAvailableError.
- * @param {Function} callback
- */
-RequestHandler.prototype.getNextConnection = function (callback) {
-  RequestHandler.borrowNextConnection(
-    this._hostIterator, this.triedHosts, this.client.profileManager, this.client.keyspace, callback);
-};
-
-RequestHandler.prototype.log = utils.log;
-
-/**
- * Gets an available connection and sends the request
- * @param {Function} callback
- */
-RequestHandler.prototype.send = function (callback) {
-  if (this.requestOptions.captureStackTrace) {
-    Error.captureStackTrace(this.stackContainer = {});
-  }
-  const self = this;
-  this.loadBalancingPolicy.newQueryPlan(this.client.keyspace, this.requestOptions, function newPlanCb(err, iterator) {
-    if (err) {
-      return callback(err);
-    }
-    self._hostIterator = iterator;
-    self._callback = callback;
-    self._startNewExecution();
-  });
-};
-
-RequestHandler.prototype._startNewExecution = function () {
-  const execution = new RequestExecution(this);
-  this._executions.push(execution);
-  const self = this;
-  execution.start(function hostAcquired(host) {
-    // This function is called when a connection to a host was successfully acquired and
-    // the execution was not yet cancelled
-    if (!self.requestOptions.isIdempotent) {
-      return;
-    }
-    const delay = self._speculativeExecutionPlan.nextExecution(host);
-    if (typeof delay !== 'number' || delay < 0) {
-      return;
-    }
-    if (delay === 0) {
-      // Multiple parallel executions
-      return process.nextTick(function startNextInParallel() {
-        // Unlike timers process.nextTick() handlers can't be cleared so we must be sure that the
-        // the previous execution wasn't cancelled before issuing the next one.
-        if (execution.wasCancelled()) {
-          return;
+        triedHosts[host.address] = err;
+        if (connection) {
+          host.removeFromPool(connection);
         }
-        self._startNewExecution();
+        // The error occurred on a different tick, so there is no risk of issuing a large number sync recursive calls
+        return RequestHandler.borrowNextConnection(iterator, triedHosts, profileManager, keyspace, callback);
+      }
+      triedHosts[host.address] = null;
+      callback(null, connection, host);
+    });
+  }
+
+  /**
+   * Borrows a connection from the provided host, changing the current keyspace, if necessary.
+   * @param {Host} host
+   * @param {String} keyspace
+   * @param {Function} callback
+   */
+  static borrowFromHost(host, keyspace, callback) {
+    host.borrowConnection(function (err, connection) {
+      if (err) {
+        return callback(err);
+      }
+      if (!keyspace || keyspace === connection.keyspace) {
+        // Connection is ready to be used
+        return callback(null, connection);
+      }
+      connection.changeKeyspace(keyspace, function (err) {
+        if (err) {
+          return callback(err, connection);
+        }
+        callback(null, connection);
       });
-    }
-    self._newExecutionTimeout = setTimeout(function startNextAfterDelay() {
-      self._startNewExecution();
-    }, delay);
-  });
-};
+    });
+  }
 
-/**
- * Sets the keyspace in any connection that is already opened.
- * @param {Client} client
- * @param {Function} callback
- */
-RequestHandler.setKeyspace = function (client, callback) {
-  let connection;
-  const hosts = client.hosts.values();
-  for (let i = 0; i < hosts.length; i++) {
-    const host = hosts[i];
-    connection = host.getActiveConnection();
-    if (connection) {
-      break;
+  /**
+   * Gets the next host from the query plan.
+   * @param {Iterator} iterator
+   * @param {ProfileManager} profileManager
+   * @param {Object} triedHosts
+   * @return {Host|null}
+   * @private
+   */
+  static _getNextHost(iterator, profileManager, triedHosts) {
+    let host;
+    // Get a host that is UP in a sync loop
+    while (true) {
+      const item = iterator.next();
+      if (item.done) {
+        return null;
+      }
+      host = item.value;
+      // set the distance relative to the client first
+      const distance = profileManager.getDistance(host);
+      if (distance === types.distance.ignored) {
+        //If its marked as ignore by the load balancing policy, move on.
+        continue;
+      }
+      if (host.isUp()) {
+        break;
+      }
+      triedHosts[host.address] = 'Host considered as DOWN';
     }
+    return host;
   }
-  if (!connection) {
-    return callback(new errors.DriverInternalError('No active connection found'));
-  }
-  connection.changeKeyspace(client.keyspace, callback);
-};
 
-/**
- * @param {Error} err
- * @param {ResultSet} [result]
- */
-RequestHandler.prototype.setCompleted = function (err, result) {
-  if (this._newExecutionTimeout !== null) {
-    clearTimeout(this._newExecutionTimeout);
+  /**
+   * Gets a connection from the next host according to the query plan or a NoHostAvailableError.
+   * @param {Function} callback
+   */
+  getNextConnection(callback) {
+    RequestHandler.borrowNextConnection(
+      this._hostIterator, this.triedHosts, this.client.profileManager, this.client.keyspace, callback);
   }
-  // Mark all executions as cancelled
-  for (let i = 0; i < this._executions.length; i++) {
-    this._executions[i].cancel();
-  }
-  if (err) {
+
+  /**
+   * Gets an available connection and sends the request
+   * @param {Function} callback
+   */
+  send(callback) {
     if (this.requestOptions.captureStackTrace) {
-      utils.fixStack(this.stackContainer.stack, err);
+      Error.captureStackTrace(this.stackContainer = {});
     }
-    return this._callback(err);
+    const self = this;
+    this.loadBalancingPolicy.newQueryPlan(this.client.keyspace, this.requestOptions, function newPlanCb(err, iterator) {
+      if (err) {
+        return callback(err);
+      }
+      self._hostIterator = iterator;
+      self._callback = callback;
+      self._startNewExecution();
+    });
   }
-  if (result.info.warnings) {
-    // Log the warnings from the response
-    result.info.warnings.forEach(function (message, i, warnings) {
-      this.log('warning', util.format(
-        'Received warning (%d of %d) "%s" for "%s"',
-        i + 1,
-        warnings.length,
-        message,
-        this.request.query || 'batch'));
-    }, this);
-  }
-  this._callback(null, result);
-};
 
-/**
- * @param {NoHostAvailableError} err
- * @param {RequestExecution} sender
- */
-RequestHandler.prototype.handleNoHostAvailable = function (err, sender) {
-  // Remove the execution
-  const index = this._executions.indexOf(sender);
-  this._executions.splice(index, 1);
-  if (this._executions.length === 0) {
-    // There aren't any other executions, we should report back to the user that there isn't
-    // a host available for executing the request
-    this.setCompleted(err);
+  _startNewExecution() {
+    const execution = new RequestExecution(this);
+    this._executions.push(execution);
+    const self = this;
+    execution.start(function hostAcquired(host) {
+      // This function is called when a connection to a host was successfully acquired and
+      // the execution was not yet cancelled
+      if (!self.requestOptions.isIdempotent) {
+        return;
+      }
+      const delay = self._speculativeExecutionPlan.nextExecution(host);
+      if (typeof delay !== 'number' || delay < 0) {
+        return;
+      }
+      if (delay === 0) {
+        // Multiple parallel executions
+        return process.nextTick(function startNextInParallel() {
+          // Unlike timers process.nextTick() handlers can't be cleared so we must be sure that the
+          // the previous execution wasn't cancelled before issuing the next one.
+          if (execution.wasCancelled()) {
+            return;
+          }
+          self._startNewExecution();
+        });
+      }
+      self._newExecutionTimeout = setTimeout(() => self._startNewExecution(), delay);
+    });
   }
-};
+
+  /**
+   * Sets the keyspace in any connection that is already opened.
+   * @param {Client} client
+   * @param {Function} callback
+   */
+  static setKeyspace(client, callback) {
+    let connection;
+    const hosts = client.hosts.values();
+    for (let i = 0; i < hosts.length; i++) {
+      const host = hosts[i];
+      connection = host.getActiveConnection();
+      if (connection) {
+        break;
+      }
+    }
+    if (!connection) {
+      return callback(new errors.DriverInternalError('No active connection found'));
+    }
+    connection.changeKeyspace(client.keyspace, callback);
+  }
+
+  /**
+   * @param {Error} err
+   * @param {ResultSet} [result]
+   */
+  setCompleted(err, result) {
+    if (this._newExecutionTimeout !== null) {
+      clearTimeout(this._newExecutionTimeout);
+    }
+    // Mark all executions as cancelled
+    for (let i = 0; i < this._executions.length; i++) {
+      this._executions[i].cancel();
+    }
+    if (err) {
+      if (this.requestOptions.captureStackTrace) {
+        utils.fixStack(this.stackContainer.stack, err);
+      }
+      return this._callback(err);
+    }
+    if (result.info.warnings) {
+      // Log the warnings from the response
+      result.info.warnings.forEach(function (message, i, warnings) {
+        this.log('warning', util.format(
+          'Received warning (%d of %d) "%s" for "%s"',
+          i + 1,
+          warnings.length,
+          message,
+          this.request.query || 'batch'));
+      }, this);
+    }
+    this._callback(null, result);
+  }
+
+  /**
+   * @param {NoHostAvailableError} err
+   * @param {RequestExecution} sender
+   */
+  handleNoHostAvailable(err, sender) {
+    // Remove the execution
+    const index = this._executions.indexOf(sender);
+    this._executions.splice(index, 1);
+    if (this._executions.length === 0) {
+      // There aren't any other executions, we should report back to the user that there isn't
+      // a host available for executing the request
+      this.setCompleted(err);
+    }
+  }
+}
 
 module.exports = RequestHandler;

--- a/lib/requests.js
+++ b/lib/requests.js
@@ -305,7 +305,7 @@ BatchRequest.prototype.write = function (encoder, streamId) {
       // Contains prepared queries
       frameWriter.writeByte(1);
       frameWriter.writeShortBytes(item.queryId);
-      hints = item.meta.columns.map(function (c) { return c.type; });
+      hints = item.meta.columns.map(c => c.type);
       const paramsInfo = utils.adaptNamedParamsPrepared(params, item.meta.columns);
       params = paramsInfo.params;
     }

--- a/lib/requests.js
+++ b/lib/requests.js
@@ -31,36 +31,37 @@ const batchFlag = {
 
 /**
  * Abstract class Request
- * @constructor
  */
-function Request() {
+class Request {
+  constructor() {
 
-}
-
-/**
- * @abstract
- * @param {Encoder} encoder
- * @param {Number} streamId
- * @throws {TypeError}
- * @returns {Buffer}
- */
-Request.prototype.write = function (encoder, streamId) {
-  throw new Error('Method must be implemented');
-};
-
-/**
- * Creates a new instance using the same constructor as the current instance, copying the properties.
- * @return {Request}
- */
-Request.prototype.clone = function () {
-  const newRequest = new (this.constructor)();
-  const keysArray = Object.keys(this);
-  for (let i = 0; i < keysArray.length; i++) {
-    const key = keysArray[i];
-    newRequest[key] = this[key];
   }
-  return newRequest;
-};
+
+  /**
+   * @abstract
+   * @param {Encoder} encoder
+   * @param {Number} streamId
+   * @throws {TypeError}
+   * @returns {Buffer}
+   */
+  write(encoder, streamId) {
+    throw new Error('Method must be implemented');
+  }
+
+  /**
+   * Creates a new instance using the same constructor as the current instance, copying the properties.
+   * @return {Request}
+   */
+  clone() {
+    const newRequest = new (this.constructor)();
+    const keysArray = Object.keys(this);
+    for (let i = 0; i < keysArray.length; i++) {
+      const key = keysArray[i];
+      newRequest[key] = this[key];
+    }
+    return newRequest;
+  }
+}
 
 /**
  * Writes a execute query (given a prepared queryId)
@@ -69,266 +70,84 @@ Request.prototype.clone = function () {
  * @param {Array} params
  * @param options
  */
-function ExecuteRequest(query, queryId, params, options) {
-  this.query = query;
-  this.queryId = queryId;
-  this.params = params;
-  this.setOptions(options);
-}
-
-util.inherits(ExecuteRequest, Request);
-
-ExecuteRequest.prototype.write = function (encoder, streamId) {
-  //v1: <queryId>
-  //      <n><value_1>....<value_n><consistency>
-  //v2: <queryId>
-  //      <consistency><flags>[<n><value_1>...<value_n>][<result_page_size>][<paging_state>][<serial_consistency>]
-  //v3: <queryId>
-  //      <consistency><flags>[<n>[name_1]<value_1>...[name_n]<value_n>][<result_page_size>][<paging_state>][<serial_consistency>][<timestamp>]
-  const frameWriter = new FrameWriter(types.opcodes.execute);
-  let headerFlags = this.options.traceQuery ? types.frameFlags.tracing : 0;
-  if (this.options.customPayload) {
-    //The body may contain the custom payload
-    headerFlags |= types.frameFlags.customPayload;
-    frameWriter.writeCustomPayload(this.options.customPayload);
+class ExecuteRequest extends Request {
+  constructor(query, queryId, params, options) {
+    super();
+    this.query = query;
+    this.queryId = queryId;
+    this.params = params;
+    this.setOptions(options);
   }
-  frameWriter.writeShortBytes(this.queryId);
-  this.writeQueryParameters(frameWriter, encoder);
-  return frameWriter.write(encoder.protocolVersion, streamId, headerFlags);
-};
 
-/**
- * Writes v1 and v2 execute query parameters
- * @param {FrameWriter} frameWriter
- * @param {Encoder} encoder
- */
-ExecuteRequest.prototype.writeQueryParameters = function (frameWriter, encoder) {
-  //v1: <n><value_1>....<value_n><consistency>
-  //v2: <consistency><flags>[<n><value_1>...<value_n>][<result_page_size>][<paging_state>][<serial_consistency>]
-  //v3: <consistency><flags>[<n>[name_1]<value_1>...[name_n]<value_n>][<result_page_size>][<paging_state>][<serial_consistency>][<timestamp>]
-  let flags = 0;
-  if (types.protocolVersion.supportsPaging(encoder.protocolVersion)) {
-    flags |= (this.params && this.params.length) ? queryFlag.values : 0;
-    flags |= (this.options.fetchSize > 0) ? queryFlag.pageSize : 0;
-    flags |= this.options.pageState ? queryFlag.withPagingState : 0;
-    flags |= this.options.serialConsistency ? queryFlag.withSerialConsistency : 0;
-    flags |= this.options.timestamp ? queryFlag.withDefaultTimestamp : 0;
-    flags |= this.options.namedParameters ? queryFlag.withNameForValues : 0;
-    frameWriter.writeShort(this.consistency);
-    frameWriter.writeByte(flags);
-  }
-  if (this.params && this.params.length) {
-    frameWriter.writeShort(this.params.length);
-    for (let i = 0; i < this.params.length; i++) {
-      let paramValue = this.params[i];
-      if (flags & queryFlag.withNameForValues) {
-        //parameter is composed by name / value
-        frameWriter.writeString(paramValue.name);
-        paramValue = paramValue.value;
-      }
-      frameWriter.writeBytes(encoder.encode(paramValue, this.hints[i]));
+  write(encoder, streamId) {
+    //v1: <queryId>
+    //      <n><value_1>....<value_n><consistency>
+    //v2: <queryId>
+    //      <consistency><flags>[<n><value_1>...<value_n>][<result_page_size>][<paging_state>][<serial_consistency>]
+    //v3: <queryId>
+    //      <consistency><flags>[<n>[name_1]<value_1>...[name_n]<value_n>][<result_page_size>][<paging_state>][<serial_consistency>][<timestamp>]
+    const frameWriter = new FrameWriter(types.opcodes.execute);
+    let headerFlags = this.options.traceQuery ? types.frameFlags.tracing : 0;
+    if (this.options.customPayload) {
+      //The body may contain the custom payload
+      headerFlags |= types.frameFlags.customPayload;
+      frameWriter.writeCustomPayload(this.options.customPayload);
     }
-  }
-  if (!types.protocolVersion.supportsPaging(encoder.protocolVersion)) {
-    if (!this.params || !this.params.length) {
-      //zero parameters
-      frameWriter.writeShort(0);
-    }
-    frameWriter.writeShort(this.consistency);
-    return;
-  }
-  if (flags & queryFlag.pageSize) {
-    frameWriter.writeInt(this.options.fetchSize);
-  }
-  if (flags & queryFlag.withPagingState) {
-    frameWriter.writeBytes(this.options.pageState);
-  }
-  if (flags & queryFlag.withSerialConsistency) {
-    frameWriter.writeShort(this.options.serialConsistency);
-  }
-  if (flags & queryFlag.withDefaultTimestamp) {
-    let timestamp = this.options.timestamp;
-    if (typeof timestamp === 'number') {
-      timestamp = types.Long.fromNumber(timestamp);
-    }
-    frameWriter.writeLong(timestamp);
-  }
-};
-
-ExecuteRequest.prototype.setOptions = function (options) {
-  this.options = options || utils.emptyObject;
-  this.consistency = this.options.consistency || types.consistencies.one;
-  this.hints = this.options.hints || utils.emptyArray;
-};
-
-function QueryRequest(query, params, options) {
-  this.query = query;
-  this.params = params;
-  this.setOptions(options);
-}
-
-util.inherits(QueryRequest, ExecuteRequest);
-
-QueryRequest.prototype.write = function (encoder, streamId) {
-  //v1: <query><consistency>
-  //v2: <query>
-  //      <consistency><flags>[<n><value_1>...<value_n>][<result_page_size>][<paging_state>][<serial_consistency>]
-  //v3: <query>
-  //      <consistency><flags>[<n>[name_1]<value_1>...[name_n]<value_n>][<result_page_size>][<paging_state>][<serial_consistency>][<timestamp>]
-  const frameWriter = new FrameWriter(types.opcodes.query);
-  let headerFlags = this.options.traceQuery ? types.frameFlags.tracing : 0;
-  if (this.options.customPayload) {
-    //The body may contain the custom payload
-    headerFlags |= types.frameFlags.customPayload;
-    frameWriter.writeCustomPayload(this.options.customPayload);
-  }
-  frameWriter.writeLString(this.query);
-  if (!types.protocolVersion.supportsPaging(encoder.protocolVersion)) {
-    frameWriter.writeShort(this.consistency);
-  }
-  else {
-    //Use the same fields as the execute writer
+    frameWriter.writeShortBytes(this.queryId);
     this.writeQueryParameters(frameWriter, encoder);
+    return frameWriter.write(encoder.protocolVersion, streamId, headerFlags);
   }
-  return frameWriter.write(encoder.protocolVersion, streamId, headerFlags);
-};
 
-function PrepareRequest(query) {
-  this.query = query;
-}
-
-util.inherits(PrepareRequest, Request);
-
-PrepareRequest.prototype.write = function (encoder, streamId) {
-  const frameWriter = new FrameWriter(types.opcodes.prepare);
-  frameWriter.writeLString(this.query);
-  return frameWriter.write(encoder.protocolVersion, streamId);
-};
-
-function StartupRequest(cqlVersion) {
-  this.cqlVersion = cqlVersion || '3.0.0';
-}
-
-util.inherits(StartupRequest, Request);
-
-StartupRequest.prototype.write = function (encoder, streamId) {
-  const frameWriter = new FrameWriter(types.opcodes.startup);
-  frameWriter.writeStringMap({
-    CQL_VERSION: this.cqlVersion
-  });
-  return frameWriter.write(encoder.protocolVersion, streamId);
-};
-
-function RegisterRequest(events) {
-  this.events = events;
-}
-
-util.inherits(RegisterRequest, Request);
-
-RegisterRequest.prototype.write = function (encoder, streamId) {
-  const frameWriter = new FrameWriter(types.opcodes.register);
-  frameWriter.writeStringList(this.events);
-  return frameWriter.write(encoder.protocolVersion, streamId);
-};
-
-/**
- * Represents an AUTH_RESPONSE request
- * @param {Buffer} token
- * @constructor
- */
-function AuthResponseRequest(token) {
-  this.token = token;
-}
-
-util.inherits(AuthResponseRequest, Request);
-
-AuthResponseRequest.prototype.write = function (encoder, streamId) {
-  const frameWriter = new FrameWriter(types.opcodes.authResponse);
-  frameWriter.writeBytes(this.token);
-  return frameWriter.write(encoder.protocolVersion, streamId);
-};
-
-/**
- * Represents a protocol v1 CREDENTIALS request message
- * @constructor
- */
-function CredentialsRequest(username, password) {
-  this.username = username;
-  this.password = password;
-}
-
-util.inherits(CredentialsRequest, Request);
-
-CredentialsRequest.prototype.write = function (encoder, streamId) {
-  const frameWriter = new FrameWriter(types.opcodes.credentials);
-  frameWriter.writeStringMap({ username:this.username, password:this.password });
-  return frameWriter.write(encoder.protocolVersion, streamId);
-};
-
-/**
- * Writes a batch request
- * @param {Array.<{query, params, [info]}>} queries Array of objects with the properties query and params
- * @param {QueryOptions} options
- * @constructor
- */
-function BatchRequest(queries, options) {
-  this.queries = queries;
-  /** @type {QueryOptions} */
-  this.options = options;
-  this.type = options.logged ? 0 : 1;
-  this.type = options.counter ? 2 : this.type;
-  this.hints = options.hints || utils.emptyArray;
-}
-
-util.inherits(BatchRequest, Request);
-
-BatchRequest.prototype.write = function (encoder, streamId) {
-  //v2: <type><n><query_1>...<query_n><consistency>
-  //v3: <type><n><query_1>...<query_n><consistency><flags>[<serial_consistency>][<timestamp>]
-  if (!this.queries || !(this.queries.length > 0)) {
-    throw new TypeError(util.format('Invalid queries provided %s', this.queries));
-  }
-  const frameWriter = new FrameWriter(types.opcodes.batch);
-  let headerFlags = this.options.traceQuery ? types.frameFlags.tracing : 0;
-  if (this.options.customPayload) {
-    //The body may contain the custom payload
-    headerFlags |= types.frameFlags.customPayload;
-    frameWriter.writeCustomPayload(this.options.customPayload);
-  }
-  frameWriter.writeByte(this.type);
-  frameWriter.writeShort(this.queries.length);
-  const self = this;
-  this.queries.forEach(function eachQuery(item, i) {
-    let hints = self.hints[i];
-    let params = item.params || utils.emptyArray;
-    if (item.queryId) {
-      // Contains prepared queries
-      frameWriter.writeByte(1);
-      frameWriter.writeShortBytes(item.queryId);
-      hints = item.meta.columns.map(c => c.type);
-      const paramsInfo = utils.adaptNamedParamsPrepared(params, item.meta.columns);
-      params = paramsInfo.params;
+  /**
+   * Writes v1 and v2 execute query parameters
+   * @param {FrameWriter} frameWriter
+   * @param {Encoder} encoder
+   */
+  writeQueryParameters(frameWriter, encoder) {
+    //v1: <n><value_1>....<value_n><consistency>
+    //v2: <consistency><flags>[<n><value_1>...<value_n>][<result_page_size>][<paging_state>][<serial_consistency>]
+    //v3: <consistency><flags>[<n>[name_1]<value_1>...[name_n]<value_n>][<result_page_size>][<paging_state>][<serial_consistency>][<timestamp>]
+    let flags = 0;
+    if (types.protocolVersion.supportsPaging(encoder.protocolVersion)) {
+      flags |= (this.params && this.params.length) ? queryFlag.values : 0;
+      flags |= (this.options.fetchSize > 0) ? queryFlag.pageSize : 0;
+      flags |= this.options.pageState ? queryFlag.withPagingState : 0;
+      flags |= this.options.serialConsistency ? queryFlag.withSerialConsistency : 0;
+      flags |= this.options.timestamp ? queryFlag.withDefaultTimestamp : 0;
+      flags |= this.options.namedParameters ? queryFlag.withNameForValues : 0;
+      frameWriter.writeShort(this.consistency);
+      frameWriter.writeByte(flags);
     }
-    else {
-      // Contains string queries
-      frameWriter.writeByte(0);
-      frameWriter.writeLString(item.query);
+    if (this.params && this.params.length) {
+      frameWriter.writeShort(this.params.length);
+      for (let i = 0; i < this.params.length; i++) {
+        let paramValue = this.params[i];
+        if (flags & queryFlag.withNameForValues) {
+          //parameter is composed by name / value
+          frameWriter.writeString(paramValue.name);
+          paramValue = paramValue.value;
+        }
+        frameWriter.writeBytes(encoder.encode(paramValue, this.hints[i]));
+      }
     }
-    frameWriter.writeShort(params.length);
-    params.forEach(function (param, paramIndex) {
-      frameWriter.writeBytes(encoder.encode(param, hints ? hints[paramIndex] : null));
-    });
-  }, this);
-  frameWriter.writeShort(this.options.consistency);
-  if (types.protocolVersion.supportsTimestamp(encoder.protocolVersion)) {
-    //Batch flags
-    let flags = this.options.serialConsistency ? batchFlag.withSerialConsistency : 0;
-    flags |= this.options.timestamp ? batchFlag.withDefaultTimestamp : 0;
-    frameWriter.writeByte(flags);
-    if (this.options.serialConsistency) {
+    if (!types.protocolVersion.supportsPaging(encoder.protocolVersion)) {
+      if (!this.params || !this.params.length) {
+        //zero parameters
+        frameWriter.writeShort(0);
+      }
+      frameWriter.writeShort(this.consistency);
+      return;
+    }
+    if (flags & queryFlag.pageSize) {
+      frameWriter.writeInt(this.options.fetchSize);
+    }
+    if (flags & queryFlag.withPagingState) {
+      frameWriter.writeBytes(this.options.pageState);
+    }
+    if (flags & queryFlag.withSerialConsistency) {
       frameWriter.writeShort(this.options.serialConsistency);
     }
-    if (this.options.timestamp) {
+    if (flags & queryFlag.withDefaultTimestamp) {
       let timestamp = this.options.timestamp;
       if (typeof timestamp === 'number') {
         timestamp = types.Long.fromNumber(timestamp);
@@ -336,12 +155,198 @@ BatchRequest.prototype.write = function (encoder, streamId) {
       frameWriter.writeLong(timestamp);
     }
   }
-  return frameWriter.write(encoder.protocolVersion, streamId, headerFlags);
-};
 
-BatchRequest.prototype.clone = function () {
-  return new BatchRequest(this.queries, this.options);
-};
+  setOptions(options) {
+    this.options = options || utils.emptyObject;
+    this.consistency = this.options.consistency || types.consistencies.one;
+    this.hints = this.options.hints || utils.emptyArray;
+  }
+}
+
+class QueryRequest extends ExecuteRequest {
+  constructor(query, params, options) {
+    super(query, null, params, options);
+  }
+
+  write(encoder, streamId) {
+    //v1: <query><consistency>
+    //v2: <query>
+    //      <consistency><flags>[<n><value_1>...<value_n>][<result_page_size>][<paging_state>][<serial_consistency>]
+    //v3: <query>
+    //      <consistency><flags>[<n>[name_1]<value_1>...[name_n]<value_n>][<result_page_size>][<paging_state>][<serial_consistency>][<timestamp>]
+    const frameWriter = new FrameWriter(types.opcodes.query);
+    let headerFlags = this.options.traceQuery ? types.frameFlags.tracing : 0;
+    if (this.options.customPayload) {
+      //The body may contain the custom payload
+      headerFlags |= types.frameFlags.customPayload;
+      frameWriter.writeCustomPayload(this.options.customPayload);
+    }
+    frameWriter.writeLString(this.query);
+    if (!types.protocolVersion.supportsPaging(encoder.protocolVersion)) {
+      frameWriter.writeShort(this.consistency);
+    }
+    else {
+      //Use the same fields as the execute writer
+      this.writeQueryParameters(frameWriter, encoder);
+    }
+    return frameWriter.write(encoder.protocolVersion, streamId, headerFlags);
+  }
+}
+
+class PrepareRequest extends Request {
+  constructor(query) {
+    super();
+    this.query = query;
+  }
+
+  write(encoder, streamId) {
+    const frameWriter = new FrameWriter(types.opcodes.prepare);
+    frameWriter.writeLString(this.query);
+    return frameWriter.write(encoder.protocolVersion, streamId);
+  }
+}
+class StartupRequest extends Request {
+  constructor(cqlVersion) {
+    super();
+    this.cqlVersion = cqlVersion || '3.0.0';
+  }
+
+  write(encoder, streamId) {
+    const frameWriter = new FrameWriter(types.opcodes.startup);
+    frameWriter.writeStringMap({
+      CQL_VERSION: this.cqlVersion
+    });
+    return frameWriter.write(encoder.protocolVersion, streamId);
+  }
+}
+
+class RegisterRequest extends Request {
+  constructor(events) {
+    super();
+    this.events = events;
+  }
+
+  write(encoder, streamId) {
+    const frameWriter = new FrameWriter(types.opcodes.register);
+    frameWriter.writeStringList(this.events);
+    return frameWriter.write(encoder.protocolVersion, streamId);
+  }
+}
+
+/**
+ * Represents an AUTH_RESPONSE request
+ * @param {Buffer} token
+ */
+class AuthResponseRequest extends Request {
+  constructor(token) {
+    super();
+    this.token = token;
+  }
+
+  write(encoder, streamId) {
+    const frameWriter = new FrameWriter(types.opcodes.authResponse);
+    frameWriter.writeBytes(this.token);
+    return frameWriter.write(encoder.protocolVersion, streamId);
+  }
+}
+
+/**
+ * Represents a protocol v1 CREDENTIALS request message
+ */
+class CredentialsRequest extends Request {
+  constructor(username, password) {
+    super();
+    this.username = username;
+    this.password = password;
+  }
+
+  write(encoder, streamId) {
+    const frameWriter = new FrameWriter(types.opcodes.credentials);
+    frameWriter.writeStringMap({ username:this.username, password:this.password });
+    return frameWriter.write(encoder.protocolVersion, streamId);
+  }
+}
+
+class BatchRequest extends Request {
+  /**
+   * Creates a new instance of BatchRequest.
+   * @param {Array.<{query, params, [info]}>} queries Array of objects with the properties query and params
+   * @param {QueryOptions} options
+   */
+  constructor(queries, options) {
+    super();
+    this.queries = queries;
+    /** @type {QueryOptions} */
+    this.options = options;
+    this.type = options.logged ? 0 : 1;
+    this.type = options.counter ? 2 : this.type;
+    this.hints = options.hints || utils.emptyArray;
+  }
+
+  /**
+   * Writes a batch request
+   */
+  write(encoder, streamId) {
+    //v2: <type><n><query_1>...<query_n><consistency>
+    //v3: <type><n><query_1>...<query_n><consistency><flags>[<serial_consistency>][<timestamp>]
+    if (!this.queries || !(this.queries.length > 0)) {
+      throw new TypeError(util.format('Invalid queries provided %s', this.queries));
+    }
+    const frameWriter = new FrameWriter(types.opcodes.batch);
+    let headerFlags = this.options.traceQuery ? types.frameFlags.tracing : 0;
+    if (this.options.customPayload) {
+      //The body may contain the custom payload
+      headerFlags |= types.frameFlags.customPayload;
+      frameWriter.writeCustomPayload(this.options.customPayload);
+    }
+    frameWriter.writeByte(this.type);
+    frameWriter.writeShort(this.queries.length);
+    const self = this;
+    this.queries.forEach(function eachQuery(item, i) {
+      let hints = self.hints[i];
+      let params = item.params || utils.emptyArray;
+      if (item.queryId) {
+        // Contains prepared queries
+        frameWriter.writeByte(1);
+        frameWriter.writeShortBytes(item.queryId);
+        hints = item.meta.columns.map(c => c.type);
+        const paramsInfo = utils.adaptNamedParamsPrepared(params, item.meta.columns);
+        params = paramsInfo.params;
+      }
+      else {
+        // Contains string queries
+        frameWriter.writeByte(0);
+        frameWriter.writeLString(item.query);
+      }
+      frameWriter.writeShort(params.length);
+      params.forEach(function (param, paramIndex) {
+        frameWriter.writeBytes(encoder.encode(param, hints ? hints[paramIndex] : null));
+      });
+    }, this);
+    frameWriter.writeShort(this.options.consistency);
+    if (types.protocolVersion.supportsTimestamp(encoder.protocolVersion)) {
+      //Batch flags
+      let flags = this.options.serialConsistency ? batchFlag.withSerialConsistency : 0;
+      flags |= this.options.timestamp ? batchFlag.withDefaultTimestamp : 0;
+      frameWriter.writeByte(flags);
+      if (this.options.serialConsistency) {
+        frameWriter.writeShort(this.options.serialConsistency);
+      }
+      if (this.options.timestamp) {
+        let timestamp = this.options.timestamp;
+        if (typeof timestamp === 'number') {
+          timestamp = types.Long.fromNumber(timestamp);
+        }
+        frameWriter.writeLong(timestamp);
+      }
+    }
+    return frameWriter.write(encoder.protocolVersion, streamId, headerFlags);
+  }
+
+  clone() {
+    return new BatchRequest(this.queries, this.options);
+  }
+}
 
 exports.AuthResponseRequest = AuthResponseRequest;
 exports.BatchRequest = BatchRequest;

--- a/lib/stream-id-stack.js
+++ b/lib/stream-id-stack.js
@@ -141,9 +141,7 @@ StreamIdStack.prototype._tryIssueRelease = function () {
     return;
   }
   const self = this;
-  this.releaseTimeout = setTimeout(function () {
-    self._releaseGroups();
-  }, releaseDelay);
+  this.releaseTimeout = setTimeout(() => self._releaseGroups(), releaseDelay);
 };
 
 StreamIdStack.prototype._releaseGroups = function () {

--- a/lib/stream-id-stack.js
+++ b/lib/stream-id-stack.js
@@ -7,6 +7,7 @@ const types = require('./types');
  * @type {number}
  */
 const groupSize = 128;
+
 /**
  * Number used to right shift ids to allocate them into groups
  * @const
@@ -21,12 +22,14 @@ const shiftToGroup = 7;
  * @type {number}
  */
 const releasableSize = 4;
+
 /**
  * 32K possible stream ids depending for protocol v3 and above
  * @const
  * @type {number}
  */
 const maxGroupsFor2Bytes = 256;
+
 /**
  * Delay used to check if groups can be released
  * @const
@@ -34,133 +37,141 @@ const maxGroupsFor2Bytes = 256;
  */
 // eslint-disable-next-line prefer-const
 let releaseDelay = 5000;
+
 /**
  * Represents a queue of ids from 0 to maximum stream id supported by the protocol version.
- * Clients can dequeue a stream id using {@link StreamIdStack#shift()} and enqueue (release) using {@link StreamIdStack#push()}
- * @param {Number} version Protocol version
- * @constructor
+ * Clients can dequeue a stream id using {@link StreamIdStack#shift()} and enqueue (release) using
+ * {@link StreamIdStack#push()}
  */
-function StreamIdStack(version) {
-  //Ecmascript Number is 64-bit double, it can be optimized by the engine into a 32-bit int, but nothing below that.
-  //We try to allocate as few as possible in arrays of 128
-  this.currentGroup = generateGroup(0);
-  this.groupIndex = 0;
-  this.groups = [this.currentGroup];
-  this.releaseTimeout = null;
-  this.setVersion(version);
+class StreamIdStack {
   /**
-   * Returns the amount of ids currently in use
-   * @member {number}
+   * Creates a new instance of StreamIdStack.
+   * @param {Number} version Protocol version
+   * @constructor
    */
-  this.inUse = 0;
-}
-
-/**
- * Sets the protocol version
- * @param {Number} version
- */
-StreamIdStack.prototype.setVersion = function (version) {
-  //128 or 32K stream ids depending on the protocol version
-  this.maxGroups = types.protocolVersion.uses2BytesStreamIds(version) ? maxGroupsFor2Bytes : 1;
-};
-
-/**
- * Dequeues an id.
- * Similar to {@link Array#pop()}.
- * @returns {Number} Returns an id or null
- */
-StreamIdStack.prototype.pop = function () {
-  let id = this.currentGroup.pop();
-  if (typeof id !== 'undefined') {
-    this.inUse++;
-    return id;
+  constructor(version) {
+    //Ecmascript Number is 64-bit double, it can be optimized by the engine into a 32-bit int, but nothing below that.
+    //We try to allocate as few as possible in arrays of 128
+    this.currentGroup = generateGroup(0);
+    this.groupIndex = 0;
+    this.groups = [this.currentGroup];
+    this.releaseTimeout = null;
+    this.setVersion(version);
+    /**
+     * Returns the amount of ids currently in use
+     * @member {number}
+     */
+    this.inUse = 0;
   }
-  //try to use the following groups
-  while (this.groupIndex < this.groups.length - 1) {
-    //move to the following group
-    this.currentGroup = this.groups[++this.groupIndex];
-    //try dequeue
-    id = this.currentGroup.pop();
+
+  /**
+   * Sets the protocol version
+   * @param {Number} version
+   */
+  setVersion(version) {
+    //128 or 32K stream ids depending on the protocol version
+    this.maxGroups = types.protocolVersion.uses2BytesStreamIds(version) ? maxGroupsFor2Bytes : 1;
+  }
+
+  /**
+   * Dequeues an id.
+   * Similar to {@link Array#pop()}.
+   * @returns {Number} Returns an id or null
+   */
+  pop() {
+    let id = this.currentGroup.pop();
     if (typeof id !== 'undefined') {
       this.inUse++;
       return id;
     }
-  }
-  return this._tryCreateGroup();
-};
-/**
- * Enqueue an id for future use.
- * Similar to {@link Array#push()}.
- * @param {Number} id
- */
-StreamIdStack.prototype.push = function (id) {
-  this.inUse--;
-  const groupIndex = id >> shiftToGroup;
-  const group = this.groups[groupIndex];
-  group.push(id);
-  if (groupIndex < this.groupIndex) {
-    //Set the lower group to be used to dequeue from
-    this.groupIndex = groupIndex;
-    this.currentGroup = group;
-  }
-  this._tryIssueRelease();
-};
-
-/**
- * Clears all timers
- */
-StreamIdStack.prototype.clear = function () {
-  if (this.releaseTimeout) {
-    clearTimeout(this.releaseTimeout);
-    this.releaseTimeout = null;
-  }
-};
-
-/**
- * Tries to create an additional group and returns a new id
- * @returns {Number} Returns a new id or null if it's not possible to create a new group
- * @private
- */
-StreamIdStack.prototype._tryCreateGroup = function () {
-  if (this.groups.length === this.maxGroups) {
-    //we can have an additional group
-    return null;
-  }
-  //Add a new group at the last position
-  this.groupIndex = this.groups.length;
-  //Using 128 * groupIndex as initial value
-  this.currentGroup = generateGroup(this.groupIndex << shiftToGroup);
-  this.groups.push(this.currentGroup);
-  this.inUse++;
-  return this.currentGroup.pop();
-};
-
-StreamIdStack.prototype._tryIssueRelease = function () {
-  if (this.releaseTimeout || this.groups.length <= releasableSize) {
-    //Nothing to release or a release delay has been issued
-    return;
-  }
-  const self = this;
-  this.releaseTimeout = setTimeout(() => self._releaseGroups(), releaseDelay);
-};
-
-StreamIdStack.prototype._releaseGroups = function () {
-  let counter = 0;
-  let index = this.groups.length - 1;
-  //only release up to n groups (n = releasable size)
-  //shrink back up to n groups not all the way up to 1
-  while (counter++ < releasableSize && this.groups.length > releasableSize && index > this.groupIndex) {
-    if (this.groups[index].length !== groupSize) {
-      //the group is being used
-      break;
+    //try to use the following groups
+    while (this.groupIndex < this.groups.length - 1) {
+      //move to the following group
+      this.currentGroup = this.groups[++this.groupIndex];
+      //try dequeue
+      id = this.currentGroup.pop();
+      if (typeof id !== 'undefined') {
+        this.inUse++;
+        return id;
+      }
     }
-    this.groups.pop();
-    index--;
+    return this._tryCreateGroup();
   }
-  this.releaseTimeout = null;
-  //Issue next release if applies
-  this._tryIssueRelease();
-};
+
+  /**
+   * Enqueue an id for future use.
+   * Similar to {@link Array#push()}.
+   * @param {Number} id
+   */
+  push(id) {
+    this.inUse--;
+    const groupIndex = id >> shiftToGroup;
+    const group = this.groups[groupIndex];
+    group.push(id);
+    if (groupIndex < this.groupIndex) {
+      //Set the lower group to be used to dequeue from
+      this.groupIndex = groupIndex;
+      this.currentGroup = group;
+    }
+    this._tryIssueRelease();
+  }
+
+  /**
+   * Clears all timers
+   */
+  clear() {
+    if (this.releaseTimeout) {
+      clearTimeout(this.releaseTimeout);
+      this.releaseTimeout = null;
+    }
+  }
+
+  /**
+   * Tries to create an additional group and returns a new id
+   * @returns {Number} Returns a new id or null if it's not possible to create a new group
+   * @private
+   */
+  _tryCreateGroup() {
+    if (this.groups.length === this.maxGroups) {
+      //we can have an additional group
+      return null;
+    }
+    //Add a new group at the last position
+    this.groupIndex = this.groups.length;
+    //Using 128 * groupIndex as initial value
+    this.currentGroup = generateGroup(this.groupIndex << shiftToGroup);
+    this.groups.push(this.currentGroup);
+    this.inUse++;
+    return this.currentGroup.pop();
+  }
+
+  _tryIssueRelease() {
+    if (this.releaseTimeout || this.groups.length <= releasableSize) {
+      //Nothing to release or a release delay has been issued
+      return;
+    }
+    const self = this;
+    this.releaseTimeout = setTimeout(() => self._releaseGroups(), releaseDelay);
+  }
+
+  _releaseGroups() {
+    let counter = 0;
+    let index = this.groups.length - 1;
+    //only release up to n groups (n = releasable size)
+    //shrink back up to n groups not all the way up to 1
+    while (counter++ < releasableSize && this.groups.length > releasableSize && index > this.groupIndex) {
+      if (this.groups[index].length !== groupSize) {
+        //the group is being used
+        break;
+      }
+      this.groups.pop();
+      index--;
+    }
+    this.releaseTimeout = null;
+    //Issue next release if applies
+    this._tryIssueRelease();
+  }
+}
 
 function generateGroup(initialValue) {
   const arr = new Array(groupSize);

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -20,162 +20,296 @@ const mconst5 = MutableLong.fromNumber(0x52dce729);
 const mconst6 = MutableLong.fromNumber(0x38495ab5);
 
 /**
- * Represents a set of methods that are able to generate and parse tokens for the C* partitioner
- * @constructor
+ * Represents a set of methods that are able to generate and parse tokens for the C* partitioner.
+ * @abstract
  */
-function Tokenizer() {
+class Tokenizer {
+  constructor() {
 
+  }
+
+  /**
+   * Creates a token based on the Buffer value provided
+   * @abstract
+   * @param {Buffer|Array} value
+   */
+  hash(value) {
+    throw new Error('You must implement a hash function for the tokenizer');
+  }
+
+  /**
+   * Parses a token string and returns a representation of the token
+   * @abstract
+   * @param {String} value
+   */
+  parse(value) {
+    throw new Error('You must implement a parse function for the tokenizer');
+  }
+
+  /**
+   * Returns 0 if the values are equal, 1 if val1 is greater then val2 and -1 if val2 is greater than val1
+   * @param val1
+   * @param val2
+   * @returns {number}
+   */
+  compare(val1, val2) {
+    if (val1 > val2) {
+      return 1;
+    }
+    if (val1 < val2) {
+      return -1;
+    }
+    return 0;
+  }
+
+  stringify(value) {
+    return value.toString();
+  }
 }
-
-/**
- * Creates a token based on the Buffer value provided
- * @param {Buffer|Array} value
- */
-Tokenizer.prototype.hash = function (value) {
-  throw new Error('You must implement a hash function for the tokenizer');
-};
-
-/**
- * Parses a token string and returns a representation of the token
- * @param {String} value
- */
-Tokenizer.prototype.parse = function (value) {
-  throw new Error('You must implement a parse function for the tokenizer');
-};
-
-/**
- * Returns 0 if the values are equal, 1 if val1 is greater then val2 and -1 if val2 is greater than val1
- * @param val1
- * @param val2
- * @returns {number}
- */
-Tokenizer.prototype.compare = function (val1, val2) {
-  if (val1 > val2) {
-    return 1;
-  }
-  if (val1 < val2) {
-    return -1;
-  }
-  return 0;
-};
-
-Tokenizer.prototype.stringify = function (value) {
-  return value.toString();
-};
 
 /**
  * Uniformly distributes data across the cluster based on Cassandra flavored Murmur3 hashed values.
- * @constructor
  */
-function Murmur3Tokenizer() {
-
-}
-
-util.inherits(Murmur3Tokenizer, Tokenizer);
-
-Murmur3Tokenizer.prototype.hash = function hash(value) {
-  // This is an adapted version of the MurmurHash.hash3_x64_128 from Cassandra used
-  // for M3P. Compared to that methods, there's a few inlining of arguments and we
-  // only return the first 64-bits of the result since that's all M3 partitioner uses.
-
-  const data = value;
-  let offset = 0;
-  const length = data.length;
-
-  const nblocks = length >> 4; // Process as 128-bit blocks.
-
-  const h1 = new MutableLong();
-  const h2 = new MutableLong();
-  let k1 = new MutableLong();
-  let k2 = new MutableLong();
-
-  for (let i = 0; i < nblocks; i++) {
-    k1 = this.getBlock(data, offset, i * 2);
-    k2 = this.getBlock(data, offset, i * 2 + 1);
-
-    k1.multiply(mconst1);
-    this.rotl64(k1, 31);
-    k1.multiply(mconst2);
-
-    h1.xor(k1);
-    this.rotl64(h1, 27);
-    h1.add(h2);
-    h1.multiply(mlongFive).add(mconst5);
-
-    k2.multiply(mconst2);
-    this.rotl64(k2, 33);
-    k2.multiply(mconst1);
-    h2.xor(k2);
-    this.rotl64(h2, 31);
-    h2.add(h1);
-    h2.multiply(mlongFive).add(mconst6);
+class Murmur3Tokenizer extends Tokenizer {
+  constructor() {
+    super();
   }
-  //----------
-  // tail
 
-  // Advance offset to the unprocessed tail of the data.
-  offset += nblocks * 16;
+  hash(value) {
+    // This is an adapted version of the MurmurHash.hash3_x64_128 from Cassandra used
+    // for M3P. Compared to that methods, there's a few inlining of arguments and we
+    // only return the first 64-bits of the result since that's all M3 partitioner uses.
 
-  k1 = new MutableLong();
-  k2 = new MutableLong();
+    const data = value;
+    let offset = 0;
+    const length = data.length;
 
-  /* eslint-disable no-fallthrough */
-  switch(length & 15) {
-    case 15:
-      k2.xor(fromSignedByte(data[offset+14]).shiftLeft(48));
-    case 14:
-      k2.xor(fromSignedByte(data[offset+13]).shiftLeft(40));
-    case 13:
-      k2.xor(fromSignedByte(data[offset+12]).shiftLeft(32));
-    case 12:
-      k2.xor(fromSignedByte(data[offset+12]).shiftLeft(24));
-    case 11:
-      k2.xor(fromSignedByte(data[offset+10]).shiftLeft(16));
-    case 10:
-      k2.xor(fromSignedByte(data[offset+9]).shiftLeft(8));
-    case 9:
-      k2.xor(fromSignedByte(data[offset+8]));
+    const nblocks = length >> 4; // Process as 128-bit blocks.
+
+    const h1 = new MutableLong();
+    const h2 = new MutableLong();
+    let k1 = new MutableLong();
+    let k2 = new MutableLong();
+
+    for (let i = 0; i < nblocks; i++) {
+      k1 = this.getBlock(data, offset, i * 2);
+      k2 = this.getBlock(data, offset, i * 2 + 1);
+
+      k1.multiply(mconst1);
+      this.rotl64(k1, 31);
+      k1.multiply(mconst2);
+
+      h1.xor(k1);
+      this.rotl64(h1, 27);
+      h1.add(h2);
+      h1.multiply(mlongFive).add(mconst5);
+
       k2.multiply(mconst2);
       this.rotl64(k2, 33);
       k2.multiply(mconst1);
       h2.xor(k2);
-    case 8:
-      k1.xor(fromSignedByte(data[offset+7]).shiftLeft(56));
-    case 7:
-      k1.xor(fromSignedByte(data[offset+6]).shiftLeft(48));
-    case 6:
-      k1.xor(fromSignedByte(data[offset+5]).shiftLeft(40));
-    case 5:
-      k1.xor(fromSignedByte(data[offset+4]).shiftLeft(32));
-    case 4:
-      k1.xor(fromSignedByte(data[offset+3]).shiftLeft(24));
-    case 3:
-      k1.xor(fromSignedByte(data[offset+2]).shiftLeft(16));
-    case 2:
-      k1.xor(fromSignedByte(data[offset+1]).shiftLeft(8));
-    case 1:
-      k1.xor(fromSignedByte(data[offset]));
-      k1.multiply(mconst1);
-      this.rotl64(k1,31);
-      k1.multiply(mconst2);
-      h1.xor(k1);
+      this.rotl64(h2, 31);
+      h2.add(h1);
+      h2.multiply(mlongFive).add(mconst6);
+    }
+    //----------
+    // tail
+
+    // Advance offset to the unprocessed tail of the data.
+    offset += nblocks * 16;
+
+    k1 = new MutableLong();
+    k2 = new MutableLong();
+
+    /* eslint-disable no-fallthrough */
+    switch(length & 15) {
+      case 15:
+        k2.xor(fromSignedByte(data[offset+14]).shiftLeft(48));
+      case 14:
+        k2.xor(fromSignedByte(data[offset+13]).shiftLeft(40));
+      case 13:
+        k2.xor(fromSignedByte(data[offset+12]).shiftLeft(32));
+      case 12:
+        k2.xor(fromSignedByte(data[offset+12]).shiftLeft(24));
+      case 11:
+        k2.xor(fromSignedByte(data[offset+10]).shiftLeft(16));
+      case 10:
+        k2.xor(fromSignedByte(data[offset+9]).shiftLeft(8));
+      case 9:
+        k2.xor(fromSignedByte(data[offset+8]));
+        k2.multiply(mconst2);
+        this.rotl64(k2, 33);
+        k2.multiply(mconst1);
+        h2.xor(k2);
+      case 8:
+        k1.xor(fromSignedByte(data[offset+7]).shiftLeft(56));
+      case 7:
+        k1.xor(fromSignedByte(data[offset+6]).shiftLeft(48));
+      case 6:
+        k1.xor(fromSignedByte(data[offset+5]).shiftLeft(40));
+      case 5:
+        k1.xor(fromSignedByte(data[offset+4]).shiftLeft(32));
+      case 4:
+        k1.xor(fromSignedByte(data[offset+3]).shiftLeft(24));
+      case 3:
+        k1.xor(fromSignedByte(data[offset+2]).shiftLeft(16));
+      case 2:
+        k1.xor(fromSignedByte(data[offset+1]).shiftLeft(8));
+      case 1:
+        k1.xor(fromSignedByte(data[offset]));
+        k1.multiply(mconst1);
+        this.rotl64(k1,31);
+        k1.multiply(mconst2);
+        h1.xor(k1);
+    }
+    /* eslint-enable no-fallthrough */
+
+    h1.xor(MutableLong.fromNumber(length));
+    h2.xor(MutableLong.fromNumber(length));
+
+    h1.add(h2);
+    h2.add(h1);
+
+
+    this.fmix(h1);
+    this.fmix(h2);
+
+    h1.add(h2);
+
+    return h1;
   }
-  /* eslint-enable no-fallthrough */
 
-  h1.xor(MutableLong.fromNumber(length));
-  h2.xor(MutableLong.fromNumber(length));
+  /**
+   *
+   * @param {Array<Number>} key
+   * @param {Number} offset
+   * @param {Number} index
+   * @return {MutableLong}
+   */
+  getBlock(key, offset, index) {
+    const i8 = index << 3;
+    const blockOffset = offset + i8;
+    return new MutableLong(
+      (key[blockOffset]) | (key[blockOffset + 1] << 8),
+      (key[blockOffset + 2]) | (key[blockOffset + 3] << 8),
+      (key[blockOffset + 4]) | (key[blockOffset + 5] << 8),
+      (key[blockOffset + 6]) | (key[blockOffset + 7] << 8)
+    );
+  }
 
-  h1.add(h2);
-  h2.add(h1);
+  /**
+   * @param {MutableLong} v
+   * @param {Number} n
+   */
+  rotl64(v, n) {
+    const left = v.clone().shiftLeft(n);
+    v.shiftRightUnsigned(64 - n).or(left);
+  }
 
+  /** @param {MutableLong} k */
+  fmix(k) {
+    k.xor(new MutableLong(k.getUint16(2) >>> 1 | ((k.getUint16(3) << 15) & 0xffff), k.getUint16(3) >>> 1, 0, 0));
+    k.multiply(mconst3);
+    const other = new MutableLong(
+      (k.getUint16(2) >>> 1) | ((k.getUint16(3) << 15) & 0xffff),
+      k.getUint16(3) >>> 1,
+      0,
+      0
+    );
+    k.xor(other);
+    k.multiply(mconst4);
+    k.xor(new MutableLong(k.getUint16(2) >>> 1 | (k.getUint16(3) << 15 & 0xffff), k.getUint16(3) >>> 1, 0, 0));
+  }
 
-  this.fmix(h1);
-  this.fmix(h2);
+  /**
+   * Parses a int64 decimal string representation into a MutableLong.
+   * @param {String} value
+   * @returns {MutableLong}
+   */
+  parse(value) {
+    return MutableLong.fromString(value);
+  }
 
-  h1.add(h2);
+  /**
+   * @param {MutableLong} val1
+   * @param {MutableLong} val2
+   * @returns {number}
+   */
+  compare(val1, val2) {
+    return val1.compare(val2);
+  }
 
-  return h1;
-};
+  /**
+   * @param {MutableLong} value
+   * @return {String}
+   */
+  stringify(value) {
+    // We need a way to uniquely represent a token, it doesn't have to be the decimal string representation
+    // Using the uint16 avoids divisions and other expensive operations on the longs
+    return value.getUint16(0) + ',' + value.getUint16(1) + ',' + value.getUint16(2) + ',' + value.getUint16(3);
+  }
+}
+
+/**
+ * Uniformly distributes data across the cluster based on MD5 hash values.
+ */
+class RandomTokenizer extends Tokenizer {
+  constructor() {
+    super();
+    // eslint-disable-next-line
+    this._crypto = require('crypto');
+  }
+
+  /**
+   * @param {Buffer|Array} value
+   * @returns {Integer}
+   */
+  hash(value) {
+    if (util.isArray(value)) {
+      value = utils.allocBufferFromArray(value);
+    }
+    const hashedValue = this._crypto.createHash('md5').update(value).digest();
+    return Integer.fromBuffer(hashedValue).abs();
+  }
+
+  /**
+   * @returns {Integer}
+   */
+  parse(value) {
+    return Integer.fromString(value);
+  }
+
+  /**
+   * @param {Integer} val1
+   * @param {Integer} val2
+   * @returns {number}
+   */
+  compare(val1, val2) {
+    return val1.compare(val2);
+  }
+}
+
+class ByteOrderedTokenizer extends Tokenizer {
+  constructor() {
+    super();
+  }
+
+  /**
+   * @param {Buffer|Array} value
+   * @returns {Buffer}
+   */
+  hash(value) {
+    return value;
+  }
+
+  stringify(value) {
+    return value.toString('hex');
+  }
+
+  parse(value) {
+    return utils.allocBufferFromString(value);
+  }
+}
 
 /**
  * @param {Number} value
@@ -187,137 +321,6 @@ function fromSignedByte(value) {
   }
   return new MutableLong((value - 256) & 0xffff, 0xffff, 0xffff, 0xffff);
 }
-
-/**
- *
- * @param {Array<Number>} key
- * @param {Number} offset
- * @param {Number} index
- * @return {MutableLong}
- */
-Murmur3Tokenizer.prototype.getBlock = function (key, offset, index) {
-  const i8 = index << 3;
-  const blockOffset = offset + i8;
-  return new MutableLong(
-    (key[blockOffset]) | (key[blockOffset + 1] << 8),
-    (key[blockOffset + 2]) | (key[blockOffset + 3] << 8),
-    (key[blockOffset + 4]) | (key[blockOffset + 5] << 8),
-    (key[blockOffset + 6]) | (key[blockOffset + 7] << 8)
-  );
-};
-
-/**
- * @param {MutableLong} v
- * @param {Number} n
- */
-Murmur3Tokenizer.prototype.rotl64 = function (v, n) {
-  const left = v.clone().shiftLeft(n);
-  v.shiftRightUnsigned(64 - n).or(left);
-};
-
-/** @param {MutableLong} k */
-Murmur3Tokenizer.prototype.fmix = function (k) {
-  k.xor(new MutableLong(k.getUint16(2) >>> 1 | ((k.getUint16(3) << 15) & 0xffff), k.getUint16(3) >>> 1, 0, 0));
-  k.multiply(mconst3);
-  const other = new MutableLong(
-    (k.getUint16(2) >>> 1) | ((k.getUint16(3) << 15) & 0xffff),
-    k.getUint16(3) >>> 1,
-    0,
-    0
-  );
-  k.xor(other);
-  k.multiply(mconst4);
-  k.xor(new MutableLong(k.getUint16(2) >>> 1 | (k.getUint16(3) << 15 & 0xffff), k.getUint16(3) >>> 1, 0, 0));
-};
-
-/**
- * Parses a int64 decimal string representation into a MutableLong.
- * @param {String} value
- * @returns {MutableLong}
- */
-Murmur3Tokenizer.prototype.parse = function (value) {
-  return MutableLong.fromString(value);
-};
-
-/**
- * @param {MutableLong} val1
- * @param {MutableLong} val2
- * @returns {number}
- */
-Murmur3Tokenizer.prototype.compare = function (val1, val2) {
-  return val1.compare(val2);
-};
-
-/**
- * @param {MutableLong} value
- * @return {String}
- */
-Murmur3Tokenizer.prototype.stringify = function (value) {
-  // We need a way to uniquely represent a token, it doesn't have to be the decimal string representation
-  // Using the uint16 avoids divisions and other expensive operations on the longs
-  return value.getUint16(0) + ',' + value.getUint16(1) + ',' + value.getUint16(2) + ',' + value.getUint16(3);
-};
-
-/**
- * Uniformly distributes data across the cluster based on MD5 hash values.
- * @constructor
- */
-function RandomTokenizer() {
-  // eslint-disable-next-line
-  this._crypto = require('crypto');
-}
-
-util.inherits(RandomTokenizer, Tokenizer);
-
-/**
- * @param {Buffer|Array} value
- * @returns {Integer}
- */
-RandomTokenizer.prototype.hash = function (value) {
-  if (util.isArray(value)) {
-    value = utils.allocBufferFromArray(value);
-  }
-  const hashedValue = this._crypto.createHash('md5').update(value).digest();
-  return Integer.fromBuffer(hashedValue).abs();
-};
-
-/**
- * @returns {Integer}
- */
-RandomTokenizer.prototype.parse = function (value) {
-  return Integer.fromString(value);
-};
-
-/**
- * @param {Integer} val1
- * @param {Integer} val2
- * @returns {number}
- */
-RandomTokenizer.prototype.compare = function (val1, val2) {
-  return val1.compare(val2);
-};
-
-function ByteOrderedTokenizer() {
-
-}
-
-util.inherits(ByteOrderedTokenizer, Tokenizer);
-
-/**
- * @param {Buffer|Array} value
- * @returns {Buffer}
- */
-ByteOrderedTokenizer.prototype.hash = function (value) {
-  return value;
-};
-
-ByteOrderedTokenizer.prototype.stringify = function (value) {
-  return value.toString('hex');
-};
-
-ByteOrderedTokenizer.prototype.parse = function (value) {
-  return utils.allocBufferFromString(value);
-};
 
 exports.Murmur3Tokenizer = Murmur3Tokenizer;
 exports.RandomTokenizer = RandomTokenizer;

--- a/lib/types/mutable-long.js
+++ b/lib/types/mutable-long.js
@@ -49,7 +49,7 @@ MutableLong.fromString = function fromString(str, radix) {
     return new MutableLong();
   }
   radix = radix || 10;
-  if (radix < 2 || 36 < radix) {
+  if (radix < 2 || radix > 36) {
     throw Error('radix out of range: ' + radix);
   }
 

--- a/lib/writers.js
+++ b/lib/writers.js
@@ -1,6 +1,5 @@
 'use strict';
 const events = require('events');
-const util = require('util');
 
 const types = require('./types');
 const utils = require('./utils.js');
@@ -8,258 +7,266 @@ const FrameHeader = types.FrameHeader;
 
 /**
  * Contains the logic to write all the different types to the frame.
- * @param {Number} opcode
- * @constructor
  */
-function FrameWriter(opcode) {
-  if (!opcode) {
-    throw new Error('Opcode not provided');
+class FrameWriter {
+  /**
+   * Creates a new instance of FrameWriter.
+   * @param {Number} opcode
+   */
+  constructor(opcode) {
+    if (!opcode) {
+      throw new Error('Opcode not provided');
+    }
+    this.buffers = [];
+    this.opcode = opcode;
+    this.bodyLength = 0;
   }
-  this.buffers = [];
-  this.opcode = opcode;
-  this.bodyLength = 0;
-}
 
-FrameWriter.prototype.add = function(buf) {
-  this.buffers.push(buf);
-  this.bodyLength += buf.length;
-};
-
-FrameWriter.prototype.writeShort = function(num) {
-  const buf = utils.allocBufferUnsafe(2);
-  buf.writeUInt16BE(num, 0);
-  this.add(buf);
-};
-
-FrameWriter.prototype.writeInt = function(num) {
-  const buf = utils.allocBufferUnsafe(4);
-  buf.writeInt32BE(num, 0);
-  this.add(buf);
-};
-
-/** @param {Long} num */
-FrameWriter.prototype.writeLong = function(num) {
-  this.add(types.Long.toBuffer(num));
-};
-
-/**
- * Writes bytes according to Cassandra <int byteLength><bytes>
- * @param {Buffer|null|types.unset} bytes
- */
-FrameWriter.prototype.writeBytes = function(bytes) {
-  if (bytes === null) {
-    //Only the length buffer containing -1
-    this.writeInt(-1);
-    return;
+  add(buf) {
+    this.buffers.push(buf);
+    this.bodyLength += buf.length;
   }
-  if (bytes === types.unset) {
-    this.writeInt(-2);
-    return;
+
+  writeShort(num) {
+    const buf = utils.allocBufferUnsafe(2);
+    buf.writeUInt16BE(num, 0);
+    this.add(buf);
   }
-  //Add the length buffer
-  this.writeInt(bytes.length);
-  //Add the actual buffer
-  this.add(bytes);
-};
 
-/**
- * Writes a buffer according to Cassandra protocol: bytes.length (2) + bytes
- * @param {Buffer} bytes
- */
-FrameWriter.prototype.writeShortBytes = function(bytes) {
-  if(bytes === null) {
-    //Only the length buffer containing -1
-    this.writeShort(-1);
-    return;
+  writeInt(num) {
+    const buf = utils.allocBufferUnsafe(4);
+    buf.writeInt32BE(num, 0);
+    this.add(buf);
   }
-  //Add the length buffer
-  this.writeShort(bytes.length);
-  //Add the actual buffer
-  this.add(bytes);
-};
 
-/**
- * Writes a single byte
- * @param {Number} num Value of the byte, a number between 0 and 255.
- */
-FrameWriter.prototype.writeByte = function (num) {
-  this.add(utils.allocBufferFromArray([num]));
-};
-
-FrameWriter.prototype.writeString = function(str) {
-  if (typeof str === "undefined") {
-    throw new Error("can not write undefined");
+  /** @param {Long} num */
+  writeLong(num) {
+    this.add(types.Long.toBuffer(num));
   }
-  const len = Buffer.byteLength(str, 'utf8');
-  const buf = utils.allocBufferUnsafe(2 + len);
-  buf.writeUInt16BE(len, 0);
-  buf.write(str, 2, buf.length-2, 'utf8');
-  this.add(buf);
-};
 
-FrameWriter.prototype.writeLString = function(str) {
-  const len = Buffer.byteLength(str, 'utf8');
-  const buf = utils.allocBufferUnsafe(4 + len);
-  buf.writeInt32BE(len, 0);
-  buf.write(str, 4, buf.length-4, 'utf8');
-  this.add(buf);
-};
+  /**
+   * Writes bytes according to Cassandra <int byteLength><bytes>
+   * @param {Buffer|null|types.unset} bytes
+   */
+  writeBytes(bytes) {
+    if (bytes === null) {
+      //Only the length buffer containing -1
+      this.writeInt(-1);
+      return;
+    }
+    if (bytes === types.unset) {
+      this.writeInt(-2);
+      return;
+    }
+    //Add the length buffer
+    this.writeInt(bytes.length);
+    //Add the actual buffer
+    this.add(bytes);
+  }
 
-FrameWriter.prototype.writeStringList = function (values) {
-  this.writeShort(values.length);
-  values.forEach(this.writeString, this);
-};
+  /**
+   * Writes a buffer according to Cassandra protocol: bytes.length (2) + bytes
+   * @param {Buffer} bytes
+   */
+  writeShortBytes(bytes) {
+    if(bytes === null) {
+      //Only the length buffer containing -1
+      this.writeShort(-1);
+      return;
+    }
+    //Add the length buffer
+    this.writeShort(bytes.length);
+    //Add the actual buffer
+    this.add(bytes);
+  }
 
-FrameWriter.prototype.writeCustomPayload = function (payload) {
-  const keys = Object.keys(payload);
-  this.writeShort(keys.length);
-  keys.forEach(function (k) {
-    this.writeString(k);
-    this.writeBytes(payload[k]);
-  }, this);
-};
+  /**
+   * Writes a single byte
+   * @param {Number} num Value of the byte, a number between 0 and 255.
+   */
+  writeByte(num) {
+    this.add(utils.allocBufferFromArray([num]));
+  }
 
-FrameWriter.prototype.writeStringMap = function (map) {
-  const keys = [];
-  for (const k in map) {
-    if (map.hasOwnProperty(k)) {
-      keys.push(k);
+  writeString(str) {
+    if (typeof str === "undefined") {
+      throw new Error("can not write undefined");
+    }
+    const len = Buffer.byteLength(str, 'utf8');
+    const buf = utils.allocBufferUnsafe(2 + len);
+    buf.writeUInt16BE(len, 0);
+    buf.write(str, 2, buf.length-2, 'utf8');
+    this.add(buf);
+  }
+
+  writeLString(str) {
+    const len = Buffer.byteLength(str, 'utf8');
+    const buf = utils.allocBufferUnsafe(4 + len);
+    buf.writeInt32BE(len, 0);
+    buf.write(str, 4, buf.length-4, 'utf8');
+    this.add(buf);
+  }
+
+  writeStringList(values) {
+    this.writeShort(values.length);
+    values.forEach(this.writeString, this);
+  }
+
+  writeCustomPayload(payload) {
+    const keys = Object.keys(payload);
+    this.writeShort(keys.length);
+    keys.forEach(function (k) {
+      this.writeString(k);
+      this.writeBytes(payload[k]);
+    }, this);
+  }
+
+  writeStringMap(map) {
+    const keys = [];
+    for (const k in map) {
+      if (map.hasOwnProperty(k)) {
+        keys.push(k);
+      }
+    }
+
+    this.writeShort(keys.length);
+
+    for(let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      this.writeString(key);
+      this.writeString(map[key]);
     }
   }
 
-  this.writeShort(keys.length);
-
-  for(let i = 0; i < keys.length; i++) {
-    const key = keys[i];
-    this.writeString(key);
-    this.writeString(map[key]);
+  /**
+   * @param {Number} version
+   * @param {Number} streamId
+   * @param {Number} [flags] Header flags
+   * @returns {Buffer}
+   * @throws {TypeError}
+   */
+  write(version, streamId, flags) {
+    const header = new FrameHeader(version, flags || 0, streamId, this.opcode, this.bodyLength);
+    const headerBuffer = header.toBuffer();
+    this.buffers.unshift(headerBuffer);
+    return Buffer.concat(this.buffers, headerBuffer.length + this.bodyLength);
   }
-};
-
-/**
- * @param {Number} version
- * @param {Number} streamId
- * @param {Number} [flags] Header flags
- * @returns {Buffer}
- * @throws {TypeError}
- */
-FrameWriter.prototype.write = function (version, streamId, flags) {
-  const header = new FrameHeader(version, flags || 0, streamId, this.opcode, this.bodyLength);
-  const headerBuffer = header.toBuffer();
-  this.buffers.unshift(headerBuffer);
-  return Buffer.concat(this.buffers, headerBuffer.length + this.bodyLength);
-};
+}
 
 /**
  * Represents a queue that process one write at a time (FIFO).
- * @param {Socket} netClient
- * @param {Encoder} encoder
- * @param {ClientOptions} options
  * @extends {EventEmitter}
  */
-function WriteQueue (netClient, encoder, options) {
-  WriteQueue.super_.call(this);
-  this.netClient = netClient;
-  this.encoder = encoder;
-  this.isRunning = false;
-  /** @type {Array<{operation: OperationState, callback: Function}>} */
-  this.queue = [];
-  this.coalescingThreshold = options.socketOptions.coalescingThreshold;
-  this.error = null;
-}
-
-util.inherits(WriteQueue, events.EventEmitter);
-/**
- * Enqueues a new request
- * @param {OperationState} operation
- * @param {Function} callback The write callback.
- */
-WriteQueue.prototype.push = function (operation, callback) {
-  const self = this;
-  if (this.error) {
-    // There was a write error, there is no point in further trying to write to the socket.
-    return process.nextTick(function writePushError() {
-      callback(self.error);
-    });
+class WriteQueue extends events.EventEmitter {
+  /**
+   * Creates a new WriteQueue instance.
+   * @param {Socket} netClient
+   * @param {Encoder} encoder
+   * @param {ClientOptions} options
+   */
+  constructor(netClient, encoder, options) {
+    super();
+    this.netClient = netClient;
+    this.encoder = encoder;
+    this.isRunning = false;
+    /** @type {Array<{operation: OperationState, callback: Function}>} */
+    this.queue = [];
+    this.coalescingThreshold = options.socketOptions.coalescingThreshold;
+    this.error = null;
   }
-  this.queue.push({ operation: operation, callback: callback});
-  this.run();
-};
 
-WriteQueue.prototype.run = function () {
-  if (!this.isRunning) {
-    this.process();
-  }
-};
-
-WriteQueue.prototype.process = function () {
-  const self = this;
-  utils.whilst(
-    function condition() {
-      return self.queue.length > 0;
-    },
-    function whileProcess(next) {
-      self.isRunning = true;
-      const buffers = [];
-      const callbacks = [];
-      let totalLength = 0;
-      while (totalLength < self.coalescingThreshold && self.queue.length > 0) {
-        const writeItem = self.queue.shift();
-        try {
-          const data = writeItem.operation.request.write(self.encoder, writeItem.operation.streamId);
-          totalLength += data.length;
-          buffers.push(data);
-          callbacks.push(writeItem.callback);
-        }
-        catch (err) {
-          writeItem.callback(err);
-          // Break and flush what we have
-          break;
-        }
-      }
-      if (buffers.length === 0) {
-        // No need to invoke socket.write()
-        return next();
-      }
-      // Before invoking socket.write(), mark that the request has been written to avoid race conditions.
-      for (let i = 0; i < callbacks.length; i++) {
-        callbacks[i]();
-      }
-      self.netClient.write(Buffer.concat(buffers, totalLength), function socketWriteCallback(err) {
-        if (err) {
-          self.setWriteError(err);
-        }
-        // Allow IO between writes
-        setImmediate(next);
+  /**
+   * Enqueues a new request
+   * @param {OperationState} operation
+   * @param {Function} callback The write callback.
+   */
+  push(operation, callback) {
+    const self = this;
+    if (this.error) {
+      // There was a write error, there is no point in further trying to write to the socket.
+      return process.nextTick(function writePushError() {
+        callback(self.error);
       });
-    },
-    function loopFinished() {
-      // The queue is now empty
-      self.isRunning = false;
     }
-  );
-};
-
-/**
- * Emits the 'error' event and callbacks items that haven't been written and clears them from the queue.
- * @param err
- */
-WriteQueue.prototype.setWriteError = function (err) {
-  err.isSocketError = true;
-  this.error = new types.DriverError('Socket was closed');
-  this.error.isSocketError = true;
-  // Use an special flag for items that haven't been written
-  this.error.requestNotWritten = true;
-  this.error.innerError = err;
-  const q = this.queue;
-  // Not more items can be added to the queue.
-  this.queue = utils.emptyArray;
-  for (let i = 0; i < q.length; i++) {
-    const item = q[i];
-    // Use the error marking that it was not written
-    item.callback(this.error);
+    this.queue.push({ operation: operation, callback: callback});
+    this.run();
   }
-};
+
+  run() {
+    if (!this.isRunning) {
+      this.process();
+    }
+  }
+
+  process() {
+    const self = this;
+    utils.whilst(
+      function condition() {
+        return self.queue.length > 0;
+      },
+      function whileProcess(next) {
+        self.isRunning = true;
+        const buffers = [];
+        const callbacks = [];
+        let totalLength = 0;
+        while (totalLength < self.coalescingThreshold && self.queue.length > 0) {
+          const writeItem = self.queue.shift();
+          try {
+            const data = writeItem.operation.request.write(self.encoder, writeItem.operation.streamId);
+            totalLength += data.length;
+            buffers.push(data);
+            callbacks.push(writeItem.callback);
+          }
+          catch (err) {
+            writeItem.callback(err);
+            // Break and flush what we have
+            break;
+          }
+        }
+        if (buffers.length === 0) {
+          // No need to invoke socket.write()
+          return next();
+        }
+        // Before invoking socket.write(), mark that the request has been written to avoid race conditions.
+        for (let i = 0; i < callbacks.length; i++) {
+          callbacks[i]();
+        }
+        self.netClient.write(Buffer.concat(buffers, totalLength), function socketWriteCallback(err) {
+          if (err) {
+            self.setWriteError(err);
+          }
+          // Allow IO between writes
+          setImmediate(next);
+        });
+      },
+      function loopFinished() {
+        // The queue is now empty
+        self.isRunning = false;
+      }
+    );
+  }
+
+  /**
+   * Emits the 'error' event and callbacks items that haven't been written and clears them from the queue.
+   * @param err
+   */
+  setWriteError(err) {
+    err.isSocketError = true;
+    this.error = new types.DriverError('Socket was closed');
+    this.error.isSocketError = true;
+    // Use an special flag for items that haven't been written
+    this.error.requestNotWritten = true;
+    this.error.innerError = err;
+    const q = this.queue;
+    // Not more items can be added to the queue.
+    this.queue = utils.emptyArray;
+    for (let i = 0; i < q.length; i++) {
+      const item = q[i];
+      // Use the error marking that it was not written
+      item.callback(this.error);
+    }
+  }
+}
 
 exports.WriteQueue = WriteQueue;
 exports.FrameWriter = FrameWriter;

--- a/test/integration/long/client-metadata-tests.js
+++ b/test/integration/long/client-metadata-tests.js
@@ -126,7 +126,7 @@ function validateMurmurReplicas(client) {
   assert.ok(replicas);
   //2 replicas per each dc
   assert.strictEqual(replicas.length, 4);
-  assert.strictEqual(replicas.reduce(function (val, h) { return val + (h.datacenter === 'dc1' ? 1 : 0);}, 0), 2);
+  assert.strictEqual(replicas.reduce((val, h) => (val + (h.datacenter === 'dc1' ? 1 : 0)), 0), 2);
 
   //pre-calculated based on murmur3
   let lastOctets = replicas.map(helper.lastOctetOf);
@@ -139,7 +139,7 @@ function validateMurmurReplicas(client) {
   assert.ok(replicas);
   //2 replicas per each dc
   assert.strictEqual(replicas.length, 4);
-  assert.strictEqual(replicas.reduce(function (val, h) { return val + (h.datacenter === 'dc1' ? 1 : 0);}, 0), 2);
+  assert.strictEqual(replicas.reduce((val, h) => (val + (h.datacenter === 'dc1' ? 1 : 0)), 0), 2);
   //pre-calculated based on murmur3
   lastOctets = replicas.map(helper.lastOctetOf);
   assert.strictEqual(lastOctets[0], '1');

--- a/test/integration/short/client-batch-tests.js
+++ b/test/integration/short/client-batch-tests.js
@@ -180,7 +180,7 @@ describe('Client', function () {
           assert.ifError(err);
           assert.ok(result && result.rows);
           assert.strictEqual(result.rows.length, 2);
-          assert.strictEqual(helper.find(result.rows, function (row) { return row.id.equals(id2); })['int_sample'], -1);
+          assert.strictEqual(helper.find(result.rows, row => row.id.equals(id2))['int_sample'], -1);
           done();
         });
       });

--- a/test/integration/short/client-execute-prepared-tests.js
+++ b/test/integration/short/client-execute-prepared-tests.js
@@ -335,13 +335,13 @@ describe('Client', function () {
         },
         function selectData(seriesNext) {
           //Make ? markers C*1.2-compatible
-          const markers = values.map(function () { return '?'; }).join(',');
+          const markers = values.map(() => '?').join(',');
           const query = util.format('SELECT * FROM %s WHERE id IN (' + markers + ')', table);
-          client.execute(query, values.map(function (x) { return x[0]; }), {prepare: true}, function (err, result) {
+          client.execute(query, values.map(x => x[0]), {prepare: true}, function (err, result) {
             assert.ifError(err);
             assert.ok(result.rows.length);
             result.rows.forEach(function (row) {
-              const expectedValues = helper.first(values, function (item) { return item[0].equals(row.id); });
+              const expectedValues = helper.first(values, item => item[0].equals(row.id));
               helper.assertInstanceOf(row['map_text_text'], MapPF);
               assert.strictEqual(row['map_text_text'].toString(), expectedValues[1].toString());
               assert.strictEqual(row['map_int_date'].toString(), expectedValues[2].toString());
@@ -394,13 +394,13 @@ describe('Client', function () {
         },
         function selectData(seriesNext) {
           //Make ? markers C*1.2-compatible
-          const markers = values.map(function () { return '?'; }).join(',');
+          const markers = values.map(() => '?').join(',');
           const query = util.format('SELECT * FROM %s WHERE id IN (' + markers + ')', table);
-          client.execute(query, values.map(function (x) { return x[0]; }), {prepare: true}, function (err, result) {
+          client.execute(query, values.map(x => x[0]), {prepare: true}, function (err, result) {
             assert.ifError(err);
             assert.ok(result.rows.length);
             result.rows.forEach(function (row) {
-              const expectedValues = helper.first(values, function (item) { return item[0].equals(row.id); });
+              const expectedValues = helper.first(values, item => item[0].equals(row.id));
               helper.assertInstanceOf(row['set_text'], SetPF);
               assert.strictEqual(row['set_text'].toString(), expectedValues[1].toString());
               assert.strictEqual(row['set_timestamp'].toString(), expectedValues[2].toString());

--- a/test/integration/short/client-execute-tests.js
+++ b/test/integration/short/client-execute-tests.js
@@ -339,9 +339,7 @@ describe('Client', function () {
         },
         function (parallelNext) {
           utils.times(200, function (n, next) {
-            setTimeout(function () {
-              execute(next);
-            }, n * 5 + 50);
+            setTimeout(() => execute(next), n * 5 + 50);
           }, parallelNext);
         }
       ], helper.finish(client, done));

--- a/test/integration/short/client-pool-tests.js
+++ b/test/integration/short/client-pool-tests.js
@@ -649,7 +649,7 @@ describe('Client', function () {
             const expectedPoolInfo = { '1': connectionsPerHost, '2': connectionsPerHost, '3': connectionsPerHost};
             expectedPoolInfo[ignoredHost] = 0;
             assert.deepEqual(getPoolInfo(client), expectedPoolInfo );
-            assert.deepEqual(coordinators, [ '1', '2', '3'].filter(function (x) { return x !== ignoredHost;}));
+            assert.deepEqual(coordinators, [ '1', '2', '3'].filter(x => x !== ignoredHost));
           }),
           client.shutdown.bind(client),
           function checkPoolState(next) {

--- a/test/integration/short/metadata-tests.js
+++ b/test/integration/short/metadata-tests.js
@@ -400,7 +400,7 @@ describe('metadata', function () {
             assert.ok(table.caching);
             assert.strictEqual(typeof table.caching, 'string');
             const columns = table.columns
-              .map(function (c) { return c.name; })
+              .map(c => c.name)
               .sort();
             helper.assertValueEqual(columns, ['id', 'text_sample']);
             assert.strictEqual(table.isCompact, false);
@@ -421,7 +421,7 @@ describe('metadata', function () {
             assert.ok(table);
             assert.strictEqual(table.columns.length, 2);
             const columns = table.columns
-              .map(function (c) { return c.name; })
+              .map(c => c.name)
               .sort();
             helper.assertValueEqual(columns, ['id', 'text_sample']);
             assert.strictEqual(table.isCompact, false);
@@ -443,7 +443,7 @@ describe('metadata', function () {
             assert.ok(table.caching);
             assert.strictEqual(table.columns.length, 2);
             const columns = table.columns
-              .map(function (c) { return c.name; })
+              .map(c => c.name)
               .sort();
             helper.assertValueEqual(columns, ['id', 'text_sample']);
             assert.strictEqual(table.isCompact, false);
@@ -468,7 +468,7 @@ describe('metadata', function () {
             assert.ok(table.caching);
             assert.strictEqual(table.columns.length, 4);
             const columns = table.columns
-              .map(function (c) { return c.name; })
+              .map(c => c.name)
               .sort();
             helper.assertValueEqual(columns, ['id1', 'id3', 'int_sample', 'zid2']);
             assert.strictEqual(table.isCompact, false);
@@ -493,7 +493,7 @@ describe('metadata', function () {
             assert.ok(table);
             assert.strictEqual(table.columns.length, 3);
             const columns = table.columns
-              .map(function (c) { return c.name; })
+              .map(c => c.name)
               .sort();
             helper.assertValueEqual(columns, ['id', 'rating_value', 'rating_votes']);
             assert.strictEqual(table.isCompact, false);
@@ -520,7 +520,7 @@ describe('metadata', function () {
             assert.ok(table.caching);
             assert.strictEqual(table.columns.length, 3);
             const columns = table.columns
-              .map(function (c) { return c.name; })
+              .map(c => c.name)
               .sort();
             helper.assertValueEqual(columns, ['id', 'text1', 'text2']);
             assert.strictEqual(table.isCompact, true);
@@ -540,7 +540,7 @@ describe('metadata', function () {
             assert.ok(table);
             assert.strictEqual(table.columns.length, 3);
             const columns = table.columns
-              .map(function (c) { return c.name; })
+              .map(c => c.name)
               .sort();
             helper.assertValueEqual(columns, ['id1', 'id2', 'text1']);
             assert.strictEqual(table.isCompact, true);
@@ -560,7 +560,7 @@ describe('metadata', function () {
             assert.ifError(err);
             assert.ok(table);
             const columns = table.columns
-              .map(function (c) { return c.name; })
+              .map(c => c.name)
               .sort();
             helper.assertValueEqual(columns, ['ck', 'id', 'int_sample', 'list_sample', 'map_sample', 'set_sample']);
             assert.strictEqual(table.isCompact, false);
@@ -602,7 +602,7 @@ describe('metadata', function () {
             assert.ok(table);
             assert.ok(table.indexes);
             assert.ok(table.indexes.length > 0);
-            const index = table.indexes.filter(function (x) { return x.name === 'map_keys_index'; })[0];
+            const index = table.indexes.filter(x => x.name === 'map_keys_index')[0];
             assert.ok(index, 'Index not found');
             assert.strictEqual(index.name, 'map_keys_index');
             assert.strictEqual(index.target, 'keys(map_keys)');
@@ -623,7 +623,7 @@ describe('metadata', function () {
             assert.ok(table);
             assert.ok(table.indexes);
             assert.ok(table.indexes.length > 0);
-            const index = table.indexes.filter(function (x) { return x.name === 'map_values_index'; })[0];
+            const index = table.indexes.filter(x => x.name === 'map_values_index')[0];
             assert.ok(index, 'Index not found');
             assert.strictEqual(index.name, 'map_values_index');
             assert.strictEqual(index.target, is3 ? 'values(map_values)' : 'map_values');
@@ -644,7 +644,7 @@ describe('metadata', function () {
             assert.ok(table);
             assert.ok(table.indexes);
             assert.ok(table.indexes.length > 0);
-            const index = table.indexes.filter(function (x) { return x.name === 'map_entries_index'; })[0];
+            const index = table.indexes.filter(x => x.name === 'map_entries_index')[0];
             assert.ok(index, 'Index not found');
             assert.strictEqual(index.name, 'map_entries_index');
             assert.strictEqual(index.target, 'entries(map_entries)');
@@ -673,7 +673,7 @@ describe('metadata', function () {
             ];
 
             indexes.forEach(function(idx) {
-              const index = table.indexes.filter(function (x) { return x.name === idx.name; })[0];
+              const index = table.indexes.filter(x => x.name === idx.name)[0];
               assert.ok(index, 'Index not found');
               assert.strictEqual(index.name, idx.name);
               assert.strictEqual(index.target, idx.target);
@@ -739,7 +739,7 @@ describe('metadata', function () {
             client.metadata.getTable(keyspace, 'tbl_udts1', function (err, table) {
               assert.ifError(err);
               assert.ok(table);
-              assert.deepEqual(table.columns.map(function (c) { return c.name; }), ['id', 'udt_sample']);
+              assert.deepEqual(table.columns.map(c => c.name), ['id', 'udt_sample']);
               const udtColumn = table.columnsByName['udt_sample'];
               assert.ok(udtColumn);
               assert.strictEqual(udtColumn.type.code, types.dataTypes.udt);
@@ -760,7 +760,7 @@ describe('metadata', function () {
             client.metadata.getTable(keyspace, 'tbl_udts2', function (err, table) {
               assert.ifError(err);
               assert.ok(table);
-              assert.deepEqual(table.columns.map(function (c) { return c.name; }), ['id']);
+              assert.deepEqual(table.columns.map(c => c.name), ['id']);
               const udtColumn = table.columns[0];
               assert.ok(udtColumn);
               assert.strictEqual(table.partitionKeys[0], udtColumn);
@@ -821,7 +821,7 @@ describe('metadata', function () {
             client.metadata.getTable(keyspace, 'tbl_udts_with_quoted', function (err, table) {
               assert.ifError(err);
               assert.ok(table);
-              assert.deepEqual(table.columns.map(function (c) { return c.name; }), ['id', 'udt_sample']);
+              assert.deepEqual(table.columns.map(c => c.name), ['id', 'udt_sample']);
               const udtColumn = table.columnsByName['udt_sample'];
               assert.ok(udtColumn);
               assert.strictEqual(udtColumn.type.code, types.dataTypes.udt);
@@ -932,7 +932,7 @@ describe('metadata', function () {
               assert.strictEqual(view.clusteringKeys[0].name, 'score');
               assert.strictEqual(view.clusteringKeys[1].name, 'user');
               assert.strictEqual(view.partitionKeys.length, 4);
-              assert.strictEqual(view.partitionKeys.map(function (x) { return x.name;}).join(', '), 'game, year, month, day');
+              assert.strictEqual(view.partitionKeys.map(x => x.name).join(', '), 'game, year, month, day');
               next();
             });
           },
@@ -957,8 +957,8 @@ describe('metadata', function () {
                 assert.ifError(err);
                 assert.ok(view);
                 assert.strictEqual(view.partitionKeys.length, 3);
-                assert.strictEqual(view.partitionKeys.map(function (x) { return x.name;}).join(', '), 'game, year, month');
-                assert.strictEqual(view.clusteringKeys.map(function (x) { return x.name;}).join(', '), 'score, user, day');
+                assert.strictEqual(view.partitionKeys.map(x => x.name).join(', '), 'game, year, month');
+                assert.strictEqual(view.clusteringKeys.map(x => x.name).join(', '), 'score, user, day');
                 helper.assertContains(view.compactionClass, 'SizeTieredCompactionStrategy');
                 eachNext();
               });
@@ -1008,8 +1008,8 @@ describe('metadata', function () {
             client.metadata.getMaterializedView('ks_view_meta', 'users_by_first_all', function (err, view) {
               assert.ifError(err);
               assert.ok(view);
-              assert.strictEqual(view.partitionKeys.map(function (x) { return x.name;}).join(', '), 'first_name');
-              assert.strictEqual(view.clusteringKeys.map(function (x) { return x.name;}).join(', '), 'user');
+              assert.strictEqual(view.partitionKeys.map(x => x.name).join(', '), 'first_name');
+              assert.strictEqual(view.clusteringKeys.map(x => x.name).join(', '), 'user');
               // includeAllColumns should be true since 'select *' was used.
               assert.strictEqual(view.includeAllColumns, true);
               next();
@@ -1019,8 +1019,8 @@ describe('metadata', function () {
             client.metadata.getMaterializedView('ks_view_meta', 'users_by_first', function (err, view) {
               assert.ifError(err);
               assert.ok(view);
-              assert.strictEqual(view.partitionKeys.map(function (x) { return x.name;}).join(', '), 'first_name');
-              assert.strictEqual(view.clusteringKeys.map(function (x) { return x.name;}).join(', '), 'user');
+              assert.strictEqual(view.partitionKeys.map(x => x.name).join(', '), 'first_name');
+              assert.strictEqual(view.clusteringKeys.map(x => x.name).join(', '), 'user');
               assert.strictEqual(view.includeAllColumns, false);
               next();
             });
@@ -1031,8 +1031,8 @@ describe('metadata', function () {
             client.metadata.getMaterializedView('ks_view_meta', 'users_by_first_all', function(err, view) {
               assert.ifError(err);
               assert.ok(view);
-              assert.strictEqual(view.partitionKeys.map(function (x) { return x.name;}).join(', '), 'first_name');
-              assert.strictEqual(view.clusteringKeys.map(function (x) { return x.name;}).join(', '), 'user');
+              assert.strictEqual(view.partitionKeys.map(x => x.name).join(', '), 'first_name');
+              assert.strictEqual(view.clusteringKeys.map(x => x.name).join(', '), 'user');
               assert.ok(view.columnsByName['last_name']);
               assert.ok(view.columnsByName['last_name'].type.code === types.dataTypes.varchar ||
                 view.columnsByName['last_name'].type.code === types.dataTypes.text);
@@ -1046,8 +1046,8 @@ describe('metadata', function () {
             client.metadata.getMaterializedView('ks_view_meta', 'users_by_first', function (err, view) {
               assert.ifError(err);
               assert.ok(view);
-              assert.strictEqual(view.partitionKeys.map(function (x) { return x.name;}).join(', '), 'first_name');
-              assert.strictEqual(view.clusteringKeys.map(function (x) { return x.name;}).join(', '), 'user');
+              assert.strictEqual(view.partitionKeys.map(x => x.name).join(', '), 'first_name');
+              assert.strictEqual(view.clusteringKeys.map(x => x.name).join(', '), 'user');
               assert.strictEqual(view.columnsByName['last_name'], undefined);
               assert.strictEqual(view.columns.length, 2);
               assert.strictEqual(view.includeAllColumns, false);

--- a/test/integration/simulacron.js
+++ b/test/integration/simulacron.js
@@ -14,9 +14,7 @@ const simulacronHelper = {
     // If process hasn't completed in 10 seconds.
     let timeout = undefined;
     if(cb) {
-      timeout = setTimeout(function() {
-        cb('Timed out while waiting for ' + processName + ' to complete.');
-      }, 10000);
+      timeout = setTimeout(() => cb('Timed out while waiting for ' + processName + ' to complete.'), 10000);
     }
 
     const p = spawn(processName, params, {});
@@ -68,9 +66,7 @@ const simulacronHelper = {
     const params = ['-jar', simulacronJarPath, '--ip', self.startingIp, '-p', this.defaultPort];
     let initialized = false;
 
-    const timeout = setTimeout(function() {
-      cb(new Error('Timed out while waiting for Simulacron server to start.'));
-    }, 10000);
+    const timeout = setTimeout(() => cb(new Error('Timed out while waiting for Simulacron server to start.')), 10000);
 
     self.sProcess = self._execute(processName, params, function() {
       if(!initialized) {
@@ -306,7 +302,6 @@ SimulacronTopic.prototype.start = function(callback) {
 };
 
 SimulacronTopic.prototype._filterLogs = function(data) {
-  // TODO implement for cluster and dc.
   return data;
 };
 

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -331,8 +331,8 @@ const helper = {
    * @returns {Boolean}
    */
   isCassandraGreaterThan: function (version) {
-    const instanceVersion = this.getCassandraVersion().split('.').map(function (x) { return parseInt(x, 10);});
-    const compareVersion = version.split('.').map(function (x) { return parseInt(x, 10) || 0;});
+    const instanceVersion = this.getCassandraVersion().split('.').map(x => parseInt(x, 10));
+    const compareVersion = version.split('.').map(x => parseInt(x, 10) || 0);
     for (let i = 0; i < compareVersion.length; i++) {
       const compare = compareVersion[i] || 0;
       if (instanceVersion[i] > compare) {
@@ -911,7 +911,7 @@ function MapPolyFill(arr) {
   this.arr = arr || [];
   const self = this;
   Object.defineProperty(this, 'size', {
-    get: function() { return self.arr.length; },
+    get: () => self.arr.length,
     configurable: false
   });
 }

--- a/test/unit/basic-tests.js
+++ b/test/unit/basic-tests.js
@@ -158,14 +158,14 @@ describe('types', function () {
     const LocalDate = types.LocalDate;
     describe('new LocalDate', function (){
       it('should refuse to create LocalDate from invalid values.', function () {
-        assert.throws(function () { return new types.LocalDate(); }, Error);
-        assert.throws(function () { return new types.LocalDate(undefined); }, Error);
+        assert.throws(() => new types.LocalDate(), Error);
+        assert.throws(() => new types.LocalDate(undefined), Error);
         // Outside of ES5 Date range.
-        assert.throws(function () { return new types.LocalDate(-271821, 4, 19); }, Error);
-        assert.throws(function () { return new types.LocalDate(275760, 9, 14); }, Error);
+        assert.throws(() => new types.LocalDate(-271821, 4, 19), Error);
+        assert.throws(() => new types.LocalDate(275760, 9, 14), Error);
         // Outside of LocalDate range.
-        assert.throws(function () { return new types.LocalDate(-2147483649); }, Error);
-        assert.throws(function () { return new types.LocalDate(2147483648); }, Error);
+        assert.throws(() => new types.LocalDate(-2147483649), Error);
+        assert.throws(() => new types.LocalDate(2147483648), Error);
 
       });
     });
@@ -252,11 +252,11 @@ describe('types', function () {
     describe('new LocalTime', function () {
       it('should refuse to create LocalTime from invalid values.', function () {
         // Not a long.
-        assert.throws(function () { return new types.LocalTime(23.0); }, Error);
+        assert.throws(() => new types.LocalTime(23.0), Error);
         // < 0
-        assert.throws(function () { return new types.LocalTime(types.Long(-1)); }, Error);
+        assert.throws(() => new types.LocalTime(types.Long(-1)), Error);
         // > maxNanos
-        assert.throws(function () { return new types.LocalTime(Long.fromString('86400000000000')); }, Error);
+        assert.throws(() => new types.LocalTime(Long.fromString('86400000000000')), Error);
       });
     });
     describe('#toString()', function () {
@@ -539,9 +539,9 @@ describe('utils', function () {
   describe('#funcCompare()', function () {
     it('should return a compare function valid for Array#sort', function () {
       const values = [
-        {id: 1, getValue : function () { return 100;}},
-        {id: 2, getValue : function () { return 3;}},
-        {id: 3, getValue : function () { return 1;}}
+        {id: 1, getValue : () => 100},
+        {id: 2, getValue : () => 3},
+        {id: 3, getValue : () => 1}
       ];
       values.sort(utils.funcCompare('getValue'));
       assert.strictEqual(values[0].id, 3);

--- a/test/unit/client-tests.js
+++ b/test/unit/client-tests.js
@@ -682,7 +682,7 @@ describe('Client', function () {
       const Client = rewire('../../lib/client');
       const client = new Client(helper.baseOptions);
       let metaCalled = 0;
-      client._getEncoder = function () { return { setRoutingKey: helper.noop}; };
+      client._getEncoder = () => ({ setRoutingKey: helper.noop});
       client.controlConnection = { protocolVersion: 2};
       client.metadata = {
         adaptUserHints: function (ks, h, cb) {
@@ -705,7 +705,7 @@ describe('Client', function () {
     it('should use meta columns', function (done) {
       const Client = rewire('../../lib/client');
       const client = new Client(helper.baseOptions);
-      client._getEncoder = function () { return { setRoutingKey: helper.noop}; };
+      client._getEncoder = () => ({ setRoutingKey: helper.noop});
       client.controlConnection = { protocolVersion: 2};
       const meta = {
         columns: [
@@ -725,7 +725,7 @@ describe('Client', function () {
     it('should use the meta partition keys to fill the routingIndexes', function (done) {
       const Client = rewire('../../lib/client');
       const client = new Client(helper.baseOptions);
-      client._getEncoder = function () { return { setRoutingKey: helper.noop}; };
+      client._getEncoder = () => ({ setRoutingKey: helper.noop});
       client.controlConnection = { protocolVersion: 4};
       const meta = {
         columns: [
@@ -750,7 +750,7 @@ describe('Client', function () {
       const Client = rewire('../../lib/client');
       const client = new Client(helper.baseOptions);
       let metaCalled = 0;
-      client._getEncoder = function () { return { setRoutingKey: helper.noop}; };
+      client._getEncoder = () => ({ setRoutingKey: helper.noop});
       client.controlConnection = { protocolVersion: 3};
       const meta = {
         keyspace: 'ks1',
@@ -825,7 +825,7 @@ function newConnectedInstance(requestHandlerMock, options, prepareHandlerMock) {
   Client.__set__("RequestHandler", requestHandlerMock || function () {});
   Client.__set__("PrepareHandler", prepareHandlerMock || function () {});
   const client = new Client(utils.extend({}, helper.baseOptions, options));
-  client._getEncoder = function () { return new Encoder(2, {});};
+  client._getEncoder = () => new Encoder(2, {});
   client.connect = helper.callbackNoop;
   return client;
 }

--- a/test/unit/connection-tests.js
+++ b/test/unit/connection-tests.js
@@ -160,7 +160,7 @@ describe('Connection', function () {
         // Only 4 request were sent, no idle query
         assert.deepEqual(sent.map(function (op) {
           return op.request.query;
-        }), Array.apply(null, new Array(4)).map(function (x, i) { return 'QUERY' + i; }));
+        }), Array.apply(null, new Array(4)).map((x, i) => 'QUERY' + i));
         c.close();
         done();
       }, 40);

--- a/test/unit/control-connection-tests.js
+++ b/test/unit/control-connection-tests.js
@@ -38,15 +38,15 @@ describe('ControlConnection', function () {
       const cc = new CcMock(clientOptions.extend({ contactPoints: ['my-host-name'] }), null, getContext({
         queryResults: { 'system\\.peers': {
           rows: expectedHosts
-            .filter(function (address) { return address !== '1:9042'; })
-            .map(function (address) { return { 'rpc_address': address.split(':')[0] }; })
+            .filter(address => address !== '1:9042')
+            .map(address => ({'rpc_address': address.split(':')[0] }))
         }}
       }));
       cc.init(function (err) {
         const hosts = cc.hosts.values();
         cc.shutdown();
         assert.ifError(err);
-        assert.deepEqual(hosts.map(function (h) { return h.address; }), expectedHosts);
+        assert.deepEqual(hosts.map(h => h.address), expectedHosts);
         done();
       });
     }
@@ -60,7 +60,7 @@ describe('ControlConnection', function () {
         assert.ifError(err);
         const hosts = cc.hosts.values();
         assert.strictEqual(hosts.length, 2);
-        assert.deepEqual(hosts.map(function (h) { return h.address; }).sort(), [ '127.0.0.1:9042', '::1:9042' ]);
+        assert.deepEqual(hosts.map(h => h.address).sort(), [ '127.0.0.1:9042', '::1:9042' ]);
         done();
       });
     });
@@ -74,7 +74,7 @@ describe('ControlConnection', function () {
         assert.ifError(err);
         const hosts = cc.hosts.values();
         assert.ok(hosts.length >= 1);
-        assert.strictEqual(hosts.filter(function (h) { return h.address === '127.0.0.1:9999'; }).length, 1);
+        assert.strictEqual(hosts.filter(h => h.address === '127.0.0.1:9999').length, 1);
         done();
       });
     });

--- a/test/unit/load-balancing-tests.js
+++ b/test/unit/load-balancing-tests.js
@@ -784,5 +784,5 @@ function toHost(address) {
 }
 
 function toFunc(val) {
-  return (function () { return val; });
+  return (() => val);
 }

--- a/test/unit/metadata-tests.js
+++ b/test/unit/metadata-tests.js
@@ -145,8 +145,8 @@ describe('Metadata', function () {
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.tokenizer = new tokenizer.Murmur3Tokenizer();
       //Use the value as token
-      metadata.tokenizer.hash = function (b) { return b[0];};
-      metadata.tokenizer.compare = function (a, b) { return a - b; };
+      metadata.tokenizer.hash = (b) => b[0];
+      metadata.tokenizer.compare = (a, b) => a - b;
       metadata.tokenizer.stringify = stringifyDefault;
       metadata.ring = [0, 1, 2, 3, 4, 5];
       metadata.ringTokensAsStrings = ['0', '1', '2', '3', '4', '5'];
@@ -459,7 +459,7 @@ describe('Metadata', function () {
             }));
           });
         },
-        getEncoder: function () { return new Encoder(1, {});}
+        getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks1: { udts: {}}};
@@ -479,7 +479,7 @@ describe('Metadata', function () {
             cb(new Error('Test error'));
           });
         },
-        getEncoder: function () { return new Encoder(1, {});}
+        getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks1: { udts: {}}};
@@ -495,7 +495,7 @@ describe('Metadata', function () {
             cb(null, new types.ResultSet({ rows: [], flags: utils.emptyObject}));
           });
         },
-        getEncoder: function () { return new Encoder(1, {});}
+        getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks1: { udts: {}}};
@@ -517,7 +517,7 @@ describe('Metadata', function () {
             }));
           });
         },
-        getEncoder: function () { return new Encoder(1, {});}
+        getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       //no keyspace named ks1 in metadata
@@ -542,7 +542,7 @@ describe('Metadata', function () {
             }));
           });
         },
-        getEncoder: function () { return new Encoder(1, {});}
+        getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       //no keyspace named ks1 in metadata
@@ -577,7 +577,7 @@ describe('Metadata', function () {
             }));
           });
         },
-        getEncoder: function () { return new Encoder(1, {});}
+        getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       //no keyspace named ks1 in metadata
@@ -605,7 +605,7 @@ describe('Metadata', function () {
             cb(null, new types.ResultSet({ rows: [], flags: utils.emptyObject}));
           });
         },
-        getEncoder: function () { return new Encoder(1, {});}
+        getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks1: { udts: {}}};
@@ -646,7 +646,7 @@ describe('Metadata', function () {
             cb(null, { rows: eventRows});
           });
         },
-        getEncoder: function () { return new Encoder(1, {});}
+        getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.getTrace(types.Uuid.random(), types.consistencies.all, function (err, trace) {
@@ -691,7 +691,7 @@ describe('Metadata', function () {
             cb(null, { rows: eventRows});
           });
         },
-        getEncoder: function () { return new Encoder(1, {});}
+        getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.getTrace(types.Uuid.random(), function (err, trace) {
@@ -735,7 +735,7 @@ describe('Metadata', function () {
             cb(null, { rows: eventRows});
           });
         },
-        getEncoder: function () { return new Encoder(1, {});}
+        getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.getTrace(types.Uuid.random(), function (err, trace) {
@@ -772,7 +772,7 @@ describe('Metadata', function () {
             cb(null, { rows: rows});
           });
         },
-        getEncoder: function () { return new Encoder(1, {});}
+        getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.getTrace(types.Uuid.random(), function (err, trace) {
@@ -812,7 +812,7 @@ describe('Metadata', function () {
             cb(null, {rows: []});
           });
         },
-        getEncoder: function () { return new Encoder(1, {}); }
+        getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
@@ -854,7 +854,7 @@ describe('Metadata', function () {
             cb(null, {rows: columnRows});
           });
         },
-        getEncoder: function () { return new Encoder(1, {}); }
+        getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
@@ -894,7 +894,7 @@ describe('Metadata', function () {
             cb(null, {rows: columnRows});
           });
         },
-        getEncoder: function () { return new Encoder(1, {}); }
+        getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
@@ -925,7 +925,7 @@ describe('Metadata', function () {
             cb(null, {rows: []});
           });
         },
-        getEncoder: function () { return new Encoder(1, {}); }
+        getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
@@ -1366,7 +1366,7 @@ describe('Metadata', function () {
           //not present, default
           assert.strictEqual(table.populateCacheOnFlush, false);
           assert.strictEqual(table.columns.length, 6);
-          assert.deepEqual(table.columns.map(function (x) { return x.type.code; }),
+          assert.deepEqual(table.columns.map(x => x.type.code),
             [dataTypes.text, dataTypes.uuid, dataTypes.blob, dataTypes.int, dataTypes.custom, dataTypes.timeuuid]);
           assert.strictEqual(table.partitionKeys.length, 2);
           assert.strictEqual(table.partitionKeys[0].name, 'pk1');
@@ -1574,7 +1574,7 @@ describe('Metadata', function () {
               cb(null, {rows: rows});
             });
           },
-          getEncoder: function () { return new Encoder(4, {}); }
+          getEncoder: () => new Encoder(4, {})
         };
         const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { functions: {}};
@@ -1602,7 +1602,7 @@ describe('Metadata', function () {
               cb(null, {rows: rows});
             });
           },
-          getEncoder: function () { return new Encoder(4, {}); }
+          getEncoder: () => new Encoder(4, {})
         };
         const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { functions: {}};
@@ -1635,7 +1635,7 @@ describe('Metadata', function () {
               cb(null, {rows: rows});
             });
           },
-          getEncoder: function () { return new Encoder(4, {}); }
+          getEncoder: () => new Encoder(4, {})
         };
         const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { functions: {}};
@@ -1674,7 +1674,7 @@ describe('Metadata', function () {
               cb(null, {rows: rows});
             });
           },
-          getEncoder: function () { return new Encoder(4, {}); }
+          getEncoder: () => new Encoder(4, {})
         };
         const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { functions: {}};
@@ -1827,7 +1827,7 @@ describe('Metadata', function () {
             cb(null, {rows: rows});
           });
         },
-        getEncoder: function () { return new Encoder(4, {}); }
+        getEncoder: () => new Encoder(4, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces['ks_udf'] = { functions: {}};
@@ -1856,7 +1856,7 @@ describe('Metadata', function () {
             cb(null, {rows: rows});
           });
         },
-        getEncoder: function () { return new Encoder(4, {}); }
+        getEncoder: () => new Encoder(4, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.keyspaces['ks_udf'] = { functions: {}};
@@ -1950,7 +1950,7 @@ describe('Metadata', function () {
               cb(null, {rows: rows});
             });
           },
-          getEncoder: function () { return new Encoder(4, {}); }
+          getEncoder: () => new Encoder(4, {})
         };
         const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { aggregates: {}};
@@ -1978,7 +1978,7 @@ describe('Metadata', function () {
               cb(null, {rows: rows});
             });
           },
-          getEncoder: function () { return new Encoder(4, {}); }
+          getEncoder: () => new Encoder(4, {})
         };
         const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { aggregates: {}};
@@ -2011,7 +2011,7 @@ describe('Metadata', function () {
               cb(null, {rows: rows});
             });
           },
-          getEncoder: function () { return new Encoder(4, {}); }
+          getEncoder: () => new Encoder(4, {})
         };
         const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { aggregates: {}};
@@ -2051,7 +2051,7 @@ describe('Metadata', function () {
               cb(null, {rows: rows});
             });
           },
-          getEncoder: function () { return new Encoder(4, {}); }
+          getEncoder: () => new Encoder(4, {})
         };
         const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { aggregates: {}};
@@ -2180,7 +2180,7 @@ describe('Metadata', function () {
             cb(null, {rows: []});
           });
         },
-        getEncoder: function () { return new Encoder(4, {}); }
+        getEncoder: () => new Encoder(4, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       metadata.setCassandraVersion([3, 0]);
@@ -2298,7 +2298,7 @@ function getControlConnectionForTable(tableRow, columnRows, indexRows) {
         cb(null, {rows: columnRows});
       });
     },
-    getEncoder: function () { return new Encoder(1, {}); }
+    getEncoder: () => new Encoder(1, {})
   };
 }
 
@@ -2312,7 +2312,7 @@ function getControlConnectionForRows(rows, protocolVersion) {
         cb(null, {rows: rows});
       });
     },
-    getEncoder: function () { return new Encoder(protocolVersion || 4, {}); }
+    getEncoder: () => new Encoder(protocolVersion || 4, {})
   };
 }
 
@@ -2327,8 +2327,8 @@ function getAddress(h) {
 function getTokenizer() {
   const t = new tokenizer.Murmur3Tokenizer();
   //Use the first byte as token
-  t.hash = function (b) { return b[0];};
-  t.compare = function (a, b) { return a - b; };
+  t.hash = (b => b[0]);
+  t.compare = ((a, b) => a - b);
   t.stringify = stringifyDefault;
   t.parse = function (b) {
     return parseInt(b, 10);


### PR DESCRIPTION
[As detailed in the ticket](https://datastax-oss.atlassian.net/browse/NODEJS-406) there is a feature on ES6 that prevents us from moving public declarations to class syntax (`TypeError: Class constructor cannot be invoked without 'new'`).

I've migrated some of the internal prototypes and included the eslint rule `constructor-super` which is super useful in implementations like `Request`.
I've also changed some occurrences of functions to arrow functions and, as explained in the ticket comments, I've included the rule `"arrow-body-style": ["error", "as-needed"]`.

I'm happy with the result, specially with modules like `requests.js`, `prepare-handler.js`, `operation-state.js`. If I have more time, I would like to migrate `stream-id-stack.js`, `tokenizer.js` and `writers.js`.