### PR TITLE
Fix RangeError on empty buffer in Encoder.decodeMap

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -62,6 +62,13 @@ const singleFqTypeNamesLength = Object.keys(singleTypeNames).reduce(function (pr
 const durationTypeName = 'org.apache.cassandra.db.marshal.DurationType';
 const nullValueBuffer = utils.allocBufferFromArray([255, 255, 255, 255]);
 const unsetValueBuffer = utils.allocBufferFromArray([255, 255, 255, 254]);
+const zeroLengthTypesSupported = new Set([
+  dataTypes.text,
+  dataTypes.ascii,
+  dataTypes.varchar,
+  dataTypes.custom,
+  dataTypes.blob
+]);
 
 /**
  * Serializes and deserializes to and from a CQL type and a Javascript Type.
@@ -207,7 +214,7 @@ function defineInstanceMembers() {
         offset += keyLength;
         const valueLength = self.decodeCollectionLength(bytes, offset);
         offset += self.collectionLengthSize;
-        if (valueLength < 0) {
+        if (valueLength < 0 || (valueLength === 0 && !zeroLengthTypesSupported.has(subtypes[1].code))) {
           callback.call(thisArg, key, null);
           continue;
         }

--- a/test/unit/encoder-tests.js
+++ b/test/unit/encoder-tests.js
@@ -629,23 +629,63 @@ describe('encoder', function () {
       const encoder = new Encoder(2, { encoding: { useUndefinedAsUnset: true}});
       assert.strictEqual(encoder.encode(undefined), null);
     });
-    it('should decode 0-length map values, v2', function () {
-      const encoder = new Encoder(2, {});
-      const buffer = utils.allocBufferFromString('000100046b6579310000', 'hex');
-      const value = encoder.decode(buffer,
-        { code: types.dataTypes.map, info: [ { code: types.dataTypes.text }, { code: types.dataTypes.text } ]});
-      assert.ok(value);
-      assert.deepEqual(Object.keys(value), ['key1']);
-      assert.strictEqual(value['key1'], '');
+    it('should decode 0-length map values of supported types into 0-length values', function () {
+      const input = {'key1': Buffer.from([])};
+      [2, 3].forEach(v => {
+        const encoder = new Encoder(v, {});
+        const buffer = encoder.encode(input, dataTypes.map);
+        [
+          dataTypes.text,
+          dataTypes.ascii,
+          dataTypes.varchar,
+          dataTypes.blob,
+          dataTypes.custom,
+        ].forEach(function(t){
+          const type = { code: types.dataTypes.map, info: [ { code: types.dataTypes.text }, { code: t } ]};
+          const value = encoder.decode(buffer, type);
+          assert.ok(value);
+          assert.deepEqual(Object.keys(value), Object.keys(input));
+          assert.strictEqual(value['key1'].length, 0);
+        });
+      });
     });
-    it('should decode 0-length map values, v3', function () {
-      const encoder = new Encoder(3, {});
-      const buffer = utils.allocBufferFromString('00000001000000046b65793100000000', 'hex');
-      const value = encoder.decode(buffer,
-        { code: types.dataTypes.map, info: [ { code: types.dataTypes.text }, { code: types.dataTypes.text } ]});
-      assert.ok(value);
-      assert.deepEqual(Object.keys(value), ['key1']);
-      assert.strictEqual(value['key1'], '');
+    it('should decode 0-length map values of unsupported types into null values', function () {
+      // For some unperceivable reason the server can give us an empty buffer as a map value for any type.
+      // We must be able to handle this behaviour.
+      const input = {'key1': Buffer.from([])};
+      [2, 3].forEach(v => {
+        const encoder = new Encoder(v, {});
+        const buffer = encoder.encode(input, dataTypes.map);
+        [
+          dataTypes.bigint,
+          dataTypes.boolean,
+          dataTypes.counter,
+          dataTypes.decimal,
+          dataTypes.double,
+          dataTypes.float,
+          dataTypes.int,
+          dataTypes.timestamp,
+          dataTypes.uuid,
+          dataTypes.varint,
+          dataTypes.timeuuid,
+          dataTypes.inet,
+          dataTypes.date,
+          dataTypes.time,
+          dataTypes.smallint,
+          dataTypes.tinyint,
+          dataTypes.list,
+          dataTypes.map,
+          dataTypes.set,
+          dataTypes.udt,
+          dataTypes.tuple
+        ].forEach(t => {
+          const type = { code: types.dataTypes.map, info: [ { code: types.dataTypes.text }, { code: t } ]};
+          const value = encoder.decode(buffer, type);
+          assert.ok(value);
+          assert.deepEqual(Object.keys(value), Object.keys(input));
+          assert.strictEqual(value['key1'], null);
+        });
+      });
     });
     it('should decode null map values', function () {
       // technically this should not be possible as nulls are not allowed in collections.
@@ -795,7 +835,7 @@ describe('encoder', function () {
       }, TypeError);
     });
     it('should throw TypeError if invalid routingKey type is provided', function () {
-      assert.throws(() => { 
+      assert.throws(() => {
         encoder.setRoutingKeyFromUser([1, 'text'], { routingKey: 123 });
       }, TypeError);
     });


### PR DESCRIPTION
I've encountered an error similar to the one described here: https://stackoverflow.com/questions/42119104/rangeerror-index-out-of-range-when-connect-to-cassandra-databse-in-node-js

Null value is retrieved from map as empty buffer. Looks like the condition I've modified was intended to handle this situation properly but in fact it does not, leading to RangeError while attempting to read from empty buffer.

This fix helped me get rid of RangeError.