### PR TITLE
Add 'host' query option to enable host targeting

### DIFF
--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -222,6 +222,10 @@ function createQueryOptions(client, userOptions, rowCallback, logged) {
   userOptions = (!userOptions || typeof userOptions === 'function') ? utils.emptyObject : userOptions;
   const defaultQueryOptions = client.options.queryOptions;
 
+  if (userOptions.host !== null && !(userOptions.host instanceof Host)) {
+    throw new TypeError('host must be an instance of Host');
+  }
+
   // Using fixed property names is 2 order of magnitude faster than dynamically shallow clone objects
   const result = {
     autoPage: ifUndefined(userOptions.autoPage, defaultQueryOptions.autoPage),
@@ -320,3 +324,5 @@ exports.createQueryOptions = createQueryOptions;
 exports.maxRequestsPerConnectionV2 = maxRequestsPerConnectionV2;
 exports.maxRequestsPerConnectionV3 = maxRequestsPerConnectionV3;
 exports.setProtocolDependentDefaults = setProtocolDependentDefaults;
+
+const Host = require('./host').Host;

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -231,6 +231,7 @@ function createQueryOptions(client, userOptions, rowCallback, logged) {
     executionProfile: profile,
     fetchSize: ifUndefined(userOptions.fetchSize, defaultQueryOptions.fetchSize),
     hints: userOptions.hints,
+    host: userOptions.host,
     isIdempotent: ifUndefined(userOptions.isIdempotent, defaultQueryOptions.isIdempotent),
     keyspace: userOptions.keyspace,
     logged: ifUndefined(userOptions.logged, logged),

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -222,7 +222,7 @@ function createQueryOptions(client, userOptions, rowCallback, logged) {
   userOptions = (!userOptions || typeof userOptions === 'function') ? utils.emptyObject : userOptions;
   const defaultQueryOptions = client.options.queryOptions;
 
-  if (userOptions.host !== null && !(userOptions.host instanceof Host)) {
+  if (userOptions.host && !(userOptions.host instanceof Host)) {
     throw new TypeError('host must be an instance of Host');
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -212,6 +212,27 @@ const warmupLimit = 32;
  * @property {Number} [fetchSize] Amount of rows to retrieve per page.
  * @property {Array|Array<Array>} [hints] Type hints for parameters given in the query, ordered as for the parameters.
  * <p>For batch queries, an array of such arrays, ordered as with the queries in the batch.</p>
+ * @property {Host} [host] The host that should handle the query.
+ * <p>
+ *   Use of this option is <em>heavily discouraged</em> and should only be used in the following cases:
+ * </p>
+ * <ol>
+ *   <li>
+ *     Querying node-local tables, such as tables in the <code>system</code> and <code>system_views</code>
+ *     keyspaces.
+ *   </li>
+ *   <li>
+ *     Applying a series of schema changes, where it may be advantageous to execute schema changes in sequence on the
+ *     same node.
+ *   </li>
+ * </ol> 
+ * <p>
+ *   Configuring a specific host causes the configured
+ *   [LoadBalancingPolicy]{@link module:policies/loadBalancing~LoadBalancingPolicy} to be completely bypassed.
+ *   However, if the load balancing policy dictates that the host is at a
+ *   [distance of ignored]{@link module:types~distance} or there is no active connectivity to the host, the request will
+ *   fail with a [NoHostAvailableError]{@link module:errors~NoHostAvailableError}.
+ * </p>
  * @property {Boolean} [isIdempotent] Defines whether the query can be applied multiple times without changing the result
  * beyond the initial application.
  * <p>

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -6,6 +6,8 @@ const types = require('./types');
 const utils = require('./utils');
 const RequestExecution = require('./request-execution');
 
+const doneIteratorObject = Object.freeze({ done: true });
+
 /**
  * Handles a BATCH, QUERY and EXECUTE request to the server, dealing with host fail-over and retries on error
  */
@@ -153,15 +155,31 @@ class RequestHandler {
     if (this.requestOptions.captureStackTrace) {
       Error.captureStackTrace(this.stackContainer = {});
     }
+    this._callback = callback;
     const self = this;
-    this.loadBalancingPolicy.newQueryPlan(this.client.keyspace, this.requestOptions, function newPlanCb(err, iterator) {
-      if (err) {
-        return callback(err);
-      }
-      self._hostIterator = iterator;
-      self._callback = callback;
+    if (this.requestOptions.host) {
+      // if host is configured bypass load balancing policy and use
+      // a single host plan.
+      let hostProvided = false; 
+      self._hostIterator = { 
+        next: () => {
+          if (!hostProvided) {
+            hostProvided = true;
+            return { value: self.requestOptions.host, done: false };
+          }
+          return doneIteratorObject;
+        }
+      };
       self._startNewExecution();
-    });
+    } else {
+      this.loadBalancingPolicy.newQueryPlan(this.client.keyspace, this.requestOptions, function newPlanCb(err, iterator) {
+        if (err) {
+          return self._callback(err);
+        }
+        self._hostIterator = iterator;
+        self._startNewExecution();
+      });
+    }
   }
 
   _startNewExecution() {

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -6,8 +6,6 @@ const types = require('./types');
 const utils = require('./utils');
 const RequestExecution = require('./request-execution');
 
-const doneIteratorObject = Object.freeze({ done: true });
-
 /**
  * Handles a BATCH, QUERY and EXECUTE request to the server, dealing with host fail-over and retries on error
  */
@@ -160,16 +158,7 @@ class RequestHandler {
     if (this.requestOptions.host) {
       // if host is configured bypass load balancing policy and use
       // a single host plan.
-      let hostProvided = false; 
-      self._hostIterator = { 
-        next: () => {
-          if (!hostProvided) {
-            hostProvided = true;
-            return { value: self.requestOptions.host, done: false };
-          }
-          return doneIteratorObject;
-        }
-      };
+      self._hostIterator = utils.arrayIterator([self.requestOptions.host]);
       self._startNewExecution();
     } else {
       this.loadBalancingPolicy.newQueryPlan(this.client.keyspace, this.requestOptions, function newPlanCb(err, iterator) {

--- a/test/integration/short/client-execute-simulator-tests.js
+++ b/test/integration/short/client-execute-simulator-tests.js
@@ -12,7 +12,8 @@ const WhiteListPolicy = require('../../../lib/policies').loadBalancing.WhiteList
 
 const query = "select * from data";
 
-describe('Client', () => {
+describe('Client', function() {
+  this.timeout(30000);
   describe('#execute(query, params, {host: h})', () => {
 
     const setupInfo = simulacron.setup([4], { initClient: false });

--- a/test/integration/short/client-execute-simulator-tests.js
+++ b/test/integration/short/client-execute-simulator-tests.js
@@ -68,7 +68,7 @@ describe('Client', function() {
         client.execute(query, [], { host: host }, (err, result) => {
           assert.ok(err);
           helper.assertInstanceOf(err, errors.NoHostAvailableError);
-          assert.deepEqual(Object.keys(err.innerErrors), [node.address]);
+          assert.strictEqual(Object.keys(err.innerErrors).length, 1);
           const nodeError = err.innerErrors[node.address];
           assert.strictEqual(nodeError.code, responseErrorCodes.unavailableException);
           done();
@@ -81,12 +81,15 @@ describe('Client', function() {
       // connectivity to that node.
       const node = cluster.node(3);
       const host = client.hosts.get(node.address);
+      let caughtErr = null;
       return client.execute(query, [], { host: host })
         .catch((err) => {
+          caughtErr = err;
           helper.assertInstanceOf(err, errors.NoHostAvailableError);
           // no hosts should have been attempted.
-          assert.deepEqual(Object.keys(err.innerErrors), []);
-        });
+          assert.strictEqual(Object.keys(err.innerErrors).length, 0);
+        })
+        .then(() => assert.ok(caughtErr));
     });
   });
 });

--- a/test/integration/short/client-execute-simulator-tests.js
+++ b/test/integration/short/client-execute-simulator-tests.js
@@ -3,7 +3,6 @@ const assert = require('assert');
 const simulacron = require('../simulacron');
 const helper = require('../../test-helper');
 const utils = require('../../../lib/utils');
-const util = require('util');
 const errors = require('../../../lib/errors');
 
 const responseErrorCodes = require('../../../lib/types').responseErrorCodes;

--- a/test/integration/short/client-execute-simulator-tests.js
+++ b/test/integration/short/client-execute-simulator-tests.js
@@ -6,9 +6,10 @@ const utils = require('../../../lib/utils');
 const util = require('util');
 const errors = require('../../../lib/errors');
 
+const responseErrorCodes = require('../../../lib/types').responseErrorCodes;
 const Client = require('../../../lib/client.js');
-const { responseErrorCodes } = require('../../../lib/types');
-const { WhiteListPolicy, DCAwareRoundRobinPolicy } = require('../../../lib/policies').loadBalancing;
+const DCAwareRoundRobinPolicy = require('../../../lib/policies').loadBalancing.DCAwareRoundRobinPolicy;
+const WhiteListPolicy = require('../../../lib/policies').loadBalancing.WhiteListPolicy;
 
 const query = "select * from data";
 

--- a/test/integration/short/client-execute-simulator-tests.js
+++ b/test/integration/short/client-execute-simulator-tests.js
@@ -1,0 +1,84 @@
+'use strict';
+const assert = require('assert');
+const simulacron = require('../simulacron');
+const helper = require('../../test-helper');
+const utils = require('../../../lib/utils');
+const util = require('util');
+const errors = require('../../../lib/errors');
+
+const Client = require('../../../lib/client.js');
+const { responseErrorCodes } = require('../../../lib/types');
+const { WhiteListPolicy, DCAwareRoundRobinPolicy } = require('../../../lib/policies').loadBalancing;
+
+const query = "select * from data";
+
+describe('Client', () => {
+  describe('#execute(query, params, {host: h})', () => {
+
+    const setupInfo = simulacron.setup([4], { initClient: false });
+    const cluster = setupInfo.cluster;
+    let client;
+
+    before(() => {
+      client = new Client({
+        contactPoints: [simulacron.startingIp],
+        policies: {
+          loadBalancing: new WhiteListPolicy(new DCAwareRoundRobinPolicy(), [
+            cluster.node(0).address,
+            cluster.node(1).address,
+            cluster.node(2).address
+          ])
+        }
+      });
+      return client.connect();
+    });
+  
+    after(() => client.shutdown());
+  
+    it('should send request to host used in options', (done) => {
+      utils.times(10, (n, next) => {
+        const nodeIndex = n % 3;
+        const node = cluster.node(nodeIndex);
+        const host = client.hosts.get(node.address);
+        client.execute(query, [], { host: host }, (err, result) => {
+          assert.ifError(err);
+          assert.strictEqual(result.info.queriedHost, node.address);
+          assert.deepEqual(Object.keys(result.info.triedHosts), [node.address]);
+          next();
+        });
+      }, done);
+    });
+
+    it('should throw an error if host used raises an error', () => {
+      const node = cluster.node(0);
+      const host = client.hosts.get(node.address);
+      const prime = util.promisify(node.prime.bind(node));
+      return prime({
+        when: {
+          query: query
+        },
+        then: {
+          result: 'unavailable',
+          alive: 0,
+          required: 1,
+          consistency_level: 'LOCAL_ONE'
+        }})
+        .then(() => client.execute(query, [], { host: host }))
+        .catch((err) => {
+          helper.assertInstanceOf(err, errors.NoHostAvailableError);
+          assert.deepEqual(Object.keys(err.innerErrors), [node.address]);
+          const nodeError = err.innerErrors[node.address];
+          assert.strictEqual(nodeError.code, responseErrorCodes.unavailableException);
+        });
+    });
+  
+    it('should throw an error if host used in options is ignored by load balancing policy', () => {
+      const node = cluster.node(3);
+      const host = client.hosts.get(node.address);
+      return client.execute(query, [], { host: host })
+        .catch((err) => {
+          helper.assertInstanceOf(err, errors.NoHostAvailableError);
+        });
+    });
+  });
+});


### PR DESCRIPTION
For [NODEJS-443](https://datastax-oss.atlassian.net/browse/NODEJS-443).

Adds a new 'host' query option for host targeting, i.e.:

```javascript
const host = client.hosts.get('127.0.0.2:9042');
client.execute('select rpc_address from system.local', [], { host: host })
  .then((result) => console.log('Queried host:', result.info.queriedHost, '\nRows:', result.rows));
```

emits:

    Queried host: 127.0.0.2:9042
    Rows: [ Row { rpc_address: InetAddress: 127.0.0.2 } ]