### PR TITLE
Add additional validation in Encoder.setRoutingKeyFromUser

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -8,6 +8,7 @@ const Integer = types.Integer;
 const BigDecimal = types.BigDecimal;
 const MutableLong = require('./types/mutable-long');
 const utils = require('./utils');
+const token = require('./token');
 
 const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const int16Zero = utils.allocBufferFromArray([0, 0]);
@@ -716,7 +717,15 @@ function defineInstanceMembers() {
       options.routingKey = concatRoutingKey(options.routingKey, totalLength);
       return;
     }
-    if (options.routingKey instanceof Buffer || !params || params.length === 0) {
+    // If routingKey is present, ensure it is a Buffer, Token, or TokenRange.  Otherwise throw an error.
+    if (options.routingKey) {
+      if (options.routingKey instanceof Buffer || options.routingKey instanceof token.Token || options.routingKey instanceof token.TokenRange) {
+        return;
+      }
+      throw new TypeError('Unexpected routingKey \'' + util.inspect(options.routingKey) + '\' provided.  Expected Buffer, Array<Buffer>, Token, or TokenRange.');
+    }
+    // If no params are present, return as routing key cannot be determined.
+    if (!params || params.length === 0) {
       return;
     }
     let routingIndexes = options.routingIndexes;

--- a/test/integration/short/load-balancing-tests.js
+++ b/test/integration/short/load-balancing-tests.js
@@ -145,10 +145,10 @@ context('with a reusable 3 node cluster', function () {
       }, helper.finish(client, done));
     });
     it('should target the correct replica using user-provided Buffer routingKey', function (done) {
-      testWithQueryOptions((client) => {
-        // Use [0] which should map to host 1.
-        return { routingKey: Buffer.from([0]) };
-      }, '1', done);
+      // Use [0] which should map to node 1
+      testWithQueryOptions((client) => ({
+        routingKey: Buffer.from([0])
+      }), '1', done);
     });
     it('should target the correct replica using user-provided Token routingKey', function (done) {
       testWithQueryOptions((client) => {

--- a/test/integration/short/load-balancing-tests.js
+++ b/test/integration/short/load-balancing-tests.js
@@ -168,20 +168,17 @@ context('with a reusable 3 node cluster', function () {
         return { routingKey: range };
       }, '3', done);
     });
-    it('should throw TypeError if invalid routingKey type is provided', function () {
+    it('should throw TypeError if invalid routingKey type is provided', function (done) {
       const client = new Client({
         policies: { loadBalancing: new TokenAwarePolicy(new RoundRobinPolicy()) },
         keyspace: 'ks_network_rp1',
         contactPoints: helper.baseOptions.contactPoints
       });
       const query = 'select * from system.local';
-      return client.execute(query, [], { routingKey: 'this is not valid' })
-        .then((result) => assert.ifError(result))
-        .catch((err) => {
-          assert.ok(err);
-          helper.assertInstanceOf(err, TypeError);
-        })
-        .then(() => client.shutdown());
+      client.execute(query, [], { routingKey: 'this is not valid' }, err => {
+        helper.assertInstanceOf(err, TypeError);
+        client.shutdown(done);
+      });
     });
   });
 });

--- a/test/integration/short/load-balancing-tests.js
+++ b/test/integration/short/load-balancing-tests.js
@@ -144,8 +144,68 @@ context('with a reusable 3 node cluster', function () {
         });
       }, helper.finish(client, done));
     });
+    it('should target the correct replica using user-provided Buffer routingKey', function (done) {
+      testWithQueryOptions((client) => {
+        // Use [0] which should map to host 1.
+        return { routingKey: Buffer.from([0]) };
+      }, '1', done);
+    });
+    it('should target the correct replica using user-provided Token routingKey', function (done) {
+      testWithQueryOptions((client) => {
+        // Find TokenRange for host 2 and use the end token (which is inclusive).
+        const host = helper.findHost(client, 2);
+        const ranges = client.metadata.getTokenRangesForHost('ks_network_rp1', host);
+        const range = ranges.values().next().value;
+        return { routingKey: range.end };
+      }, '2', done);
+    });
+    it('should target the correct replica using user-provided TokenRange routingKey', function (done) {
+      testWithQueryOptions((client) => {
+        // Find TokenRange for host 3 and use it.
+        const host = helper.findHost(client, 3);
+        const ranges = client.metadata.getTokenRangesForHost('ks_network_rp1', host);
+        const range = ranges.values().next().value;
+        return { routingKey: range };
+      }, '3', done);
+    });
+    it('should throw TypeError if invalid routingKey type is provided', function () {
+      const client = new Client({
+        policies: { loadBalancing: new TokenAwarePolicy(new RoundRobinPolicy()) },
+        keyspace: 'ks_network_rp1',
+        contactPoints: helper.baseOptions.contactPoints
+      });
+      const query = 'select * from system.local';
+      return client.execute(query, [], { routingKey: 'this is not valid' })
+        .then((result) => assert.ifError(result))
+        .catch((err) => {
+          assert.ok(err);
+          helper.assertInstanceOf(err, TypeError);
+        })
+        .then(() => client.shutdown());
+    });
   });
 });
