### PR TITLE
Verify Buffer.from() is not Int8Array.from()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -101,6 +101,7 @@ module.exports = {
     "Promise": true,
     "Symbol": false,
     "Uint16Array": false,
+    "Int8Array": false,
     "process": false,
     "setTimeout": false,
     "setImmediate": false,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,13 +29,13 @@ const allocBufferUnsafe = Buffer.allocUnsafe || allocBufferDeprecated;
  * Forward-compatible allocation of buffer to contain a string.
  * @type {Function}
  */
-const allocBufferFromString = Buffer.from || allocBufferFromStringDeprecated;
+const allocBufferFromString = (Int8Array.from !== Buffer.from && Buffer.from) || allocBufferFromStringDeprecated;
 
 /**
  * Forward-compatible allocation of buffer from an array of bytes
  * @type {Function}
  */
-const allocBufferFromArray = Buffer.from || allocBufferFromArrayDeprecated;
+const allocBufferFromArray = (Int8Array.from !== Buffer.from && Buffer.from) || allocBufferFromArrayDeprecated;
 
 function allocBufferDeprecated(size) {
   // eslint-disable-next-line


### PR DESCRIPTION
Older versions of Node.js 4 imported Int8Array.from() function on Buffer, which is different from Buffer.from() introduced in Node.js 4.5.