### PR TITLE
Support callback parameter in TimeUuid.now() and TimeUuid.fromDate()

### DIFF
--- a/lib/types/time-uuid.js
+++ b/lib/types/time-uuid.js
@@ -19,6 +19,12 @@ const _unixToGregorian = 12219292800000;
  * @private
  */
 const _ticksInMs = 10000;
+
+const minNodeId = utils.allocBufferFromString('808080808080', 'hex');
+const minClockId = utils.allocBufferFromString('8080', 'hex');
+const maxNodeId = utils.allocBufferFromString('7f7f7f7f7f7f', 'hex');
+const maxClockId = utils.allocBufferFromString('7f7f', 'hex');
+
 /**
  * Counter used to generate up to 10000 different timeuuid values with the same Date
  * @private
@@ -37,6 +43,7 @@ let _ticksForCurrentTime = 0;
  * @type {number}
  */
 let _lastTimestamp = 0;
+
 /**
  * Creates a new instance of Uuid based on the parameters provided according to rfc4122.
  * If any of the arguments is not provided, it will be randomly generated, except for the date that will use the current date.
@@ -76,9 +83,59 @@ util.inherits(TimeUuid, Uuid);
  * If not provided, a random nodeId will be generated.
  * @param {String|Buffer} [clockId] A 2-length Buffer or string of 6 ascii characters representing the clock identifier.
  * If not provided a random clockId will be generated.
+ * @param {Function} [callback] An optional callback to be invoked with the error as first parameter and the created
+ * <code>TimeUuid</code> as second parameter. When a callback is provided, the random portions of the
+ * <code>TimeUuid</code> instance are created asynchronously.
+ * <p>
+ *   When nodeId and/or clockId portions are not provided, this method will generate them using
+ *   <code>crypto.randomBytes()</code>. As it's possible that <code>crypto.randomBytes()</code> might block, it's
+ *   recommended that you use the callback-based version of this method in that case.
+ * </p>
+ * @example <caption>Generate a TimeUuid from a ECMAScript Date</caption>
+ * const timeuuid = TimeUuid.fromDate(new Date());
+ * @example <caption>Generate a TimeUuid from a Date with ticks portion</caption>
+ * const timeuuid = TimeUuid.fromDate(new Date(), 1203);
+ * @example <caption>Generate a TimeUuid from a Date without any random portion</caption>
+ * const timeuuid = TimeUuid.fromDate(new Date(), 1203, 'host01', '02');
+ * @example <caption>Generate a TimeUuid from a Date with random node and clock identifiers</caption>
+ * TimeUuid.fromDate(new Date(), 1203, function (err, timeuuid) {
+ *   // do something with the generated timeuuid
+ * });
  */
