### PR TITLE
Bring back custom utils.extend() function

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -116,6 +116,30 @@ function totalLength (arr) {
 }
 
 /**
+ * Merge the contents of two or more objects together into the first object. Similar to jQuery.extend / Object.assign.
+ * The main difference between this method is that declared properties with an <code>undefined</code> value are not set
+ * to the target.
+ */
+function extend(target) {
+  const sources = Array.prototype.slice.call(arguments, 1);
+  sources.forEach(function (source) {
+    if (!source) {
+      return;
+    }
+    const keys = Object.keys(source);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      const value = source[key];
+      if (value === undefined) {
+        continue;
+      }
+      target[key] = value;
+    }
+  });
+  return target;
+}
+
+/**
  * Returns a new object with the property names set to lowercase.
  */
 function toLowerCaseProperties(obj) {
@@ -865,7 +889,7 @@ exports.eachSeries = eachSeries;
 exports.emptyArray = Object.freeze([]);
 /** @const */
 exports.emptyObject = emptyObject;
-exports.extend = Object.assign;
+exports.extend = extend;
 exports.fixStack = fixStack;
 exports.forEachOf = forEachOf;
 exports.funcCompare = funcCompare;


### PR DESCRIPTION
As part of #288, I've replaced `utils.extend()` implementation with `Object.assign()` unintentionally causing behavioural changes as `Object.assign()` replaces `undefined` values. This patch reverts it.