### PR TITLE
Update dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ cache:
   directories:
     - node_modules
 script:
+  - npm install npm -g
   - npm install -g eslint@4; npm run eslint;
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ sudo: false
 cache:
   directories:
     - node_modules
-script:
+before_install:
   - npm install npm -g
+script:
   - npm install -g eslint@4; npm run eslint;
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ sudo: false
 cache:
   directories:
     - node_modules
-before_install:
-  - npm install npm -g
 script:
   - npm install -g eslint@4; npm run eslint;
   - npm test

--- a/build.yaml
+++ b/build.yaml
@@ -46,9 +46,9 @@ build:
       multi=mocha-jenkins-reporter=-
       SIMULACRON_PATH=$HOME/simulacron.jar
       TEST_TRACE=on
+  - npm: install
   - npm: install mocha-jenkins-reporter@0
   - npm: install mocha-multi@0
-  - npm: install
   - npm: run-script ci
     graceful: true
   - script: |

--- a/build.yaml
+++ b/build.yaml
@@ -46,7 +46,8 @@ build:
       multi=mocha-jenkins-reporter=-
       SIMULACRON_PATH=$HOME/simulacron.jar
       TEST_TRACE=on
-  - npm: install npm -g
+  - npm: install mocha-jenkins-reporter@0
+  - npm: install mocha-multi@0
   - npm: install
   - npm: run-script ci
     graceful: true

--- a/build.yaml
+++ b/build.yaml
@@ -46,6 +46,7 @@ build:
       multi=mocha-jenkins-reporter=-
       SIMULACRON_PATH=$HOME/simulacron.jar
       TEST_TRACE=on
+  - npm: install npm -g
   - npm: install
   - npm: run-script ci
     graceful: true

--- a/build.yaml
+++ b/build.yaml
@@ -48,8 +48,7 @@ build:
       TEST_TRACE=on
   - npm: install
   - npm: install mocha-jenkins-reporter@0
-  - npm: install mocha-multi@0
-  - npm: run-script ci
+  - npm: run ci_jenkins
     graceful: true
   - script: |
       cd examples

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -1,10 +1,10 @@
 environment:
   appveyor_build_worker_cloud: gce
-  ci_type: ci_unit
+  ci_type: ci_unit_appveyor
   matrix:
     - nodejs_version: 8
       TEST_CASSANDRA_VERSION: 3.11.2
-      ci_type: ci
+      ci_type: ci_appveyor
     - nodejs_version: 10
     - nodejs_version: 6 
     - nodejs_version: 4
@@ -16,7 +16,6 @@ install:
   - ps: .\ci\appveyor.ps1
   - npm install
   - npm install mocha-appveyor-reporter@0
-  - npm install mocha-multi@0
 build: off
 test_script:
   - "npm run %ci_type%"

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -14,7 +14,8 @@ platform:
 install:
   - ps: .\ci\hardwareinfo.ps1
   - ps: .\ci\appveyor.ps1
-  - npm install npm -g
+  - npm install mocha-appveyor-reporter@0
+  - npm install mocha-multi@0
   - npm install
 build: off
 test_script:

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -14,6 +14,7 @@ platform:
 install:
   - ps: .\ci\hardwareinfo.ps1
   - ps: .\ci\appveyor.ps1
+  - npm install npm -g
   - npm install
 build: off
 test_script:

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -14,9 +14,9 @@ platform:
 install:
   - ps: .\ci\hardwareinfo.ps1
   - ps: .\ci\appveyor.ps1
+  - npm install
   - npm install mocha-appveyor-reporter@0
   - npm install mocha-multi@0
