### PR TITLE
Fix table metadata retrieval when using ECMAScript Map/Set

### DIFF
--- a/lib/metadata/data-collection.js
+++ b/lib/metadata/data-collection.js
@@ -61,14 +61,15 @@ function DataCollection(name) {
    */
   this.localReadRepairChance = 0;
   /**
-   * Specifies the probability with which read repairs should be invoked on non-quorum reads. The value must be between 0 and 1.
+   * Specifies the probability with which read repairs should be invoked on non-quorum reads. The value must be
+   * between 0 and 1.
    * @type {number}
    */
   this.readRepairChance = 0;
   /**
    * An associative Array containing extra metadata for the table.
    * <p>
-   * For Cassandra versions prior to 3.0.0, this method always returns {@code null}.
+   * For Apache Cassandra versions prior to 3.0.0, this method always returns <code>null</code>.
    * </p>
    * @type {Object}
    */
@@ -78,7 +79,7 @@ function DataCollection(name) {
    * with which checksums for compressed blocks are checked during reads.
    * The default value for this options is 1.0 (always check).
    * <p>
-   *   For Cassandra versions prior to 3.0.0, this method always returns {@code null}.
+   *   For Apache Cassandra versions prior to 3.0.0, this method always returns <code>null</code>.
    * </p>
    * @type {Number|null}
    */
@@ -90,25 +91,19 @@ function DataCollection(name) {
   this.populateCacheOnFlush = false;
   /**
    * Returns the default TTL for this table.
-   * <p>
-   * Note: this option is not available in Cassandra 1.2 and will return 0 (no default TTL) when connected to 1.2 nodes.
-   * </p>
    * @type {Number}
    */
   this.defaultTtl = 0;
   /**
    * * Returns the speculative retry option for this table.
-   * <p>
-   * Note: this option is not available in Cassandra 1.2 and will return "NONE" (no speculative retry) when connected
-   * to 1.2 nodes.
-   * </p>
    * @type {String}
    */
   this.speculativeRetry = 'NONE';
   /**
    * Returns the minimum index interval option for this table.
    * <p>
-   *   Note: this option is available in Cassandra 2.1 and above, and will return {@code null} for earlier versions.
+   *   Note: this option is available in Apache Cassandra 2.1 and above, and will return <code>null</code> for
+   *   earlier versions.
    * </p>
    * @type {Number|null}
    */
@@ -116,7 +111,8 @@ function DataCollection(name) {
   /**
    * Returns the maximum index interval option for this table.
    * <p>
-   * Note: this option is available in Cassandra 2.1 and above, and will return {@code null} for earlier versions.
+   * Note: this option is available in Apache Cassandra 2.1 and above, and will return <code>null</code> for
+   * earlier versions.
    * </p>
    * @type {Number|null}
    */

--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -59,7 +59,7 @@ function Metadata (options, controlConnection) {
   Object.defineProperty(this, 'controlConnection', { value: controlConnection, enumerable: false, writable: false});
   this.keyspaces = {};
   this.initialized = false;
-  this._schemaParser = schemaParserFactory.getByVersion(controlConnection, this.getUdt.bind(this));
+  this._schemaParser = schemaParserFactory.getByVersion(options, controlConnection, this.getUdt.bind(this));
   const self = this;
   this._preparedQueries = new PreparedQueries(options.maxPrepared, function () {
     self.log.apply(self, arguments);
@@ -74,7 +74,7 @@ function Metadata (options, controlConnection) {
  */
 Metadata.prototype.setCassandraVersion = function (version) {
   this._schemaParser = schemaParserFactory.getByVersion(
-    this.controlConnection, this.getUdt.bind(this), version, this._schemaParser);
+    this.options, this.controlConnection, this.getUdt.bind(this), version, this._schemaParser);
 };
 
 /**

--- a/lib/metadata/schema-index.js
+++ b/lib/metadata/schema-index.js
@@ -14,7 +14,7 @@ const kind = {
  * @classdesc Describes a CQL index.
  * @param {String} name
  * @param {String} target
- * @param {Number} kind
+ * @param {Number|String} kind
  * @param {Object} options
  * @alias module:metadata~Index
  * @constructor
@@ -34,7 +34,7 @@ function Index(name, target, kind, options) {
    * A numeric value representing index kind (0: custom, 1: keys, 2: composite);
    * @type {Number}
    */
-  this.kind = kind;
+  this.kind = typeof kind === 'string' ? getKindByName(kind) : kind;
   /**
    * An associative array containing the index options
    * @type {Object}
@@ -68,6 +68,7 @@ Index.prototype.isCustomKind = function () {
 
 /**
  * Parses Index information from rows in the 'system_schema.indexes' table
+ * @deprecated It will be removed in the next major version.
  * @param {Array.<Row>} indexRows
  * @returns {Array.<Index>}
  */
@@ -82,7 +83,8 @@ Index.fromRows = function (indexRows) {
 };
 
 /**
- * Parses Index information from rows in the legacy 'system.schema_columns' table
+ * Parses Index information from rows in the legacy 'system.schema_columns' table.
+ * @deprecated It will be removed in the next major version.
  * @param {Array.<Row>} columnRows
  * @param {Object.<String, {name, type}>} columnsByName
  * @returns {Array.<Index>}

--- a/lib/metadata/schema-parser.js
+++ b/lib/metadata/schema-parser.js
@@ -39,12 +39,14 @@ const _selectVirtualColumns = "SELECT * FROM system_virtual_schema.columns where
 
 /**
  * @abstract
+ * @param {ClientOptions} options The client options
  * @param {ControlConnection} cc
  * @constructor
  * @ignore
  */
-function SchemaParser(cc) {
+function SchemaParser(options, cc) {
   this.cc = cc;
+  this.encodingOptions = options.encoding;
   this.selectTable = null;
   this.selectColumns = null;
   this.selectIndexes = null;
@@ -363,14 +365,43 @@ SchemaParser.prototype._parseAggregate = function (row, callback) {
 SchemaParser.prototype._parseFunction = function (row, callback) {
 };
 
+/** @returns {Map} */
+SchemaParser.prototype._asMap = function (obj) {
+  if (!obj) {
+    return new Map();
+  }
+
+  if (this.encodingOptions.map && obj instanceof this.encodingOptions.map) {
+    // Its already a Map or a polyfill of a Map
+    return obj;
+  }
+
+  return new Map(Object.keys(obj).map(k => [ k, obj[k]]));
+};
+
+SchemaParser.prototype._mapAsObject = function (map) {
+  if (!map) {
+    return map;
+  }
+
+  if (this.encodingOptions.map && map instanceof this.encodingOptions.map) {
+    const result = {};
+    map.forEach((value, key) => result[key] = value);
+    return result;
+  }
+
+  return map;
+};
+
 /**
  * Used to parse schema information for Cassandra versions 1.2.x, and 2.x
+ * @param {ClientOptions} options The client options
  * @param {ControlConnection} cc
  * @constructor
  * @ignore
  */
-function SchemaParserV1(cc) {
-  SchemaParser.call(this, cc);
+function SchemaParserV1(options, cc) {
+  SchemaParser.call(this, options, cc);
   this.selectTable = _selectTableV1;
   this.selectColumns = _selectColumnsV1;
   this.selectUdt = _selectUdtV1;
@@ -642,13 +673,14 @@ SchemaParserV1.prototype._parseUdt = function (udtInfo, row, callback) {
 
 /**
  * Used to parse schema information for Cassandra versions 3.x and above
+ * @param {ClientOptions} options The client options
  * @param {ControlConnection} cc The control connection to be used
  * @param {Function} udtResolver The function to be used to retrieve the udts.
  * @constructor
  * @ignore
  */
-function SchemaParserV2(cc, udtResolver) {
-  SchemaParser.call(this, cc);
+function SchemaParserV2(options, cc, udtResolver) {
+  SchemaParser.call(this, options, cc);
   this.udtResolver = udtResolver;
   this.selectTable = _selectTableV2;
   this.selectColumns = _selectColumnsV2;
@@ -835,22 +867,28 @@ SchemaParserV2.prototype._parseTableOrView = function (tableInfo, tableRow, colu
   tableInfo.bloomFilterFalsePositiveChance = tableRow['bloom_filter_fp_chance'];
   tableInfo.caching = JSON.stringify(tableRow['caching']);
   tableInfo.comment = tableRow['comment'];
-  const compaction = tableRow['compaction'];
+
+  // Regardless of the encoding options, use always an Object to represent an associative Array
+  const compaction = this._asMap(tableRow['compaction']);
   if (compaction) {
+    // compactionOptions as an Object<String, String>
     tableInfo.compactionOptions = {};
-    tableInfo.compactionClass = compaction['class'];
-    for (const key in compaction) {
-      if (!compaction.hasOwnProperty(key) || key === 'class') {
-        continue;
+    tableInfo.compactionClass = compaction.get('class');
+    compaction.forEach((value, key) => {
+      if (key === 'class') {
+        return;
       }
-      tableInfo.compactionOptions[key] = compaction[key];
-    }
+      tableInfo.compactionOptions[key] = compaction.get(key);
+    });
   }
-  tableInfo.compression = tableRow['compression'];
+
+  // Convert compression to an Object<String, String>
+  tableInfo.compression = this._mapAsObject(tableRow['compression']);
+
   tableInfo.gcGraceSeconds = tableRow['gc_grace_seconds'];
   tableInfo.localReadRepairChance = tableRow['dclocal_read_repair_chance'];
   tableInfo.readRepairChance = tableRow['read_repair_chance'];
-  tableInfo.extensions = tableRow['extensions'];
+  tableInfo.extensions = this._mapAsObject(tableRow['extensions']);
   tableInfo.crcCheckChance = tableRow['crc_check_chance'];
   tableInfo.memtableFlushPeriod = tableRow['memtable_flush_period_in_ms'] || tableInfo.memtableFlushPeriod;
   tableInfo.defaultTtl = tableRow['default_time_to_live'] || tableInfo.defaultTtl;
@@ -863,7 +901,9 @@ SchemaParserV2.prototype._parseTableOrView = function (tableInfo, tableRow, colu
       tableInfo.cdc = cdc;
     }
   }
-  utils.map(columnRows, columnRowMapper, function (err, columns) {
+
+  // Map all columns asynchronously
+  utils.map(columnRows, columnRowMapper, (err, columns) => {
     if (err) {
       return callback(err);
     }
@@ -879,17 +919,26 @@ SchemaParserV2.prototype._parseTableOrView = function (tableInfo, tableRow, colu
     tableInfo.clusteringOrder = clusteringKeys.map(function (item) {
       return item.order;
     });
+
     if (isView) {
       tableInfo.tableName = tableRow['base_table_name'];
       tableInfo.whereClause = tableRow['where_clause'];
       tableInfo.includeAllColumns = tableRow['include_all_columns'];
       return callback();
     }
-    tableInfo.indexes = Index.fromRows(indexRows);
-    const flags = tableRow['flags'];
-    const isDense = flags.indexOf('dense') >= 0;
-    const isSuper = flags.indexOf('super') >= 0;
-    const isCompound = flags.indexOf('compound') >= 0;
+
+    tableInfo.indexes = this._getIndexes(indexRows);
+
+    // flags can be an instance of Array or Set (real or polyfill)
+    let flags = tableRow['flags'];
+    if (Array.isArray(flags)) {
+      flags = new Set(flags);
+    }
+
+    const isDense = flags.has('dense');
+    const isSuper = flags.has('super');
+    const isCompound = flags.has('compound');
+
     tableInfo.isCompact = isSuper || isDense || !isCompound;
     //remove the columns related to Thrift
     const isStaticCompact = !isSuper && !isDense && !isCompound;
@@ -900,6 +949,17 @@ SchemaParserV2.prototype._parseTableOrView = function (tableInfo, tableRow, colu
       pruneDenseTableColumns(tableInfo);
     }
     callback();
+  });
+};
+
+SchemaParserV2.prototype._getIndexes = function (indexRows) {
+  if (!indexRows || indexRows.length === 0) {
+    return utils.emptyArray;
+  }
+
+  return indexRows.map((row) => {
+    const options = this._mapAsObject(row['options']);
+    return new Index(row['index_name'], options['target'], row['kind'], options);
   });
 };
 
@@ -1012,13 +1072,14 @@ SchemaParserV2.prototype._parseUdt = function (udtInfo, row, callback) {
  * This parser similar to [SchemaParserV2] expect it also parses virtual
  * keyspaces.
  *
+ * @param {ClientOptions} options The client options
  * @param {ControlConnection} cc The control connection to be used
  * @param {Function} udtResolver The function to be used to retrieve the udts.
  * @constructor
  * @ignore
  */
-function SchemaParserV3(cc, udtResolver) {
-  SchemaParserV2.call(this, cc, udtResolver);
+function SchemaParserV3(options, cc, udtResolver) {
+  SchemaParserV2.call(this, options, cc, udtResolver);
   this.supportsVirtual = true;
 }
 
@@ -1300,13 +1361,14 @@ function isDoneForToken(replicationFactors, datacenters, replicasByDc) {
 /**
  * Creates a new instance if the currentInstance is not valid for the
  * provided Cassandra version
+ * @param {ClientOptions} options The client options
  * @param {ControlConnection} cc The control connection to be used
  * @param {Function} udtResolver The function to be used to retrieve the udts.
  * @param {Array.<Number>} [version] The cassandra version
  * @param {SchemaParser} [currentInstance] The current instance
  * @returns {SchemaParser}
  */
-function getByVersion(cc, udtResolver, version, currentInstance) {
+function getByVersion(options, cc, udtResolver, version, currentInstance) {
   let parserConstructor = SchemaParserV1;
   if (version && version[0] === 3) {
     parserConstructor = SchemaParserV2;
@@ -1314,7 +1376,7 @@ function getByVersion(cc, udtResolver, version, currentInstance) {
     parserConstructor = SchemaParserV3;
   }
   if (!currentInstance || !(currentInstance instanceof parserConstructor)){
-    return new parserConstructor(cc, udtResolver);
+    return new parserConstructor(options, cc, udtResolver);
   }
   return currentInstance;
 }

--- a/lib/metadata/table-metadata.js
+++ b/lib/metadata/table-metadata.js
@@ -22,18 +22,14 @@ function TableMetadata(name) {
   this.replicateOnWrite = true;
   /**
    * Returns the memtable flush period (in milliseconds) option for this table.
-   * <p>
-   * Note: this option is available only on Cassandra 2.x and will return 0 (no periodic
-   * flush) when connected to 1.2 nodes.
-   * </p>
    * @type {Number}
    */
   this.memtableFlushPeriod = 0;
   /**
    * Returns the index interval option for this table.
    * <p>
-   * Note: this option is only available in Cassandra 2.0. It is deprecated in Cassandra 2.1 and above, and will
-   * therefore return {@code null} for 2.1 nodes.
+   * Note: this option is only available in Apache Cassandra 2.0. It is deprecated in Apache Cassandra 2.1 and
+   * above, and will therefore return <code>null</code> for 2.1 nodes.
    * </p>
    * @type {Number|null}
    */

--- a/test/integration/short/metadata-tests.js
+++ b/test/integration/short/metadata-tests.js
@@ -1019,6 +1019,44 @@ describe('metadata', function () {
             });
         });
       });
+
+      context('with ECMAScript Map and Set', () => {
+        const client = new Client(Object.assign({}, helper.baseOptions, {
+          keyspace,
+          encoding: { map: Map, set: Set }
+        }));
+
+        before(() => client.connect());
+        after(() => client.shutdown());
+
+        it('should retrieve the table metadata using the same representation', () =>
+          client.metadata.getTable(keyspace, 'tbl7')
+            .then(table => {
+              assert.ok(table);
+              assert.strictEqual(table.columns.length, 4);
+              assert.strictEqual(typeof table.compactionClass, 'string');
+
+              assert.ok(table.compactionOptions);
+              assert.strictEqual(table.compactionOptions.constructor, Object);
+
+              assert.ok(table.compression);
+              assert.strictEqual(table.compression.constructor, Object);
+            }));
+
+        vit('2.1', 'should retrieve the secondary indexes metadata using the same representation', () =>
+          client.metadata.getTable(keyspace, 'tbl_indexes1')
+            .then(table => {
+              assert.ok(table.indexes.length > 0);
+              const index = table.indexes.filter(x => x.name === 'map_values_index')[0];
+              assert.ok(index, 'Index not found');
+              assert.strictEqual(index.name, 'map_values_index');
+              assert.strictEqual(index.isCompositesKind(), true);
+              assert.strictEqual(index.isCustomKind(), false);
+              assert.strictEqual(index.isKeysKind(), false);
+              assert.ok(index.options);
+              assert.strictEqual(index.options.constructor, Object);
+            }));
+      });
     });
     vdescribe('3.0', '#getMaterializedView()', function () {
       const keyspace = 'ks_view_meta';
@@ -1192,6 +1230,31 @@ describe('metadata', function () {
               return client.shutdown();
             });
         });
+      });
+
+      context('with ECMAScript Map and Set', () => {
+        const client = new Client(Object.assign({}, helper.baseOptions, {
+          keyspace,
+          encoding: { map: Map, set: Set }
+        }));
+
+        before(() => client.connect());
+        after(() => client.shutdown());
+
+        it('should retrieve the view metadata using the same representation', () =>
+          client.metadata.getMaterializedView(keyspace, 'dailyhigh')
+            .then(view => {
+              assert.ok(view);
+              assert.strictEqual(view.tableName, 'scores');
+              assert.strictEqual(view.partitionKeys.length, 4);
+              assert.strictEqual(view.clusteringKeys.length, 2);
+
+              assert.ok(view.compactionOptions);
+              assert.strictEqual(view.compactionOptions.constructor, Object);
+
+              assert.ok(view.compression);
+              assert.strictEqual(view.compression.constructor, Object);
+            }));
       });
     });
   });


### PR DESCRIPTION
https://datastax-oss.atlassian.net/browse/NODEJS-465

Fixes an issue when retrieving metadata and having ECMAScript `Set` configured for CQL `set`.

Additionally, it makes sure that the representation for `TableMetadata` and `MaterializedView` is the same regardless of what's configured (associative arrays should still be represented as `Object` instances).