### PR TITLE
shutdown on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ const client = new cassandra.Client({ contactPoints: ['h1', 'h2'], keyspace: 'ks
 const query = 'SELECT name, email FROM users WHERE key = ?';
 client.execute(query, [ 'someone' ])
   .then(result => console.log('User with email %s', result.rows[0].email));
+client.shutdown()
 ```
 
 Alternatively, you can use the callback-based execution for all asynchronous methods of the API.
@@ -52,6 +53,7 @@ client.execute(query, [ 'someone' ], function(err, result) {
   assert.ifError(err);
   console.log('User with email %s', result.rows[0].email);
 });
+client.shutdown();
 ```
 
 ### Prepare your queries


### PR DESCRIPTION
**Problem**

- Someone who has never used this library will be puzzled why a simple code like:
```
client = new cassandra.Client(....)
client.execute(query)
```
will never let your node process exit. 
- Even though, doing a `shutdown()` it's something one should do for proper cleanup, when starting up development of an application it's not obvious that one needs to do this. 

**Proposal** 

- Add the shutdown command 😄 