-TimeUuid.fromDate = function (date, ticks, nodeId, clockId) {
-  return new TimeUuid(date, ticks, nodeId, clockId);
+TimeUuid.fromDate = function (date, ticks, nodeId, clockId, callback) {
+  if (typeof ticks === 'function') {
+    callback = ticks;
+    ticks = nodeId = clockId = null;
+  } else if (typeof nodeId === 'function') {
+    callback = nodeId;
+    nodeId = clockId = null;
+  } else if (typeof clockId === 'function') {
+    callback = clockId;
+    clockId = null;
+  }
+
+  if (!callback) {
+    return new TimeUuid(date, ticks, nodeId, clockId);
+  }
+
+  utils.parallel([
+    next => getOrGenerateRandom(nodeId, 6, (err, buffer) => next(err, nodeId = buffer)),
+    next => getOrGenerateRandom(clockId, 2, (err, buffer) => next(err, clockId = buffer)),
+  ], (err) => {
+    if (err) {
+      return callback(err);
+    }
+
+    let timeUuid;
+    try {
+      timeUuid = new TimeUuid(date, ticks, nodeId, clockId);
+    }
+    catch (e) {
+      return callback(e);
+    }
+
+    callback(null, timeUuid);
+  });
 };
 
 /**
@@ -94,16 +151,14 @@ TimeUuid.fromString = function (value) {
  * Returns the smaller possible type 1 uuid with the provided Date.
  */
 TimeUuid.min = function (date, ticks) {
-  return new TimeUuid(
-    date, ticks, utils.allocBufferFromString('808080808080', 'hex'), utils.allocBufferFromString('8080', 'hex'));
+  return new TimeUuid(date, ticks, minNodeId, minClockId);
 };
 
 /**
  * Returns the biggest possible type 1 uuid with the provided Date.
  */
 TimeUuid.max = function (date, ticks) {
-  return new TimeUuid(
-    date, ticks, utils.allocBufferFromString('7f7f7f7f7f7f', 'hex'), utils.allocBufferFromString('7f7f', 'hex'));
+  return new TimeUuid(date, ticks, maxNodeId, maxClockId);
 };
 
 /**
@@ -112,9 +167,25 @@ TimeUuid.max = function (date, ticks) {
  * If not provided, a random nodeId will be generated.
  * @param {String|Buffer} [clockId] A 2-length Buffer or string of 6 ascii characters representing the clock identifier.
  * If not provided a random clockId will be generated.
+ * @param {Function} [callback] An optional callback to be invoked with the error as first parameter and the created
+ * <code>TimeUuid</code> as second parameter. When a callback is provided, the random portions of the
+ * <code>TimeUuid</code> instance are created asynchronously.
+ * <p>
+ *   When nodeId and/or clockId portions are not provided, this method will generate them using
+ *   <code>crypto.randomBytes()</code>. As it's possible that <code>crypto.randomBytes()</code> might block, it's
+ *   recommended that you use the callback-based version of this method in that case.
+ * </p>
+ * @example <caption>Generate a TimeUuid from a Date without any random portion</caption>
+ * const timeuuid = TimeUuid.now('host01', '02');
+ * @example <caption>Generate a TimeUuid with random node and clock identifiers</caption>
+ * TimeUuid.now(function (err, timeuuid) {
+ *   // do something with the generated timeuuid
+ * });
+ * @example <caption>Generate a TimeUuid based on the current date (might block)</caption>
+ * const timeuuid = TimeUuid.now();
  */
-TimeUuid.now = function (nodeId, clockId) {
-  return new TimeUuid(null, null, nodeId, clockId);
+TimeUuid.now = function (nodeId, clockId, callback) {
+  return TimeUuid.fromDate(null, null, nodeId, clockId, callback);
 };
 
 
@@ -154,6 +225,14 @@ TimeUuid.prototype.getDate = function () {
  */
 TimeUuid.prototype.getNodeId = function () {
   return this.buffer.slice(10);
+};
+
+/**
+ * Returns the clock id this instance, with the variant applied (first 2 msb being 1 and 0).
+ * @returns {Buffer}
+ */
+TimeUuid.prototype.getClockId = function () {
+  return this.buffer.slice(8, 10);
 };
 
 /**
@@ -261,6 +340,13 @@ function getTimeWithTicks(date, ticks) {
 
 function getRandomBytes(length) {
   return crypto.randomBytes(length);
+}
+
+function getOrGenerateRandom(id, length, callback) {
+  if (id) {
+    return callback(null, id);
+  }
+  crypto.randomBytes(length, callback);
 }
 
 /**

--- a/lib/types/time-uuid.js
+++ b/lib/types/time-uuid.js
@@ -46,7 +46,14 @@ let _lastTimestamp = 0;
 
 /**
  * Creates a new instance of Uuid based on the parameters provided according to rfc4122.
- * If any of the arguments is not provided, it will be randomly generated, except for the date that will use the current date.
+ * If any of the arguments is not provided, it will be randomly generated, except for the date that will use the current
+ * date.
+ * <p>
+ *   Note that when nodeId and/or clockId portions are not provided, the constructor will generate them using
+ *   <code>crypto.randomBytes()</code>. As it's possible that <code>crypto.randomBytes()</code> might block, it's
+ *   recommended that you use the callback-based version of the static methods <code>fromDate()</code> or
+ *   <code>now()</code> in that case.
+ * </p>
  * @class
  * @classdesc Represents an immutable version 1 universally unique identifier (UUID). A UUID represents a 128-bit value.
  * <p>Usage: <code>TimeUuid.now()</code></p>

--- a/lib/types/uuid.js
+++ b/lib/types/uuid.js
@@ -65,7 +65,7 @@ Uuid.prototype.getBuffer = function () {
  * @param {Uuid} other The other value to test for equality.
  */
 Uuid.prototype.equals = function (other) {
-  return !!(other instanceof Uuid && this.buffer.toString('hex') === other.buffer.toString('hex'));
+  return other instanceof Uuid && this.buffer.equals(other.buffer);
 };
 
 /**


### PR DESCRIPTION
Expose optional callback parameter on `TimeUuid.now()` and
`TimeUuid.fromDate()` for non-blocking creation of random portions.

Additionally, I've made a minor improvement to Uuid equality comparison
and exposed TimeUuid#getClockId() method.