### PR TITLE
Fix RangeError on empty buffer in Encoder.decodeMap

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -207,7 +207,7 @@ function defineInstanceMembers() {
         offset += keyLength;
         const valueLength = self.decodeCollectionLength(bytes, offset);
         offset += self.collectionLengthSize;
-        if (valueLength < 0) {
+        if (valueLength <= 0) {
           callback.call(thisArg, key, null);
           continue;
         }


### PR DESCRIPTION
I've encountered an error similar to the one described here: https://stackoverflow.com/questions/42119104/rangeerror-index-out-of-range-when-connect-to-cassandra-databse-in-node-js

Null value is retrieved from map as empty buffer. Looks like the condition I've modified was intended to handle this situation properly but in fact it does not, leading to RangeError while attempting to read from empty buffer.

This fix helped me get rid of RangeError.