### PR TITLE
Log driver version on Client.connect

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -9,6 +9,8 @@ const ProfileManager = require('./execution-profile').ProfileManager;
 const requests = require('./requests');
 const clientOptions = require('./client-options');
 const ClientState = require('./metadata/client-state');
+const description = require('../package.json').description;
+const version = require('../package.json').version;
 
 // Allow injection of the following modules
 /* eslint-disable prefer-const */
@@ -401,6 +403,7 @@ Client.prototype._connectCb = function (callback) {
   }
   this.connecting = true;
   const self = this;
+  this.log('info', util.format("Connecting to cluster using '%s' version %s", description, version));
   utils.series([
     function initControlConnection(next) {
       self.controlConnection.init(next);


### PR DESCRIPTION
For [NODEJS-426](https://datastax-oss.atlassian.net/browse/NODEJS-426).  Since `Client` emits log events, it made the most sense to emit a log message on connect instead of `Client` instantiation, as in that case there would be no opportunity for user to register a log event.