### PR TITLE
Bypass retry logic when query is marked as non-idempotent

### DIFF
--- a/doc/features/tuning-policies/README.md
+++ b/doc/features/tuning-policies/README.md
@@ -160,13 +160,13 @@ unexpected error, invoked in the following situations:
 The [operation info][OperationInfo], passed as a parameter to the retry policy methods, exposes the `query` and query 
 `options` as properties.
 
-A default and base retry policy is included, along with `IdempotenceAwareRetryPolicy` that considers query idempotence.
+A default and base retry policy are included.
 
 ### Query idempotence
 
-Note that the current behaviour of the driver allows the `RetryPolicy` to retrieve the query idempotence as part of the
-information and take a decision whether to retry the execution or not. In future versions, the driver will rethrow the
-error back to the consumer for non-idempotent queries, without using the `RetryPolicy` for this case.
+Note that as of version 4.0, the configured `RetryPolicy` is not engaged when a query errors with a
+`WriteTimeoutException` or request error and the query was not [idempotent][idempotent].
 
 [generators]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator
 [OperationInfo]: /api/module.policies/module.retry/type.OperationInfo/
+[idempotent]: ../speculative-executions/#query-idempotence

--- a/lib/policies/retry.js
+++ b/lib/policies/retry.js
@@ -155,7 +155,8 @@ RetryPolicy.retryDecision = {
  * [RetryPolicy]{@link module:policies/retry~RetryPolicy} as child policy.
  * @extends module:policies/retry~RetryPolicy
  * @constructor
- * @deprecated since 4.0 non-idempotent operations are never tried for write timeout or request error.
+ * @deprecated since 4.0 non-idempotent operations are never tried for write timeout or request error, use the default
+ * retry policy instead.
  */
 function IdempotenceAwareRetryPolicy(childPolicy) {
   this._childPolicy = childPolicy || new RetryPolicy();

--- a/lib/policies/retry.js
+++ b/lib/policies/retry.js
@@ -155,6 +155,7 @@ RetryPolicy.retryDecision = {
  * [RetryPolicy]{@link module:policies/retry~RetryPolicy} as child policy.
  * @extends module:policies/retry~RetryPolicy
  * @constructor
+ * @deprecated since 4.0 non-idempotent operations are never tried for write timeout or request error.
  */
 function IdempotenceAwareRetryPolicy(childPolicy) {
   this._childPolicy = childPolicy || new RetryPolicy();

--- a/lib/request-execution.js
+++ b/lib/request-execution.js
@@ -149,7 +149,10 @@ class RequestExecution {
     };
     const self = this;
     function onRequestError() {
-      return self._parent.retryPolicy.onRequestError(operationInfo, self._request.consistency, err);
+      if(operationInfo.options.isIdempotent) {
+        return self._parent.retryPolicy.onRequestError(operationInfo, self._request.consistency, err);
+      }
+      return { decision: retry.RetryPolicy.retryDecision.rethrow };
     }
     if (err.isSocketError) {
       if (err.requestNotWritten) {
@@ -176,8 +179,10 @@ class RequestExecution {
           return this._parent.retryPolicy.onReadTimeout(
             operationInfo, err.consistencies, err.received, err.blockFor, err.isDataPresent);
         case types.responseErrorCodes.writeTimeout:
-          return this._parent.retryPolicy.onWriteTimeout(
-            operationInfo, err.consistencies, err.received, err.blockFor, err.writeType);
+          if(operationInfo.options.isIdempotent) {
+            return this._parent.retryPolicy.onWriteTimeout(
+              operationInfo, err.consistencies, err.received, err.blockFor, err.writeType);
+          }
       }
     }
     return { decision: retry.RetryPolicy.retryDecision.rethrow };

--- a/test/integration/short/client-pool-tests.js
+++ b/test/integration/short/client-pool-tests.js
@@ -676,7 +676,8 @@ describe('Client', function () {
     beforeEach(helper.ccmHelper.start(3));
     afterEach(helper.ccmHelper.remove);
     it('should failover after a node goes down', function (done) {
-      const client = newInstance();
+      // treat queries as idempotent so they can be safely retried on another node
+      const client = newInstance({ queryOptions: { isIdempotent: true } });
       const hosts = {};
       const hostsDown = [];
       utils.series([

--- a/test/integration/short/timeout-tests.js
+++ b/test/integration/short/timeout-tests.js
@@ -37,59 +37,13 @@ describe('client read timeouts', function () {
     it('should move to next host for prepared queries executions', getMoveNextHostTest(true, true));
     it('should move to next host for prepared requests', getMoveNextHostTest(true, false));
     it('should move to next host for the initial prepare', getMoveNextHostTest(true, false));
-    it('should callback in error when retryOnTimeout is false', function (done) {
-      const client = newInstance({ socketOptions: { readTimeout: 3000 } });
-      let coordinators = {};
-      const errorsReceived = [];
-      utils.series([
-        client.connect.bind(client),
-        function warmup(next) {
-          utils.timesSeries(10, function (n, timesNext) {
-            client.execute('SELECT key FROM system.local', function (err, result) {
-              if (err) {
-                return timesNext(err);
-              }
-              coordinators[helper.lastOctetOf(result.info.queriedHost)] = true;
-              timesNext();
-            });
-          }, next);
-        },
-        helper.toTask(helper.ccmHelper.pauseNode, null, 2),
-        function checkTimeouts(next) {
-          assert.strictEqual(Object.keys(coordinators).length, 2);
-          assert.strictEqual(coordinators['1'], true);
-          assert.strictEqual(coordinators['2'], true);
-          coordinators = {};
-          utils.times(10, function (n, timesNext) {
-            client.execute('SELECT key FROM system.local', [], { retryOnTimeout: false }, function (err, result) {
-              if (err) {
-                errorsReceived.push(err);
-              }
-              else {
-                coordinators[helper.lastOctetOf(result.info.queriedHost)] = true;
-              }
-              timesNext();
-            });
-          }, function (err) {
-            if (err) {
-              return next(err);
-            }
-            assert.strictEqual(Object.keys(coordinators).length, 1);
-            assert.strictEqual(coordinators['1'], true);
-            //half of the executions failed
-            assert.strictEqual(errorsReceived.length, 5);
-            assert.ok(errorsReceived.reduce(function (previous, current) {
-              return previous && (current instanceof errors.OperationTimedOutError);
-            }, true));
-            next();
-          });
-        },
-        helper.toTask(helper.ccmHelper.resumeNode, null, 2),
-        client.shutdown.bind(client)
-      ], done);
-    });
+    it('should callback in error when isIdempotent is false', getTimeoutErrorExpectedTest({ isIdempotent: false }));
+    it('should callback in error when retryOnTimeout is false', getTimeoutErrorExpectedTest({ retryOnTimeout: false }));
     it('defunct the connection when the threshold passed', function (done) {
       const client = newInstance({
+        queryOptions: { 
+          isIdempotent: true
+        },
         socketOptions: {
           readTimeout: 3000,
           defunctReadTimeoutThreshold: 16
@@ -150,7 +104,7 @@ describe('client read timeouts', function () {
       ], done);
     });
     it('should move to next host for eachRow() executions', function (done) {
-      const client = newInstance({ socketOptions: { readTimeout: 3000 } });
+      const client = newInstance({ socketOptions: { readTimeout: 3000 }, queryOptions: { isIdempotent: true } });
       let coordinators = {};
       utils.series([
         client.connect.bind(client),
@@ -240,7 +194,7 @@ describe('client read timeouts', function () {
         policies: { loadBalancing: new FixedOrderLoadBalancingPolicy() },
         pooling: { warmup: true, coreConnectionsPerHost: { '0': 1 }},
         socketOptions: { readTimeout: 1000 },
-        queryOptions: { consistency: types.consistencies.one }
+        queryOptions: { consistency: types.consistencies.one, isIdempotent: true }
       });
       utils.series([
         client.connect.bind(client),
@@ -270,7 +224,7 @@ describe('client read timeouts', function () {
         policies: { loadBalancing: new FixedOrderLoadBalancingPolicy() },
         pooling: { warmup: true, coreConnectionsPerHost: { '0': 1 }},
         socketOptions: { readTimeout: 1000 },
-        queryOptions: { consistency: types.consistencies.one }
+        queryOptions: { consistency: types.consistencies.one, isIdempotent: true }
       });
       utils.series([
         client.connect.bind(client),
@@ -324,7 +278,7 @@ function getMoveNextHostTest(prepare, prepareWarmup, expectedTimeoutMillis, read
   }
   profiles = profiles || [];
   return (function moveNextHostTest(done) {
-    const client = newInstance({ profiles: profiles, socketOptions: { readTimeout: readTimeout } });
+    const client = newInstance({ profiles: profiles, socketOptions: { readTimeout: readTimeout }, queryOptions: { isIdempotent: true } });
     const timeoutLogs = [];
     client.on('log', function (level, constructorName, info) {
       if (level !== 'warning' || info.indexOf('timeout') === -1) {
@@ -393,7 +347,7 @@ function getTimeoutErrorNotExpectedTest(prepare, prepareWarmup, readTimeout, que
   profiles = profiles || [];
 
   return (function timeoutErrorNotExpectedTest(done) {
-    const client = newInstance({ profiles: profiles, socketOptions: { readTimeout: readTimeout } });
+    const client = newInstance({ profiles: profiles, socketOptions: { readTimeout: readTimeout, isIdempotent: true } });
     let coordinators = {};
     utils.series([
       client.connect.bind(client),
@@ -444,6 +398,60 @@ function getTimeoutErrorNotExpectedTest(prepare, prepareWarmup, readTimeout, que
         assert.strictEqual(coordinators['2'], true);
         next();
       },
+      client.shutdown.bind(client)
+    ], done);
+  });
+}
+
+function getTimeoutErrorExpectedTest (queryOptions) {
+  return (function (done) {
+    const client = newInstance({ socketOptions: { readTimeout: 3000 }, queryOptions: { isIdempotent: true } });
+    let coordinators = {};
+    const errorsReceived = [];
+    utils.series([
+      client.connect.bind(client),
+      function warmup(next) {
+        utils.timesSeries(10, function (n, timesNext) {
+          client.execute('SELECT key FROM system.local', function (err, result) {
+            if (err) {
+              return timesNext(err);
+            }
+            coordinators[helper.lastOctetOf(result.info.queriedHost)] = true;
+            timesNext();
+          });
+        }, next);
+      },
+      helper.toTask(helper.ccmHelper.pauseNode, null, 2),
+      function checkTimeouts(next) {
+        assert.strictEqual(Object.keys(coordinators).length, 2);
+        assert.strictEqual(coordinators['1'], true);
+        assert.strictEqual(coordinators['2'], true);
+        coordinators = {};
+        utils.times(10, function (n, timesNext) {
+          client.execute('SELECT key FROM system.local', [], queryOptions, function (err, result) {
+            if (err) {
+              errorsReceived.push(err);
+            }
+            else {
+              coordinators[helper.lastOctetOf(result.info.queriedHost)] = true;
+            }
+            timesNext();
+          });
+        }, function (err) {
+          if (err) {
+            return next(err);
+          }
+          assert.strictEqual(Object.keys(coordinators).length, 1);
+          assert.strictEqual(coordinators['1'], true);
+          //half of the executions failed
+          assert.strictEqual(errorsReceived.length, 5);
+          assert.ok(errorsReceived.reduce(function (previous, current) {
+            return previous && (current instanceof errors.OperationTimedOutError);
+          }, true));
+          next();
+        });
+      },
+      helper.toTask(helper.ccmHelper.resumeNode, null, 2),
       client.shutdown.bind(client)
     ], done);
   });

--- a/test/unit/request-handler-tests.js
+++ b/test/unit/request-handler-tests.js
@@ -50,7 +50,7 @@ describe('RequestHandler', function () {
         cb(null, {});
       });
       const retryPolicy = new TestRetryPolicy();
-      const handler = newInstance(queryRequest, null, lbp, retryPolicy);
+      const handler = newInstance(queryRequest, null, lbp, retryPolicy, true);
       handler.send(function (err, result) {
         assert.ifError(err);
         helper.assertInstanceOf(result, types.ResultSet);
@@ -69,13 +69,88 @@ describe('RequestHandler', function () {
         cb(null, {});
       });
       const retryPolicy = new TestRetryPolicy(false);
-      const handler = newInstance(queryRequest, null, lbp, retryPolicy);
+      const handler = newInstance(queryRequest, null, lbp, retryPolicy, true);
       handler.send(function (err) {
         helper.assertInstanceOf(err, errors.OperationTimedOutError);
         const hosts = lbp.getFixedQueryPlan();
         assert.strictEqual(hosts[0].sendStreamCalled, 1);
         assert.strictEqual(hosts[1].sendStreamCalled, 0);
         assert.strictEqual(retryPolicy.requestErrors.length, 1);
+        done();
+      });
+    });
+    it('should not use the retry policy if query is non-idempotent on writeTimeout', function (done) {
+      const lbp = helper.getLoadBalancingPolicyFake([ {}, {} ], undefined, function sendStreamCb(r, h, cb) {
+        if (h.address === '0') {
+          return cb(new errors.ResponseError(types.responseErrorCodes.writeTimeout, 'Test error'));
+        }
+        cb(null, {});
+      });
+      const retryPolicy = new TestRetryPolicy();
+      const handler = newInstance(queryRequest, null, lbp, retryPolicy, false);
+      handler.send(function (err, result) {
+        helper.assertInstanceOf(err, errors.ResponseError);
+        assert.strictEqual(err.code, types.responseErrorCodes.writeTimeout);
+        const hosts = lbp.getFixedQueryPlan();
+        assert.strictEqual(hosts[0].sendStreamCalled, 1);
+        assert.strictEqual(hosts[1].sendStreamCalled, 0);
+        assert.strictEqual(retryPolicy.writeTimeoutErrors.length, 0);
+        done();
+      });
+    });
+    it('should not use the retry policy if query is non-idempotent on OperationTimedOutError', function (done) {
+      const lbp = helper.getLoadBalancingPolicyFake([ {}, {} ], undefined, function sendStreamCb(r, h, cb) {
+        if (h.address === '0') {
+          return cb(new errors.OperationTimedOutError('Test error'));
+        }
+        cb(null, {});
+      });
+      const retryPolicy = new TestRetryPolicy(false);
+      const handler = newInstance(queryRequest, null, lbp, retryPolicy, false);
+      handler.send(function (err) {
+        helper.assertInstanceOf(err, errors.OperationTimedOutError);
+        const hosts = lbp.getFixedQueryPlan();
+        assert.strictEqual(hosts[0].sendStreamCalled, 1);
+        assert.strictEqual(hosts[1].sendStreamCalled, 0);
+        assert.strictEqual(retryPolicy.requestErrors.length, 0);
+        done();
+      });
+    });
+    it('should use the retry policy even if query is non-idempotent on readTimeout', function (done) {
+      const lbp = helper.getLoadBalancingPolicyFake([ {}, {} ], undefined, function sendStreamCb(r, h, cb) {
+        if (h.address === '0') {
+          return cb(new errors.ResponseError(types.responseErrorCodes.readTimeout, 'Test error'));
+        }
+        cb(null, {});
+      });
+      const retryPolicy = new TestRetryPolicy();
+      const handler = newInstance(queryRequest, null, lbp, retryPolicy, false);
+      handler.send(function (err, result) {
+        assert.ifError(err);
+        helper.assertInstanceOf(result, types.ResultSet);
+        const hosts = lbp.getFixedQueryPlan();
+        assert.strictEqual(hosts[0].sendStreamCalled, 1);
+        assert.strictEqual(hosts[1].sendStreamCalled, 1);
+        assert.strictEqual(retryPolicy.readTimeoutErrors.length, 1);
+        done();
+      });
+    });
+    it('should use the retry policy even if query is non-idempotent on unavailable', function (done) {
+      const lbp = helper.getLoadBalancingPolicyFake([ {}, {} ], undefined, function sendStreamCb(r, h, cb) {
+        if (h.address === '0') {
+          return cb(new errors.ResponseError(types.responseErrorCodes.unavailableException, 'Test error'));
+        }
+        cb(null, {});
+      });
+      const retryPolicy = new TestRetryPolicy();
+      const handler = newInstance(queryRequest, null, lbp, retryPolicy, false);
+      handler.send(function (err, result) {
+        assert.ifError(err);
+        helper.assertInstanceOf(result, types.ResultSet);
+        const hosts = lbp.getFixedQueryPlan();
+        assert.strictEqual(hosts[0].sendStreamCalled, 1);
+        assert.strictEqual(hosts[1].sendStreamCalled, 1);
+        assert.strictEqual(retryPolicy.unavailableErrors.length, 1);
         done();
       });
     });


### PR DESCRIPTION
For [NODEJS-331](https://datastax-oss.atlassian.net/browse/NODEJS-331).