### PR TITLE
Borrow a connection from the pool before retrying on the same host

### DIFF
--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -242,7 +242,8 @@ ControlConnection.prototype.borrowAConnection = function (callback) {
 
 /** Default implementation for borrowing connections, that can be injected at constructor level */
 ControlConnection.prototype.borrowHostConnection = function (host, callback) {
-  host.borrowConnection(null, callback);
+  // Borrow any open connection, regardless of the keyspace
+  host.borrowConnection(null, null, callback);
 };
 
 /**

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -242,7 +242,7 @@ ControlConnection.prototype.borrowAConnection = function (callback) {
 
 /** Default implementation for borrowing connections, that can be injected at constructor level */
 ControlConnection.prototype.borrowHostConnection = function (host, callback) {
-  host.borrowConnection(callback);
+  host.borrowConnection(null, callback);
 };
 
 /**

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -102,12 +102,20 @@ util.inherits(ArgumentError, DriverError);
 /**
  * Represents a client-side error that is raised when the client didn't hear back from the server within
  * {@link ClientOptions.socketOptions.readTimeout}.
+ * @param {String} message The error message.
+ * @param {String} [host] Address of the server host that caused the operation to time out.
  * @constructor
  */
-function OperationTimedOutError(message) {
+function OperationTimedOutError(message, host) {
   DriverError.call(this, message, this.constructor);
   this.info = 'Represents a client-side error that is raised when the client did not hear back from the server ' +
     'within socketOptions.readTimeout';
+
+  /**
+   * When defined, it gets the address of the host that caused the operation to time out.
+   * @type {String|undefined}
+   */
+  this.host = host;
 }
 
 util.inherits(OperationTimedOutError, DriverError);

--- a/lib/host-connection-pool.js
+++ b/lib/host-connection-pool.js
@@ -63,24 +63,26 @@ class HostConnectionPool extends events.EventEmitter {
 
   /**
    * Borrows a connection from the pool.
+   * @param {String} keyspace
    * @param {Function} callback
    */
-  createAndBorrowConnection(callback) {
+  createAndBorrowConnection(keyspace, callback) {
     this.create(false, err => {
       if (err) {
         return callback(err);
       }
 
-      this.borrowConnection(null, callback);
+      this.borrowConnection(keyspace, null, callback);
     });
   }
 
   /**
    * Tries to borrow one of the existing connections of the pool.
    * @param {Connection} previousConnection When provided, the pool should try to provide a different connection.
+   * @param {String} keyspace
    * @param {Function} callback
    */
-  borrowConnection(previousConnection, callback) {
+  borrowConnection(keyspace, previousConnection, callback) {
     if (this.connections.length === 0) {
       return callback(new Error('No connection available'));
     }
@@ -91,7 +93,15 @@ class HostConnectionPool extends events.EventEmitter {
     if (c.getInFlight() >= maxRequests) {
       return callback(new errors.BusyConnectionError(this._address, maxRequests, this.connections.length));
     }
-    callback(null, c);
+
+    if (!keyspace || keyspace === c.keyspace) {
+      // Connection is ready to be used
+      return callback(null, c);
+    }
+
+    c.changeKeyspace(keyspace, (err) => {
+      callback(err, c);
+    });
   }
 
   /**

--- a/lib/host-connection-pool.js
+++ b/lib/host-connection-pool.js
@@ -77,7 +77,7 @@ class HostConnectionPool extends events.EventEmitter {
   }
 
   /**
-   * Tries to borrow one of the existing connections of the pool.
+   * Tries to borrow one of the existing connections from the pool.
    * @param {Connection} previousConnection When provided, the pool should try to provide a different connection.
    * @param {String} keyspace
    * @param {Function} callback

--- a/lib/host-connection-pool.js
+++ b/lib/host-connection-pool.js
@@ -65,24 +65,33 @@ class HostConnectionPool extends events.EventEmitter {
    * Borrows a connection from the pool.
    * @param {Function} callback
    */
-  borrowConnection(callback) {
+  createAndBorrowConnection(callback) {
     this.create(false, err => {
       if (err) {
         return callback(err);
       }
-      if (this.connections.length === 0) {
-        // Normally it should have callback in error, but better to handle this possibility
-        return callback(new Error('No connection available'));
-      }
 
-      const maxRequests = this.options.pooling.maxRequestsPerConnection;
-      const c = HostConnectionPool.minInFlight(this.connections, maxRequests);
-
-      if (c.getInFlight() >= maxRequests) {
-        return callback(new errors.BusyConnectionError(this._address, maxRequests, this.connections.length));
-      }
-      callback(null, c);
+      this.borrowConnection(null, callback);
     });
+  }
+
+  /**
+   * Tries to borrow one of the existing connections of the pool.
+   * @param {Connection} previousConnection When provided, the pool should try to provide a different connection.
+   * @param {Function} callback
+   */
+  borrowConnection(previousConnection, callback) {
+    if (this.connections.length === 0) {
+      return callback(new Error('No connection available'));
+    }
+
+    const maxRequests = this.options.pooling.maxRequestsPerConnection;
+    const c = HostConnectionPool.minInFlight(this.connections, maxRequests, previousConnection);
+
+    if (c.getInFlight() >= maxRequests) {
+      return callback(new errors.BusyConnectionError(this._address, maxRequests, this.connections.length));
+    }
+    callback(null, c);
   }
 
   /**
@@ -91,9 +100,10 @@ class HostConnectionPool extends events.EventEmitter {
    * the amount of in-flight requests is lower than maxRequests.
    * @param {Array.<Connection>} connections
    * @param {Number} maxRequests
+   * @param {Connection} previousConnection
    * @returns {Connection}
    */
-  static minInFlight(connections, maxRequests) {
+  static minInFlight(connections, maxRequests, previousConnection) {
     const length = connections.length;
     if (length === 1) {
       return connections[0];
@@ -108,10 +118,21 @@ class HostConnectionPool extends events.EventEmitter {
     let current;
     for (let index = connectionIndex; index < connectionIndex + length; index++) {
       current = connections[index % length];
-      const next = connections[(index + 1) % length];
+      if (current === previousConnection) {
+        // Increment the index and skip
+        current = connections[(++index) % length];
+      }
+
+      let next = connections[(index + 1) % length];
+      if (next === previousConnection) {
+        // Skip
+        next = connections[(index + 2) % length];
+      }
+
       if (next.getInFlight() < current.getInFlight()) {
         current = next;
       }
+
       if (current.getInFlight() < maxRequests) {
         // Check as few connections as possible, as long as the amount of in-flight
         // requests is lower than maxRequests

--- a/lib/host.js
+++ b/lib/host.js
@@ -207,12 +207,19 @@ Host.prototype.setProtocolVersion = function (value) {
 /**
  * It gets an open connection to the host.
  * If there isn't an available connections, it will open a new one according to the pooling options.
+ * @param {Connection} previousConnection The previous connection. When provided, the pool should try to provide a
+ * different connection.
  * @param {Function} callback
  * @internal
  * @ignore
  */
-Host.prototype.borrowConnection = function (callback) {
-  this.pool.borrowConnection(callback);
+Host.prototype.borrowConnection = function (previousConnection, callback) {
+  if (previousConnection) {
+    // Obtain one of the existing connections
+    return this.pool.borrowConnection(previousConnection, callback);
+  }
+
+  this.pool.createAndBorrowConnection(callback);
 };
 
 /**

--- a/lib/host.js
+++ b/lib/host.js
@@ -207,19 +207,21 @@ Host.prototype.setProtocolVersion = function (value) {
 /**
  * It gets an open connection to the host.
  * If there isn't an available connections, it will open a new one according to the pooling options.
+ * @param {String} keyspace The keyspace that the connection must be using. When the keyspace provided is null, no
+ * keyspace check is performed.
  * @param {Connection} previousConnection The previous connection. When provided, the pool should try to provide a
  * different connection.
  * @param {Function} callback
  * @internal
  * @ignore
  */
-Host.prototype.borrowConnection = function (previousConnection, callback) {
+Host.prototype.borrowConnection = function (keyspace, previousConnection, callback) {
   if (previousConnection) {
     // Obtain one of the existing connections
-    return this.pool.borrowConnection(previousConnection, callback);
+    return this.pool.borrowConnection(keyspace, previousConnection, callback);
   }
 
-  this.pool.createAndBorrowConnection(callback);
+  this.pool.createAndBorrowConnection(keyspace, callback);
 };
 
 /**

--- a/lib/operation-state.js
+++ b/lib/operation-state.js
@@ -90,7 +90,7 @@ class OperationState {
     this._timeout = setTimeout(function requestTimedOut() {
       onTimeout();
       const message = util.format('The host %s did not reply before timeout %d ms', address, millis);
-      self._markAsTimedOut(new errors.OperationTimedOutError(message), onResponse);
+      self._markAsTimedOut(new errors.OperationTimedOutError(message, address), onResponse);
     }, millis);
   }
 

--- a/lib/policies/retry.js
+++ b/lib/policies/retry.js
@@ -197,6 +197,10 @@ IdempotenceAwareRetryPolicy.prototype.onWriteTimeout = function (info, consisten
  * [retryDecision]{@link module:policies/retry~RetryPolicy.retryDecision}.
  * @property {Number} [consistency] The [consistency level]{@link module:types~consistencies}.
  * @property {useCurrentHost} [useCurrentHost] Determines if it should use the same host to retry the request.
+ * <p>
+ *   In the case that the current host is not available anymore, it will be retried on the next host even when
+ *   <code>useCurrentHost></code> is set to <code>true</code>.
+ * </p>
  */
 
 /**

--- a/lib/policies/retry.js
+++ b/lib/policies/retry.js
@@ -199,7 +199,7 @@ IdempotenceAwareRetryPolicy.prototype.onWriteTimeout = function (info, consisten
  * @property {useCurrentHost} [useCurrentHost] Determines if it should use the same host to retry the request.
  * <p>
  *   In the case that the current host is not available anymore, it will be retried on the next host even when
- *   <code>useCurrentHost></code> is set to <code>true</code>.
+ *   <code>useCurrentHost</code> is set to <code>true</code>.
  * </p>
  */
 

--- a/lib/prepare-handler.js
+++ b/lib/prepare-handler.js
@@ -187,7 +187,8 @@ class PrepareHandler {
     if (queries.length === 0) {
       return callback();
     }
-    RequestHandler.borrowFromHost(host, keyspace, function borrowCallback(err, connection) {
+
+    host.borrowConnection(keyspace, null, function borrowCallback(err, connection) {
       if (err) {
         return callback(err);
       }
@@ -213,7 +214,8 @@ class PrepareHandler {
       if (host.address === hostToAvoid.address) {
         return next();
       }
-      RequestHandler.borrowFromHost(host, keyspace, function borrowCallback(err, connection) {
+
+      host.borrowConnection(keyspace, null, function borrowCallback(err, connection) {
         if (err) {
           // Don't mind about issues with the pool in this case
           return next();

--- a/lib/request-execution.js
+++ b/lib/request-execution.js
@@ -7,7 +7,7 @@ const retry = require('./policies/retry');
 const types = require('./types');
 const utils = require('./utils');
 
-const retryOnNextCurrentHost = Object.freeze({
+const retryOnCurrentHost = Object.freeze({
   decision: retry.RetryPolicy.retryDecision.retry,
   useCurrentHost: true,
   consistency: undefined
@@ -156,7 +156,7 @@ class RequestExecution {
         // The request was definitely not applied, it's safe to retry.
         // Retry on the current host as there might be other connections open, in case it fails to obtain a connection
         // on the current host, the driver will immediately retry on the next host.
-        return retryOnNextCurrentHost;
+        return retryOnCurrentHost;
       }
       return onRequestError();
     }

--- a/lib/request-execution.js
+++ b/lib/request-execution.js
@@ -193,21 +193,37 @@ class RequestExecution {
       // No point in retrying
       return;
     }
+
     this._parent.log('info', 'Retrying request');
     this._retryCount++;
+
     if (typeof consistency === 'number' && this._request.consistency !== consistency) {
       this._request = this._request.clone();
       this._request.consistency = consistency;
     }
+
     if (useCurrentHost !== false) {
-      // Use existing host (default)
-      return this._sendOnConnection();
+      // Use existing host (default).
+      // Reusing the existing connection is suitable for the most common scenarios, like server read timeouts that
+      // will be fixed with a new request.
+      // To cover all scenarios (e.g., where a different connection to the same host might mean something different),
+      // we obtain a new connection from the host pool.
+      return this._host.borrowConnection((err, connection) => {
+        if (err) {
+          // All connections are busy (`BusyConnectionError`) or there isn't a ready connection in the pool (`Error`)
+          // The retry policy declared the intention to retry on the current host but its not available anymore.
+          // Use the next host
+          return this.start();
+        }
+
+        this._connection = connection;
+        this._sendOnConnection();
+      });
     }
+
     // Use the next host in the query plan to send the request
     this.start();
   }
-
-
 
   /**
    * Issues a PREPARE request on the current connection.

--- a/lib/request-execution.js
+++ b/lib/request-execution.js
@@ -206,12 +206,13 @@ class RequestExecution {
 
     if (useCurrentHost !== false) {
       // Use existing host (default).
+      const keyspace = this._parent.client.keyspace;
       // Reusing the existing connection is suitable for the most common scenarios, like server read timeouts that
       // will be fixed with a new request.
       // To cover all scenarios (e.g., where a different connection to the same host might mean something different),
       // we obtain a new connection from the host pool.
-      // When there was a socket error, the connection provided was already removed from the pool earlier
-      return this._host.borrowConnection(this._connection, (err, connection) => {
+      // When there was a socket error, the connection provided was already removed from the pool earlier.
+      return this._host.borrowConnection(keyspace, this._connection, (err, connection) => {
         if (err) {
           // All connections are busy (`BusyConnectionError`) or there isn't a ready connection in the pool (`Error`)
           // The retry policy declared the intention to retry on the current host but its not available anymore.

--- a/lib/request-execution.js
+++ b/lib/request-execution.js
@@ -7,9 +7,9 @@ const retry = require('./policies/retry');
 const types = require('./types');
 const utils = require('./utils');
 
-const retryOnNextHostDecision = Object.freeze({
+const retryOnNextCurrentHost = Object.freeze({
   decision: retry.RetryPolicy.retryDecision.retry,
-  useCurrentHost: false,
+  useCurrentHost: true,
   consistency: undefined
 });
 
@@ -153,8 +153,10 @@ class RequestExecution {
     }
     if (err.isSocketError) {
       if (err.requestNotWritten) {
-        // The request was definitely not applied, it's safe to retry
-        return retryOnNextHostDecision;
+        // The request was definitely not applied, it's safe to retry.
+        // Retry on the current host as there might be other connections open, in case it fails to obtain a connection
+        // on the current host, the driver will immediately retry on the next host.
+        return retryOnNextCurrentHost;
       }
       return onRequestError();
     }
@@ -208,7 +210,8 @@ class RequestExecution {
       // will be fixed with a new request.
       // To cover all scenarios (e.g., where a different connection to the same host might mean something different),
       // we obtain a new connection from the host pool.
-      return this._host.borrowConnection((err, connection) => {
+      // When there was a socket error, the connection provided was already removed from the pool earlier
+      return this._host.borrowConnection(this._connection, (err, connection) => {
         if (err) {
           // All connections are busy (`BusyConnectionError`) or there isn't a ready connection in the pool (`Error`)
           // The retry policy declared the intention to retry on the current host but its not available anymore.

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -54,7 +54,7 @@ class RequestHandler {
       return callback(new errors.NoHostAvailableError(triedHosts));
     }
 
-    RequestHandler.borrowFromHost(host, keyspace, function borrowFromHostCallback(err, connection) {
+    host.borrowConnection(keyspace, null, function borrowFromHostCallback(err, connection) {
       if (err) {
         triedHosts[host.address] = err;
         if (connection) {
@@ -66,30 +66,6 @@ class RequestHandler {
       }
       triedHosts[host.address] = null;
       callback(null, connection, host);
-    });
-  }
-
-  /**
-   * Borrows a connection from the provided host, changing the current keyspace, if necessary.
-   * @param {Host} host
-   * @param {String} keyspace
-   * @param {Function} callback
-   */
-  static borrowFromHost(host, keyspace, callback) {
-    host.borrowConnection(null, (err, connection) => {
-      if (err) {
-        return callback(err);
-      }
-      if (!keyspace || keyspace === connection.keyspace) {
-        // Connection is ready to be used
-        return callback(null, connection);
-      }
-      connection.changeKeyspace(keyspace, function (err) {
-        if (err) {
-          return callback(err, connection);
-        }
-        callback(null, connection);
-      });
     });
   }
 

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -76,7 +76,7 @@ class RequestHandler {
    * @param {Function} callback
    */
   static borrowFromHost(host, keyspace, callback) {
-    host.borrowConnection(function (err, connection) {
+    host.borrowConnection(null, (err, connection) => {
       if (err) {
         return callback(err);
       }

--- a/test/integration/short/pool-simulator-tests.js
+++ b/test/integration/short/pool-simulator-tests.js
@@ -120,12 +120,13 @@ describe('pool', function () {
             [types.distance.local]: 2
           },
           maxRequestsPerConnection: 50
-        }
+        },
+        socketOptions: { defunctReadTimeoutThreshold: Number.MAX_SAFE_INTEGER }
       });
 
       return client.connect()
         .then(() => firstHost = client.hosts.values()[0].address)
-        .then(() => client.execute('SELECT * FROM paused_on_first', null, { readTimeout: 200 }))
+        .then(() => client.execute('SELECT * FROM paused_on_first', null, { readTimeout: 200, isIdempotent: true }))
         .then(() => assert.strictEqual(retryCount, 2))
         .then(() => client.shutdown());
     });
@@ -157,7 +158,8 @@ describe('pool', function () {
             [types.distance.local]: 2
           },
           maxRequestsPerConnection: 50
-        }
+        },
+        socketOptions: { defunctReadTimeoutThreshold: Number.MAX_SAFE_INTEGER }
       });
 
       const promises = [];
@@ -171,7 +173,7 @@ describe('pool', function () {
             client.execute('SELECT * FROM paused_on_first', null, { readTimeout: 2000 })));
 
           // The pool will be busy after this request, so the retry will occur on the next host
-          const p2 = client.execute('SELECT * FROM paused_on_first', null, { readTimeout: 50 });
+          const p2 = client.execute('SELECT * FROM paused_on_first', null, { readTimeout: 50, isIdempotent: true });
           promises.push(p2);
           return p2;
         })

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -698,7 +698,7 @@ const helper = {
       h.prepareCalled = 0;
       h.sendStreamCalled = 0;
       h.changeKeyspaceCalled = 0;
-      h.borrowConnection = function (cb) {
+      h.borrowConnection = function (c, cb) {
         if (!h.isUp() || h.shouldBeIgnored) {
           return cb(new Error('This host should not be used'));
         }

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -697,11 +697,14 @@ const helper = {
       h.shouldBeIgnored = !!info.ignored;
       h.prepareCalled = 0;
       h.sendStreamCalled = 0;
-      h.changeKeyspaceCalled = 0;
-      h.borrowConnection = function (c, cb) {
+      h.connectionKeyspace = [];
+      h.borrowConnection = function (ks, c, cb) {
         if (!h.isUp() || h.shouldBeIgnored) {
           return cb(new Error('This host should not be used'));
         }
+
+        h.connectionKeyspace.push(ks);
+
         cb(null, {
           prepareOnce: function (q, cb) {
             h.prepareCalled++;
@@ -720,10 +723,6 @@ const helper = {
               op.setResult(null, {});
             });
             return op;
-          },
-          changeKeyspace: function (ks, cb) {
-            h.changeKeyspaceCalled++;
-            cb();
           }
         });
       };

--- a/test/unit/host-tests.js
+++ b/test/unit/host-tests.js
@@ -112,7 +112,7 @@ describe('HostConnectionPool', function () {
       });
     });
   });
-  describe('#borrowConnection()', function () {
+  describe('#createAndBorrowConnection()', function () {
     it('should get an open connection', function (done) {
       const hostPool = newHostConnectionPoolInstance();
       hostPool.coreConnectionsLength = 10;
@@ -125,7 +125,7 @@ describe('HostConnectionPool', function () {
           getInFlight: helper.functionOf(0)
         };
       };
-      hostPool.createAndBorrowConnection(function (err, c) {
+      hostPool.createAndBorrowConnection(null, function (err, c) {
         assert.equal(err, null);
         assert.notEqual(c, null);
         //its a connection or is a mock
@@ -145,7 +145,7 @@ describe('HostConnectionPool', function () {
       ];
       const result = [];
       utils.times(8, (n, next) => {
-        hostPool.createAndBorrowConnection((err, c) => {
+        hostPool.createAndBorrowConnection(null, (err, c) => {
           result.push(c);
           next(err);
         });
@@ -366,7 +366,7 @@ describe('Host', function () {
         c.open = helper.callbackNoop;
         return c;
       };
-      host.borrowConnection(null, function () {
+      host.borrowConnection(null, null, function () {
         host.pool.connections[0].emit('idleRequestError', new Error('Test error'), c);
       });
     });
@@ -388,7 +388,7 @@ describe('Host', function () {
         c.open = helper.callbackNoop;
         return c;
       };
-      host.borrowConnection(null, function (err, c) {
+      host.borrowConnection(null, null, function (err, c) {
         assert.equal(err, null);
         assert.notEqual(c, null);
         //its a connection or is a mock
@@ -409,7 +409,7 @@ describe('Host', function () {
       };
       // setup the distance and expected connections for the host
       host.setDistance(types.distance.local);
-      host.borrowConnection(null, function (err, c) {
+      host.borrowConnection(null, null, function (err, c) {
         assert.equal(err, null);
         assert.notEqual(c, null);
         //its a connection or is a mock
@@ -434,7 +434,7 @@ describe('Host', function () {
       };
       utils.series([
         function (next) {
-          host.borrowConnection(null, function (err, c) {
+          host.borrowConnection(null, null, function (err, c) {
             assert.equal(err, null);
             assert.notEqual(c, null);
             //Just 1 connection at the beginning
@@ -444,7 +444,7 @@ describe('Host', function () {
         },
         function (next) {
           host.setDistance(types.distance.local);
-          host.borrowConnection(null, function (err) {
+          host.borrowConnection(null, null, function (err) {
             assert.ifError(err);
             //Pool resizing happen in the background
             setTimeout(next, 100);
@@ -453,7 +453,7 @@ describe('Host', function () {
         function (next) {
           //Check multiple times in parallel
           utils.times(10, function (n, timesNext) {
-            host.borrowConnection(null, function (err, c) {
+            host.borrowConnection(null, null, function (err, c) {
               assert.equal(err, null);
               assert.notEqual(c, null);
               //The right size afterwards
@@ -655,7 +655,7 @@ describe('Host', function () {
       host._distance = types.distance.local;
       host.pool.coreConnectionsLength = 4;
       host.pool._createConnection = () => newConnectionMock({ open: helper.callbackNoop });
-      host.borrowConnection(null, function (err) {
+      host.borrowConnection(null, null, function (err) {
         assert.ifError(err);
         host.warmupPool(function (err) {
           assert.ifError(err);
@@ -672,7 +672,7 @@ describe('Host', function () {
       host._distance = types.distance.local;
       host.pool.coreConnectionsLength = 3;
       host.pool._createConnection = () => newConnectionMock({ open: (cb) => setTimeout(cb, 20)});
-      host.borrowConnection(null, function (err) {
+      host.borrowConnection(null, null, function (err) {
         assert.ifError(err);
         host.warmupPool(function (err) {
           assert.ifError(err);

--- a/test/unit/prepare-handler-tests.js
+++ b/test/unit/prepare-handler-tests.js
@@ -100,7 +100,7 @@ describe('PrepareHandler', function () {
     });
     it('should callback in error when there is an error borrowing a connection', function (done) {
       const host = helper.getHostsMock([ {} ])[0];
-      host.borrowConnection = function (cb) {
+      host.borrowConnection = function (c, cb) {
         cb(new Error('Test error'));
       };
       PrepareHandler.prepareAllQueries(host, [{ query: 'query1' }], function (err) {

--- a/test/unit/prepare-handler-tests.js
+++ b/test/unit/prepare-handler-tests.js
@@ -90,7 +90,7 @@ describe('PrepareHandler', function () {
       ];
       PrepareHandler.prepareAllQueries(host, preparedInfoArray, function (err) {
         assert.ifError(err);
-        assert.strictEqual(host.changeKeyspaceCalled, 3);
+        assert.deepStrictEqual(host.connectionKeyspace, [ 'system', 'system_schema', 'userks', null ]);
         assert.strictEqual(host.prepareCalled, 5);
         done();
       });
@@ -100,7 +100,7 @@ describe('PrepareHandler', function () {
     });
     it('should callback in error when there is an error borrowing a connection', function (done) {
       const host = helper.getHostsMock([ {} ])[0];
-      host.borrowConnection = function (c, cb) {
+      host.borrowConnection = function (ks, c, cb) {
         cb(new Error('Test error'));
       };
       PrepareHandler.prepareAllQueries(host, [{ query: 'query1' }], function (err) {
@@ -123,7 +123,7 @@ describe('PrepareHandler', function () {
       ];
       PrepareHandler.prepareAllQueries(host, preparedInfoArray, function (err) {
         helper.assertInstanceOf(err, Error);
-        assert.strictEqual(host.changeKeyspaceCalled, 1);
+        assert.deepStrictEqual(host.connectionKeyspace, ['system']);
         assert.strictEqual(host.prepareCalled, 2);
         done();
       });


### PR DESCRIPTION
https://datastax-oss.atlassian.net/browse/NODEJS-474

Use a different connection from the pool (if possible) when retrying on the same host.
It contains a minor improvement to include the host address for `OperationTimedOutError`.