### PR TITLE
Remove buffers `noAssert` argument

### DIFF
--- a/lib/types/time-uuid.js
+++ b/lib/types/time-uuid.js
@@ -171,9 +171,9 @@ function writeTime(buffer, time, ticks) {
     .multiply(Long.fromNumber(10000))
     .add(Long.fromNumber(ticks));
   const timeHigh = val.getHighBitsUnsigned();
-  buffer.writeUInt32BE(val.getLowBitsUnsigned(), 0, true);
-  buffer.writeUInt16BE(timeHigh & 0xffff, 4, true);
-  buffer.writeUInt16BE(timeHigh >>> 16 & 0xffff, 6, true);
+  buffer.writeUInt32BE(val.getLowBitsUnsigned(), 0);
+  buffer.writeUInt16BE(timeHigh & 0xffff, 4);
+  buffer.writeUInt16BE(timeHigh >>> 16 & 0xffff, 6);
 }
 
 /**


### PR DESCRIPTION
Support for the `noAssert` argument dropped in the upcoming Node.js
v.10. This removes the argument to make sure everything works as it
should.

Refs: https://github.com/nodejs/node/pull/18395