### PR TITLE
Reject promise for schema metadata methods when not connected

### DIFF
--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -306,9 +306,13 @@ ControlConnection.prototype.refreshHosts = function (newNodesUp, callback) {
       self.metadata.setCassandraVersion(host.getCassandraVersion());
       self.metadata.buildTokens(self.hosts);
       if (!self.options.isMetadataSyncEnabled) {
+        self.metadata.initialized = true;
         return next();
       }
-      self.metadata.refreshKeyspaces(false, next);
+      self.metadata._refreshKeyspaces(false, true, () => {
+        self.metadata.initialized = true;
+        next();
+      });
     }
   ], callback);
 };

--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -177,6 +177,9 @@ Metadata.prototype.refreshKeyspace = function (name, callback) {
  * @private
  */
 Metadata.prototype._refreshKeyspaceCb = function (name, callback) {
+  if (!this.initialized) {
+    return callback(this._uninitializedError(), null);
+  }
   this.log('info', util.format('Retrieving keyspace %s metadata', name));
   const self = this;
   this._schemaParser.getKeyspace(name, function (err, ksInfo) {
@@ -211,17 +214,31 @@ Metadata.prototype.refreshKeyspaces = function (waitReconnect, callback) {
     waitReconnect = true;
   }
 
+  return this._refreshKeyspaces(waitReconnect, false, callback);
+};
+
+/**
+ * @param {Boolean} waitReconnect
+ * @param {Boolean} internal Whether or not this was called by driver (i.e. control connection)
+ * @param {Function} [callback] 
+ * @private
+ */
+Metadata.prototype._refreshKeyspaces = function (waitReconnect, internal, callback) {
   return utils.promiseWrapper.call(this, this.options, callback, function handler(cb) {
-    this._refreshKeyspacesCb(waitReconnect, cb);
+    this._refreshKeyspacesCb(waitReconnect, internal, cb);
   });
 };
 
 /**
  * @param {Boolean} waitReconnect
+ * @param {Boolean} internal
  * @param {Function} callback
  * @private
  */
-Metadata.prototype._refreshKeyspacesCb = function (waitReconnect, callback) {
+Metadata.prototype._refreshKeyspacesCb = function (waitReconnect, internal, callback) {
+  if (!internal && !this.initialized) {
+    return callback(this._uninitializedError(), null);
+  }
   this.log('info', 'Retrieving keyspaces metadata');
   const self = this;
   this._schemaParser.getKeyspaces(waitReconnect, function getKeyspacesCallback(err, keyspaces) {
@@ -230,7 +247,6 @@ Metadata.prototype._refreshKeyspacesCb = function (waitReconnect, callback) {
       return callback(err);
     }
     self.keyspaces = keyspaces;
-    self.initialized = true;
     callback(null, keyspaces);
   });
 };
@@ -294,7 +310,7 @@ Metadata.prototype.getReplicas = function (keyspaceName, token) {
 /**
  * Gets the token ranges that define data distribution in the ring.
  *
- * @returns {Set<TokenRange>} The ranges of the ring.
+ * @returns {Set<TokenRange>} The ranges of the ring or empty set if schema metadata is not enabled.
  */
 Metadata.prototype.getTokenRanges = function () {
   return this.tokenRanges;
@@ -306,7 +322,7 @@ Metadata.prototype.getTokenRanges = function () {
  *
  * @param {String} keyspaceName The name of the keyspace to get ranges for.
  * @param {Host} host The host.
- * @returns {Set<TokenRange>|null} Ranges for the keyspace on this host or null if keyspace isn't found.
+ * @returns {Set<TokenRange>|null} Ranges for the keyspace on this host or null if keyspace isn't found or hasn't been loaded.
  */
 Metadata.prototype.getTokenRangesForHost = function (keyspaceName, host) {
   if (!this.ring) {
@@ -407,16 +423,9 @@ Metadata.prototype.getAllPrepared = function () {
   return this._preparedQueries.getAll();
 };
 
-/** 
- * Retrieves keyspace from cache.
- * @ignore 
- * @throws {Error} If metadata has not been initialized.
- */
-Metadata.prototype._getKeyspaceFromCache = function (keyspaceName) {
-  if (!this.initialized) {
-    throw new Error('Metadata has not been initialized.  This could only happen if you have not connected yet.');
-  }
-  return this.keyspaces[keyspaceName];
+/** @ignore */
+Metadata.prototype._uninitializedError = function () {
+  return new Error('Metadata has not been initialized.  This could only happen if you have not connected yet.');
 };
 
 /**
@@ -446,9 +455,12 @@ Metadata.prototype.getUdt = function (keyspaceName, name, callback) {
  * @private
  */
 Metadata.prototype._getUdtCb = function (keyspaceName, name, callback) {
+  if (!this.initialized) {
+    return callback(this._uninitializedError(), null);
+  }
   let cache;
   if (this.options.isMetadataSyncEnabled) {
-    const keyspace = this._getKeyspaceFromCache(keyspaceName);
+    const keyspace = this.keyspaces[keyspaceName];
     if (!keyspace) {
       return callback(null, null);
     }
@@ -485,9 +497,12 @@ Metadata.prototype.getTable = function (keyspaceName, name, callback) {
  * @private
  */
 Metadata.prototype._getTableCb = function (keyspaceName, name, callback) {
+  if (!this.initialized) {
+    return callback(this._uninitializedError(), null);
+  }
   let cache;
   if (this.options.isMetadataSyncEnabled) {
-    const keyspace = this._getKeyspaceFromCache(keyspaceName);
+    const keyspace = this.keyspaces[keyspaceName];
     if (!keyspace) {
       return callback(null, null);
     }
@@ -653,9 +668,12 @@ Metadata.prototype.getMaterializedView = function (keyspaceName, name, callback)
  * @private
  */
 Metadata.prototype._getMaterializedViewCb = function (keyspaceName, name, callback) {
+  if (!this.initialized) {
+    return callback(this._uninitializedError(), null);
+  }
   let cache;
   if (this.options.isMetadataSyncEnabled) {
-    const keyspace = this._getKeyspaceFromCache(keyspaceName);
+    const keyspace = this.keyspaces[keyspaceName];
     if (!keyspace) {
       return callback(null, null);
     }
@@ -673,9 +691,12 @@ Metadata.prototype._getMaterializedViewCb = function (keyspaceName, name, callba
  * @private
  */
 Metadata.prototype._getFunctions = function (keyspaceName, name, aggregate, callback) {
+  if (!this.initialized) {
+    return callback(this._uninitializedError(), null);
+  }
   let cache;
   if (this.options.isMetadataSyncEnabled) {
-    const keyspace = this._getKeyspaceFromCache(keyspaceName);
+    const keyspace = this.keyspaces[keyspaceName];
     if (!keyspace) {
       return callback(null, null);
     }
@@ -759,6 +780,9 @@ Metadata.prototype.getTrace = function (traceId, consistency, callback) {
  * @private
  */
 Metadata.prototype._getTraceCb = function (traceId, consistency, callback) {
+  if (!this.initialized) {
+    return callback(this._uninitializedError(), null);
+  }
   let trace;
   let attempts = 0;
   const requestOptions = { consistency: consistency };

--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -58,6 +58,7 @@ function Metadata (options, controlConnection) {
   Object.defineProperty(this, 'options', { value: options, enumerable: false, writable: false});
   Object.defineProperty(this, 'controlConnection', { value: controlConnection, enumerable: false, writable: false});
   this.keyspaces = {};
+  this.initialized = false;
   this._schemaParser = schemaParserFactory.getByVersion(controlConnection, this.getUdt.bind(this));
   const self = this;
   this._preparedQueries = new PreparedQueries(options.maxPrepared, function () {
@@ -229,6 +230,7 @@ Metadata.prototype._refreshKeyspacesCb = function (waitReconnect, callback) {
       return callback(err);
     }
     self.keyspaces = keyspaces;
+    self.initialized = true;
     callback(null, keyspaces);
   });
 };
@@ -405,6 +407,18 @@ Metadata.prototype.getAllPrepared = function () {
   return this._preparedQueries.getAll();
 };
 
+/** 
+ * Retrieves keyspace from cache.
+ * @ignore 
+ * @throws {Error} If metadata has not been initialized.
+ */
+Metadata.prototype._getKeyspaceFromCache = function (keyspaceName) {
+  if (!this.initialized) {
+    throw new Error('Metadata has not been initialized.  This could only happen if you have not connected yet.');
+  }
+  return this.keyspaces[keyspaceName];
+};
+
 /**
  * Gets the definition of an user-defined type.
  * <p>
@@ -434,7 +448,7 @@ Metadata.prototype.getUdt = function (keyspaceName, name, callback) {
 Metadata.prototype._getUdtCb = function (keyspaceName, name, callback) {
   let cache;
   if (this.options.isMetadataSyncEnabled) {
-    const keyspace = this.keyspaces[keyspaceName];
+    const keyspace = this._getKeyspaceFromCache(keyspaceName);
     if (!keyspace) {
       return callback(null, null);
     }
@@ -473,7 +487,7 @@ Metadata.prototype.getTable = function (keyspaceName, name, callback) {
 Metadata.prototype._getTableCb = function (keyspaceName, name, callback) {
   let cache;
   if (this.options.isMetadataSyncEnabled) {
-    const keyspace = this.keyspaces[keyspaceName];
+    const keyspace = this._getKeyspaceFromCache(keyspaceName);
     if (!keyspace) {
       return callback(null, null);
     }
@@ -641,7 +655,7 @@ Metadata.prototype.getMaterializedView = function (keyspaceName, name, callback)
 Metadata.prototype._getMaterializedViewCb = function (keyspaceName, name, callback) {
   let cache;
   if (this.options.isMetadataSyncEnabled) {
-    const keyspace = this.keyspaces[keyspaceName];
+    const keyspace = this._getKeyspaceFromCache(keyspaceName);
     if (!keyspace) {
       return callback(null, null);
     }
@@ -661,7 +675,7 @@ Metadata.prototype._getMaterializedViewCb = function (keyspaceName, name, callba
 Metadata.prototype._getFunctions = function (keyspaceName, name, aggregate, callback) {
   let cache;
   if (this.options.isMetadataSyncEnabled) {
-    const keyspace = this.keyspaces[keyspaceName];
+    const keyspace = this._getKeyspaceFromCache(keyspaceName);
     if (!keyspace) {
       return callback(null, null);
     }

--- a/test/unit/metadata-tests.js
+++ b/test/unit/metadata-tests.js
@@ -39,6 +39,7 @@ describe('Metadata', function () {
         }
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.tokenizer = getTokenizer();
       const hosts = new HostMap();
       const h1 = new Host('127.0.0.1', 2, clientOptions.defaultOptions());
@@ -84,6 +85,7 @@ describe('Metadata', function () {
         }
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.tokenizer = getTokenizer();
       const hosts = new HostMap();
       const h1 = new Host('127.0.0.1', 2, clientOptions.defaultOptions());
@@ -150,6 +152,7 @@ describe('Metadata', function () {
         }
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.tokenizer = getTokenizer();
       metadata.setCassandraVersion([3, 0]);
       metadata.ring = [0, 1, 2, 3, 4, 5].map((t) => token(t));
@@ -178,6 +181,7 @@ describe('Metadata', function () {
         }
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.tokenizer = getTokenizer();
       metadata.setCassandraVersion([3, 0]);
       metadata.ring = [0, 1, 2, 3, 4, 5].map((t) => token(t));
@@ -208,6 +212,7 @@ describe('Metadata', function () {
         }
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.tokenizer = getTokenizer();
       metadata.ring = [0, 1, 2, 3, 4, 5].map((t) => token(t));
       metadata.ringTokensAsStrings = ['0', '1', '2', '3', '4', '5'];
@@ -242,6 +247,7 @@ describe('Metadata', function () {
       }]);
       const options = clientOptions.extend({}, helper.baseOptions);
       const metadata = new Metadata(options, cc);
+      metadata.initialized = true;
       metadata.tokenizer = getTokenizer();
       const racks = new utils.HashSet();
       racks.add('rack1');
@@ -282,6 +288,7 @@ describe('Metadata', function () {
       }]);
       const options = clientOptions.extend({}, helper.baseOptions);
       const metadata = new Metadata(options, cc);
+      metadata.initialized = true;
       metadata.tokenizer = getTokenizer();
       const racksDc1 = new utils.HashSet();
       racksDc1.add('dc1_r1');
@@ -328,6 +335,7 @@ describe('Metadata', function () {
       }]);
       const options = clientOptions.extend({}, helper.baseOptions);
       const metadata = new Metadata(options, cc);
+      metadata.initialized = true;
       metadata.tokenizer = getTokenizer();
       const racksDc1 = new utils.HashSet();
       racksDc1.add('dc1_r1');
@@ -375,6 +383,7 @@ describe('Metadata', function () {
       }]);
       const options = clientOptions.extend({}, helper.baseOptions);
       const metadata = new Metadata(options, cc);
+      metadata.initialized = true;
       metadata.tokenizer = getTokenizer();
       const racksDc1 = new utils.HashSet();
       racksDc1.add('dc1_r1');
@@ -425,6 +434,7 @@ describe('Metadata', function () {
       }]);
       const options = clientOptions.extend({}, helper.baseOptions);
       const metadata = new Metadata(options, cc);
+      metadata.initialized = true;
       metadata.tokenizer = getTokenizer();
       const racksDc1 = new utils.HashSet();
       racksDc1.add('dc1_r1');
@@ -483,6 +493,7 @@ describe('Metadata', function () {
   describe('#clearPrepared()', function () {
     it('should clear the internal state', function () {
       const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      metadata.initialized = true;
       const info1 = metadata.getPreparedInfo(null, 'QUERY1');
       // Should be created once
       assert.strictEqual(info1, metadata.getPreparedInfo(null, 'QUERY1'));
@@ -495,6 +506,7 @@ describe('Metadata', function () {
   describe('#getPreparedInfo()', function () {
     it('should create a new EventEmitter when the query has not been prepared', function () {
       const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      metadata.initialized = true;
       let info = metadata.getPreparedInfo(null, 'query1');
       helper.assertInstanceOf(info, events.EventEmitter);
       info = metadata.getPreparedInfo(null, 'query2');
@@ -502,6 +514,7 @@ describe('Metadata', function () {
     });
     it('should get the same EventEmitter when the query is the same', function () {
       const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      metadata.initialized = true;
       const info1 = metadata.getPreparedInfo(null, 'query1');
       helper.assertInstanceOf(info1, events.EventEmitter);
       const info2 = metadata.getPreparedInfo(null, 'query1');
@@ -510,6 +523,7 @@ describe('Metadata', function () {
     });
     it('should create a new EventEmitter when the query is the same but the keyspace is different', function () {
       const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      metadata.initialized = true;
       const info0 = metadata.getPreparedInfo(null, 'query1');
       const info1 = metadata.getPreparedInfo('ks1', 'query1');
       const info2 = metadata.getPreparedInfo('ks2', 'query1');
@@ -537,6 +551,7 @@ describe('Metadata', function () {
         getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.keyspaces = { ks1: { udts: {}}};
       metadata.getUdt('ks1', 'udt1', function (err, udtInfo) {
         assert.ifError(err);
@@ -546,6 +561,14 @@ describe('Metadata', function () {
         assert.strictEqual(udtInfo.fields.length, 3);
         done();
       });
+    });
+    it('should reject if have not connected yet', () => {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      return metadata.getUdt('ks1', 'udt1')
+        .catch((err) => {
+          helper.assertInstanceOf(err, Error);
+          assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
+        });
     });
     it('should callback in err when there is an error', function (done) {
       const cc = {
@@ -557,6 +580,7 @@ describe('Metadata', function () {
         getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.keyspaces = { ks1: { udts: {}}};
       metadata.getUdt('ks1', 'udt1', function (err) {
         helper.assertInstanceOf(err, Error);
@@ -573,6 +597,7 @@ describe('Metadata', function () {
         getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.keyspaces = { ks1: { udts: {}}};
       metadata.getUdt('ks1', 'udt1', function (err, udtInfo) {
         assert.ifError(err);
@@ -595,6 +620,7 @@ describe('Metadata', function () {
         getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       //no keyspace named ks1 in metadata
       metadata.keyspaces = {};
       metadata.getUdt('ks1', 'udt1', function (err, udtInfo) {
@@ -621,6 +647,7 @@ describe('Metadata', function () {
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       //no keyspace named ks1 in metadata
+      metadata.initialized = true;
       metadata.keyspaces = { ks1: { udts: {}}};
       //Invoke multiple times in parallel
       utils.times(50, function (n, next) {
@@ -656,6 +683,7 @@ describe('Metadata', function () {
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
       //no keyspace named ks1 in metadata
+      metadata.initialized = true;
       metadata.keyspaces = { ks1: { udts: {}}};
       //Invoke multiple times in parallel
       utils.timesSeries(50, function (n, next) {
@@ -683,6 +711,7 @@ describe('Metadata', function () {
         getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.keyspaces = { ks1: { udts: {}}};
       utils.timesSeries(20, function (n, next) {
         metadata.getUdt('ks1', 'udt20', function (err, udtInfo) {
@@ -724,6 +753,7 @@ describe('Metadata', function () {
         getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.getTrace(types.Uuid.random(), types.consistencies.all, function (err, trace) {
         assert.ifError(err);
         assert.ok(trace);
@@ -769,6 +799,7 @@ describe('Metadata', function () {
         getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.getTrace(types.Uuid.random(), function (err, trace) {
         assert.ifError(err);
         assert.ok(trace);
@@ -813,6 +844,7 @@ describe('Metadata', function () {
         getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.getTrace(types.Uuid.random(), function (err, trace) {
         assert.ifError(err);
         assert.ok(trace);
@@ -850,6 +882,7 @@ describe('Metadata', function () {
         getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.getTrace(types.Uuid.random(), function (err, trace) {
         assert.ok(err);
         assert.ok(!trace);
@@ -868,6 +901,7 @@ describe('Metadata', function () {
         }
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.getTrace(types.Uuid.random(), function (receivedErr, trace) {
         assert.ok(err);
         assert.strictEqual(receivedErr, err);
@@ -890,6 +924,7 @@ describe('Metadata', function () {
         getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
       metadata.getTable('ks_tbl_meta', 'tbl_does_not_exists', function (err, table) {
         assert.ifError(err);
@@ -897,8 +932,17 @@ describe('Metadata', function () {
         done();
       });
     });
+    it('should reject if have not connected yet', () => {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      return metadata.getTable('ks1', 'tbl1')
+        .catch((err) => {
+          helper.assertInstanceOf(err, Error);
+          assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
+        });
+    });
     it('should be null when keyspace does not exists', function (done) {
       const metadata = new Metadata(clientOptions.defaultOptions(), {});
+      metadata.initialized = true;
       metadata.keyspaces = { };
       metadata.getTable('ks_does_not_exists', 'tbl1', function (err, table) {
         assert.ifError(err);
@@ -932,6 +976,7 @@ describe('Metadata', function () {
         getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
       utils.map(new Array(100), function (n, next) {
         metadata.getTable('ks_tbl_meta', 'tbl1', next);
@@ -972,6 +1017,7 @@ describe('Metadata', function () {
         getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
       utils.mapSeries(new Array(100), function (n, next) {
         metadata.getTable('ks_tbl_meta', 'tbl1', next);
@@ -1003,6 +1049,7 @@ describe('Metadata', function () {
         getEncoder: () => new Encoder(1, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
       utils.mapSeries(new Array(100), function (n, next) {
         metadata.getTable('ks_tbl_meta', 'tbl1', next);
@@ -1027,6 +1074,7 @@ describe('Metadata', function () {
       options.isMetadataSyncEnabled = false;
       const cc = getControlConnectionForTable(tableRow, columnRows);
       const metadata = new Metadata(options, cc);
+      metadata.initialized = true;
       metadata.keyspaces = { };
       metadata.setCassandraVersion([3, 0]);
       utils.mapSeries(new Array(100), function (n, next) {
@@ -1058,6 +1106,7 @@ describe('Metadata', function () {
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'valcus3', component_index: 1, index_name: null, index_options: null, index_type: null, type: 'regular', validator: customType }
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.initialized = true;
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
           assert.ifError(err);
@@ -1109,6 +1158,7 @@ describe('Metadata', function () {
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'text1', component_index: null, index_name: null, index_options: 'null', index_type: null, type: 'compact_value', validator: 'org.apache.cassandra.db.marshal.UTF8Type' }
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.initialized = true;
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
           assert.ifError(err);
@@ -1134,6 +1184,7 @@ describe('Metadata', function () {
           {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"text2","component_index":null,"index_name":null,"index_options":"null","index_type":null,"type":"regular","validator":"org.apache.cassandra.db.marshal.UTF8Type"}
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.initialized = true;
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
           assert.ifError(err);
@@ -1157,6 +1208,7 @@ describe('Metadata', function () {
           {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"text1","component_index":null,"index_name":"custom_index","index_options":'{"foo":"bar", "class_name":"dummy.DummyIndex"}',"index_type":"CUSTOM","type":"regular","validator":"org.apache.cassandra.db.marshal.UTF8Type"}
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.initialized = true;
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
           assert.ifError(err);
@@ -1183,6 +1235,7 @@ describe('Metadata', function () {
           {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"text1","component_index":null,"index_name":"custom_index","index_options":'{"index_keys": ""}',"index_type":"KEYS","type":"regular","validator":"org.apache.cassandra.db.marshal.UTF8Type"}
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.initialized = true;
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'b@706172656e745f70617468', function (err, table) {
           assert.ifError(err);
@@ -1212,6 +1265,7 @@ describe('Metadata', function () {
           {"keyspace_name":"ks_tbl_meta","columnfamily_name":"tbl1","column_name":"b@706172656e745f70617468","component_index":null,"index_name":"cfs_archive_parent_path","index_options":"\"null\"","index_type":"KEYS","type":"regular","validator":"org.apache.cassandra.db.marshal.UTF8Type"}
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.initialized = true;
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'b@706172656e745f70617468', function (err, table) {
           assert.ifError(err);
@@ -1244,6 +1298,7 @@ describe('Metadata', function () {
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'valcus3', component_index: 1, index_name: null, index_options: null, index_type: null, validator: customType }
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.initialized = true;
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
           assert.ifError(err);
@@ -1276,6 +1331,7 @@ describe('Metadata', function () {
           key_aliases: '["id"]', key_validator: 'org.apache.cassandra.db.marshal.UUIDType', local_read_repair_chance: 0, max_compaction_threshold: 32, min_compaction_threshold: 4, populate_io_cache_on_flush: false, read_repair_chance: 0.1, replicate_on_write: true, subcomparator: null, type: 'Standard', value_alias: null };
         const columnRows = [ { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'text_sample', component_index: 0, index_name: null, index_options: null, index_type: null, validator: 'org.apache.cassandra.db.marshal.UTF8Type' } ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.initialized = true;
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
           assert.ifError(err);
@@ -1297,6 +1353,7 @@ describe('Metadata', function () {
           value_alias: 'text1' };
         const columnRows = [];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.initialized = true;
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
           assert.ifError(err);
@@ -1320,6 +1377,7 @@ describe('Metadata', function () {
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl1', column_name: 'text2', component_index: null, index_name: null, index_options: null, index_type: null, validator: 'org.apache.cassandra.db.marshal.UTF8Type' }
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.initialized = true;
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
           assert.ifError(err);
@@ -1338,6 +1396,7 @@ describe('Metadata', function () {
           comparator: 'org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.TimeUUIDType,org.apache.cassandra.db.marshal.UTF8Type)', compression_parameters: '{"sstable_compression":"org.apache.cassandra.io.compress.SnappyCompressor"}', default_validator: 'org.apache.cassandra.db.marshal.BytesType', gc_grace_seconds: 864000, id: null, key_alias: null, key_aliases: '["id1"]', key_validator: 'org.apache.cassandra.db.marshal.UUIDType', local_read_repair_chance: 0, max_compaction_threshold: 32, min_compaction_threshold: 4, populate_io_cache_on_flush: false, read_repair_chance: 0.1, replicate_on_write: true, subcomparator: null, type: 'Standard', value_alias: '' };
         const columnRows = [];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.initialized = true;
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
           assert.ifError(err);
@@ -1367,6 +1426,7 @@ describe('Metadata', function () {
           { keyspace_name: 'ks_tbl_meta', columnfamily_name: 'tbl_c22', column_name: 'custom_sample', component_index: 0, index_name: null, index_options: 'null', index_type: null, type: 'regular', validator: customType }
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.initialized = true;
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl_c22', function (err, table) {
           assert.ifError(err);
@@ -1424,6 +1484,7 @@ describe('Metadata', function () {
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl4", "column_name": "zck", "clustering_order": "asc", "column_name_bytes": "0x7a636b", "kind": "clustering", "position": 0, "type": "timeuuid"}
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.initialized = true;
         metadata.setCassandraVersion([3, 0]);
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl4', function (err, table) {
@@ -1459,6 +1520,7 @@ describe('Metadata', function () {
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl1", "column_name": "text_sample", "clustering_order": "none", "column_name_bytes": "0x746578745f73616d706c65", "kind": "regular", "position": -1, "type": "text"}
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.initialized = true;
         metadata.setCassandraVersion([3, 0]);
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
@@ -1483,6 +1545,7 @@ describe('Metadata', function () {
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl5", "column_name": "text1", "clustering_order": "none", "column_name_bytes": "0x7465787431", "kind": "regular", "position": -1, "type": "text"}
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.initialized = true;
         metadata.setCassandraVersion([3, 0]);
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl5', function (err, table) {
@@ -1511,6 +1574,7 @@ describe('Metadata', function () {
           {"index_name": "custom_index", "kind": "CUSTOM", "options": {"foo":"bar","class_name":"dummy.DummyIndex","target":"a, b, keys(c)"}}
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows,indexRows));
+        metadata.initialized = true;
         metadata.setCassandraVersion([3, 0]);
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl5', function (err, table) {
@@ -1544,6 +1608,7 @@ describe('Metadata', function () {
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl6", "column_name": "value", "clustering_order": "none", "column_name_bytes": "0x76616c7565", "kind": "regular", "position": -1, "type": "blob"}
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.initialized = true;
         metadata.setCassandraVersion([3, 0]);
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl6', function (err, table) {
@@ -1569,6 +1634,7 @@ describe('Metadata', function () {
           {"keyspace_name": "ks_tbl_meta", "table_name": "tbl10", "column_name": "value", "clustering_order": "none", "column_name_bytes": "0x76616c7565", "kind": "regular", "position": -1, "type": "empty"}
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.initialized = true;
         metadata.setCassandraVersion([3, 0]);
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'tbl1', function (err, table) {
@@ -1606,6 +1672,7 @@ describe('Metadata', function () {
             validator: 'org.apache.cassandra.db.marshal.UTF8Type' }
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForTable(tableRow, columnRows));
+        metadata.initialized = true;
         metadata.setCassandraVersion([2, 1]);
         metadata.keyspaces = { ks_tbl_meta: { tables: {}}};
         metadata.getTable('ks_tbl_meta', 'ThriftSecondaryIndexTest', function (err, table) {
@@ -1628,6 +1695,7 @@ describe('Metadata', function () {
   describe('#getFunctions()', function () {
     it('should return an empty array when not found', function (done) {
       const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
+      metadata.initialized = true;
       metadata.keyspaces['ks_udf'] = { functions: {}};
       metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
         assert.ifError(err);
@@ -1635,6 +1703,14 @@ describe('Metadata', function () {
         assert.strictEqual(funcArray.length, 0);
         done();
       });
+    });
+    it('should reject if have not connected yet', () => {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      return metadata.getFunctions('ks_udf', 'plus')
+        .catch((err) => {
+          helper.assertInstanceOf(err, Error);
+          assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
+        });
     });
     describe('with C* 2.2 metadata rows', function () {
       it('should query once when called in parallel', function (done) {
@@ -1652,6 +1728,7 @@ describe('Metadata', function () {
           getEncoder: () => new Encoder(4, {})
         };
         const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        metadata.initialized = true;
         metadata.keyspaces['ks_udf'] = { functions: {}};
         utils.times(10, function (n, next) {
           metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
@@ -1680,6 +1757,7 @@ describe('Metadata', function () {
           getEncoder: () => new Encoder(4, {})
         };
         const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        metadata.initialized = true;
         metadata.keyspaces['ks_udf'] = { functions: {}};
         utils.timesSeries(10, function (n, next) {
           metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
@@ -1713,6 +1791,7 @@ describe('Metadata', function () {
           getEncoder: () => new Encoder(4, {})
         };
         const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        metadata.initialized = true;
         metadata.keyspaces['ks_udf'] = { functions: {}};
         utils.timesSeries(10, function (n, next) {
           metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
@@ -1752,6 +1831,7 @@ describe('Metadata', function () {
           getEncoder: () => new Encoder(4, {})
         };
         const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        metadata.initialized = true;
         metadata.keyspaces['ks_udf'] = { functions: {}};
         utils.timesSeries(10, function (n, next) {
           metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
@@ -1778,6 +1858,7 @@ describe('Metadata', function () {
           {"keyspace_name":"ks_udf","function_name":"plus","signature":["int","int"],"argument_names":["arg1","arg2"],"argument_types":["org.apache.cassandra.db.marshal.Int32Type","org.apache.cassandra.db.marshal.Int32Type"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.Int32Type"}
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+        metadata.initialized = true;
         metadata.keyspaces['ks_udf'] = { functions: {}};
         metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
           assert.ifError(err);
@@ -1814,6 +1895,7 @@ describe('Metadata', function () {
           {"keyspace_name":"ks_udf","function_name":"return_one","signature":[],"argument_names":null,"argument_types":null,"body":"return 1;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.Int32Type"}
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+        metadata.initialized = true;
         metadata.keyspaces['ks_udf'] = { functions: {}};
         metadata.getFunctions('ks_udf', 'return_one', function (err, funcArray) {
           assert.ifError(err);
@@ -1836,6 +1918,7 @@ describe('Metadata', function () {
           {"keyspace_name": "ks_udf", "function_name": "plus", "argument_types": ["int", "int"], "argument_names": ["s", "v"], "body": "return s+v;", "called_on_null_input": false, "language": "java", "return_type": "int"}
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+        metadata.initialized = true;
         metadata.setCassandraVersion([3, 0]);
         metadata.keyspaces['ks_udf'] = { functions: {}};
         metadata.getFunctions('ks_udf', 'plus', function (err, funcArray) {
@@ -1862,12 +1945,22 @@ describe('Metadata', function () {
     context('with no callback specified', function () {
       it('should return a Promise', function () {
         const metadata = newInstance();
+        metadata.initialized = true;
         const p = metadata.getFunction('ks1', 'fn1', []);
         helper.assertInstanceOf(p, Promise);
       });
     });
+    it('should reject if have not connected yet', () => {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      return metadata.getFunction('ks1', 'fn1', [])
+        .catch((err) => {
+          helper.assertInstanceOf(err, Error);
+          assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
+        });
+    });
     it('should callback in error if keyspace or name are not provided', function (done) {
       const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
+      metadata.initialized = true;
       metadata.keyspaces['ks_udf'] = { functions: {}};
       metadata.getFunction('ks_udf', null, [], function (err) {
         helper.assertInstanceOf(err, errors.ArgumentError);
@@ -1876,6 +1969,7 @@ describe('Metadata', function () {
     });
     it('should callback in error if signature is not an array', function (done) {
       const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
+      metadata.initialized = true;
       metadata.keyspaces['ks_udf'] = { functions: {}};
       metadata.getFunction('ks_udf', 'func1', {}, function (err) {
         helper.assertInstanceOf(err, errors.ArgumentError);
@@ -1884,6 +1978,7 @@ describe('Metadata', function () {
     });
     it('should callback in error if signature types are not found', function (done) {
       const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
+      metadata.initialized = true;
       metadata.keyspaces['ks_udf'] = { functions: {}};
       metadata.getFunction('ks_udf', 'func1', [{code: 0x1000}], function (err) {
         helper.assertInstanceOf(err, errors.ArgumentError);
@@ -1905,6 +2000,7 @@ describe('Metadata', function () {
         getEncoder: () => new Encoder(4, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.keyspaces['ks_udf'] = { functions: {}};
       utils.times(10, function (n, next) {
         metadata.getFunction('ks_udf', 'plus', ['bigint', 'bigint'], function (err, func) {
@@ -1934,6 +2030,7 @@ describe('Metadata', function () {
         getEncoder: () => new Encoder(4, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.keyspaces['ks_udf'] = { functions: {}};
       utils.timesSeries(10, function (n, next) {
         metadata.getFunction('ks_udf', 'plus', ['bigint', 'bigint'], function (err, func) {
@@ -1950,6 +2047,7 @@ describe('Metadata', function () {
     });
     it('should return null when not found', function (done) {
       const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
+      metadata.initialized = true;
       metadata.keyspaces['ks_udf'] = { functions: {}};
       metadata.getFunction('ks_udf', 'plus', [], function (err, func) {
         assert.ifError(err);
@@ -1963,6 +2061,7 @@ describe('Metadata', function () {
         {"keyspace_name":"ks_udf","function_name":"plus","signature":["int","int"],"argument_names":["arg1","arg2"],"argument_types":["org.apache.cassandra.db.marshal.Int32Type","org.apache.cassandra.db.marshal.Int32Type"],"body":"return s+v;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.Int32Type"}
       ];
       const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+      metadata.initialized = true;
       metadata.keyspaces['ks_udf'] = { functions: {}};
       metadata.getFunction('ks_udf', 'plus', ['int', 'int'], function (err, func) {
         assert.ifError(err);
@@ -1985,6 +2084,7 @@ describe('Metadata', function () {
         {"keyspace_name":"ks_udf","function_name":"return_one","signature":[],"argument_names":null,"argument_types":null,"body":"return 1;","called_on_null_input":false,"language":"java","return_type":"org.apache.cassandra.db.marshal.Int32Type"}
       ];
       const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+      metadata.initialized = true;
       metadata.keyspaces['ks_udf'] = { functions: {}};
       metadata.getFunction('ks_udf', 'return_one', [], function (err, func) {
         assert.ifError(err);
@@ -2003,6 +2103,7 @@ describe('Metadata', function () {
   describe('#getAggregates()', function () {
     it('should return an empty array when not found', function (done) {
       const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
+      metadata.initialized = true;
       metadata.keyspaces['ks_udf'] = { aggregates: {}};
       metadata.getAggregates('ks_udf', 'plus', function (err, funcArray) {
         assert.ifError(err);
@@ -2010,6 +2111,14 @@ describe('Metadata', function () {
         assert.strictEqual(funcArray.length, 0);
         done();
       });
+    });
+    it('should reject if have not connected yet', () => {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      return metadata.getAggregates('ks_udf', 'plus', [])
+        .catch((err) => {
+          helper.assertInstanceOf(err, Error);
+          assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
+        });
     });
     describe('with C* 2.2 metadata rows', function () {
       it('should query once when called in parallel', function (done) {
@@ -2028,6 +2137,7 @@ describe('Metadata', function () {
           getEncoder: () => new Encoder(4, {})
         };
         const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+        metadata.initialized = true;
         metadata.keyspaces['ks_udf'] = { aggregates: {}};
         utils.times(10, function (n, next) {
           metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
@@ -2057,6 +2167,7 @@ describe('Metadata', function () {
         };
         const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { aggregates: {}};
+        metadata.initialized = true;
         utils.timesSeries(10, function (n, next) {
           metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
             assert.ifError(err);
@@ -2090,6 +2201,7 @@ describe('Metadata', function () {
         };
         const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { aggregates: {}};
+        metadata.initialized = true;
         utils.timesSeries(10, function (n, next) {
           metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
             assert.ifError(err);
@@ -2130,6 +2242,7 @@ describe('Metadata', function () {
         };
         const metadata = new Metadata(clientOptions.defaultOptions(), cc);
         metadata.keyspaces['ks_udf'] = { aggregates: {}};
+        metadata.initialized = true;
         utils.timesSeries(10, function (n, next) {
           metadata.getAggregates('ks_udf', 'sum', function (err, funcArray) {
             if (n < 5) {
@@ -2155,6 +2268,7 @@ describe('Metadata', function () {
           {"keyspace_name":"ks_udf1","aggregate_name":"sum","signature":["int"],"argument_types":["org.apache.cassandra.db.marshal.Int32Type"],"final_func":null,"initcond":utils.allocBufferFromArray([0,0,0,0]),"return_type":"org.apache.cassandra.db.marshal.Int32Type","state_func":"plus","state_type":"org.apache.cassandra.db.marshal.Int32Type"}
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+        metadata.initialized = true;
         metadata.keyspaces['ks_udf1'] = { aggregates: {}};
         metadata.getAggregates('ks_udf1', 'sum', function (err, aggregatesArray) {
           assert.ifError(err);
@@ -2198,6 +2312,7 @@ describe('Metadata', function () {
           {"keyspace_name": "ks_udf1", "aggregate_name": "sum", "argument_types": ["int"], "final_func": null, "initcond": '1', "return_type": "int", "state_func": "plus", "state_type": "int"}
         ];
         const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows(rows));
+        metadata.initialized = true;
         metadata.setCassandraVersion([3, 0]);
         metadata.keyspaces['ks_udf1'] = { aggregates: {}};
         metadata.getAggregates('ks_udf1', 'sum', function (err, aggregatesArray) {
@@ -2258,6 +2373,7 @@ describe('Metadata', function () {
         getEncoder: () => new Encoder(4, {})
       };
       const metadata = new Metadata(clientOptions.defaultOptions(), cc);
+      metadata.initialized = true;
       metadata.setCassandraVersion([3, 0]);
       metadata.keyspaces['ks_mv'] = { views: {}};
       metadata.getMaterializedView('ks_mv', 'not_found', function (err, view) {
@@ -2266,8 +2382,17 @@ describe('Metadata', function () {
         done();
       });
     });
+    it('should reject if have not connected yet', () => {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      return metadata.getMaterializedView('ks_mv', 'view1', [])
+        .catch((err) => {
+          helper.assertInstanceOf(err, Error);
+          assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
+        });
+    });
     it('should callback in error when cassandra version is lower than 3.0', function (done) {
       const metadata = new Metadata(clientOptions.defaultOptions(), {});
+      metadata.initialized = true;
       metadata.setCassandraVersion([2, 1]);
       metadata.keyspaces['ks_mv'] = { views: {}};
       metadata.getTable = function (ksName, name, cb) {

--- a/test/unit/metadata-tests.js
+++ b/test/unit/metadata-tests.js
@@ -26,7 +26,25 @@ function expectRanges(metadata, keyspace, host, expectedRanges) {
 }
 
 describe('Metadata', function () {
+  describe('#refreshKeyspace()', function () {
+    it('should reject if have not connected yet', () => {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      return metadata.refreshKeyspace('ks1')
+        .catch((err) => {
+          helper.assertInstanceOf(err, Error);
+          assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
+        });
+    });
+  });
   describe('#refreshKeyspaces()', function () {
+    it('should reject if have not connected yet', () => {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      return metadata.refreshKeyspaces()
+        .catch((err) => {
+          helper.assertInstanceOf(err, Error);
+          assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
+        });
+    });
     it('should parse C*2 keyspace metadata for simple strategy', function (done) {
       const cc = {
         query: function (q, w, cb) {
@@ -727,6 +745,14 @@ describe('Metadata', function () {
     });
   });
   describe('#getTrace()', function () {
+    it('should reject if have not connected yet', () => {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      return metadata.getTrace(types.Uuid.random(), types.consistencies.all)
+        .catch((err) => {
+          helper.assertInstanceOf(err, Error);
+          assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
+        });
+    });
     it('should return the trace if its already stored', function (done) {
       const sessionRow = {
         request: 'request value',

--- a/test/unit/metadata-tests.js
+++ b/test/unit/metadata-tests.js
@@ -20,30 +20,27 @@ const utils = require('../../lib/utils');
 const errors = require('../../lib/errors');
 const Encoder = require('../../lib/encoder');
 
-function expectRanges(metadata, keyspace, host, expectedRanges) {
-  const eRanges = new Set(expectedRanges.map((tokens) => new TokenRange(token(tokens[0]), token(tokens[1]), metadata.tokenizer)));
-  assert.deepEqual(metadata.getTokenRangesForHost(keyspace, host), eRanges);
-}
-
 describe('Metadata', function () {
   describe('#refreshKeyspace()', function () {
     it('should reject if have not connected yet', () => {
       const metadata = new Metadata(clientOptions.defaultOptions(), null);
       return metadata.refreshKeyspace('ks1')
-        .catch((err) => {
-          helper.assertInstanceOf(err, Error);
-          assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
-        });
+        .catch(validateMetadataErr());
+    });
+    it('should callback in error if have not connected yet', (done) => {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      metadata.refreshKeyspace('ks1', validateMetadataErr(done));
     });
   });
   describe('#refreshKeyspaces()', function () {
     it('should reject if have not connected yet', () => {
       const metadata = new Metadata(clientOptions.defaultOptions(), null);
       return metadata.refreshKeyspaces()
-        .catch((err) => {
-          helper.assertInstanceOf(err, Error);
-          assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
-        });
+        .catch(validateMetadataErr());
+    });
+    it('should callback in error if have not connected yet', (done) => {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      metadata.refreshKeyspaces(validateMetadataErr(done));
     });
     it('should parse C*2 keyspace metadata for simple strategy', function (done) {
       const cc = {
@@ -583,10 +580,11 @@ describe('Metadata', function () {
     it('should reject if have not connected yet', () => {
       const metadata = new Metadata(clientOptions.defaultOptions(), null);
       return metadata.getUdt('ks1', 'udt1')
-        .catch((err) => {
-          helper.assertInstanceOf(err, Error);
-          assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
-        });
+        .catch(validateMetadataErr());
+    });
+    it('should callback in error if have not connected yet', (done) => {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      metadata.getUdt('ks1', 'udt1', validateMetadataErr(done));
     });
     it('should callback in err when there is an error', function (done) {
       const cc = {
@@ -748,10 +746,11 @@ describe('Metadata', function () {
     it('should reject if have not connected yet', () => {
       const metadata = new Metadata(clientOptions.defaultOptions(), null);
       return metadata.getTrace(types.Uuid.random(), types.consistencies.all)
-        .catch((err) => {
-          helper.assertInstanceOf(err, Error);
-          assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
-        });
+        .catch(validateMetadataErr());
+    });
+    it('should callback in error if have not connected yet', (done) => {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      metadata.getTrace(types.Uuid.random(), types.consistencies.all, validateMetadataErr(done));
     });
     it('should return the trace if its already stored', function (done) {
       const sessionRow = {
@@ -961,10 +960,11 @@ describe('Metadata', function () {
     it('should reject if have not connected yet', () => {
       const metadata = new Metadata(clientOptions.defaultOptions(), null);
       return metadata.getTable('ks1', 'tbl1')
-        .catch((err) => {
-          helper.assertInstanceOf(err, Error);
-          assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
-        });
+        .catch(validateMetadataErr());
+    });
+    it('should callback in error if have not connected yet', (done) => {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      metadata.getTable('ks1', 'tbl1', validateMetadataErr(done));
     });
     it('should be null when keyspace does not exists', function (done) {
       const metadata = new Metadata(clientOptions.defaultOptions(), {});
@@ -1733,10 +1733,11 @@ describe('Metadata', function () {
     it('should reject if have not connected yet', () => {
       const metadata = new Metadata(clientOptions.defaultOptions(), null);
       return metadata.getFunctions('ks_udf', 'plus')
-        .catch((err) => {
-          helper.assertInstanceOf(err, Error);
-          assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
-        });
+        .catch(validateMetadataErr());
+    });
+    it('should callback in error if have not connected yet', (done) => {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      metadata.getFunctions('ks_udf', 'plus', validateMetadataErr(done));
     });
     describe('with C* 2.2 metadata rows', function () {
       it('should query once when called in parallel', function (done) {
@@ -1979,10 +1980,11 @@ describe('Metadata', function () {
     it('should reject if have not connected yet', () => {
       const metadata = new Metadata(clientOptions.defaultOptions(), null);
       return metadata.getFunction('ks1', 'fn1', [])
-        .catch((err) => {
-          helper.assertInstanceOf(err, Error);
-          assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
-        });
+        .catch(validateMetadataErr());
+    });
+    it('should callback in error if have not connected yet', (done) => {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      metadata.getFunction('ks1', 'fn1', [], validateMetadataErr(done));
     });
     it('should callback in error if keyspace or name are not provided', function (done) {
       const metadata = new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
@@ -2140,11 +2142,12 @@ describe('Metadata', function () {
     });
     it('should reject if have not connected yet', () => {
       const metadata = new Metadata(clientOptions.defaultOptions(), null);
-      return metadata.getAggregates('ks_udf', 'plus', [])
-        .catch((err) => {
-          helper.assertInstanceOf(err, Error);
-          assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
-        });
+      return metadata.getAggregates('ks_udf', 'plus')
+        .catch(validateMetadataErr());
+    });
+    it('should callback in error if have not connected yet', (done) => {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      metadata.getAggregates('ks_udf', 'plus', validateMetadataErr(done));
     });
     describe('with C* 2.2 metadata rows', function () {
       it('should query once when called in parallel', function (done) {
@@ -2410,11 +2413,12 @@ describe('Metadata', function () {
     });
     it('should reject if have not connected yet', () => {
       const metadata = new Metadata(clientOptions.defaultOptions(), null);
-      return metadata.getMaterializedView('ks_mv', 'view1', [])
-        .catch((err) => {
-          helper.assertInstanceOf(err, Error);
-          assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
-        });
+      return metadata.getMaterializedView('ks_mv', 'view1')
+        .catch(validateMetadataErr());
+    });
+    it('should callback in error if have not connected yet', (done) => {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      metadata.getMaterializedView('ks_mv', 'view1', validateMetadataErr(done));
     });
     it('should callback in error when cassandra version is lower than 3.0', function (done) {
       const metadata = new Metadata(clientOptions.defaultOptions(), {});
@@ -2627,4 +2631,20 @@ function stringifyDefault(v) {
 /** @returns {Metadata} */
 function newInstance() {
   return new Metadata(clientOptions.defaultOptions(), getControlConnectionForRows([]));
+}
+
+function expectRanges(metadata, keyspace, host, expectedRanges) {
+  const eRanges = new Set(expectedRanges.map((tokens) => new TokenRange(token(tokens[0]), token(tokens[1]), metadata.tokenizer)));
+  assert.deepEqual(metadata.getTokenRangesForHost(keyspace, host), eRanges);
+}
+
+function validateMetadataErr(done) {
+  return (err) => {
+    assert.ok(err);
+    helper.assertInstanceOf(err, Error);
+    assert.strictEqual(err.message, 'Metadata has not been initialized.  This could only happen if you have not connected yet.');
+    if (done) {
+      done();
+    }
+  };
 }


### PR DESCRIPTION
For [NODEJS-412](https://datastax-oss.atlassian.net/browse/NODEJS-412).

Added an `initialized` flag to `Metadata` that gets set upon the first completion of `refeshKeyspaces` (which is done as part of connection intiailization).  

This flag is only applicable if `isMetadataSyncEnabled` is true.  

In the case when a user calls `getUdt`, `getTable`, `getFunctions`, `getFunction`, `getAggregates` or `getMaterializedView` and `isMetadataSyncEnabled` is true.  The callback should be invoked in error immediately.  If `isMetadataSyncEnabled` is false, it continues down an existing path, which will raise an Error indicating that a connection cannot be acquired, i.e.:

```
{ OperationTimedOutError: A connection could not be acquired before timeout.
    at Timeout.waitTimeout [as _onTimeout] (/Users/andrew.tolbert/Documents/Projects/nodejs-driver/lib/control-connection.js:708:14)
    at ontimeout (timers.js:458:11)
    at tryOnTimeout (timers.js:296:5)
    at Timer.listOnTimeout (timers.js:259:5)
  name: 'OperationTimedOutError',
  info: 'Represents a client-side error that is raised when the client did not hear back from the server within socketOptions.readTimeout',
  message: 'A connection could not be acquired before timeout.' }
```

Wasn't sure if that behavior was ok or not.  We could optimize that by failing right away in a similar fashion.

Other metadata methods I didn't change:

* `newToken()` and `newTokenRange()` : already preemptively fail if `this.tokenizer` isn't set.
* `getReplicas()`, `getTokenRanges()`, `getTokenRangesForHost()`, currently return null if never have connected.  Should I change this?   It's not asynchronous so wasn't sure.
* `getTrace()`, `refreshKeyspaces()` attempts to acquire connection which will fail.  Should it fail earlier?