+
+function testWithQueryOptions(optionsFn, expectedHostOctet, done) {
+  const client = new Client({
+    policies: { loadBalancing: new TokenAwarePolicy(new RoundRobinPolicy()) },
+    keyspace: 'ks_network_rp1',
+    contactPoints: helper.baseOptions.contactPoints
+  });
+  client.connect(() => {
+    const query = 'select * from system.local';
+    const queryOptions = optionsFn(client);
+    utils.timesLimit(100, maxInFlightRequests, function (n, timesNext) {
+      client.execute(query, [], queryOptions, function (err, result) {
+        assert.ifError(err);
+        const hosts = Object.keys(result.info.triedHosts);
+        assert.strictEqual(hosts.length, 1);
+        assert.strictEqual(helper.lastOctetOf(hosts[0]), expectedHostOctet);
+        timesNext();
+      });
+    }, helper.finish(client, done));
+  });
+}
 
 /**
  * Check that the trace event sources only shows nodes that are replicas to fulfill a consistency ALL query.

--- a/test/unit/encoder-tests.js
+++ b/test/unit/encoder-tests.js
@@ -2,6 +2,8 @@
 const assert = require('assert');
 const util = require('util');
 const utils = require('../../lib/utils');
+const tokenizer = require('../../lib/tokenizer');
+const token = require('../../lib/token');
 
 const Encoder = require('../../lib/encoder');
 const types = require('../../lib/types');
@@ -697,6 +699,27 @@ describe('encoder', function () {
       //The routing key should take precedence over routingIndexes
       assert.strictEqual(options.routingKey.toString('hex'), initialRoutingKey);
     });
+    it('should not affect Token routing keys', function () {
+      const token = new tokenizer.Murmur3Tokenizer().hash('4611686018427387904');
+      let options = {
+        routingIndexes: [1],
+        routingKey: token
+      };
+      encoder.setRoutingKeyFromUser([1, 'text'], options);
+      assert.strictEqual(options.routingKey, token);
+    });
+    it('should not affect TokenRange routing keys', function () {
+      const murmur3 = new tokenizer.Murmur3Tokenizer();
+      const start = murmur3.hash('-9223372036854775808');
+      const end = murmur3.hash('4611686018427387904');
+      const range = new token.TokenRange(start, end, murmur3);
+      let options = {
+        routingIndexes: [1],
+        routingKey: range
+      };
+      encoder.setRoutingKeyFromUser([1, 'text'], options);
+      assert.strictEqual(options.routingKey, range);
+    });
     it('should build routing key based on routingIndexes', function () {
       /** @type {QueryOptions} */
       let options = {
@@ -769,6 +792,11 @@ describe('encoder', function () {
           routingIndexes: [0]
         };
         encoder.setRoutingKeyFromUser(['this is text'], options);
+      }, TypeError);
+    });
+    it('should throw TypeError if invalid routingKey type is provided', function () {
+      assert.throws(() => { 
+        encoder.setRoutingKeyFromUser([1, 'text'], { routingKey: 123 });
       }, TypeError);
     });
   });

--- a/test/unit/encoder-tests.js
+++ b/test/unit/encoder-tests.js
@@ -701,7 +701,7 @@ describe('encoder', function () {
     });
     it('should not affect Token routing keys', function () {
       const token = new tokenizer.Murmur3Tokenizer().hash('4611686018427387904');
-      let options = {
+      const options = {
         routingIndexes: [1],
         routingKey: token
       };
@@ -713,7 +713,7 @@ describe('encoder', function () {
       const start = murmur3.hash('-9223372036854775808');
       const end = murmur3.hash('4611686018427387904');
       const range = new token.TokenRange(start, end, murmur3);
-      let options = {
+      const options = {
         routingIndexes: [1],
         routingKey: range
       };


### PR DESCRIPTION
For [NODEJS-429](https://datastax-oss.atlassian.net/browse/NODEJS-429)

Only Array<Buffer>, Buffer, Token, and TokenRange values should be
acceptable for options.routingKey.  Throws TypeError when unexpected
type provided.