### PR TITLE
Use a fixed limit for connection writing queue and handle network stream backpressure

### DIFF
--- a/doc/features/connection-pooling/README.md
+++ b/doc/features/connection-pooling/README.md
@@ -5,11 +5,14 @@ The amount of connections per host is defined in the pooling configuration.
 
 ## Default pooling configuration 
 
-The default number of connections per host depends on the version of the Apache Cassandra cluster. When using the driver to connect to modern server versions (Apache Cassandra 2.1 and above), the driver uses one connection per host.
+The default number of connections per host depends on the version of the Apache Cassandra cluster.
+When using the driver to connect to modern server versions (Apache Cassandra 2.1 and above), the driver uses one
+connection per host.
 
 ## Setting the number of connections per host 
 
-If needed, you can set the number of connections per host depending on the distance, relative to the driver instance, in the `pooling` configuration:
+If needed, you can set the number of connections per host depending on the distance, relative to the driver instance,
+in the `pooling` configuration:
 
 ```javascript
 const cassandra = require('cassandra-driver');
@@ -26,4 +29,27 @@ const options = {
 };
 
 const client = new Client(options);
+```
+
+## Simultaneous requests per connection
+
+The driver limits the amount of concurrent requests per connection to `2048` with modern protocol versions and `128` 
+with older versions of the protocol (v1 and v2).
+
+You can throttle requests by setting the `maxRequestsPerConnection` value in the `poolingOptions`.
+
+When the limit is reached for all connections to a host, the driver will move to the next host according to the query
+plan. When the query plan is exhausted, the driver will yield a `NoHostAvailableError` containing 
+`BusyConnectionError` instances per each host in the `innerErrors` property.  
+
+## Get status of the connection pool
+
+You can use `getState()` method to get a point-in-time information of the state of the connections pools to each host.
+
+```javascript
+const state = client.getState();
+for (let host of state.getConnectedHosts()) {
+  console.log('Host %s: open connections = %d; in flight queries = %d',
+    host.address, state.getOpenConnections(host), state.getInFlightQueries(host));
+}
 ```

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -6,6 +6,26 @@ const types = require('./types');
 const utils = require('./utils');
 const errors = require('./errors');
 
+/** Core connections per host for protocol versions 1 and 2 */
+const coreConnectionsPerHostV2 = {
+  [types.distance.local]: 2,
+  [types.distance.remote]: 1,
+  [types.distance.ignored]: 0
+};
+
+/** Core connections per host for protocol version 3 and above */
+const coreConnectionsPerHostV3 = {
+  [types.distance.local]: 1,
+  [types.distance.remote]: 1,
+  [types.distance.ignored]: 0
+};
+
+/** Default maxRequestsPerConnection value for protocol v1 and v2 */
+const maxRequestsPerConnectionV2 = 128;
+
+/** Default maxRequestsPerConnection value for protocol v3+ */
+const maxRequestsPerConnectionV3 = 2048;
+
 /**
  * @returns {ClientOptions}
  */
