### PR TITLE
Fix performance regression in 4.x

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -60,8 +60,6 @@ function Connection(endpoint, protocolVersion, options) {
   this.timedOutOperations = 0;
   this._streamIds = new StreamIdStack(this.protocolVersion);
   this._metrics = options.metrics;
-  this._streamIds.on('inFlightIncrease', () => this.emit('inFlightIncrease'));
-  this._streamIds.on('inFlightDecrease', n => this.emit('inFlightDecrease', n));
 
   this.encoder = new Encoder(protocolVersion, options);
   this.keyspace = null;

--- a/lib/host-connection-pool.js
+++ b/lib/host-connection-pool.js
@@ -49,7 +49,6 @@ class HostConnectionPool extends events.EventEmitter {
     this._newConnectionTimeout = null;
     this._creating = false;
     this._state = state.initial;
-    this.inFlight = 0;
     this.responseCounter = 0;
     this.options = host.options;
     this.protocolVersion = protocolVersion;
@@ -76,6 +75,19 @@ class HostConnectionPool extends events.EventEmitter {
 
       this.borrowConnection(keyspace, null, callback);
     });
+  }
+
+  getInFlight() {
+    const length = this.connections.length;
+    if (length === 1) {
+      return this.connections[0].getInFlight();
+    }
+
+    let sum = 0;
+    for (let i = 0; i < length; i++) {
+      sum += this.connections[i].getInFlight();
+    }
+    return sum;
   }
 
   /**
@@ -215,8 +227,6 @@ class HostConnectionPool extends events.EventEmitter {
   /** @returns {Connection} */
   _createConnection() {
     const c = new Connection(this._address, this.protocolVersion, this.options);
-    c.on('inFlightIncrease', () => this.inFlight++);
-    c.on('inFlightDecrease', n => this.inFlight -= n);
     c.on('responseDequeued', () => this.responseCounter++);
 
     const self = this;

--- a/lib/host.js
+++ b/lib/host.js
@@ -329,7 +329,7 @@ Host.prototype.removeFromPool = function (connection) {
  * @ignore
  */
 Host.prototype.getInFlight = function () {
-  return this.pool.inFlight;
+  return this.pool.getInFlight();
 };
 
 /**

--- a/lib/request-execution.js
+++ b/lib/request-execution.js
@@ -110,9 +110,6 @@ class RequestExecution {
 
         this._trackResponse(process.hrtime(this._startTime), errorCode, err, length);
 
-        // Clear reference
-        this._startTime = null;
-
         if (this._cancelled) {
           // Avoid handling the response / err
           return;

--- a/lib/request-execution.js
+++ b/lib/request-execution.js
@@ -38,6 +38,7 @@ const errorCodes = {
 };
 
 const metricsHandlers = new Map([
+  [ errorCodes.none, (metrics, err, latency) => metrics.onSuccessfulResponse(latency) ],
   [ errorCodes.socketError, (metrics, err) => metrics.onConnectionError(err) ],
   [ errorCodes.clientTimeout, (metrics, err) => metrics.onClientTimeoutError(err) ],
   [ errorCodes.serverErrorOverloaded, (metrics, err) => metrics.onOtherError(err) ],
@@ -176,19 +177,12 @@ class RequestExecution {
    * @private
    */
   static _invokeMetricsHandler(errorCode, metrics, err, latency) {
-    if (errorCode === errorCodes.none) {
-      // Optimize hot path
-      metrics.onSuccessfulResponse(latency);
-      metrics.onResponse(latency);
-      return;
-    }
-
     const handler = metricsHandlers.get(errorCode);
     if (handler !== undefined) {
       handler(metrics, err, latency);
     }
 
-    if (err instanceof errors.ResponseError) {
+    if (!err || err instanceof errors.ResponseError) {
       metrics.onResponse(latency);
     }
   }

--- a/lib/request-execution.js
+++ b/lib/request-execution.js
@@ -38,7 +38,6 @@ const errorCodes = {
 };
 
 const metricsHandlers = new Map([
-  [ errorCodes.none, (metrics, err, latency) => metrics.onSuccessfulResponse(latency) ],
   [ errorCodes.socketError, (metrics, err) => metrics.onConnectionError(err) ],
   [ errorCodes.clientTimeout, (metrics, err) => metrics.onClientTimeoutError(err) ],
   [ errorCodes.serverErrorOverloaded, (metrics, err) => metrics.onOtherError(err) ],
@@ -69,6 +68,7 @@ class RequestExecution {
     this._operation = null;
     this._host = null;
     this._cancelled = false;
+    this._startTime = null;
     this._retryCount = 0;
     // The streamId information is not included in the request.
     // A pointer to the parent request can be used, except when changing the consistency level from the retry policy
@@ -102,49 +102,53 @@ class RequestExecution {
   }
 
   _sendOnConnection() {
-    const self = this;
-    const startTime = process.hrtime();
+    this._startTime = process.hrtime();
+
     this._operation =
-      this._connection.sendStream(this._request, this._parent.executionOptions, function rCb(err, response, length) {
+      this._connection.sendStream(this._request, this._parent.executionOptions, (err, response, length) => {
         const errorCode = RequestExecution._getErrorCode(err);
-        self._trackResponse(startTime, errorCode, err, length);
-        if (self._cancelled) {
+
+        this._trackResponse(process.hrtime(this._startTime), errorCode, err, length);
+
+        // Clear reference
+        this._startTime = null;
+
+        if (this._cancelled) {
           // Avoid handling the response / err
           return;
         }
 
-        if (err) {
-          return self._handleError(errorCode, err);
+        if (errorCode !== errorCodes.none) {
+          return this._handleError(errorCode, err);
         }
 
         if (response.schemaChange) {
-          return self._parent.client.handleSchemaAgreementAndRefresh(
-            self._connection, response.schemaChange, function schemaCb(agreement){
-              if (self._cancelled) {
+          return this._parent.client.handleSchemaAgreementAndRefresh(
+            this._connection, response.schemaChange, (agreement) => {
+              if (this._cancelled) {
                 // After the schema agreement method was started, this execution was cancelled
                 return;
               }
 
-              self._parent.setCompleted(null, self._getResultSet(response, agreement));
+              this._parent.setCompleted(null, this._getResultSet(response, agreement));
             });
         }
 
         if (response.keyspaceSet) {
-          self._parent.client.keyspace = response.keyspaceSet;
+          this._parent.client.keyspace = response.keyspaceSet;
         }
 
-        self._parent.setCompleted(null, self._getResultSet(response));
+        this._parent.setCompleted(null, this._getResultSet(response));
       });
   }
 
-  _trackResponse(startTime, errorCode, err, length) {
-    const latency = process.hrtime(startTime);
-
+  _trackResponse(latency, errorCode, err, length) {
     // Record metrics
     RequestExecution._invokeMetricsHandler(errorCode, this._parent.client.metrics, err, latency);
 
     // Request tracker
     const tracker = this._parent.client.options.requestTracker;
+
     if (tracker === null) {
       return;
     }
@@ -175,14 +179,20 @@ class RequestExecution {
    * @private
    */
   static _invokeMetricsHandler(errorCode, metrics, err, latency) {
-    const handler = metricsHandlers.get(errorCode);
-
-    if (!err || err instanceof errors.ResponseError) {
+    if (errorCode === errorCodes.none) {
+      // Optimize hot path
+      metrics.onSuccessfulResponse(latency);
       metrics.onResponse(latency);
+      return;
     }
 
+    const handler = metricsHandlers.get(errorCode);
     if (handler !== undefined) {
       handler(metrics, err, latency);
+    }
+
+    if (err instanceof errors.ResponseError) {
+      metrics.onResponse(latency);
     }
   }
 

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -213,16 +213,22 @@ class RequestHandler {
     if (this._newExecutionTimeout !== null) {
       clearTimeout(this._newExecutionTimeout);
     }
+
     // Mark all executions as cancelled
     for (let i = 0; i < this._executions.length; i++) {
       this._executions[i].cancel();
     }
+
     if (err) {
       if (this.executionOptions.getCaptureStackTrace()) {
         utils.fixStack(this.stackContainer.stack, err);
       }
-      return this._callback(err);
+
+      // The error already has the stack information, there is no value in maintaining the call stack
+      // for the callback invocation
+      return process.nextTick(() => this._callback(err));
     }
+
     if (result.info.warnings) {
       // Log the warnings from the response
       result.info.warnings.forEach(function (message, i, warnings) {
@@ -235,6 +241,13 @@ class RequestHandler {
       }, this);
     }
 
+    // Invoke the callback in the next tick allowing stack unwinding, that way we can continue
+    // processing the read queue before executing user code.
+    // Additionally, we prevent the optimizing compiler to optimize read and write functions together.
+    // FFR: We found corner cases where maintaining the call stack when invoking the user callback impacted the overall
+    // performance of the driver. These corner cases appeared when adding more logic to the completion of the
+    // request/response operation, that by itself had a negligible processing cost, but had a significant
+    // performance penalty when integrated.
     process.nextTick(() => this._callback(null, result));
   }
 

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -234,7 +234,8 @@ class RequestHandler {
           this.request.query || 'batch'));
       }, this);
     }
-    this._callback(null, result);
+
+    process.nextTick(() => this._callback(null, result));
   }
 
   /**

--- a/lib/stream-id-stack.js
+++ b/lib/stream-id-stack.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const events = require('events');
 const types = require('./types');
 
 /**
@@ -44,14 +43,13 @@ let releaseDelay = 5000;
  * Clients can dequeue a stream id using {@link StreamIdStack#shift()} and enqueue (release) using
  * {@link StreamIdStack#push()}
  */
-class StreamIdStack extends events.EventEmitter {
+class StreamIdStack {
   /**
    * Creates a new instance of StreamIdStack.
    * @param {Number} version Protocol version
    * @constructor
    */
   constructor(version) {
-    super();
     //Ecmascript Number is 64-bit double, it can be optimized by the engine into a 32-bit int, but nothing below that.
     //We try to allocate as few as possible in arrays of 128
     this.currentGroup = generateGroup(0);
@@ -81,41 +79,40 @@ class StreamIdStack extends events.EventEmitter {
    * @returns {Number} Returns an id or null
    */
   pop() {
-    let id = this._tryPopFromGroup();
-    if (id !== undefined){
+    let id = this.currentGroup.pop();
+    if (typeof id !== 'undefined') {
+      this.inUse++;
       return id;
     }
-
     //try to use the following groups
     while (this.groupIndex < this.groups.length - 1) {
       //move to the following group
       this.currentGroup = this.groups[++this.groupIndex];
       //try dequeue
-      id = this._tryPopFromGroup();
-      if (id !== undefined) {
+      id = this.currentGroup.pop();
+      if (typeof id !== 'undefined') {
+        this.inUse++;
         return id;
       }
     }
-
     return this._tryCreateGroup();
   }
 
   /**
-   * Enqueues an id for future use.
+   * Enqueue an id for future use.
    * Similar to {@link Array#push()}.
    * @param {Number} id
    */
   push(id) {
+    this.inUse--;
     const groupIndex = id >> shiftToGroup;
     const group = this.groups[groupIndex];
-    this._pushToGroup(id, group);
-
+    group.push(id);
     if (groupIndex < this.groupIndex) {
       //Set the lower group to be used to dequeue from
       this.groupIndex = groupIndex;
       this.currentGroup = group;
     }
-
     this._tryIssueRelease();
   }
 
@@ -127,33 +124,6 @@ class StreamIdStack extends events.EventEmitter {
       clearTimeout(this.releaseTimeout);
       this.releaseTimeout = null;
     }
-
-    if (this.inUse > 0) {
-      this.emit('inFlightDecrease', this.inUse);
-      this.inUse = 0;
-    }
-  }
-
-  _pushToGroup(id, group) {
-    group.push(id);
-    this.inUse--;
-    this.emit('inFlightDecrease', 1);
-  }
-
-  /**
-   * Tries to pop an id from the current group.
-   * @return {Number|undefined}
-   * @private
-   */
-  _tryPopFromGroup() {
-    const id = this.currentGroup.pop();
-    if (id === undefined) {
-      return undefined;
-    }
-
-    this.inUse++;
-    this.emit('inFlightIncrease');
-    return id;
   }
 
   /**
@@ -171,7 +141,8 @@ class StreamIdStack extends events.EventEmitter {
     //Using 128 * groupIndex as initial value
     this.currentGroup = generateGroup(this.groupIndex << shiftToGroup);
     this.groups.push(this.currentGroup);
-    return this._tryPopFromGroup();
+    this.inUse++;
+    return this.currentGroup.pop();
   }
 
   _tryIssueRelease() {

--- a/test/unit/stream-id-stack-tests.js
+++ b/test/unit/stream-id-stack-tests.js
@@ -68,15 +68,8 @@ describe('StreamIdStack', function () {
     //6 groups,
     const length = 128 * 5 + 2;
 
-    // Verify that the events are emitted
-    let inFlight = 0;
-    stack.on('inFlightIncrease', () => inFlight++);
-    stack.on('inFlightDecrease', n => inFlight -= n);
-
     pop(stack, length);
-
     assert.strictEqual(stack.inUse, length);
-    assert.strictEqual(inFlight, length);
 
     // return just 1 to the last group
     stack.push(128 * 5);
@@ -88,15 +81,12 @@ describe('StreamIdStack', function () {
     // push 10 more
     push(stack, 0, 10);
 
-    assert.strictEqual(stack.inUse, inFlight);
-
     assert.strictEqual(stack.groups.length, 6);
     setTimeout(function () {
       //there should be 5 groups now
       assert.strictEqual(stack.groups.length, 5);
 
       assert.strictEqual(stack.inUse, length - 12);
-      assert.strictEqual(inFlight, length - 12);
 
       stack.clear();
       done();
@@ -105,10 +95,6 @@ describe('StreamIdStack', function () {
   it('should not release the current group', function (done) {
     const releaseDelay = 100;
     const stack = newInstance(3, releaseDelay);
-
-    let inFlight = 0;
-    stack.on('inFlightIncrease', () => inFlight++);
-    stack.on('inFlightDecrease', n => inFlight -= n);
 
     //6 groups,
     pop(stack, 128 * 5 + 2);
@@ -121,7 +107,6 @@ describe('StreamIdStack', function () {
     setTimeout(function () {
       //there should be 5 groups now
       assert.strictEqual(stack.groups.length, 6);
-      assert.strictEqual(stack.inUse, inFlight);
       stack.clear();
       done();
     }, releaseDelay + osPrecision);


### PR DESCRIPTION
- Invoke the user callback in the next tick to allow stack unwinding.
- Revert changes in `StreamIdStack` #301. The host in-flight count is now the sum of all the `inUse` streamId in all connections.

With this change, performance seems up to par with 3.6.0:

### Write throughput
![boxplot-write-throughput](https://user-images.githubusercontent.com/2931196/49653687-0262af80-fa36-11e8-971c-c4f464a07d2e.png)

### Read throughput
![boxplot-read-throughput](https://user-images.githubusercontent.com/2931196/49653685-0262af80-fa36-11e8-9284-e5c490fbfe57.png)