-  - npm install
 build: off
 test_script:
   - "npm run %ci_type%"

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha test/unit -R spec -t 5000",
-    "ci": "./node_modules/.bin/mocha test/unit test/integration/short -R mocha-multi",
-    "ci_unit": "./node_modules/.bin/mocha test/unit -R mocha-multi",
+    "ci_jenkins": "./node_modules/.bin/mocha test/unit test/integration/short -R mocha-jenkins-reporter",
+    "ci_appveyor": "./node_modules/.bin/mocha test/unit test/integration/short -R mocha-appveyor-reporter",
+    "ci_unit_appveyor": "./node_modules/.bin/mocha test/unit -R mocha-appveyor-reporter",
     "eslint": "eslint lib test --ignore-pattern '/lib/types/integer.js'"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "rewire": "^4.0.1",
     "mocha-jenkins-reporter": "^0.4.1",
     "mocha-appveyor-reporter": "^0.4.1",
-    "mocha-multi": "~1.0.1"
+    "mocha-multi": "~0.11.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,26 +19,26 @@
     "long": "^2.2.0"
   },
   "devDependencies": {
-    "mocha": "~2.5.3",
-    "rewire": ">= 2.1.0",
-    "mocha-jenkins-reporter": ">= 0.1.9",
-    "mocha-appveyor-reporter": ">= 0.2.1",
-    "mocha-multi": "~0.11.0"
+    "mocha": "~5.2.0",
+    "rewire": "^4.0.1",
+    "mocha-jenkins-reporter": "^0.4.1",
+    "mocha-appveyor-reporter": "^0.4.1",
+    "mocha-multi": "~1.0.1"
   },
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/datastax/nodejs-driver.git"
+    "type": "git",
+    "url": "https://github.com/datastax/nodejs-driver.git"
   },
   "bugs": {
     "url": "https://groups.google.com/a/lists.datastax.com/forum/#!forum/nodejs-driver-user"
   },
-  "scripts":  {
+  "scripts": {
     "test": "./node_modules/.bin/mocha test/unit -R spec -t 5000",
     "ci": "./node_modules/.bin/mocha test/unit test/integration/short -R mocha-multi",
     "ci_unit": "./node_modules/.bin/mocha test/unit -R mocha-multi",
     "eslint": "eslint lib test --ignore-pattern '/lib/types/integer.js'"
   },
   "engines": {
-    "node" : ">=4"
-   }
+    "node": ">=4"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha test/unit -R spec -t 5000",
-    "ci_jenkins": "./node_modules/.bin/mocha test/unit test/integration/short -R mocha-jenkins-reporter",
-    "ci_appveyor": "./node_modules/.bin/mocha test/unit test/integration/short -R mocha-appveyor-reporter",
-    "ci_unit_appveyor": "./node_modules/.bin/mocha test/unit -R mocha-appveyor-reporter",
+    "ci_jenkins": "./node_modules/.bin/mocha test/unit test/integration/short -R mocha-jenkins-reporter --exit",
+    "ci_appveyor": "./node_modules/.bin/mocha test/unit test/integration/short -R mocha-appveyor-reporter --exit",
+    "ci_unit_appveyor": "./node_modules/.bin/mocha test/unit -R mocha-appveyor-reporter --exit",
     "eslint": "eslint lib test --ignore-pattern '/lib/types/integer.js'"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -20,10 +20,7 @@
   },
   "devDependencies": {
     "mocha": "~5.2.0",
-    "rewire": "^4.0.1",
-    "mocha-jenkins-reporter": "^0.4.1",
-    "mocha-appveyor-reporter": "^0.4.1",
-    "mocha-multi": "~0.11.1"
+    "rewire": "^4.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Addressed all vulnerabilities reported by `npm audit`.

~~In the future, FWIW~~ I think we should only include the minimal amount of dev dependencies to allow any user to run `npm test`, avoiding pushing dependencies (and possible vulnerabilities) downstream for packages that are only used in CI environments (i.e., as our dev dependencies are installed on users' test environments).

UPDATE
I've ended up removing `mocha-multi` because of the lack of support of Node.js 4 and requiring older versions of `mocha`.
TLDR, CI scripts are responsible to install their own reporters.