### PR TITLE
Parse Virtual Keyspace Metadata

### DIFF
--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -501,14 +501,16 @@ Metadata.prototype._getTableCb = function (keyspaceName, name, callback) {
     return callback(this._uninitializedError(), null);
   }
   let cache;
+  let virtual;
   if (this.options.isMetadataSyncEnabled) {
     const keyspace = this.keyspaces[keyspaceName];
     if (!keyspace) {
       return callback(null, null);
     }
     cache = keyspace.tables;
+    virtual = keyspace.virtual;
   }
-  this._schemaParser.getTable(keyspaceName, name, cache, callback);
+  this._schemaParser.getTable(keyspaceName, name, cache, virtual, callback);
 };
 
 /**

--- a/lib/metadata/schema-parser.js
+++ b/lib/metadata/schema-parser.js
@@ -1047,26 +1047,28 @@ SchemaParserV3.prototype.getKeyspaces = function (waitReconnect, callback) {
 
 /** @override */
 SchemaParserV3.prototype.getKeyspace = function (name, callback) {
-  const self = this;
-  this.cc.query(util.format(_selectSingleKeyspaceV2, name), function (err, result) {
+  this._getKeyspace(_selectSingleKeyspaceV2, name, false, (err, ks) => {
+    if (err) {
+      return callback(err);
+    }
+    if (!ks) {
+      // if not found, attempt to retrieve as virtual keyspace.
+      return this._getKeyspace(_selectSingleVirtualKeyspace, name, true, callback);
+    }
+    return callback(null, ks);
+  });
+};
+
+SchemaParserV3.prototype._getKeyspace = function (query, name, virtual, callback) {
+  this.cc.query(util.format(query, name), (err, result) => {
     if (err) {
       return callback(err);
     }
     const row = result.rows[0];
     if (!row) {
-      // if not found try virtual keyspace
-      return self.cc.query(util.format(_selectSingleVirtualKeyspace, name), function (err, result) {
-        if (err) {
-          return callback(err);
-        }
-        const row = result.rows[0];
-        if (!row) {
-          return callback(null, null);
-        }
-        callback(null, self._parseKeyspace(row, true));
-      });
+      return callback(null, null);
     }
-    callback(null, self._parseKeyspace(row, false));
+    callback(null, this._parseKeyspace(row, virtual));
   });
 };
 

--- a/lib/metadata/schema-parser.js
+++ b/lib/metadata/schema-parser.js
@@ -31,6 +31,12 @@ const _selectAggregatesV1 = "SELECT * FROM system.schema_aggregates WHERE keyspa
 const _selectAggregatesV2 = "SELECT * FROM system_schema.aggregates WHERE keyspace_name = '%s' AND aggregate_name = '%s'";
 const _selectMaterializedViewV2 = "SELECT * FROM system_schema.views WHERE keyspace_name = '%s' AND view_name = '%s'";
 
+const _selectAllVirtualKeyspaces = "SELECT * FROM system_virtual_schema.keyspaces";
+const _selectSingleVirtualKeyspace = "SELECT * FROM system_virtual_schema.keyspaces where keyspace_name = '%s'";
+const _selectVirtualTable = "SELECT * FROM system_virtual_schema.tables where keyspace_name = '%s' and table_name='%s'";
+const _selectVirtualColumns = "SELECT * FROM system_virtual_schema.columns where keyspace_name = '%s' and table_name='%s'";
+
+
 /**
  * @abstract
  * @param {ControlConnection} cc
@@ -45,6 +51,8 @@ function SchemaParser(cc) {
   this.selectUdt = null;
   this.selectAggregates = null;
   this.selectFunctions = null;
+  this.selectVirtualTable = null;
+  this.selectVirtualColumns = null;
 }
 
 /**
@@ -52,16 +60,18 @@ function SchemaParser(cc) {
  * @param durableWrites
  * @param strategy
  * @param strategyOptions
+ * @param virtual
  * @returns {{name, durableWrites, strategy, strategyOptions, tokenToReplica, udts, tables, functions, aggregates}|null}
  * @protected
  */
-SchemaParser.prototype._createKeyspace = function (name, durableWrites, strategy, strategyOptions) {
+SchemaParser.prototype._createKeyspace = function (name, durableWrites, strategy, strategyOptions, virtual) {
   const ksInfo = {
     name: name,
     durableWrites: durableWrites,
     strategy: strategy,
     strategyOptions: strategyOptions,
     tokenToReplica: null,
+    virtual: virtual === true ? true : false,
     udts: {},
     tables: {},
     functions: {},
@@ -92,9 +102,10 @@ SchemaParser.prototype.getKeyspaces = function (waitReconnect, callback) {
  * @param {String} keyspaceName
  * @param {String} name
  * @param {Object} cache
+ * @param {Boolean} virtual
  * @param {Function} callback
  */
-SchemaParser.prototype.getTable = function (keyspaceName, name, cache, callback) {
+SchemaParser.prototype.getTable = function (keyspaceName, name, cache, virtual, callback) {
   let tableInfo = cache && cache[name];
   if (!tableInfo) {
     tableInfo = new TableMetadata(name);
@@ -114,9 +125,11 @@ SchemaParser.prototype.getTable = function (keyspaceName, name, cache, callback)
   tableInfo.loading = true;
   let tableRow, columnRows, indexRows;
   const self = this;
+  let virtualTable = virtual;
   utils.series([
     function getTableRow(next) {
-      const query = util.format(self.selectTable, keyspaceName, name);
+      let selectTable = virtualTable ? self.selectVirtualTable : self.selectTable; 
+      const query = util.format(selectTable, keyspaceName, name);
       self.cc.query(query, function (err, response) {
         if (err) {
           return next(err);
@@ -125,11 +138,31 @@ SchemaParser.prototype.getTable = function (keyspaceName, name, cache, callback)
         next();
       });
     },
+    function getVirtualTableRow(next) {
+      // if we weren't sure if table was virtual or not, query virtual schema.
+      if (!tableRow && virtualTable === undefined && self.selectVirtualTable !== null) {
+        const query = util.format(self.selectVirtualTable, keyspaceName, name);
+        self.cc.query(query, function (err, response) {
+          if (err) {
+            return next(err);
+          }
+          tableRow = response.rows[0];
+          // if we got a result, this is a virtual table
+          if (tableRow) {
+            virtualTable = true;
+          }
+          next();
+        });
+      } else {
+        return next();
+      }
+    },
     function getColumnRows (next) {
       if (!tableRow) {
-        return next(null, null, null);
+        return next();
       }
-      const query = util.format(self.selectColumns, keyspaceName, name);
+      const selectColumns = virtualTable ? self.selectVirtualColumns : self.selectColumns;
+      const query = util.format(selectColumns, keyspaceName, name);
       self.cc.query(query, function (err, response) {
         if (err) {
           return next(err);
@@ -139,7 +172,7 @@ SchemaParser.prototype.getTable = function (keyspaceName, name, cache, callback)
       });
     },
     function getIndexes(next) {
-      if (!tableRow || !self.selectIndexes) {
+      if (!tableRow || !self.selectIndexes || virtualTable) {
         //either the table does not exists or it does not support indexes schema table
         return next();
       }
@@ -157,7 +190,7 @@ SchemaParser.prototype.getTable = function (keyspaceName, name, cache, callback)
       tableInfo.loading = false;
       return tableInfo.emit('load', err, null);
     }
-    self._parseTableOrView(tableInfo, tableRow, columnRows, indexRows, function (err) {
+    self._parseTableOrView(tableInfo, tableRow, columnRows, indexRows, virtualTable, function (err) {
       tableInfo.loading = false;
       tableInfo.loaded = !err;
       tableInfo.emit('load', err, tableInfo);
@@ -231,10 +264,11 @@ SchemaParser.prototype._parseUdt = function (udtInfo, row, callback) {
  * @param {Row} tableRow
  * @param {Array.<Row>} columnRows
  * @param {Array.<Row>} indexRows
+ * @param {Boolean} virtual
  * @param {Function} callback
  * @throws {Error}
  */
-SchemaParser.prototype._parseTableOrView = function (tableInfo, tableRow, columnRows, indexRows, callback) {
+SchemaParser.prototype._parseTableOrView = function (tableInfo, tableRow, columnRows, indexRows, virtual, callback) {
 };
 
 
@@ -385,7 +419,7 @@ SchemaParserV1.prototype.getKeyspace = function (name, callback) {
 };
 
 /** @override */
-SchemaParserV1.prototype._parseTableOrView = function (tableInfo, tableRow, columnRows, indexRows, callback) {
+SchemaParserV1.prototype._parseTableOrView = function (tableInfo, tableRow, columnRows, indexRows, virtual, callback) {
   let i, c, name, types;
   const encoder = this.cc.getEncoder();
   const columnsKeyed = {};
@@ -705,7 +739,7 @@ SchemaParserV2.prototype.getMaterializedView = function (keyspaceName, name, cac
     if (err || !tableRow) {
       return viewInfo.emit('load', err, null);
     }
-    self._parseTableOrView(viewInfo, tableRow, columnRows, null, function (err) {
+    self._parseTableOrView(viewInfo, tableRow, columnRows, null, false, function (err) {
       viewInfo.loading = false;
       viewInfo.loaded = !err;
       viewInfo.emit('load', err, viewInfo);
@@ -714,7 +748,7 @@ SchemaParserV2.prototype.getMaterializedView = function (keyspaceName, name, cac
 
 };
 
-SchemaParserV2.prototype._parseKeyspace = function (row) {
+SchemaParserV2.prototype._parseKeyspace = function (row, virtual) {
   const replication = row['replication'];
   let strategy;
   let strategyOptions;
@@ -732,15 +766,69 @@ SchemaParserV2.prototype._parseKeyspace = function (row) {
     row['keyspace_name'],
     row['durable_writes'],
     strategy,
-    strategyOptions);
+    strategyOptions,
+    virtual);
 };
 
 /** @override */
-SchemaParserV2.prototype._parseTableOrView = function (tableInfo, tableRow, columnRows, indexRows, callback) {
+SchemaParserV2.prototype._parseTableOrView = function (tableInfo, tableRow, columnRows, indexRows, virtual, callback) {
   const encoder = this.cc.getEncoder();
   const columnsKeyed = {};
   const partitionKeys = [];
   const clusteringKeys = [];
+  const self = this;
+
+  // maps column rows to columnInfo and also populates columnsKeyed
+  const columnRowMapper = (row, next) => {
+    encoder.parseTypeName(tableRow['keyspace_name'], row['type'], 0, null, self.udtResolver, function (err, type) {
+      if (err) {
+        return next(err);
+      }
+      const c = {
+        name: row['column_name'],
+        type: type,
+        isStatic: false
+      };
+      columnsKeyed[c.name] = c;
+      switch (row['kind']) {
+        case 'partition_key':
+          partitionKeys.push({ c: c, index: (row['position'] || 0)});
+          break;
+        case 'clustering':
+          clusteringKeys.push({ c: c, index: (row['position'] || 0), order: row['clustering_order'] === 'desc' ? 'DESC' : 'ASC'});
+          break;
+        case 'static':
+          c.isStatic = true;
+          break;
+      }
+      next(null, c);
+    });
+  };
+
+  // is table is virtual, the only relevant information to parse is the columns as the table itself has no configuration.
+  if (virtual) {
+    tableInfo.virtual = true;
+    utils.map(columnRows, columnRowMapper, function (err, columns) {
+      if (err) {
+        return callback(err);
+      }
+      tableInfo.columns = columns;
+      tableInfo.columnsByName = columnsKeyed;
+      tableInfo.partitionKeys = partitionKeys.sort(utils.propCompare('index')).map(function (item) {
+        return item.c;
+      });
+      clusteringKeys.sort(utils.propCompare('index'));
+      tableInfo.clusteringKeys = clusteringKeys.map(function (item) {
+        return item.c;
+      });
+      tableInfo.clusteringOrder = clusteringKeys.map(function (item) {
+        return item.order;
+      });
+      callback();
+    });
+    return;
+  }
+
   const isView = tableInfo instanceof MaterializedView;
   tableInfo.bloomFilterFalsePositiveChance = tableRow['bloom_filter_fp_chance'];
   tableInfo.caching = JSON.stringify(tableRow['caching']);
@@ -773,32 +861,7 @@ SchemaParserV2.prototype._parseTableOrView = function (tableInfo, tableRow, colu
       tableInfo.cdc = cdc;
     }
   }
-  const self = this;
-  utils.map(columnRows, function (row, next) {
-    encoder.parseTypeName(tableRow['keyspace_name'], row['type'], 0, null, self.udtResolver, function (err, type) {
-      if (err) {
-        return next(err);
-      }
-      const c = {
-        name: row['column_name'],
-        type: type,
-        isStatic: false
-      };
-      columnsKeyed[c.name] = c;
-      switch (row['kind']) {
-        case 'partition_key':
-          partitionKeys.push({ c: c, index: (row['position'] || 0)});
-          break;
-        case 'clustering':
-          clusteringKeys.push({ c: c, index: (row['position'] || 0), order: row['clustering_order'] === 'desc' ? 'DESC' : 'ASC'});
-          break;
-        case 'static':
-          c.isStatic = true;
-          break;
-      }
-      next(null, c);
-    });
-  }, function (err, columns) {
+  utils.map(columnRows, columnRowMapper, function (err, columns) {
     if (err) {
       return callback(err);
     }
@@ -940,6 +1003,79 @@ SchemaParserV2.prototype._parseUdt = function (udtInfo, row, callback) {
     callback(null, udtInfo);
   });
 };
+
+/**
+ * Used to parse schema information for Cassandra versions 4.x and above.
+ *
+ * This parser similar to [SchemaParserV2] expect it also parses virtual
+ * keyspaces.
+ *
+ * @param {ControlConnection} cc The control connection to be used
+ * @param {Function} udtResolver The function to be used to retrieve the udts.
+ * @constructor
+ * @ignore
+ */
+function SchemaParserV3(cc, udtResolver) {
+  SchemaParserV2.call(this, cc, udtResolver);
+  this.selectVirtualTable = "SELECT * FROM system_virtual_schema.tables where keyspace_name = '%s' and table_name='%s'";
+  this.selectVirtualColumns = "SELECT * FROM system_virtual_schema.columns where keyspace_name = '%s' and table_name='%s'";
+}
+
+util.inherits(SchemaParserV3, SchemaParserV2);
+
+/** @override */
+SchemaParserV3.prototype.getKeyspaces = function (waitReconnect, callback) {
+  const self = this;
+  const keyspaces = {};
+  const queries = [
+    { query: _selectAllKeyspacesV2, virtual: false },
+    { query: _selectAllVirtualKeyspaces, virtual: true }
+  ];
+  utils.each(queries, (q, cb) => {
+    self.cc.query(q.query, waitReconnect, (err, result) => {
+      if (err) {
+        return cb(err);
+      }
+      for (let i = 0; i < result.rows.length; i++) {
+        const ksInfo = self._parseKeyspace(result.rows[i], q.virtual);
+        keyspaces[ksInfo.name] = ksInfo;
+      }
+      cb();
+    });
+  }, (err) => {
+    callback(err, keyspaces);
+  });
+};
+
+/** @override */
+SchemaParserV3.prototype.getKeyspace = function (name, callback) {
+  const self = this;
+  this.cc.query(util.format(_selectSingleKeyspaceV2, name), function (err, result) {
+    if (err) {
+      return callback(err);
+    }
+    const row = result.rows[0];
+    if (!row) {
+      // if not found try virtual keyspace
+      return self._getVirtualKeyspace(name, callback);
+    }
+    callback(null, self._parseKeyspace(row, false));
+  });
+};
+
+SchemaParserV3.prototype._getVirtualKeyspace = function (name, callback) {
+  const self = this;
+  this.cc.query(util.format(_selectSingleVirtualKeyspace, name), function (err, result) {
+    if (err) {
+      return callback(err);
+    }
+    const row = result.rows[0];
+    if (!row) {
+      return callback(null, null);
+    }
+    callback(null, self._parseKeyspace(row, true));
+  });
+}
 
 /**
  * Upon migration from thrift to CQL, we internally create a pair of surrogate clustering/regular columns
@@ -1162,8 +1298,10 @@ function isDoneForToken(replicationFactors, datacenters, replicasByDc) {
  */
 function getByVersion(cc, udtResolver, version, currentInstance) {
   let parserConstructor = SchemaParserV1;
-  if (version && version[0] >= 3) {
+  if (version && version[0] == 3) {
     parserConstructor = SchemaParserV2;
+  } else if (version && version[0] >= 4) {
+    parserConstructor = SchemaParserV3;
   }
   if (!currentInstance || !(currentInstance instanceof parserConstructor)){
     return new parserConstructor(cc, udtResolver);

--- a/lib/metadata/schema-parser.js
+++ b/lib/metadata/schema-parser.js
@@ -51,8 +51,7 @@ function SchemaParser(cc) {
   this.selectUdt = null;
   this.selectAggregates = null;
   this.selectFunctions = null;
-  this.selectVirtualTable = null;
-  this.selectVirtualColumns = null;
+  this.supportsVirtual = false;
 }
 
 /**
@@ -71,7 +70,7 @@ SchemaParser.prototype._createKeyspace = function (name, durableWrites, strategy
     strategy: strategy,
     strategyOptions: strategyOptions,
     tokenToReplica: null,
-    virtual: virtual === true ? true : false,
+    virtual: virtual === true,
     udts: {},
     tables: {},
     functions: {},
@@ -128,7 +127,7 @@ SchemaParser.prototype.getTable = function (keyspaceName, name, cache, virtual, 
   let virtualTable = virtual;
   utils.series([
     function getTableRow(next) {
-      const selectTable = virtualTable ? self.selectVirtualTable : self.selectTable; 
+      const selectTable = virtualTable ? _selectVirtualTable : self.selectTable; 
       const query = util.format(selectTable, keyspaceName, name);
       self.cc.query(query, function (err, response) {
         if (err) {
@@ -140,8 +139,8 @@ SchemaParser.prototype.getTable = function (keyspaceName, name, cache, virtual, 
     },
     function getVirtualTableRow(next) {
       // if we weren't sure if table was virtual or not, query virtual schema.
-      if (!tableRow && virtualTable === undefined && self.selectVirtualTable !== null) {
-        const query = util.format(self.selectVirtualTable, keyspaceName, name);
+      if (!tableRow && self.supportsVirtual && virtualTable === undefined) {
+        const query = util.format(_selectVirtualTable, keyspaceName, name);
         self.cc.query(query, function (err, response) {
           if (err) {
             return next(err);
@@ -161,7 +160,7 @@ SchemaParser.prototype.getTable = function (keyspaceName, name, cache, virtual, 
       if (!tableRow) {
         return next();
       }
-      const selectColumns = virtualTable ? self.selectVirtualColumns : self.selectColumns;
+      const selectColumns = virtualTable ? _selectVirtualColumns : self.selectColumns;
       const query = util.format(selectColumns, keyspaceName, name);
       self.cc.query(query, function (err, response) {
         if (err) {
@@ -1017,8 +1016,7 @@ SchemaParserV2.prototype._parseUdt = function (udtInfo, row, callback) {
  */
 function SchemaParserV3(cc, udtResolver) {
   SchemaParserV2.call(this, cc, udtResolver);
-  this.selectVirtualTable = _selectVirtualTable;
-  this.selectVirtualColumns = _selectVirtualColumns;
+  this.supportsVirtual = true;
 }
 
 util.inherits(SchemaParserV3, SchemaParserV2);
@@ -1057,23 +1055,18 @@ SchemaParserV3.prototype.getKeyspace = function (name, callback) {
     const row = result.rows[0];
     if (!row) {
       // if not found try virtual keyspace
-      return self._getVirtualKeyspace(name, callback);
+      return self.cc.query(util.format(_selectSingleVirtualKeyspace, name), function (err, result) {
+        if (err) {
+          return callback(err);
+        }
+        const row = result.rows[0];
+        if (!row) {
+          return callback(null, null);
+        }
+        callback(null, self._parseKeyspace(row, true));
+      });
     }
     callback(null, self._parseKeyspace(row, false));
-  });
-};
-
-SchemaParserV3.prototype._getVirtualKeyspace = function (name, callback) {
-  const self = this;
-  this.cc.query(util.format(_selectSingleVirtualKeyspace, name), function (err, result) {
-    if (err) {
-      return callback(err);
-    }
-    const row = result.rows[0];
-    if (!row) {
-      return callback(null, null);
-    }
-    callback(null, self._parseKeyspace(row, true));
   });
 };
 

--- a/lib/metadata/schema-parser.js
+++ b/lib/metadata/schema-parser.js
@@ -143,7 +143,10 @@ SchemaParser.prototype.getTable = function (keyspaceName, name, cache, virtual, 
         const query = util.format(_selectVirtualTable, keyspaceName, name);
         self.cc.query(query, function (err, response) {
           if (err) {
-            return next(err);
+            // we can't error here as we can't be sure if the node
+            // supports virtual tables, in this case it is adequate
+            // to act as if there was no matching table.
+            return next();
           }
           tableRow = response.rows[0];
           // if we got a result, this is a virtual table
@@ -1032,7 +1035,13 @@ SchemaParserV3.prototype.getKeyspaces = function (waitReconnect, callback) {
   utils.each(queries, (q, cb) => {
     self.cc.query(q.query, waitReconnect, (err, result) => {
       if (err) {
-        return cb(err);
+        // only callback in error for non-virtual query as
+        // server reporting C* 4.0 may not actually implement
+        // virtual tables.
+        if (!q.virtual) {
+          return cb(err);
+        }
+        return cb();
       }
       for (let i = 0; i < result.rows.length; i++) {
         const ksInfo = self._parseKeyspace(result.rows[i], q.virtual);
@@ -1062,7 +1071,13 @@ SchemaParserV3.prototype.getKeyspace = function (name, callback) {
 SchemaParserV3.prototype._getKeyspace = function (query, name, virtual, callback) {
   this.cc.query(util.format(query, name), (err, result) => {
     if (err) {
-      return callback(err);
+      // only callback in error for non-virtual query as
+      // server reporting C* 4.0 may not actually implement
+      // virtual tables.
+      if (!virtual) {
+        return callback(err);
+      }
+      return callback(null, null);
     }
     const row = result.rows[0];
     if (!row) {

--- a/lib/metadata/schema-parser.js
+++ b/lib/metadata/schema-parser.js
@@ -128,7 +128,7 @@ SchemaParser.prototype.getTable = function (keyspaceName, name, cache, virtual, 
   let virtualTable = virtual;
   utils.series([
     function getTableRow(next) {
-      let selectTable = virtualTable ? self.selectVirtualTable : self.selectTable; 
+      const selectTable = virtualTable ? self.selectVirtualTable : self.selectTable; 
       const query = util.format(selectTable, keyspaceName, name);
       self.cc.query(query, function (err, response) {
         if (err) {
@@ -1017,8 +1017,8 @@ SchemaParserV2.prototype._parseUdt = function (udtInfo, row, callback) {
  */
 function SchemaParserV3(cc, udtResolver) {
   SchemaParserV2.call(this, cc, udtResolver);
-  this.selectVirtualTable = "SELECT * FROM system_virtual_schema.tables where keyspace_name = '%s' and table_name='%s'";
-  this.selectVirtualColumns = "SELECT * FROM system_virtual_schema.columns where keyspace_name = '%s' and table_name='%s'";
+  this.selectVirtualTable = _selectVirtualTable;
+  this.selectVirtualColumns = _selectVirtualColumns;
 }
 
 util.inherits(SchemaParserV3, SchemaParserV2);
@@ -1075,7 +1075,7 @@ SchemaParserV3.prototype._getVirtualKeyspace = function (name, callback) {
     }
     callback(null, self._parseKeyspace(row, true));
   });
-}
+};
 
 /**
  * Upon migration from thrift to CQL, we internally create a pair of surrogate clustering/regular columns
@@ -1298,7 +1298,7 @@ function isDoneForToken(replicationFactors, datacenters, replicasByDc) {
  */
 function getByVersion(cc, udtResolver, version, currentInstance) {
   let parserConstructor = SchemaParserV1;
-  if (version && version[0] == 3) {
+  if (version && version[0] === 3) {
     parserConstructor = SchemaParserV2;
   } else if (version && version[0] >= 4) {
     parserConstructor = SchemaParserV3;

--- a/lib/metadata/table-metadata.js
+++ b/lib/metadata/table-metadata.js
@@ -54,6 +54,12 @@ function TableMetadata(name) {
    * @type {Boolean|null}
    */
   this.cdc = null;
+
+  /**
+   * Determines whether the table is a virtual table or not.
+   * @type {Boolean}
+   */
+  this.virtual = false;
 }
 
 util.inherits(TableMetadata, DataCollection);

--- a/test/integration/short/metadata-tests.js
+++ b/test/integration/short/metadata-tests.js
@@ -25,6 +25,7 @@ describe('metadata', function () {
           assert.strictEqual(ks.strategy, strategy);
           assert.ok(ks.strategyOptions);
           assert.strictEqual(ks.strategyOptions[optionName], optionValue);
+          assert.strictEqual(ks.virtual, false);
         }
 
         function checkKeyspace(client, name, strategy, optionName, optionValue) {
@@ -42,6 +43,7 @@ describe('metadata', function () {
             assert.ok(m.keyspaces);
             assert.ok(m.keyspaces['system']);
             assert.ok(m.keyspaces['system'].strategy);
+            assert.strictEqual(m.keyspaces['system'].virtual, false);
             next();
           },
           helper.toTask(client.execute, client, "CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}"),
@@ -498,6 +500,7 @@ describe('metadata', function () {
             assert.strictEqual(table.partitionKeys[0].name, 'id');
             assert.strictEqual(table.clusteringKeys.length, 0);
             assert.strictEqual(table.clusteringOrder.length, 0);
+            assert.strictEqual(table.virtual, false);
             done();
           });
         });
@@ -518,6 +521,7 @@ describe('metadata', function () {
             assert.strictEqual(table.partitionKeys.length, 2);
             assert.strictEqual(table.partitionKeys[0].name, 'id');
             assert.strictEqual(table.partitionKeys[1].name, 'text_sample');
+            assert.strictEqual(table.virtual, false);
             done();
           });
         });
@@ -543,6 +547,7 @@ describe('metadata', function () {
             assert.strictEqual(table.clusteringKeys[0].name, 'text_sample');
             assert.strictEqual(table.clusteringOrder.length, 1);
             assert.strictEqual(table.clusteringOrder[0], 'ASC');
+            assert.strictEqual(table.virtual, false);
             done();
           });
         });
@@ -570,6 +575,7 @@ describe('metadata', function () {
             assert.strictEqual(table.clusteringOrder.length, 2);
             assert.strictEqual(table.clusteringOrder[0], 'ASC');
             assert.strictEqual(table.clusteringOrder[1], 'DESC');
+            assert.strictEqual(table.virtual, false);
             done();
           });
         });
@@ -595,6 +601,7 @@ describe('metadata', function () {
             assert.strictEqual(table.columnsByName['rating_votes'].type.code, types.dataTypes.counter);
             //true counter tables
             assert.strictEqual(table.replicateOnWrite, true);
+            assert.strictEqual(table.virtual, false);
             done();
           });
         });
@@ -620,6 +627,7 @@ describe('metadata', function () {
             assert.strictEqual(table.partitionKeys.length, 1);
             assert.strictEqual(table.partitionKeys[0].name, 'id');
             assert.strictEqual(table.clusteringKeys.length, 0);
+            assert.strictEqual(table.virtual, false);
             done();
           });
         });
@@ -644,6 +652,7 @@ describe('metadata', function () {
             assert.strictEqual(table.partitionKeys[0].name, 'id1');
             assert.strictEqual(table.clusteringKeys.length, 1);
             assert.strictEqual(table.clusteringKeys[0].name, 'id2');
+            assert.strictEqual(table.virtual, false);
             done();
           });
         });
@@ -664,6 +673,7 @@ describe('metadata', function () {
             assert.strictEqual(table.partitionKeys[0].name, 'id');
             assert.strictEqual(table.clusteringKeys.length, 1);
             assert.strictEqual(table.clusteringKeys[0].name, 'ck');
+            assert.strictEqual(table.virtual, false);
             client.shutdown(done);
           });
         });

--- a/test/integration/short/metadata-tests.js
+++ b/test/integration/short/metadata-tests.js
@@ -70,17 +70,17 @@ describe('metadata', function () {
               next();
             });
           },
-          helper.toTask(client.execute, client, "ALTER KEYSPACE ks3 WITH replication = {'class' : 'NetworkTopologyStrategy', 'datacenter2' : 1}"),
+          helper.toTask(client.execute, client, "ALTER KEYSPACE ks3 WITH replication = {'class' : 'NetworkTopologyStrategy', 'dc1' : 1}"),
           function checkAlteredKeyspace(next) {
             // rf strategy should have changed on client.
-            checkKeyspace(client, 'ks3', 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'datacenter2', '1');
+            checkKeyspace(client, 'ks3', 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'dc1', '1');
 
             // rf strategy should not have changed yet on nonSyncClient without refreshing explicitly.
             checkKeyspace(nonSyncClient, 'ks3', 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor', '1');
 
             nonSyncClient.metadata.refreshKeyspace('ks3', function (err, ks) {
               assert.ifError(err);
-              checkKeyspaceWithInfo(ks, 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'datacenter2', '1');
+              checkKeyspaceWithInfo(ks, 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'dc1', '1');
               next();
             });
           },
@@ -108,6 +108,49 @@ describe('metadata', function () {
             }
           ], done);
         });
+      });
+      vit('4.0', 'should retrieve virtual keyspace metadata', (done) => {
+        const client = newInstance();
+        const nonSyncClient = newInstance({ isMetadataSyncEnabled: false });
+        function checkVirtualKeyspace(ks) {
+          // table should be virtual and options should be undefined
+          assert.ok(ks.virtual);
+          assert.ifError(ks.durableWrites);
+          assert.ifError(ks.strategyOptions);
+          assert.ifError(ks.strategy);
+        }
+
+        utils.series([
+          client.connect.bind(client),
+          nonSyncClient.connect.bind(nonSyncClient),
+          function checkKeyspaces(next) {
+            const m = client.metadata;
+            checkVirtualKeyspace(m.keyspaces['system_views']);
+            next();
+          },
+          (next) => {
+            // There should be no keyspace metadata for the non synched client until its fetched via refreshKeyspace.
+            const ks = nonSyncClient.metadata.keyspaces;
+            assert.ok(ks['system_views'] === undefined);
+            nonSyncClient.metadata.refreshKeyspace('system_views', (err, ks) => {
+              assert.ifError(err);
+              checkVirtualKeyspace(ks);
+              next();
+            });
+          },
+          (next) => {
+            // Use global refreshKeyspaces and ensure that a previously unfetched virtual keyspace is fetched.
+            const ks = nonSyncClient.metadata.keyspaces;
+            assert.ok(ks['system_virtual_schema'] == undefined);
+            nonSyncClient.metadata.refreshKeyspaces((err) => {
+              assert.ifError(err);
+              checkVirtualKeyspace(nonSyncClient.metadata.keyspaces['system_virtual_schema']);
+              next();
+            });
+          },
+          client.shutdown.bind(client),
+          nonSyncClient.shutdown.bind(nonSyncClient)
+        ], done);
       });
     });
     describe('#getTokenRanges()', function () {
@@ -377,6 +420,7 @@ describe('metadata', function () {
     describe('#getTable()', function () {
       const keyspace = 'ks_tbl_meta';
       const is3 = helper.isCassandraGreaterThan('3.0');
+      const is4 = helper.isCassandraGreaterThan('4.0');
       const valuesIndex = (is3 ? "(values(map_values))" : "(map_values)");
       before(function createTables(done) {
         const client = newInstance();
@@ -387,8 +431,6 @@ describe('metadata', function () {
           "CREATE TABLE tbl2 (id uuid, text_sample text, PRIMARY KEY ((id, text_sample)))",
           "CREATE TABLE tbl3 (id uuid, text_sample text, PRIMARY KEY (id, text_sample))",
           "CREATE TABLE tbl4 (zck timeuuid, apk2 text, pk1 uuid, val2 blob, valz1 int, PRIMARY KEY ((pk1, apk2), zck))",
-          "CREATE TABLE tbl5 (id1 uuid, id2 timeuuid, text1 text, PRIMARY KEY (id1, id2)) WITH COMPACT STORAGE",
-          "CREATE TABLE tbl6 (id uuid, text1 text, text2 text, PRIMARY KEY (id)) WITH COMPACT STORAGE",
           "CREATE TABLE tbl7 (id1 uuid, id3 timeuuid, zid2 text, int_sample int, PRIMARY KEY (id1, zid2, id3)) WITH CLUSTERING ORDER BY (zid2 ASC, id3 DESC)",
           "CREATE TABLE tbl8 (id uuid, rating_value counter, rating_votes counter, PRIMARY KEY (id))",
           "CREATE TABLE tbl9 (id uuid, c1 'DynamicCompositeType(s => UTF8Type, i => Int32Type)', c2 'ReversedType(CompositeType(UTF8Type, Int32Type))', c3 'Int32Type', PRIMARY KEY (id, c1, c2))",
@@ -426,6 +468,13 @@ describe('metadata', function () {
           queries.push(
             'CREATE TABLE tbl_cdc_true (a int PRIMARY KEY, b text) WITH cdc=TRUE',
             'CREATE TABLE tbl_cdc_false (a int PRIMARY KEY, b text) WITH cdc=FALSE'
+          );
+        }
+        if (!is4) {
+          // COMPACT STORAGE is not supported by C* 4.0.
+          queries.push(
+            "CREATE TABLE tbl5 (id1 uuid, id2 timeuuid, text1 text, PRIMARY KEY (id1, id2)) WITH COMPACT STORAGE",
+            "CREATE TABLE tbl6 (id uuid, text1 text, text2 text, PRIMARY KEY (id)) WITH COMPACT STORAGE"
           );
         }
         utils.eachSeries(queries, client.execute.bind(client), helper.finish(client, done));
@@ -551,6 +600,9 @@ describe('metadata', function () {
         });
       });
       it('should retrieve the metadata of a compact storaged table', function (done) {
+        if (is4) {
+          this.skip();
+        }
         const client = newInstance({ keyspace: keyspace});
         client.connect(function (err) {
           assert.ifError(err);
@@ -573,6 +625,9 @@ describe('metadata', function () {
         });
       });
       it('should retrieve the metadata of a compact storaged table with clustering key', function (done) {
+        if (is4) {
+          this.skip();
+        }
         const client = newInstance({ keyspace: keyspace});
         client.connect(function (err) {
           assert.ifError(err);
@@ -888,6 +943,21 @@ describe('metadata', function () {
             next();
           });
         }, done);
+      });
+      vit('4.0', 'should retrieve the metadata of a virtual table', () => {
+        const client = setupInfo.client;
+        return client.metadata.getTable('system_views', 'clients')
+          .then((table) => {
+            assert.ok(table);
+            assert.ok(table.virtual);
+            assert.strictEqual(table.name, 'clients');
+            assert.deepEqual(table.columns.map(c => c.name), ['address', 'connection_stage', 'driver_name',
+              'driver_version', 'hostname', 'port', 'protocol_version', 'request_count', 'ssl_cipher_suite',
+              'ssl_enabled', 'ssl_protocol', 'username']);
+            assert.deepEqual(table.clusteringOrder, ['ASC']);
+            assert.deepEqual(table.partitionKeys.map(c => c.name), ['address']);
+            assert.deepEqual(table.clusteringKeys.map(c => c.name), ['port']);
+          });
       });
       it('should retrieve the updated metadata after a schema change', function (done) {
         const client = newInstance();

--- a/test/integration/short/metadata-tests.js
+++ b/test/integration/short/metadata-tests.js
@@ -141,7 +141,7 @@ describe('metadata', function () {
           (next) => {
             // Use global refreshKeyspaces and ensure that a previously unfetched virtual keyspace is fetched.
             const ks = nonSyncClient.metadata.keyspaces;
-            assert.ok(ks['system_virtual_schema'] == undefined);
+            assert.ok(ks['system_virtual_schema'] === undefined);
             nonSyncClient.metadata.refreshKeyspaces((err) => {
               assert.ifError(err);
               checkVirtualKeyspace(nonSyncClient.metadata.keyspaces['system_virtual_schema']);


### PR DESCRIPTION
Adds support for parsing virtual keyspace metadata.  Like the java driver implementation (datastax/java-driver#1050) virtual keyspaces and tables are exposed in the same way as regular keyspaces and tables.

In cases where where a user requests an explicit keyspace (`metadata.refreshKeyspaces`) or table (`metadata.getTable`) that weren't previously cached, we first query the `system_schema` keyspace.  If no keyspace/table is found, we then query the `system_virtual_schema` keyspace.  If we are somehow able to discern the keyspace/table are virtual ahead of time (i.e. if querying a table and we know its tied to a virtual keyspace) we query `system_virtual_schema` directly.   This logic only takes place for C* 4.0+ where I introduced a `SchemaParserV3`.