### PR TITLE
Destroy socket if close event not received within connect timeout

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -626,7 +626,15 @@ Connection.prototype.close = function (callback) {
   this.isSocketOpen = false;
   this.log('verbose', 'Closing connection to ' + this.endpoint);
   const self = this;
+
+  // If server doesn't acknowledge the half-close within connection timeout, destroy the socket.
+  let endTimeout = setTimeout(() => {
+    self.log('info', this.endpoint + ' did not respond to connection close within ' + this.options.socketOptions.connectTimeout + 'ms, destroying connection');
+    this.netClient.destroy();
+  }, this.options.socketOptions.connectTimeout);
+
   this.netClient.once('close', function (hadError) {
+    clearTimeout(endTimeout);
     if (hadError) {
       self.log('info', 'The socket closed with a transmission error');
     }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -629,7 +629,7 @@ Connection.prototype.close = function (callback) {
 
   // If server doesn't acknowledge the half-close within connection timeout, destroy the socket.
   const endTimeout = setTimeout(() => {
-    self.log('info', this.endpoint + ' did not respond to connection close within ' + this.options.socketOptions.connectTimeout + 'ms, destroying connection');
+    this.log('info', this.endpoint + ' did not respond to connection close within ' + this.options.socketOptions.connectTimeout + 'ms, destroying connection');
     this.netClient.destroy();
   }, this.options.socketOptions.connectTimeout);
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -628,7 +628,7 @@ Connection.prototype.close = function (callback) {
   const self = this;
 
   // If server doesn't acknowledge the half-close within connection timeout, destroy the socket.
-  let endTimeout = setTimeout(() => {
+  const endTimeout = setTimeout(() => {
     self.log('info', this.endpoint + ' did not respond to connection close within ' + this.options.socketOptions.connectTimeout + 'ms, destroying connection');
     this.netClient.destroy();
   }, this.options.socketOptions.connectTimeout);


### PR DESCRIPTION
For [NODEJS-428](https://datastax-oss.atlassian.net/browse/NODEJS-428).

Rather than `destroy`ing the connection always, attempt to `end` first, and if server hasn't responded within `SocketOptions.connectTimeout` then destroy it.

Tested this out locally and it seems to work good.   Attempted writing a test with this using simulacron but while I can configure it to accept connections and ignore `STARTUP` messages, it will still close the socket when it receives a FIN from the driver.   I think I can write a simple test using `ccm pause` so will push that tomorrow.