### PR TITLE
Test fixes

### DIFF
--- a/test/integration/short/client-pool-tests.js
+++ b/test/integration/short/client-pool-tests.js
@@ -831,64 +831,6 @@ describe('Client', function () {
         }
       ], done);
     });
-    it('should connect when first contact point is down', function (done) {
-      utils.series([
-        helper.toTask(helper.ccmHelper.exec, null, ['node1', 'stop']),
-        function (next) {
-          const client = newInstance({ contactPoints: ['127.0.0.1', '127.0.0.2'], pooling: { warmup: true } });
-          client.connect(function (err) {
-            assert.ifError(err);
-            client.shutdown(next);
-          });
-        }
-      ], done);
-    });
-    it('should reconnect in the background', function (done) {
-      const reconnectionDelay = 500;
-      const client = newInstance({
-        pooling: { heartBeatInterval: 0, warmup: true },
-        policies: { reconnection: new policies.reconnection.ConstantReconnectionPolicy(reconnectionDelay) }
-      });
-      utils.series([
-        client.connect.bind(client),
-        function (next) {
-          const hosts = client.hosts.values();
-          assert.strictEqual('1', helper.lastOctetOf(client.controlConnection.host));
-          assert.strictEqual(3, hosts.length);
-          hosts.forEach(function (h) {
-            assert.ok(h.pool.connections.length > 0, 'with warmup = true, it should create the core connections');
-          });
-          next();
-        },
-        helper.toTask(helper.ccmHelper.stopNode, null, 1),
-        helper.toTask(helper.ccmHelper.stopNode, null, 2),
-        helper.toTask(helper.ccmHelper.stopNode, null, 3),
-        function tryToQuery(next) {
-          utils.timesSeries(20, function (n, timesNext) {
-            client.execute(helper.queries.basic, function (err) {
-              //it should fail
-              helper.assertInstanceOf(err, errors.NoHostAvailableError);
-              if (n % 5 === 0) {
-                //wait for failed reconnection attempts to happen
-                return setTimeout(timesNext, 1500);
-              }
-              timesNext();
-            });
-          }, next);
-        },
-        helper.toTask(helper.ccmHelper.startNode, null, 3),
-        helper.waitOnHostUp(client, 3),
-        helper.delay(reconnectionDelay * 2),
-        function assertReconnected(next) {
-          assert.strictEqual('3', helper.lastOctetOf(client.controlConnection.host));
-          client.hosts.forEach(function (host) {
-            assert.strictEqual(host.isUp(), helper.lastOctetOf(host) === '3');
-          });
-          next();
-        },
-        client.shutdown.bind(client)
-      ], done);
-    });
   });
   describe('#shutdown()', function () {
     before(helper.ccmHelper.start(2));

--- a/test/integration/short/control-connection-simulator-tests.js
+++ b/test/integration/short/control-connection-simulator-tests.js
@@ -31,10 +31,16 @@ describe('ControlConnection', function() {
   });
 
   describe('#getLocalAddress()', () => {
+    const simulacronCluster = new simulacron.SimulacronCluster();
+
+    before(done => simulacronCluster.register([5], null, done));
+
+    after(done => simulacronCluster.unregister(done));
+
     it('should retrieve the local ip address of the host', () => {
       const client = new Client({ contactPoints: [simulacron.startingIp], localDataCenter: 'dc1'});
 
-      client.connect()
+      return client.connect()
         .then(() => {
           const cc = client.controlConnection;
           assert.strictEqual(typeof cc.getLocalAddress(), 'string');

--- a/test/integration/short/metadata-tests.js
+++ b/test/integration/short/metadata-tests.js
@@ -252,9 +252,13 @@ describe('metadata', function () {
               assert.strictEqual(udtInfo.fields[2].type.code, types.dataTypes.int);
               assert.strictEqual(udtInfo.fields[3].name, 'second_number');
               assert.strictEqual(udtInfo.fields[3].type.code, types.dataTypes.custom);
-              assert.strictEqual(udtInfo.fields[3].type.info, 'org.apache.cassandra.db.marshal.DynamicCompositeType('
-                + 's=>org.apache.cassandra.db.marshal.UTF8Type,'
-                + 'i=>org.apache.cassandra.db.marshal.Int32Type)');
+
+              const customTypeInfo = udtInfo.fields[3].type.info;
+              helper.assertContains(customTypeInfo, 's=>org.apache.cassandra.db.marshal.UTF8Type');
+              helper.assertContains(customTypeInfo, 'i=>org.apache.cassandra.db.marshal.Int32Type');
+              assert.strictEqual(customTypeInfo.startsWith(
+                'org.apache.cassandra.db.marshal.DynamicCompositeType('), true);
+
               next();
             });
           },
@@ -899,9 +903,12 @@ describe('metadata', function () {
               assert.ok(dynamicColumn);
               assert.strictEqual(dynamicColumn.name, 'c1');
               assert.strictEqual(dynamicColumn.type.code, types.dataTypes.custom);
-              assert.strictEqual(dynamicColumn.type.info, 'org.apache.cassandra.db.marshal.DynamicCompositeType('
-                + 's=>org.apache.cassandra.db.marshal.UTF8Type,'
-                + 'i=>org.apache.cassandra.db.marshal.Int32Type)');
+
+              const typeInfo = dynamicColumn.type.info;
+
+              helper.assertContains(typeInfo, 's=>org.apache.cassandra.db.marshal.UTF8Type');
+              helper.assertContains(typeInfo, 'i=>org.apache.cassandra.db.marshal.Int32Type');
+              assert.strictEqual(typeInfo.startsWith('org.apache.cassandra.db.marshal.DynamicCompositeType('), true);
 
               const reversedColumn = table.clusteringKeys[1];
               assert.ok(reversedColumn);


### PR DESCRIPTION
I've included fixes for integration tests that we see failing often and for tests that are likely to be affected by upcoming versions of C* and DSE.

I've replaced two pool tests that were originally using 3-node ccm clusters with simulacron-based tests.

Also, I've replaced brittle tests that were using query traces to assert the correct replicas with fixed key-to-replicas maps (based on the default tokens and partitioner).