### PR TITLE
Deprecate parameter in DCAwareRoundRobinPolicy and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # ChangeLog - DataStax Node.js Driver
 
+## 3.6.0
+
+2018-12-04
+
+### Features
+
+- [NODEJS-442] - Parse Virtual Keyspace Metadata
+- [NODEJS-443] - Provide a means of sending query to a specific node to facilitate virtual table queries
+- [NODEJS-459] - Support for Virtual Tables/System views
+- [NODEJS-487] - Deprecate DCAwareRoundRobinPolicy parameter for inter-DC failover
+
+### Bug fixes
+
+- [NODEJS-465] - Table metadata fetch fails when using ES2015 Set and C* 3.0+
+- [NODEJS-472] - Connections attempts are made when a new node is bootstrapped even if its marked as "ignored"
+- [NODEJS-474] - Retry on current host should be made on a different connection
+
 ## 3.5.0
 
 2018-04-17

--- a/docs.yaml
+++ b/docs.yaml
@@ -34,8 +34,10 @@ links:
   - title: Npm
     href:  https://www.npmjs.org/package/cassandra-driver
 versions:
+  - name: '3.6'
+    ref: '3.6'
   - name: '3.5'
-    ref: 'master'
+    ref: '3.5'
   - name: '3.4'
     ref: '3.4'
   - name: '3.3'

--- a/lib/policies/load-balancing.js
+++ b/lib/policies/load-balancing.js
@@ -100,8 +100,12 @@ RoundRobinPolicy.prototype.newQueryPlan = function (keyspace, queryOptions, call
  * host in a remote data center will be queried unless no host in the local
  * data center can be reached.
  * @param {?String} [localDc] local datacenter name.
- * @param {Number} [usedHostsPerRemoteDc] the number of host per remote datacenter that the policy will yield \
- * in a newQueryPlan after the local nodes.
+ * @param {Number} [usedHostsPerRemoteDc] Deprecated: the number of host per remote datacenter that the policy will
+ * yield in a newQueryPlan after the local nodes.
+ * <p>
+ *   Note that this parameter is deprecated and will be removed in the next major version. Handling data center
+ *   outages is better suited at a service level rather than within an application client.
+ * </p>
  * @extends {LoadBalancingPolicy}
  * @constructor
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cassandra-driver",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "DataStax Node.js Driver for Apache Cassandra",
   "author": "DataStax",
   "keywords": [


### PR DESCRIPTION
https://datastax-oss.atlassian.net/browse/NODEJS-487

Note that jsdoc only provides means to deprecate an entire symbol, so the parameter is deprecated using a jsdoc comment.