@@ -33,10 +53,7 @@ function defaultOptions () {
     },
     pooling: {
       heartBeatInterval: 30000,
-      warmup: true,
-      // TODO: Make it protocol version dependent
-      // TODO: Use min value between set by the user and the protocol maximum
-      maxRequestsPerConnection: 2048
+      warmup: true
     },
     socketOptions: {
       connectTimeout: 5000,
@@ -45,7 +62,7 @@ function defaultOptions () {
       keepAliveDelay: 0,
       readTimeout: 12000,
       tcpNoDelay: true,
-      coalescingThreshold: 8000
+      coalescingThreshold: 65536
     },
     authProvider: null,
     maxPrepared: 500,
@@ -279,22 +296,25 @@ function getTimestamp(client, userOptions, defaultValue) {
 }
 
 /**
- * Core connections per host for protocol versions 1 and 2
+ * Sets the default options that depend on the protocol version.
+ * @param {ClientOptions} options
+ * @param {Number} version
  */
-const coreConnectionsPerHostV2 = {};
-coreConnectionsPerHostV2[types.distance.local] = 2;
-coreConnectionsPerHostV2[types.distance.remote] = 1;
-coreConnectionsPerHostV2[types.distance.ignored] = 0;
-/**
- * Core connections per host for protocol version 3 and above
- */
-const coreConnectionsPerHostV3 = {};
-coreConnectionsPerHostV3[types.distance.local] = 1;
-coreConnectionsPerHostV3[types.distance.remote] = 1;
-coreConnectionsPerHostV3[types.distance.ignored] = 0;
+function setProtocolDependentDefaults(options, version) {
+  let coreConnectionsPerHost = coreConnectionsPerHostV3;
+  let maxRequestsPerConnection = maxRequestsPerConnectionV3;
+  if (!types.protocolVersion.uses2BytesStreamIds(version)) {
+    coreConnectionsPerHost = coreConnectionsPerHostV2;
+    maxRequestsPerConnection = maxRequestsPerConnectionV2;
+  }
+  options.pooling = utils.deepExtend({}, { coreConnectionsPerHost, maxRequestsPerConnection }, options.pooling);
+}
 
 exports.extend = extend;
 exports.defaultOptions = defaultOptions;
 exports.coreConnectionsPerHostV2 = coreConnectionsPerHostV2;
 exports.coreConnectionsPerHostV3 = coreConnectionsPerHostV3;
 exports.createQueryOptions = createQueryOptions;
+exports.maxRequestsPerConnectionV2 = maxRequestsPerConnectionV2;
+exports.maxRequestsPerConnectionV3 = maxRequestsPerConnectionV3;
+exports.setProtocolDependentDefaults = setProtocolDependentDefaults;

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -35,6 +35,7 @@ function defaultOptions () {
       heartBeatInterval: 30000,
       warmup: true,
       // TODO: Make it protocol version dependent
+      // TODO: Use min value between set by the user and the protocol maximum
       maxRequestsPerConnection: 2048
     },
     socketOptions: {

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -33,7 +33,9 @@ function defaultOptions () {
     },
     pooling: {
       heartBeatInterval: 30000,
-      warmup: true
+      warmup: true,
+      // TODO: Make it protocol version dependent
+      maxRequestsPerConnection: 2048
     },
     socketOptions: {
       connectTimeout: 5000,

--- a/lib/client.js
+++ b/lib/client.js
@@ -406,13 +406,8 @@ Client.prototype._connectCb = function (callback) {
       RequestHandler.setKeyspace(self, next);
     },
     function setPoolOptionsAndWarmup(next) {
-      //Set the pooling options depending on the protocol version
-      let coreConnectionsPerHost = clientOptions.coreConnectionsPerHostV3;
-      if (!types.protocolVersion.uses2BytesStreamIds(self.controlConnection.protocolVersion)) {
-        coreConnectionsPerHost = clientOptions.coreConnectionsPerHostV2;
-      }
-      self.options.pooling = utils.deepExtend(
-        {}, { coreConnectionsPerHost: coreConnectionsPerHost }, self.options.pooling);
+      clientOptions.setProtocolDependentDefaults(self.options, self.controlConnection.protocolVersion);
+
       if (!self.options.pooling.warmup) {
         return next();
       }

--- a/lib/client.js
+++ b/lib/client.js
@@ -82,6 +82,12 @@ const warmupLimit = 32;
  * driver issues a request on an active connection to avoid idle time disconnections. Default: 30000.
  * @property {Object} pooling.coreConnectionsPerHost Associative array containing amount of connections per host
  * distance.
+ * @property {Number} pooling.maxRequestsPerConnection The maximum number of requests per connection. The default
+ * value is:
+ * <ul>
+ *   <li>For modern protocol versions (v3 and above): 2048</li>
+ *   <li>For older protocol versions (v1 and v2): 128</li>
+ * </ul>
  * @property {Boolean} pooling.warmup Determines if all connections to hosts in the local datacenter must be opened on
  * connect. Default: true.
  * @property {Object} protocolOptions

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -486,6 +486,8 @@ Connection.prototype._idleTimeoutHandler = function () {
     }, this.options.pooling.heartBeatInterval);
     return;
   }
+  // TODO: if there isn't an stream id available, check last read time
+
   this.log('verbose', 'Connection idling, issuing a Request to prevent idle disconnects');
   this.sendingIdleQuery = true;
   this.sendStream(new requests.QueryRequest(idleQuery), utils.emptyObject, function (err) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -124,7 +124,7 @@ Connection.prototype.open = function (callback) {
   const self = this;
   this.log('info', 'Connecting to ' + this.address + ':' + this.port);
   if (!this.options.sslOptions) {
-    this.netClient = new net.Socket();
+    this.netClient = new net.Socket({ highWaterMark: this.options.socketOptions.coalescingThreshold });
     this.netClient.connect(this.port, this.address, function connectCallback() {
       self.log('verbose', 'Socket connected to ' + self.address + ':' + self.port);
       self.bindSocketListeners();
@@ -139,6 +139,8 @@ Connection.prototype.open = function (callback) {
       self.bindSocketListeners();
       self.startup(callback);
     });
+    // TLSSocket will validate for values from 512 to 16K (depending on the SSL protocol version)
+    this.netClient.setMaxSendFragment(this.options.socketOptions.coalescingThreshold);
   }
   this.netClient.once('error', function socketError(err) {
     self.errorConnecting(err, false, callback);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -487,7 +487,6 @@ Connection.prototype._idleTimeoutHandler = function () {
     }, this.options.pooling.heartBeatInterval);
     return;
   }
-  // TODO: if there isn't an stream id available, check last read time
   this.log('verbose', 'Connection idling, issuing a Request to prevent idle disconnects');
   this.sendingIdleQuery = true;
   this.sendStream(new requests.QueryRequest(idleQuery), utils.emptyObject, function (err) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -448,6 +448,7 @@ Connection.prototype._write = function (operation, streamId) {
   const self = this;
   this.writeQueue.push(operation, function writeCallback (err) {
     if (err) {
+      // The request was not written.
       // There was a serialization error or the operation has already timed out or was cancelled
       self._streamIds.push(streamId);
       return operation.setResult(err);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -407,18 +407,24 @@ Connection.prototype.prepareOnce = function (query, callback) {
 };
 
 /**
- * Uses the frame writer to write into the wire
+ * Queues the operation to be written to the wire and invokes the callback once the response was obtained or with an
+ * error (socket error or Opera
  * @param {Request} request
  * @param {QueryOptions|null} options
  * @param {function} callback Function to be called once the response has been received
  * @return {OperationState}
  */
 Connection.prototype.sendStream = function (request, options, callback) {
-  const self = this;
   const operation = new OperationState(request, options, callback);
   const streamId = this._getStreamId();
+
+  // Start the request timeout without waiting for the request to be written
+  operation.setRequestTimeout(this.options.socketOptions.readTimeout, this.endpoint,
+    () => this.timedOutOperations++,
+    () => this.timedOutOperations--);
+
   if (streamId === null) {
-    self.log('info',
+    this.log('info',
       'Enqueuing ' +
       this._pendingWrites.length +
       ', if this message is recurrent consider configuring more connections per host or lowering the pressure');
@@ -440,6 +446,8 @@ Connection.prototype._write = function (operation, streamId) {
   const self = this;
   this.writeQueue.push(operation, function writeCallback (err) {
     if (err) {
+      // There was a serialization error or the operation has already timed out or was cancelled
+      self._streamIds.push(streamId);
       return operation.setResult(err);
     }
     self.log('verbose', 'Sent stream #' + streamId + ' to ' + self.endpoint);
@@ -447,13 +455,6 @@ Connection.prototype._write = function (operation, streamId) {
       self.parser.setOptions(streamId, { byRow: true });
     }
     self._setIdleTimeout();
-    operation.setRequestTimeout(self.options.socketOptions.readTimeout, self.endpoint,
-      function timeoutCallback () {
-        self.timedOutOperations++;
-      },
-      function responseCallback() {
-        self.timedOutOperations--;
-      });
     self._operations[streamId] = operation;
   });
 };
@@ -487,7 +488,6 @@ Connection.prototype._idleTimeoutHandler = function () {
     return;
   }
   // TODO: if there isn't an stream id available, check last read time
-
   this.log('verbose', 'Connection idling, issuing a Request to prevent idle disconnects');
   this.sendingIdleQuery = true;
   this.sendStream(new requests.QueryRequest(idleQuery), utils.emptyObject, function (err) {
@@ -533,7 +533,18 @@ Connection.prototype._writeNext = function () {
     return;
   }
   const self = this;
-  const operation = this._pendingWrites.shift();
+  let operation;
+  while ((operation = this._pendingWrites.shift()) && !operation.canBeWritten()) {
+    // Trying to obtain an pending operation that can be written
+  }
+
+  if (!operation) {
+    // There isn't a pending operation that can be written
+    this._streamIds.push(streamId);
+    return;
+  }
+
+  // Schedule after current I/O callbacks have been executed
   setImmediate(function writeNextPending() {
     self._write(operation, streamId);
   });

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -410,7 +410,7 @@ Connection.prototype.prepareOnce = function (query, callback) {
 
 /**
  * Queues the operation to be written to the wire and invokes the callback once the response was obtained or with an
- * error (socket error or Opera
+ * error (socket error or OperationTimedOutError or serialization-related error).
  * @param {Request} request
  * @param {QueryOptions|null} options
  * @param {function} callback Function to be called once the response has been received

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -124,8 +124,27 @@ function NotSupportedError(message) {
 
 util.inherits(NotSupportedError, DriverError);
 
+/**
+ * Represents a client-side error indicating that all connections to a certain host have reached
+ * the maximum amount of in-flight requests supported.
+ * @param {String} address
+ * @param {Number} maxRequestsPerConnection
+ * @param {Number} connectionLength
+ * @constructor
+ */
+function BusyConnectionError(address, maxRequestsPerConnection, connectionLength) {
+  const message = util.format('All connections to host %s are busy, %d requests are in-flight on %s',
+    address, maxRequestsPerConnection, connectionLength === 1 ? 'a single connection': 'each connection');
+  DriverError.call(this, message, this.constructor);
+  this.info = 'Represents a client-side error indicating that all connections to a certain host have reached ' +
+    'the maximum amount of in-flight requests supported (pooling.maxRequestsPerConnection)';
+}
+
+util.inherits(BusyConnectionError, DriverError);
+
 exports.ArgumentError = ArgumentError;
 exports.AuthenticationError = AuthenticationError;
+exports.BusyConnectionError = BusyConnectionError;
 exports.DriverError = DriverError;
 exports.OperationTimedOutError = OperationTimedOutError;
 exports.DriverInternalError = DriverInternalError;

--- a/lib/host-connection-pool.js
+++ b/lib/host-connection-pool.js
@@ -74,6 +74,7 @@ class HostConnectionPool extends events.EventEmitter {
         // Normally it should have callback in error, but better to handle this possibility
         return callback(new Error('No connection available'));
       }
+
       const maxRequests = this.options.pooling.maxRequestsPerConnection;
       const c = HostConnectionPool.minInFlight(this.connections, maxRequests);
 

--- a/lib/host-connection-pool.js
+++ b/lib/host-connection-pool.js
@@ -4,6 +4,7 @@ const events = require('events');
 
 const Connection = require('./connection');
 const utils = require('./utils');
+const errors = require('./errors');
 const defaultOptions = require('./client-options').defaultOptions();
 
 // Used to get the index of the connection with less in-flight requests
@@ -61,42 +62,60 @@ class HostConnectionPool extends events.EventEmitter {
   }
 
   /**
+   * Borrows a connection from the pool.
    * @param {Function} callback
    */
   borrowConnection(callback) {
-    const self = this;
-    this.create(false, function afterCreating(err) {
+    this.create(false, err => {
       if (err) {
         return callback(err);
       }
-      if (self.connections.length === 0) {
+      if (this.connections.length === 0) {
         // Normally it should have callback in error, but better to handle this possibility
         return callback(new Error('No connection available'));
       }
-      const c = HostConnectionPool.minInFlight(self.connections);
+      const maxRequests = this.options.pooling.maxRequestsPerConnection;
+      const c = HostConnectionPool.minInFlight(this.connections, maxRequests);
+
+      if (c.getInFlight() >= maxRequests) {
+        return callback(new errors.BusyConnectionError(this._address, maxRequests, this.connections.length));
+      }
       callback(null, c);
     });
   }
 
   /**
    * Gets the connection with the minimum number of in-flight requests.
-   * Only checks for index + 1 and index, to avoid a loop through all the connections.
+   * Only checks for 2 connections (round-robin) and gets the one with minimum in-flight requests, as long as
+   * the amount of in-flight requests is lower than maxRequests.
    * @param {Array.<Connection>} connections
+   * @param {Number} maxRequests
    * @returns {Connection}
    */
-  static minInFlight(connections) {
+  static minInFlight(connections, maxRequests) {
     const length = connections.length;
     if (length === 1) {
       return connections[0];
     }
-    const index = ++connectionIndex;
+
+    // Use a single index for all hosts as a simplified way to balance the load between connections
+    connectionIndex++;
     if (connectionIndex >= connectionIndexOverflow) {
       connectionIndex = 0;
     }
-    const current = connections[index % length];
-    const previous = connections[(index - 1) % length];
-    if (previous.getInFlight() < current.getInFlight()) {
-      return previous;
+
+    let current;
+    for (let index = connectionIndex; index < connectionIndex + length; index++) {
+      current = connections[index % length];
+      const next = connections[(index + 1) % length];
+      if (next.getInFlight() < current.getInFlight()) {
+        current = next;
+      }
+      if (current.getInFlight() < maxRequests) {
+        // Check as few connections as possible, as long as the amount of in-flight
+        // requests is lower than maxRequests
+        break;
+      }
     }
     return current;
   }

--- a/lib/operation-state.js
+++ b/lib/operation-state.js
@@ -54,6 +54,13 @@ class OperationState {
   }
 
   /**
+   * Determines if the operation can be written to the wire (when it hasn't been cancelled or it hasn't timed out).
+   */
+  canBeWritten() {
+    return this._state === state.init;
+  }
+
+  /**
    * Determines if the response is going to be yielded by row.
    * @return {boolean}
    */

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -60,8 +60,9 @@ class RequestHandler {
         if (connection) {
           host.removeFromPool(connection);
         }
-        // The error occurred on a different tick, so there is no risk of issuing a large number sync recursive calls
-        return RequestHandler.borrowNextConnection(iterator, triedHosts, profileManager, keyspace, callback);
+        // Issue on next tick to avoid large numbers of sync recursive calls
+        return process.nextTick(() =>
+          RequestHandler.borrowNextConnection(iterator, triedHosts, profileManager, keyspace, callback));
       }
       triedHosts[host.address] = null;
       callback(null, connection, host);

--- a/lib/writers.js
+++ b/lib/writers.js
@@ -201,7 +201,7 @@ class WriteQueue extends events.EventEmitter {
   }
 
   run() {
-    if (!this.isRunning && !this.error) {
+    if (!this.isRunning) {
       this.isRunning = true;
       // Use nextTick to allow the queue to build up on the current phase
       process.nextTick(() => this.process());
@@ -235,11 +235,8 @@ class WriteQueue extends events.EventEmitter {
     this.netClient.uncork();
 
     if (fitsInStreamBuffer) {
-      // Drain event will not be emitted
+      // Drain event will not be emitted and it's ready to add further writes
       this.isRunning = false;
-      if (this.queue.length > 0) {
-        setImmediate(() => this.run());
-      }
     }
   }
 

--- a/lib/writers.js
+++ b/lib/writers.js
@@ -211,6 +211,12 @@ class WriteQueue extends events.EventEmitter {
         let totalLength = 0;
         while (totalLength < self.coalescingThreshold && self.queue.length > 0) {
           const writeItem = self.queue.shift();
+          if (!writeItem.operation.canBeWritten()) {
+            // Invoke the write callback with an error that is not going to be yielded to user
+            // as the operation has timed out or was cancelled.
+            writeItem.callback(new Error('The operation was already cancelled or timeout elapsed'));
+            break;
+          }
           try {
             const data = writeItem.operation.request.write(self.encoder, writeItem.operation.streamId);
             totalLength += data.length;

--- a/lib/writers.js
+++ b/lib/writers.js
@@ -201,7 +201,7 @@ class WriteQueue extends events.EventEmitter {
   }
 
   run() {
-    if (!this.isRunning) {
+    if (!this.isRunning && !this.error) {
       this.isRunning = true;
       // Use nextTick to allow the queue to build up on the current phase
       process.nextTick(() => this.process());
@@ -210,9 +210,8 @@ class WriteQueue extends events.EventEmitter {
 
   process() {
     this.netClient.cork();
-    let totalLength = 0;
-    let willEmitDrain = false;
-    while (this.queue.length > 0 && totalLength < this.coalescingThreshold && !this.error) {
+    let fitsInStreamBuffer = true;
+    while (this.queue.length > 0 && fitsInStreamBuffer && !this.error) {
       const writeItem = this.queue.shift();
       if (!writeItem.operation.canBeWritten()) {
         // Invoke the write callback with an error that is not going to be yielded to user
@@ -228,14 +227,14 @@ class WriteQueue extends events.EventEmitter {
         writeItem.callback(err);
         continue;
       }
-      totalLength += data.length;
       // Mark it as written to avoid race conditions
       writeItem.callback();
-      willEmitDrain = !this.netClient.write(data, err => this.setWriteError(err));
+      fitsInStreamBuffer = this.netClient.write(data, err => this.setWriteError(err));
     }
     // Flush all data
     this.netClient.uncork();
-    if (!willEmitDrain) {
+
+    if (fitsInStreamBuffer) {
       // Drain event will not be emitted
       this.isRunning = false;
       if (this.queue.length > 0) {

--- a/lib/writers.js
+++ b/lib/writers.js
@@ -173,14 +173,6 @@ class WriteQueue extends events.EventEmitter {
     this.queue = [];
     this.coalescingThreshold = options.socketOptions.coalescingThreshold;
     this.error = null;
-    this.netClient.on('drain', () => {
-      if (this.queue.length === 0) {
-        // It will start running once we get the next message
-        this.isRunning = false;
-        return;
-      }
-      this.process();
-    });
   }
 
   /**
@@ -209,9 +201,15 @@ class WriteQueue extends events.EventEmitter {
   }
 
   process() {
-    this.netClient.cork();
-    let fitsInStreamBuffer = true;
-    while (this.queue.length > 0 && fitsInStreamBuffer && !this.error) {
+    if (this.error) {
+      return;
+    }
+
+    const buffers = [];
+    const callbacks = [];
+    let totalLength = 0;
+
+    while (this.queue.length > 0 && totalLength < this.coalescingThreshold) {
       const writeItem = this.queue.shift();
       if (!writeItem.operation.canBeWritten()) {
         // Invoke the write callback with an error that is not going to be yielded to user
@@ -227,17 +225,36 @@ class WriteQueue extends events.EventEmitter {
         writeItem.callback(err);
         continue;
       }
-      // Mark it as written to avoid race conditions
-      writeItem.callback();
-      fitsInStreamBuffer = this.netClient.write(data, err => this.setWriteError(err));
+      totalLength += data.length;
+      buffers.push(data);
+      callbacks.push(writeItem.callback);
     }
-    // Flush all data
-    this.netClient.uncork();
 
-    if (fitsInStreamBuffer) {
-      // Drain event will not be emitted and it's ready to add further writes
+    if (totalLength === 0) {
       this.isRunning = false;
+      return;
     }
+
+    // We have to invoke the callbacks to avoid race conditions.
+    // There is a performance benefit from executing all of them in a loop
+    for (let i = 0; i < callbacks.length; i++) {
+      callbacks[i]();
+    }
+    // Concatenate buffers and write it to the socket
+    // Further writes will be throttled until flushed
+    this.netClient.write(Buffer.concat(buffers, totalLength), err => {
+      if (err) {
+        this.setWriteError(err);
+        return;
+      }
+      if (this.queue.length === 0) {
+        // It will start running once we get the next message
+        this.isRunning = false;
+        return;
+      }
+      // Allow IO between writes
+      setImmediate(() => this.process());
+    });
   }
 
   /**
@@ -245,9 +262,6 @@ class WriteQueue extends events.EventEmitter {
    * @param err
    */
   setWriteError(err) {
-    if (!err) {
-      return;
-    }
     err.isSocketError = true;
     this.error = new types.DriverError('Socket was closed');
     this.error.isSocketError = true;

--- a/lib/writers.js
+++ b/lib/writers.js
@@ -173,6 +173,14 @@ class WriteQueue extends events.EventEmitter {
     this.queue = [];
     this.coalescingThreshold = options.socketOptions.coalescingThreshold;
     this.error = null;
+    this.netClient.on('drain', () => {
+      if (this.queue.length === 0) {
+        // It will start running once we get the next message
+        this.isRunning = false;
+        return;
+      }
+      this.process();
+    });
   }
 
   /**
@@ -194,62 +202,46 @@ class WriteQueue extends events.EventEmitter {
 
   run() {
     if (!this.isRunning) {
-      this.process();
+      this.isRunning = true;
+      // Use nextTick to allow the queue to build up on the current phase
+      process.nextTick(() => this.process());
     }
   }
 
   process() {
-    const self = this;
-    utils.whilst(
-      function condition() {
-        return self.queue.length > 0;
-      },
-      function whileProcess(next) {
-        self.isRunning = true;
-        const buffers = [];
-        const callbacks = [];
-        let totalLength = 0;
-        while (totalLength < self.coalescingThreshold && self.queue.length > 0) {
-          const writeItem = self.queue.shift();
-          if (!writeItem.operation.canBeWritten()) {
-            // Invoke the write callback with an error that is not going to be yielded to user
-            // as the operation has timed out or was cancelled.
-            writeItem.callback(new Error('The operation was already cancelled or timeout elapsed'));
-            break;
-          }
-          try {
-            const data = writeItem.operation.request.write(self.encoder, writeItem.operation.streamId);
-            totalLength += data.length;
-            buffers.push(data);
-            callbacks.push(writeItem.callback);
-          }
-          catch (err) {
-            writeItem.callback(err);
-            // Break and flush what we have
-            break;
-          }
-        }
-        if (buffers.length === 0) {
-          // No need to invoke socket.write()
-          return next();
-        }
-        // Before invoking socket.write(), mark that the request has been written to avoid race conditions.
-        for (let i = 0; i < callbacks.length; i++) {
-          callbacks[i]();
-        }
-        self.netClient.write(Buffer.concat(buffers, totalLength), function socketWriteCallback(err) {
-          if (err) {
-            self.setWriteError(err);
-          }
-          // Allow IO between writes
-          setImmediate(next);
-        });
-      },
-      function loopFinished() {
-        // The queue is now empty
-        self.isRunning = false;
+    this.netClient.cork();
+    let totalLength = 0;
+    let willEmitDrain = false;
+    while (this.queue.length > 0 && totalLength < this.coalescingThreshold && !this.error) {
+      const writeItem = this.queue.shift();
+      if (!writeItem.operation.canBeWritten()) {
+        // Invoke the write callback with an error that is not going to be yielded to user
+        // as the operation has timed out or was cancelled.
+        writeItem.callback(new Error('The operation was already cancelled or timeout elapsed'));
+        continue;
       }
-    );
+      let data;
+      try {
+        data = writeItem.operation.request.write(this.encoder, writeItem.operation.streamId);
+      }
+      catch (err) {
+        writeItem.callback(err);
+        continue;
+      }
+      totalLength += data.length;
+      // Mark it as written to avoid race conditions
+      writeItem.callback();
+      willEmitDrain = !this.netClient.write(data, err => this.setWriteError(err));
+    }
+    // Flush all data
+    this.netClient.uncork();
+    if (!willEmitDrain) {
+      // Drain event will not be emitted
+      this.isRunning = false;
+      if (this.queue.length > 0) {
+        setImmediate(() => this.run());
+      }
+    }
   }
 
   /**
@@ -257,6 +249,9 @@ class WriteQueue extends events.EventEmitter {
    * @param err
    */
   setWriteError(err) {
+    if (!err) {
+      return;
+    }
     err.isSocketError = true;
     this.error = new types.DriverError('Socket was closed');
     this.error.isSocketError = true;

--- a/test/integration/short/client-execute-tests.js
+++ b/test/integration/short/client-execute-tests.js
@@ -52,9 +52,9 @@ describe('Client', function () {
         done();
       });
     });
-    it('should handle 500 parallel queries', function (done) {
+    it('should handle 250 parallel queries', function (done) {
       const client = setupInfo.client;
-      utils.times(500, function (n, next) {
+      utils.times(250, function (n, next) {
         client.execute(helper.queries.basic, [], next);
       }, done);
     });

--- a/test/integration/short/connection-tests.js
+++ b/test/integration/short/connection-tests.js
@@ -161,7 +161,7 @@ describe('Connection', function () {
       ], done);
     });
   });
-  describe('#execute()', function () {
+  describe('#sendStream()', function () {
     before(helper.ccmHelper.start(1));
     after(helper.ccmHelper.remove);
     it('should queue pending if there is not an available stream id', function (done) {
@@ -207,6 +207,39 @@ describe('Connection', function () {
           }, seriesNext);
         },
         connection.close.bind(connection)
+      ], done);
+    });
+    it('should not consume streamIds for requests that cant be serialized', function (done) {
+      const options = utils.extend({}, defaultOptions);
+      options.socketOptions.readTimeout = 0;
+      options.policies.retry = new helper.RetryMultipleTimes(3);
+      const connection = newInstance(null, null, options);
+      const testError = new Error('Dummy serialization error');
+      utils.series([
+        next => connection.open(next),
+        next => {
+          setImmediate(() => {
+            assert.strictEqual(connection.getInFlight(), 0);
+            next();
+          });
+        },
+        seriesNext => {
+          utils.timesSeries(1, function (n, next) {
+            const request = getRequest(helper.queries.basic);
+            request.write = () => { throw testError; };
+            connection.sendStream(request, null, err => {
+              assert.strictEqual(err, testError);
+              next();
+            });
+          }, seriesNext);
+        },
+        next => {
+          setImmediate(() => {
+            assert.strictEqual(connection.getInFlight(), 0);
+            next();
+          });
+        },
+        next => connection.close(next)
       ], done);
     });
   });

--- a/test/integration/short/pool-simulator-tests.js
+++ b/test/integration/short/pool-simulator-tests.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const assert = require('assert');
+const simulacron = require('../simulacron');
+const helper = require('../../test-helper');
+const errors = require('../../../lib/errors');
+const types = require('../../../lib/types');
+
+const Client = require('../../../lib/client');
+
+describe('pool', function () {
+
+  this.timeout(5000);
+  before(done => simulacron.start(done));
+  after(done => simulacron.stop(done));
+
+  describe('with a 3-node simulated cluster', function () {
+    let cluster;
+    let client;
+
+    beforeEach(done => {
+      cluster = new simulacron.SimulacronCluster();
+      cluster.register([3], null, done);
+    });
+    beforeEach(() => client = new Client({
+      contactPoints: cluster.getContactPoints(),
+      // Use a LBP with a fixed order to have predictable behaviour
+      // Warning: OrderedLoadBalancingPolicy is only suitable for testing!
+      policies: { loadBalancing: new helper.OrderedLoadBalancingPolicy() },
+      pooling: {
+        coreConnectionsPerHost: {
+          [types.distance.local]: 2
+        },
+        maxRequestsPerConnection: 50
+      }
+    }));
+    beforeEach(done => cluster.prime({
+      when: { query: 'SELECT * FROM paused' },
+      then: { result: 'success', delay_in_ms: 1000 }
+    }, done));
+    afterEach(() => client.shutdown());
+    afterEach(done => cluster.unregister(done));
+
+    it('should use next host when a host is busy', function () {
+      return client.connect()
+        .then(() => Promise.all(new Array(150).fill(null).map(() => client.execute('SELECT * FROM paused'))))
+        .then(results => {
+          const hosts = client.hosts.keys();
+          // First 100 items should be the first host (50 * 2 connections)
+          assertArray(results.slice(0, 100).map(rs => rs.info.queriedHost), hosts[0]);
+          // The next 50 items should be the second host
+          assertArray(results.slice(100).map(rs => rs.info.queriedHost), hosts[1]);
+        })
+        .then(() => validateStateOfPool(client));
+    });
+
+    it('should fail when all hosts are busy', function () {
+      return client.connect()
+        .then(() => Promise.all(new Array(350).fill(null).map(() => {
+          const resultTuple = {
+            err: null,
+            coordinator: null
+          };
+          return client.execute('SELECT * FROM paused')
+            .then(rs => resultTuple.coordinator = rs.info.queriedHost)
+            .catch(err => resultTuple.err = err)
+            .then(() => resultTuple);
+        })))
+        .then(results => {
+          const hosts = client.hosts.keys();
+
+          // The first 300 requests should have succeed
+          assertArray(results.slice(0, 100).map(r => r.coordinator), hosts[0]);
+          assertArray(results.slice(100, 200).map(r => r.coordinator), hosts[1]);
+          assertArray(results.slice(200, 300).map(r => r.coordinator), hosts[2]);
+
+          // The last 50 items should have failed (rejected)
+          results.slice(300).forEach(r => {
+            assert.strictEqual(r.coordinator, null);
+            helper.assertInstanceOf(r.err, errors.NoHostAvailableError);
+            assert.deepEqual(Object.keys(r.err.innerErrors).sort(), hosts.sort());
+            helper.values(r.err.innerErrors).forEach(err => {
+              helper.assertInstanceOf(err, errors.BusyConnectionError);
+            });
+          });
+        })
+        .then(() => validateStateOfPool(client));
+    });
+  });
+});
+
+function assertArray(arr, value) {
+  assert.deepStrictEqual(arr, new Array(arr.length).fill(null).map(() => value));
+}
+
+/**
+ * Asserts that all nodes are UP and that the LBP is selecting the first healthy node.
+ */
+function validateStateOfPool(client) {
+  return client.execute('SELECT * FROM system.local')
+    .then(rs => {
+      // Assert it didn't affect the state of the pool
+      assertArray(client.hosts.values().map(h => h.isUp()), true);
+      return assert.strictEqual(rs.info.queriedHost, client.hosts.keys()[0]);
+    });
+}

--- a/test/integration/short/ssl-tests.js
+++ b/test/integration/short/ssl-tests.js
@@ -4,6 +4,7 @@ const util = require('util');
 
 const helper = require('../../test-helper');
 const Client = require('../../../lib/client');
+const errors = require('../../../lib/errors');
 const utils = require('../../../lib/utils');
 const types = require('../../../lib/types');
 
@@ -25,6 +26,15 @@ describe('Client', function () {
         client.connect(function (err) {
           assert.ifError(err);
           assert.strictEqual(client.hosts.length, 1);
+          helper.finish(client, done)();
+        });
+      });
+      it('should callback in error when rejecting unauthorized', function (done) {
+        const client = newInstance({ sslOptions: { rejectUnauthorized: true }});
+        client.connect(function (err) {
+          helper.assertInstanceOf(err, errors.NoHostAvailableError);
+          assert.strictEqual(Object.keys(err.innerErrors).length, 1);
+          helper.assertInstanceOf(helper.values(err.innerErrors)[0], Error);
           helper.finish(client, done)();
         });
       });

--- a/test/integration/short/ssl-tests.js
+++ b/test/integration/short/ssl-tests.js
@@ -30,14 +30,14 @@ describe('Client', function () {
       });
     });
     describe('#execute()', function () {
-      it('should handle multiple requests in parallel with queueing', function (done) {
-        const parallelLimit = helper.isCassandraGreaterThan('2.0') ? 2100 : 200;
+      it('should handle multiple requests in parallel', function (done) {
+        const parallelLimit = helper.isCassandraGreaterThan('2.0') ? 800 : 120;
         const client = newInstance();
         utils.series([
           client.connect.bind(client),
           function insert(next) {
             const query = util.format('INSERT INTO %s (id, text_sample) VALUES (?, ?)', table);
-            utils.timesLimit(40000, parallelLimit, function (n, timesNext) {
+            utils.timesLimit(20000, parallelLimit, function (n, timesNext) {
               client.execute(query, [ types.Uuid.random(), 'value ' + n ], { prepare: true }, timesNext);
             }, next);
           }

--- a/test/integration/short/timeout-tests.js
+++ b/test/integration/short/timeout-tests.js
@@ -4,7 +4,6 @@ const util = require('util');
 
 const helper = require('../../test-helper');
 const Client = require('../../../lib/client');
-const Connection = require('../../../lib/connection');
 const utils = require('../../../lib/utils');
 const types = require('../../../lib/types');
 const errors = require('../../../lib/errors');
@@ -93,7 +92,7 @@ describe('client read timeouts', function () {
       const client = newInstance({
         socketOptions: {
           readTimeout: 3000,
-          defunctReadTimeoutThreshold: 32
+          defunctReadTimeoutThreshold: 16
         },
         //1 connection per host to simply it
         poolingOptions: {
@@ -105,7 +104,9 @@ describe('client read timeouts', function () {
         }
       });
       let coordinators = {};
-      let connection;
+      let hostDown = null;
+      // The driver should mark the host as down when the pool closes all connections
+      client.on('hostDown', h => hostDown = h);
       utils.series([
         client.connect.bind(client),
         function warmup(next) {
@@ -119,24 +120,13 @@ describe('client read timeouts', function () {
             });
           }, next);
         },
-        function identifyConnection(next) {
-          connection = client.hosts.values()
-            .filter(function (h) {
-              return helper.lastOctetOf(h) === '2';
-            })[0]
-            .pool
-            .connections[0];
-          helper.assertInstanceOf(connection, Connection);
-          assert.strictEqual(connection.netClient.writable, true);
-          next();
-        },
         helper.toTask(helper.ccmHelper.pauseNode, null, 2),
         function checkTimeouts(next) {
           assert.strictEqual(Object.keys(coordinators).length, 2);
           assert.strictEqual(coordinators['1'], true);
           assert.strictEqual(coordinators['2'], true);
           coordinators = {};
-          utils.times(500, function (n, timesNext) {
+          utils.timesLimit(500, 64, function (n, timesNext) {
             client.execute('SELECT key FROM system.local', function (err, result) {
               if (err) {
                 return timesNext(err);
@@ -150,9 +140,8 @@ describe('client read timeouts', function () {
             }
             assert.strictEqual(Object.keys(coordinators).length, 1);
             assert.strictEqual(coordinators['1'], true);
-            //we check using an internal property of socket which is lame
-            //and might break
-            assert.strictEqual(connection.netClient.writable, false);
+            assert.ok(hostDown);
+            assert.strictEqual(helper.lastOctetOf(hostDown), '2');
             next();
           });
         },

--- a/test/unit/basic-tests.js
+++ b/test/unit/basic-tests.js
@@ -748,20 +748,24 @@ describe('writers', function () {
   describe('WriteQueue', function () {
     it('should buffer until threshold is passed', function (done) {
       let itemCallbackCounter = 0;
+      const coalescingThreshold = 50;
       const buffers = [];
+      let totalLength = 0;
       const socketMock = {
         write: function (buf, cb) {
           buffers.push(buf);
+          totalLength += buf.length;
           if (cb) {
             setTimeout(cb, 50);
           }
+          return (totalLength < coalescingThreshold);
         },
         on: utils.noop,
         cork: utils.noop,
         uncork: utils.noop
       };
       const options = utils.extend({}, clientOptions.defaultOptions());
-      options.socketOptions.coalescingThreshold = 50;
+      options.socketOptions.coalescingThreshold = coalescingThreshold;
       const encoder = new Encoder(3, options);
       const queue = new writers.WriteQueue(socketMock, encoder, options);
       const request = {

--- a/test/unit/basic-tests.js
+++ b/test/unit/basic-tests.js
@@ -756,7 +756,7 @@ describe('writers', function () {
           buffers.push(buf);
           totalLength += buf.length;
           if (cb) {
-            setTimeout(cb, 50);
+            setTimeout(cb, 20);
           }
           return (totalLength < coalescingThreshold);
         },
@@ -779,12 +779,14 @@ describe('writers', function () {
       for (let i = 0; i < 10; i++) {
         queue.push(new OperationState(request, null, utils.noop), itemCallback);
       }
-      setTimeout(function () {
-        // 5 frames
-        assert.strictEqual(itemCallbackCounter, 5);
-        assert.strictEqual(buffers.length, 5);
+      helper.setIntervalUntil(() => itemCallbackCounter === 10, 100, 50, () => {
+        // 10 frames
+        assert.strictEqual(itemCallbackCounter, 10);
+        // 10 frames coalesced into 2 buffers of 50b each
+        assert.strictEqual(buffers.length, 2);
+        buffers.forEach(b => assert.strictEqual(b.length, 50));
         done();
-      }, 500);
+      });
     });
   });
 });

--- a/test/unit/basic-tests.js
+++ b/test/unit/basic-tests.js
@@ -752,8 +752,13 @@ describe('writers', function () {
       const socketMock = {
         write: function (buf, cb) {
           buffers.push(buf);
-          setTimeout(cb, 50);
-        }
+          if (cb) {
+            setTimeout(cb, 50);
+          }
+        },
+        on: utils.noop,
+        cork: utils.noop,
+        uncork: utils.noop
       };
       const options = utils.extend({}, clientOptions.defaultOptions());
       options.socketOptions.coalescingThreshold = 50;
@@ -771,15 +776,9 @@ describe('writers', function () {
         queue.push(new OperationState(request, null, utils.noop), itemCallback);
       }
       setTimeout(function () {
-        //10 frames
-        assert.strictEqual(itemCallbackCounter, 10);
-        assert.strictEqual(buffers.length, 3);
-        //first part is only 1 message
-        assert.strictEqual(buffers[0].length, 10);
-        //second part contains 5 messages
-        assert.strictEqual(buffers[1].length, 50);
-        //second part contains 4 messages
-        assert.strictEqual(buffers[2].length, 40);
+        // 5 frames
+        assert.strictEqual(itemCallbackCounter, 5);
+        assert.strictEqual(buffers.length, 5);
         done();
       }, 500);
     });

--- a/test/unit/host-tests.js
+++ b/test/unit/host-tests.js
@@ -134,8 +134,8 @@ describe('HostConnectionPool', function () {
       });
     });
     it('should balance between connections avoiding busy ones', function (done) {
-      const maxRequestsPerConnection = clientOptions.defaultOptions().pooling.maxRequestsPerConnection;
-      const hostPool = newHostConnectionPoolInstance();
+      const maxRequestsPerConnection = clientOptions.maxRequestsPerConnectionV3;
+      const hostPool = newHostConnectionPoolInstance({ pooling: { maxRequestsPerConnection }});
       hostPool.coreConnectionsLength = 4;
       hostPool.connections = [
         { getInFlight: helper.functionOf(maxRequestsPerConnection) },
@@ -154,8 +154,8 @@ describe('HostConnectionPool', function () {
           return done(err);
         }
         // Second and third connections should be selected
-        assert.strictEqual(6, result.filter(c => c === hostPool.connections[2]).length);
-        assert.strictEqual(2, result.filter(c => c === hostPool.connections[3]).length);
+        const expectedConnections = hostPool.connections.slice(2);
+        assert.strictEqual(8, result.filter(c => expectedConnections.indexOf(c) >= 0).length);
         done();
       });
     });

--- a/test/unit/host-tests.js
+++ b/test/unit/host-tests.js
@@ -133,6 +133,32 @@ describe('HostConnectionPool', function () {
         done();
       });
     });
+    it('should balance between connections avoiding busy ones', function (done) {
+      const maxRequestsPerConnection = clientOptions.defaultOptions().pooling.maxRequestsPerConnection;
+      const hostPool = newHostConnectionPoolInstance();
+      hostPool.coreConnectionsLength = 4;
+      hostPool.connections = [
+        { getInFlight: helper.functionOf(maxRequestsPerConnection) },
+        { getInFlight: helper.functionOf(maxRequestsPerConnection) },
+        { getInFlight: helper.functionOf(0) },
+        { getInFlight: helper.functionOf(0) },
+      ];
+      const result = [];
+      utils.times(8, (n, next) => {
+        hostPool.borrowConnection((err, c) => {
+          result.push(c);
+          next(err);
+        });
+      }, err => {
+        if (err) {
+          return done(err);
+        }
+        // Second and third connections should be selected
+        assert.strictEqual(6, result.filter(c => c === hostPool.connections[2]).length);
+        assert.strictEqual(2, result.filter(c => c === hostPool.connections[3]).length);
+        done();
+      });
+    });
   });
   describe('#drainAndShutdown()', function () {
     it('should wait for connections to drain before shutting down', function (done) {
@@ -262,7 +288,7 @@ describe('HostConnectionPool', function () {
     });
   });
   describe('minInFlight()', function () {
-    it('should round robin with between connections with the same amount of in-flight requests', function () {
+    it('should round robin between connections with the same amount of in-flight requests', function () {
       /** @type {Array.<Connection>} */
       const connections = [];
       for (let i = 0; i < 3; i++) {
@@ -576,9 +602,7 @@ describe('Host', function () {
       const host = newHostInstance(defaultOptions);
       host._distance = types.distance.local;
       host.pool.coreConnectionsLength = 4;
-      host.pool._createConnection = function () {
-        return { open: helper.callbackNoop };
-      };
+      host.pool._createConnection = () => newConnectionMock({ open: helper.callbackNoop });
       host.borrowConnection(function (err) {
         assert.ifError(err);
         host.warmupPool(function (err) {
@@ -595,11 +619,7 @@ describe('Host', function () {
       const host = newHostInstance(defaultOptions);
       host._distance = types.distance.local;
       host.pool.coreConnectionsLength = 3;
-      host.pool._createConnection = function () {
-        return ({ open: function open(cb) {
-          setTimeout(cb, 20);
-        }});
-      };
+      host.pool._createConnection = () => newConnectionMock({ open: (cb) => setTimeout(cb, 20)});
       host.borrowConnection(function (err) {
         assert.ifError(err);
         host.warmupPool(function (err) {
@@ -616,9 +636,7 @@ describe('Host', function () {
       const host = newHostInstance(defaultOptions);
       host._distance = types.distance.local;
       host.pool.coreConnectionsLength = 4;
-      host.pool._createConnection = function () {
-        return { open: helper.callbackNoop };
-      };
+      host.pool._createConnection = () => newConnectionMock({ open: helper.callbackNoop });
       host.warmupPool(function (err) {
         assert.ifError(err);
         assert.strictEqual(host.pool.coreConnectionsLength, host.pool.connections.length);
@@ -632,11 +650,7 @@ describe('Host', function () {
       const host = newHostInstance(defaultOptions);
       host._distance = types.distance.local;
       host.pool.coreConnectionsLength = 3;
-      host.pool._createConnection = function () {
-        return ({ open: function open(cb) {
-          setTimeout(cb, 20);
-        }});
-      };
+      host.pool._createConnection = () => newConnectionMock({ open: (cb) => setTimeout(cb, 20)});
       host.warmupPool(function (err) {
         assert.ifError(err);
         assert.strictEqual(host.pool.coreConnectionsLength, host.pool.connections.length);
@@ -703,8 +717,9 @@ function newHostInstance(options) {
 /**
  * @returns {Connection}
  */
-function newConnectionMock() {
-  return ({
-    close: helper.noop
-  });
+function newConnectionMock(properties) {
+  return utils.extend({
+    close: helper.noop,
+    getInFlight: helper.functionOf(0)
+  }, properties);
 }


### PR DESCRIPTION
~~Still a work in progress but most of the logic is in.~~

The request handler is responsible to check for busy connections (above thresholds) and move to the next connection if possible.

The connection can still enqueue above stream id (rare, specially on modern protocol versions), that way it doesn't affect heart beats and control connection queries. The timeout of those enqueued requests is started immediately as they are added to the queue.