### PR TITLE
Test: Use multiple dc with ccm to get a consistent dc name

### DIFF
--- a/test/integration/long/client-metadata-tests.js
+++ b/test/integration/long/client-metadata-tests.js
@@ -137,12 +137,12 @@ function partitionerSuite(partitionerName) {
             vnodes: vnodes
           };
 
-          const setupInfo = helper.setup(3, {
+          const setupInfo = helper.setup('3:0', {
             ccmOptions: ccmOptions,
             queries: [
               'CREATE KEYSPACE ks_simple_rf1 WITH replication = {\'class\': \'SimpleStrategy\', \'replication_factor\': 1}',
               'CREATE KEYSPACE ks_simple_rf2 WITH replication = {\'class\': \'SimpleStrategy\', \'replication_factor\': 2}',
-              'CREATE KEYSPACE ks_nts_rf2 WITH replication = {\'class\': \'NetworkTopologyStrategy\', \'datacenter1\' : 2}',
+              'CREATE KEYSPACE ks_nts_rf2 WITH replication = {\'class\': \'NetworkTopologyStrategy\', \'dc1\' : 2}',
               'CREATE TABLE ks_simple_rf1.foo (i int primary key)',
               'INSERT INTO ks_simple_rf1.foo (i) VALUES (1)',
               'INSERT INTO ks_simple_rf1.foo (i) VALUES (2)',

--- a/test/integration/short/metadata-tests.js
+++ b/test/integration/short/metadata-tests.js
@@ -10,7 +10,7 @@ const vdescribe = helper.vdescribe;
 
 describe('metadata', function () {
   this.timeout(60000);
-  const setupInfo = helper.setup(2, { ccmOptions: {
+  const setupInfo = helper.setup('2:0', { ccmOptions: {
     vnodes: true,
     yaml: helper.isCassandraGreaterThan('3.10') ? ['cdc_enabled:true'] : null
   }});
@@ -47,12 +47,12 @@ describe('metadata', function () {
           helper.toTask(client.execute, client, "CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}"),
           helper.toTask(client.execute, client, "CREATE KEYSPACE ks2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 2}"),
           helper.toTask(client.execute, client, "CREATE KEYSPACE ks3 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}"),
-          helper.toTask(client.execute, client, "CREATE KEYSPACE ks4 WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1' : 1}"),
+          helper.toTask(client.execute, client, "CREATE KEYSPACE ks4 WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1' : 1}"),
           function checkKeyspaces(next) {
             checkKeyspace(client, 'ks1', 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor', '3');
             checkKeyspace(client, 'ks2', 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor', '2');
             checkKeyspace(client, 'ks3', 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor', '1');
-            checkKeyspace(client, 'ks4', 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'datacenter1', '1');
+            checkKeyspace(client, 'ks4', 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'dc1', '1');
 
             // There should be no keyspace metadata for the non sync client until its fetched via refreshKeyspaces.
             const ks = nonSyncClient.metadata.keyspaces;
@@ -66,7 +66,7 @@ describe('metadata', function () {
               checkKeyspace(nonSyncClient, 'ks1', 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor', '3');
               checkKeyspace(nonSyncClient, 'ks2', 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor', '2');
               checkKeyspace(nonSyncClient, 'ks3', 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor', '1');
-              checkKeyspace(nonSyncClient, 'ks4', 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'datacenter1', '1');
+              checkKeyspace(nonSyncClient, 'ks4', 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'dc1', '1');
               next();
             });
           },
@@ -132,7 +132,7 @@ describe('metadata', function () {
           client.connect.bind(client),
           helper.toTask(client.execute, client, "CREATE KEYSPACE ksrf1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}"),
           helper.toTask(client.execute, client, "CREATE KEYSPACE ksrf2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 2}"),
-          helper.toTask(client.execute, client, "CREATE KEYSPACE ksntsrf2 WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1' : 2}"),
+          helper.toTask(client.execute, client, "CREATE KEYSPACE ksntsrf2 WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1' : 2}"),
           function getRanges(next) {
             const host1 = helper.findHost(client, 1);
             const host2 = helper.findHost(client, 2);

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -16,7 +16,8 @@ util.inherits(RetryMultipleTimes, policies.retry.RetryPolicy);
 const helper = {
   /**
    * Creates a ccm cluster, initializes a Client instance the before() and after() hooks, create
-   * @param {Number} nodeLength
+   * @param {Number|String} nodeLength A number representing the amount of nodes in a single datacenter or a string
+   * representing the amount of nodes in each datacenter, ie: "3:4".
    * @param {Object} [options]
    * @param {Object} [options.ccmOptions]
    * @param {Boolean} [options.initClient] Determines whether to create a Client instance.

--- a/test/unit/metadata-tests.js
+++ b/test/unit/metadata-tests.js
@@ -367,7 +367,7 @@ describe('Metadata', function () {
       });
     });
     it('should return quickly with many replicas and 0 nodes in one DC.', function (done) {
-      this.timeout(2000);
+      this.timeout(5000);
       const cc = getControlConnectionForRows([{
         'keyspace_name': 'dummy',
         'strategy_class': 'NetworkTopologyStrategy',
@@ -417,7 +417,7 @@ describe('Metadata', function () {
       });
     });
     it('should return quickly with many replicas and not enough nodes in a DC to satisfy RF.', function (done) {
-      this.timeout(2000);
+      this.timeout(5000);
       const cc = getControlConnectionForRows([{
         'keyspace_name': 'dummy',
         'strategy_class': 'NetworkTopologyStrategy',


### PR DESCRIPTION
Default `data_center` names in C* and DSE are different, causing test failures on the DSE side.

It uses the "x:y" ccm notation for node length to get the same data center names (dc1 and dc2) on both servers.