### PR TITLE
Defer use of host map until metadata retrieval

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -435,7 +435,6 @@ Connection.prototype.changeKeyspace = function (keyspace, callback) {
 /**
  * Prepares a query on a given connection. If its already being prepared, it queues the callback.
  * @param {String} query
- * @param {String} keyspace
  * @param {function} callback
  */
 Connection.prototype.prepareOnce = function (query, callback) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -30,14 +30,34 @@ let net = require('net');
 function Connection(endpoint, protocolVersion, options) {
   events.EventEmitter.call(this);
   this.setMaxListeners(0);
-  if (!endpoint || endpoint.indexOf(':') < 0) {
+
+  if (!options) {
+    throw new Error('options is not defined');
+  }
+
+  /**
+   * Gets the ip and port of the server endpoint.
+   * @type {String}
+   */
+  this.endpoint = endpoint;
+
+  /**
+   * Gets the friendly name of the host, used to identify the connection in log messages.
+   * With direct connect, this is the address and port.
+   * @type {String}
+   */
+  this.endpointFriendlyName = endpoint;
+
+  if (!this.endpoint || this.endpoint.indexOf(':') < 0) {
     throw new Error('EndPoint must contain the ip address and port separated by : symbol');
   }
-  this.endpoint = endpoint;
-  const portSeparatorIndex = endpoint.lastIndexOf(':');
-  this.address = endpoint.substr(0, portSeparatorIndex);
-  this.port = endpoint.substr(portSeparatorIndex + 1);
+
+  const portSeparatorIndex = this.endpoint.lastIndexOf(':');
+  this.address = this.endpoint.substr(0, portSeparatorIndex);
+  this.port = this.endpoint.substr(portSeparatorIndex + 1);
+
   Object.defineProperty(this, "options", { value: options, enumerable: false, writable: false});
+
   if (protocolVersion === null) {
     // Set initial protocol version
     protocolVersion = types.protocolVersion.maxSupported;
@@ -48,11 +68,13 @@ function Connection(endpoint, protocolVersion, options) {
     // Allow to check version using this connection instance
     this._checkingVersion = true;
   }
+
   this.protocolVersion = protocolVersion;
   /** @type {Object.<String, OperationState>} */
   this._operations = {};
   this._pendingWrites = [];
   this._preparing = {};
+
   /**
    * The timeout state for the idle request (heartbeat)
    */
@@ -88,15 +110,14 @@ Connection.prototype.bindSocketListeners = function() {
   this.netClient.removeAllListeners('timeout');
   // The socket is expected to be open at this point
   this.isSocketOpen = true;
-  const self = this;
-  this.netClient.on('close', function() {
-    self.log('info', 'Connection to ' + self.endpoint + ' closed');
-    self.isSocketOpen = false;
-    const wasConnected = self.connected;
-    self.close();
+  this.netClient.on('close', () => {
+    this.log('info', `Connection to ${this.endpointFriendlyName} closed`);
+    this.isSocketOpen = false;
+    const wasConnected = this.connected;
+    this.close();
     if (wasConnected) {
       // Emit only when it was closed unexpectedly
-      self.emit('socketClose');
+      this.emit('socketClose');
     }
   });
 
@@ -122,38 +143,45 @@ Connection.prototype.bindSocketListeners = function() {
  */
 Connection.prototype.open = function (callback) {
   const self = this;
-  this.log('info', 'Connecting to ' + this.address + ':' + this.port);
+  this.log('info', `Connecting to ${this.endpointFriendlyName}`);
+
   if (!this.options.sslOptions) {
     this.netClient = new net.Socket({ highWaterMark: this.options.socketOptions.coalescingThreshold });
     this.netClient.connect(this.port, this.address, function connectCallback() {
-      self.log('verbose', 'Socket connected to ' + self.address + ':' + self.port);
+      self.log('verbose', `Socket connected to ${self.endpointFriendlyName}`);
       self.bindSocketListeners();
       self.startup(callback);
     });
-  }
-  else {
-    //use TLS
-    const sslOptions = utils.extend({rejectUnauthorized: false}, this.options.sslOptions);
+  } else {
+    // Use TLS
+    const sslOptions = utils.extend({ rejectUnauthorized: false }, this.options.sslOptions);
+
     this.netClient = tls.connect(this.port, this.address, sslOptions, function tlsConnectCallback() {
-      self.log('verbose', 'Secure socket connected to ' + self.address + ':' + self.port);
+      self.log('verbose', `Secure socket connected to ${self.endpointFriendlyName}`);
       self.bindSocketListeners();
       self.startup(callback);
     });
+
     // TLSSocket will validate for values from 512 to 16K (depending on the SSL protocol version)
     this.netClient.setMaxSendFragment(this.options.socketOptions.coalescingThreshold);
   }
+
   this.netClient.once('error', function socketError(err) {
     self.errorConnecting(err, false, callback);
   });
+
   this.netClient.once('timeout', function connectTimedOut() {
     const err = new types.DriverError('Connection timeout');
     self.errorConnecting(err, true, callback);
   });
+
   this.netClient.setTimeout(this.options.socketOptions.connectTimeout);
+
   // Improve failure detection with TCP keep-alives
   if (this.options.socketOptions.keepAlive) {
     this.netClient.setKeepAlive(true, this.options.socketOptions.keepAliveDelay);
   }
+
   this.netClient.setNoDelay(!!this.options.socketOptions.tcpNoDelay);
 };
 
@@ -220,7 +248,7 @@ Connection.prototype.startup = function (callback) {
 };
 
 Connection.prototype.errorConnecting = function (err, destroy, callback) {
-  this.log('warning', 'There was an error when trying to connect to the host ' + this.address, err);
+  this.log('warning', `There was an error when trying to connect to the host ${this.endpointFriendlyName}`, err);
   if (destroy) {
     //there is a TCP connection that should be killed.
     this.netClient.destroy();
@@ -394,7 +422,7 @@ Connection.prototype.changeKeyspace = function (keyspace, callback) {
     null,
     function changeKeyspaceResponseCallback(err) {
       if (err) {
-        self.log('error', util.format('Connection to %s could not switch active keyspace', self.endpoint), err);
+        self.log('error', `Connection to ${self.endpointFriendlyName} could not switch active keyspace`, err);
       }
       else {
         self.keyspace = keyspace;
@@ -407,6 +435,7 @@ Connection.prototype.changeKeyspace = function (keyspace, callback) {
 /**
  * Prepares a query on a given connection. If its already being prepared, it queues the callback.
  * @param {String} query
+ * @param {String} keyspace
  * @param {function} callback
  */
 Connection.prototype.prepareOnce = function (query, callback) {
@@ -483,7 +512,7 @@ Connection.prototype._write = function (operation, streamId) {
       self._streamIds.push(streamId);
       return operation.setResult(err);
     }
-    self.log('verbose', 'Sent stream #' + streamId + ' to ' + self.endpoint);
+    self.log('verbose', 'Sent stream #' + streamId + ' to ' + self.endpointFriendlyName);
     if (operation.isByRow()) {
       self.parser.setOptions(streamId, { byRow: true });
     }
@@ -511,26 +540,24 @@ Connection.prototype._setIdleTimeout = function () {
  * Function that gets executed once the idle timeout has passed to issue a request to keep the connection alive
  */
 Connection.prototype._idleTimeoutHandler = function () {
-  const self = this;
   if (this.sendingIdleQuery) {
     //don't issue another
     //schedule for next time
-    this._idleTimeout = setTimeout(function () {
-      self._idleTimeoutHandler();
-    }, this.options.pooling.heartBeatInterval);
+    this._idleTimeout = setTimeout(() => this._idleTimeoutHandler(), this.options.pooling.heartBeatInterval);
     return;
   }
-  this.log('verbose', 'Connection idling, issuing a Request to prevent idle disconnects');
+
+  this.log('verbose', `Connection to ${this.endpointFriendlyName} idling, issuing a request to prevent disconnects`);
   this.sendingIdleQuery = true;
-  this.sendStream(requests.options, null, function (err) {
-    self.sendingIdleQuery = false;
+  this.sendStream(requests.options, null, (err) => {
+    this.sendingIdleQuery = false;
     if (!err) {
       //The sending succeeded
       //There is a valid response but we don't care about the response
       return;
     }
-    self.log('warning', 'Received heartbeat request error', err);
-    self.emit('idleRequestError', err, self);
+    this.log('warning', 'Received heartbeat request error', err);
+    this.emit('idleRequestError', err, this);
   });
 };
 
@@ -602,7 +629,7 @@ Connection.prototype.handleResult = function (header, err, result) {
   if (!operation) {
     return this.log('error', 'The server replied with a wrong streamId #' + streamId);
   }
-  this.log('verbose', 'Received frame #' + streamId + ' from ' + this.endpoint);
+  this.log('verbose', 'Received frame #' + streamId + ' from ' + this.endpointFriendlyName);
   operation.setResult(err, result, header.bodyLength);
 };
 
@@ -654,12 +681,13 @@ Connection.prototype.close = function (callback) {
   }
   // Set the socket as closed now (before socket.end() is called) to avoid being invoked more than once
   this.isSocketOpen = false;
-  this.log('verbose', 'Closing connection to ' + this.endpoint);
+  this.log('verbose', `Closing connection to ${this.endpointFriendlyName}`);
   const self = this;
 
   // If server doesn't acknowledge the half-close within connection timeout, destroy the socket.
   const endTimeout = setTimeout(() => {
-    this.log('info', this.endpoint + ' did not respond to connection close within ' + this.options.socketOptions.connectTimeout + 'ms, destroying connection');
+    this.log('info', `${this.endpointFriendlyName} did not respond to connection close within ` +
+      `${this.options.socketOptions.connectTimeout}ms, destroying connection`);
     this.netClient.destroy();
   }, this.options.socketOptions.connectTimeout);
 

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -725,6 +725,7 @@ ControlConnection.prototype.setLocalInfo = function (initializing, setCurrentHos
   if (initializing) {
     localHost = new Host(endpoint, this.protocolVersion, this.options, this.metadata);
     this.hosts.set(endpoint, localHost);
+    this.log('info', `Adding host ${endpoint}`);
   } else {
     localHost = this.hosts.get(endpoint);
 

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -729,6 +729,7 @@ ControlConnection.prototype.setLocalInfo = function (initializing, setCurrentHos
   localHost.datacenter = row['data_center'];
   localHost.rack = row['rack'];
   localHost.tokens = row['tokens'];
+  localHost.hostId = row['host_id'];
   localHost.cassandraVersion = row['release_version'];
   this.metadata.setPartitioner(row['partitioner']);
   this.log('info', 'Local info retrieved');
@@ -781,6 +782,7 @@ ControlConnection.prototype.setPeersInfo = function (initializing, err, result, 
       host.datacenter = row['data_center'];
       host.rack = row['rack'];
       host.tokens = row['tokens'];
+      host.hostId = row['host_id'];
       host.cassandraVersion = row['release_version'];
 
       if (host.datacenter) {

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -212,9 +212,11 @@ ControlConnection.prototype.setHealthListeners = function (host, connection) {
     }
 
     if (hostDown) {
-      self.log('warning', f('Host %s used by the ControlConnection DOWN', host.address));
+      self.log('warning',
+        `Host ${host.address} used by the ControlConnection DOWN, ` +
+        `connection to ${connection.endpointFriendlyName} will not longer by used`);
     } else {
-      self.log('warning', f('Connection to %s used by the ControlConnection was closed', host.address));
+      self.log('warning', `Connection to ${connection.endpointFriendlyName} used by the ControlConnection was closed`);
     }
 
     self.refresh();
@@ -514,7 +516,7 @@ ControlConnection.prototype.refresh = function (reuseQueryPlan, callback) {
       self.setHealthListeners(self.host, self.connection);
       self.reconnectionSchedule = self.reconnectionPolicy.newSchedule();
       self.emit('newConnection', null, self.connection, self.host);
-      self.log('info', f('ControlConnection connected to %s and up to date', self.host.address));
+      self.log('info', `ControlConnection connected to ${self.connection.endpointFriendlyName} and up to date`);
 
       return callback();
     }

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -8,6 +8,7 @@ const Host = require('./host').Host;
 const HostMap = require('./host').HostMap;
 const Metadata = require('./metadata');
 const EventDebouncer = require('./metadata/event-debouncer');
+const Connection = require('./connection');
 const requests = require('./requests');
 const utils = require('./utils');
 const types = require('./types');
@@ -32,7 +33,8 @@ const schemaChangeTypes = {
  * <p>It uses an existing connection from the hosts' connection pool to maintain the driver metadata up-to-date.</p>
  * @param {Object} options
  * @param {ProfileManager} profileManager
- * @param {{borrowHostConnection: function}} [context] An object containing methods to allow dependency injection.
+ * @param {{borrowHostConnection: function, createConnection: function}} [context] An object containing methods to
+ * allow dependency injection.
  * @extends EventEmitter
  * @constructor
  */
@@ -75,12 +77,84 @@ function ControlConnection(options, profileManager, context) {
   this.hostIterator = null;
   this.triedHosts = null;
   this._resolvedContactPoints = new Map();
+  this._contactPoints = new Set();
+
   if (context && context.borrowHostConnection) {
     this.borrowHostConnection = context.borrowHostConnection;
+  }
+
+  if (context && context.createConnection) {
+    this.createConnection = context.createConnection;
   }
 }
 
 util.inherits(ControlConnection, events.EventEmitter);
+
+/**
+ * Stores the contact point information and what it resolved to.
+ * @param {String|null} address
+ * @param {String} port
+ * @param {String} name
+ * @param {Boolean} isIPv6
+ */
+ControlConnection.prototype.addContactPoint = function(address, port, name, isIPv6) {
+  if (address === null) {
+    // Contact point could not be resolved, store that the resolution came back empty
+    this._resolvedContactPoints.set(name, utils.emptyArray);
+    return;
+  }
+
+  const portNumber = parseInt(port, 10) || this.options.protocolOptions.port;
+  const endpoint = `${address}:${portNumber}`;
+  this._contactPoints.add(endpoint);
+
+  // Use RFC 3986 for IPv4 and IPv6
+  const standardEndpoint = !isIPv6 ? endpoint : `[${address}]:${portNumber}`;
+
+  let resolvedAddressedByName = this._resolvedContactPoints.get(name);
+  if (resolvedAddressedByName === undefined) {
+    resolvedAddressedByName = [];
+    this._resolvedContactPoints.set(name, resolvedAddressedByName);
+  }
+
+  resolvedAddressedByName.push(standardEndpoint);
+};
+
+ControlConnection.prototype.parseEachContactPoint = function(name, next) {
+  let addressOrName = name;
+  let port = null;
+
+  if (name.indexOf('[') === 0 && name.indexOf(']:') > 1) {
+    // IPv6 host notation [ip]:port (RFC 3986 section 3.2.2)
+    const index = name.lastIndexOf(']:');
+    addressOrName = name.substr(1, index - 1);
+    port = name.substr(index + 2);
+  } else if (name.indexOf(':') > 0) {
+    // IPv4 or host name with port notation
+    const parts = name.split(':');
+    if (parts.length === 2) {
+      addressOrName = parts[0];
+      port = parts[1];
+    }
+  }
+
+  if (net.isIP(addressOrName)) {
+    this.addContactPoint(addressOrName, port, name, net.isIPv6(addressOrName));
+    return next();
+  }
+
+  resolveAll(addressOrName, (err, addresses) => {
+    if (err) {
+      this.log('error', `Host with name ${addressOrName} could not be resolved`, err);
+      this.addContactPoint(null, null, name, false);
+      return next();
+    }
+
+    addresses.forEach(addressInfo => this.addContactPoint(addressInfo.address, port, name, addressInfo.isIPv6));
+
+    next();
+  });
+};
 
 /**
  * Tries to determine a suitable protocol version to be used.
@@ -89,88 +163,30 @@ util.inherits(ControlConnection, events.EventEmitter);
  */
 ControlConnection.prototype.init = function (callback) {
   if (this.initialized) {
-    //prevent multiple serial initializations
+    // Prevent multiple serial initializations
     return callback();
   }
-  const self = this;
 
-  function addHost(address, port, name, isIPv6, cb) {
-    port = port || self.options.protocolOptions.port;
-    const endPoint = `${address}:${port}`;
-    const h = new Host(endPoint, self.protocolVersion, self.options, self.metadata);
-    self.hosts.set(endPoint, h);
+  utils.each(
+    this.options.contactPoints,
+    (name, eachNext) => this.parseEachContactPoint(name, eachNext),
+    (err) => {
+      if (!err && this._contactPoints.size === 0) {
+        err = new errors.NoHostAvailableError({}, 'No host could be resolved');
+      }
 
-    let resolvedAddressedByName = self._resolvedContactPoints.get(name);
-    if (resolvedAddressedByName === undefined) {
-      resolvedAddressedByName = [];
-      self._resolvedContactPoints.set(name, resolvedAddressedByName);
-    }
+      if (err) {
+        return callback(err);
+      }
 
-    // Use RFC 3986 for IPv4 and IPv6
-    resolvedAddressedByName.push(!isIPv6 ? endPoint : `[${address}]:${port}`);
-
-    self.log('info', 'Adding host ' + endPoint);
-    if (cb) {
-      cb();
-    }
-  }
-
-  utils.series([
-    function resolveNames(next) {
-      utils.each(self.options.contactPoints, function eachResolve(name, eachNext) {
-        if (name.indexOf('[') === 0 && name.indexOf(']:') > 1) {
-          // IPv6 host notation [ip]:port (RFC 3986 section 3.2.2)
-          const index = name.lastIndexOf(']:');
-          return addHost(name.substr(1, index - 1), name.substr(index + 2), name, true, eachNext);
-        }
-
-        let host = name;
-        let port = null;
-        if (name.indexOf(':') > 0) {
-          // IPv4 or host name with port notation
-          const parts = name.split(':');
-          if (parts.length === 2) {
-            host = parts[0];
-            port = parts[1];
-          }
-        }
-
-        if (net.isIPv4(host)) {
-          return addHost(host, port, name, false, eachNext);
-        } else if (net.isIPv6(host)) {
-          return addHost(host, port, name, true, eachNext);
-        }
-
-        resolveAll(host, function (err, addresses) {
-          if (err) {
-            self.log('error', 'Host with name ' + host + ' could not be resolved', err);
-            self._resolvedContactPoints.set(name, utils.emptyArray);
-            return eachNext();
-          }
-
-          addresses.forEach(addressInfo => addHost(addressInfo.address, port, name, addressInfo.isIPv6));
-
-          eachNext();
-        });
-      }, function (err) {
-        if (!err && self.hosts.length === 0) {
-          err = new errors.NoHostAvailableError(null, 'No host could be resolved');
-        }
-        next(err);
+      this.refresh(false, err => {
+        this.initialized = !err;
+        callback(err);
       });
-    },
-    function startRefresh(next) {
-      self.refresh(false, next);
-    }
-  ], function seriesFinished(err) {
-    self.initialized = !err;
-    callback(err);
-  });
+    });
 };
 
-ControlConnection.prototype.setHealthListeners = function () {
-  const host = this.host;
-  const connection = this.connection;
+ControlConnection.prototype.setHealthListeners = function (host, connection) {
   const self = this;
   let wasRefreshCalled = 0;
 
@@ -185,19 +201,20 @@ ControlConnection.prototype.setHealthListeners = function () {
       // Prevent multiple calls to reconnect
       return;
     }
+
     removeListeners();
+
     if (self.isShuttingDown) {
       // Don't attempt to reconnect when the ControlConnection is being shutdown
       return;
     }
+
     if (hostDown) {
       self.log('warning', f('Host %s used by the ControlConnection DOWN', host.address));
-    }
-    else {
+    } else {
       self.log('warning', f('Connection to %s used by the ControlConnection was closed', host.address));
     }
-    self.host = null;
-    self.connection = null;
+
     self.refresh();
   }
 
@@ -222,6 +239,7 @@ ControlConnection.prototype.borrowAConnection = function (callback) {
   const self = this;
   let host;
   let connection = null;
+
   utils.whilst(
     function condition() {
       // while there isn't a valid connection
@@ -239,22 +257,31 @@ ControlConnection.prototype.borrowAConnection = function (callback) {
         if (!host.isUp() || distance === types.distance.ignored) {
           return next();
         }
+
+        self.borrowHostConnection(host, function (err, c) {
+          self.triedHosts[host.address] = err;
+          connection = c;
+          next();
+        });
+      } else {
+        // Host is an endpoint string
+        self.createConnection(host, (err, c) => {
+          self.triedHosts[host] = err;
+          connection = c;
+          next();
+        });
       }
-      self.borrowHostConnection(host, function borrowConnectionCallback(err, c) {
-        self.triedHosts[host.address] = err;
-        connection = c;
-        next();
-      });
     },
     function whilstEnded() {
       if (!connection) {
         return callback(new errors.NoHostAvailableError(self.triedHosts));
       }
+
       if (!self.initialized) {
         self.protocolVersion = connection.protocolVersion;
         self.encoder = connection.encoder;
       }
-      self.host = host;
+
       self.connection = connection;
       callback();
     });
@@ -266,34 +293,51 @@ ControlConnection.prototype.borrowHostConnection = function (host, callback) {
   host.borrowConnection(null, null, callback);
 };
 
+/** Default implementation for creating initial connections, that can be injected at constructor level */
+ControlConnection.prototype.createConnection = function (endpoint, callback) {
+  const c = new Connection(endpoint, null, this.options);
+  c.open(err => {
+    if (err) {
+      setImmediate(() => c.close());
+      return callback(err);
+    }
+
+    callback(null, c);
+  });
+};
+
 /**
  * Gets the info from local and peer metadata, reloads the keyspaces metadata and rebuilds tokens.
  * @param {Boolean} initializing Determines whether this function was called in order to initialize the control
- * connection the first time.
+ * connection the first time
+ * @param {Boolean} setCurrentHost
  * @param {Function} [callback]
  */
-ControlConnection.prototype.refreshHosts = function (initializing, callback) {
+ControlConnection.prototype.refreshHosts = function (initializing, setCurrentHost, callback) {
   callback = callback || utils.noop;
-  // it's possible that this was called as a result of a topology change, but the connection was lost
-  // between scheduling time and now.
-  if (!this.connection) {
-    callback();
-    // this will be called again when there is a new connection.
-    return;
+
+  // Get a reference to the current connection as it might change from external events
+  const c = this.connection;
+
+  if (!c) {
+    // it's possible that this was called as a result of a topology change, but the connection was lost
+    // between scheduling time and now. This will be called again when there is a new connection.
+    return callback();
   }
+
   const self = this;
   this.log('info', 'Refreshing local and peers info');
-  const c = this.connection;
-  const host = this.host;
-  if (!self.host.protocolVersion) {
-    self.host.setProtocolVersion(self.protocolVersion);
-  }
 
   utils.series([
     function getLocalInfo(next) {
       const request = new requests.QueryRequest(selectLocal, null, null);
       c.sendStream(request, null, function (err, result) {
-        self.setLocalInfo(c.endpoint, result);
+        self.setLocalInfo(initializing, setCurrentHost, c, result);
+
+        if (!err && !self.host) {
+          return next(new errors.DriverInternalError('Information from system.local could not be retrieved'));
+        }
+
         next(err);
       });
     },
@@ -315,9 +359,16 @@ ControlConnection.prototype.refreshHosts = function (initializing, callback) {
 
         // if protocol version changed, reconnect the control connection with new version.
         if (reconnect) {
-          self.log('info', 'Reconnecting since the protocol version changed to 0x' + highestCommon.toString(16));
+          self.log('info', `Reconnecting since the protocol version changed to 0x${highestCommon.toString(16)}`);
           c.decreaseVersion(self.protocolVersion);
-          c.close(() => c.open(next));
+          c.close(() =>
+            setImmediate(() => c.open(err => {
+              if (err) {
+                c.close();
+              }
+
+              next(err);
+            })));
           return;
         }
       }
@@ -325,7 +376,7 @@ ControlConnection.prototype.refreshHosts = function (initializing, callback) {
     },
     function getKeyspaces(next) {
       // to acquire metadata we need to specify the cassandra version
-      self.metadata.setCassandraVersion(host.getCassandraVersion());
+      self.metadata.setCassandraVersion(self.host.getCassandraVersion());
       self.metadata.buildTokens(self.hosts);
       if (!self.options.isMetadataSyncEnabled) {
         self.metadata.initialized = true;
@@ -375,24 +426,37 @@ ControlConnection.prototype.refreshHosts = function (initializing, callback) {
 ControlConnection.prototype.refresh = function (reuseQueryPlan, callback) {
   const initializing = !this.initialized;
   callback = callback || utils.noop;
-  // Reset the state of the host field, that way we can identify when the query plan was exhausted
+
+  if (this.isShuttingDown) {
+    this.log('info', 'The ControlConnection will not be refreshed as the Client is being shutdown');
+    return callback(new errors.NoHostAvailableError({}, 'ControlConnection is shutting down'));
+  }
+
+  // Reset host and connection
   this.host = null;
+  this.connection = null;
+
   const self = this;
+
   utils.series([
     function getHostIterator(next) {
       if (reuseQueryPlan) {
         return next();
       }
+
       self.triedHosts = {};
+
       if (initializing) {
         self.log('info', 'Getting first connection');
-        // randomize order of hosts resolved from contact points.
-        const hosts = self.hosts.values().slice();
+        const hosts = Array.from(self._contactPoints);
+        // Randomize order of contact points resolved.
         utils.shuffleArray(hosts);
-        self.hostIterator = utils.arrayIterator(hosts);
+        self.hostIterator = hosts[Symbol.iterator]();
         return next();
       }
+
       self.log('info', 'Trying to acquire a connection to a new host');
+
       self.profileManager.getDefaultLoadBalancing().newQueryPlan(null, null, function onNewPlan(err, iterator) {
         if (err) {
           self.log('error', 'ControlConnection could not retrieve a query plan to determine which hosts to use', err);
@@ -406,14 +470,13 @@ ControlConnection.prototype.refresh = function (reuseQueryPlan, callback) {
       self.borrowAConnection(next);
     },
     function getLocalAndPeersInfo(next) {
-      if (initializing) {
-        self.log('info', f('ControlConnection using protocol version 0x%s, connected to %s',
-          self.protocolVersion.toString(16), self.host.address));
-      }
-      else {
-        self.log('info', f('ControlConnection connected to %s', self.host.address));
-      }
-      self.refreshHosts(initializing, next);
+      self.log('info',
+        (initializing
+          ? `ControlConnection using protocol version 0x${self.protocolVersion.toString(16)},`
+          : `ControlConnection`) +
+        ` connected to ${self.connection.endpoint}`);
+
+      self.refreshHosts(initializing, true, next);
     },
     function subscribeConnectionEvents(next) {
       self.connection.on('nodeTopologyChange', self.nodeTopologyChangeHandler.bind(self));
@@ -423,6 +486,11 @@ ControlConnection.prototype.refresh = function (reuseQueryPlan, callback) {
       self.connection.sendStream(request, null, next);
     }
   ], function refreshSeriesEnd(err) {
+    // Refresh ended, possible scenarios:
+    // - There was a failure obtaining a connection
+    // - There was a failure in metadata retrieval
+    // - There wasn't a failure but connection is now disconnected at this time
+    // - Everything succeeded
     if (!err) {
       if (!self.connection.connected) {
         // Before refreshSeriesEnd() was invoked, the connection changed to a "not connected" state.
@@ -431,26 +499,37 @@ ControlConnection.prototype.refresh = function (reuseQueryPlan, callback) {
         self.log('info', f('Connection to %s was closed before finishing refresh', self.host.address));
         return self.refresh(false, callback);
       }
-      self.setHealthListeners();
+
+      if (initializing) {
+        // The healthy connection used to initialize should be part of the Host pool
+        self.host.pool.addExistingConnection(self.connection);
+      }
+
+      self.setHealthListeners(self.host, self.connection);
       self.reconnectionSchedule = self.reconnectionPolicy.newSchedule();
       self.emit('newConnection', null, self.connection, self.host);
       self.log('info', f('ControlConnection connected to %s and up to date', self.host.address));
+
       return callback();
     }
-    if (!self.host) {
+
+    if (!self.connection) {
       self.log('error', 'ControlConnection failed to acquire a connection', err);
-      if (!initializing) {
+      if (!initializing && !self.isShuttingDown) {
         self.noOpenConnectionHandler();
+        self.emit('newConnection', err);
       }
-      self.emit('newConnection', err);
+
       return callback(err);
     }
+
     self.log('error', 'ControlConnection failed to retrieve topology and keyspaces information', err);
-    self.triedHosts[self.host.address] = err;
-    if (err && err.isSocketError) {
+    self.triedHosts[self.connection.endpoint] = err;
+
+    if (err && err.isSocketError && !initializing && self.host) {
       self.host.removeFromPool(self.connection);
     }
-    self.connection = null;
+
     // Retry the whole thing with the same query plan, in the background or foreground
     self.refresh(true, callback);
   });
@@ -612,29 +691,52 @@ ControlConnection.prototype.scheduleKeyspaceRefresh = function (keyspaceName, pr
  */
 ControlConnection.prototype.scheduleRefreshHosts = function (callback) {
   this.debouncer.eventReceived({
-    handler: cb => this.refreshHosts(false, cb),
+    handler: cb => this.refreshHosts(false, false, cb),
     all: true,
     callback
   }, false);
 };
 
-ControlConnection.prototype.setLocalInfo = function (endPoint, result) {
+/**
+ * Sets the information for the host used by the control connection.
+ * @param {Boolean} initializing
+ * @param {Connection} c
+ * @param {Boolean} setCurrentHost Determines if the host retrieved must be set as the current host
+ * @param result
+ */
+ControlConnection.prototype.setLocalInfo = function (initializing, setCurrentHost, c, result) {
   if (!result || !result.rows || !result.rows.length) {
-    this.log('warning', 'No local info provided');
+    this.log('warning', 'No local info could be obtained');
     return;
   }
+
   const row = result.rows[0];
-  const localHost = this.hosts.get(endPoint);
-  if (!localHost) {
-    this.log('error', 'Localhost could not be found');
-    return;
+
+  let localHost;
+
+  if (initializing) {
+    localHost = new Host(c.endpoint, this.protocolVersion, this.options, this.metadata);
+    this.hosts.set(c.endpoint, localHost);
+  } else {
+    localHost = this.hosts.get(c.endpoint);
+
+    if (!localHost) {
+      this.log('error', 'Localhost could not be found');
+      return;
+    }
   }
+
   localHost.datacenter = row['data_center'];
   localHost.rack = row['rack'];
   localHost.tokens = row['tokens'];
   localHost.cassandraVersion = row['release_version'];
   this.metadata.setPartitioner(row['partitioner']);
   this.log('info', 'Local info retrieved');
+
+  if (setCurrentHost) {
+    // Set the host as the one being used by the ControlConnection.
+    this.host = localHost;
+  }
 };
 
 /**
@@ -648,14 +750,17 @@ ControlConnection.prototype.setPeersInfo = function (initializing, err, result, 
   if (!result || !result.rows || err) {
     return callback(err);
   }
-  const self = this;
-  //A map of peers, could useful for in case there are discrepancies
+
+  // A map of peers, could useful for in case there are discrepancies
   const peers = {};
   const port = this.options.protocolOptions.port;
   const foundDataCenters = new Set();
-  if (self.host && self.host.datacenter) {
-    foundDataCenters.add(self.host.datacenter);
+
+  if (this.host && this.host.datacenter) {
+    foundDataCenters.add(this.host.datacenter);
   }
+
+  const self = this;
 
   utils.eachSeries(result.rows, function eachPeer(row, next) {
     self.getAddressForPeerHost(row, port, function getAddressForPeerCallback(endPoint) {
@@ -780,19 +885,23 @@ ControlConnection.prototype.waitForReconnection = function (callback) {
  * @param {Function} callback
  */
 ControlConnection.prototype.query = function (cqlQuery, waitReconnect, callback) {
-  const self = this;
   if (typeof waitReconnect === 'function') {
     callback = waitReconnect;
     waitReconnect = true;
   }
+
+  const self = this;
+
   function queryOnConnection() {
+    if (!self.connection) {
+      return callback(new errors.NoHostAvailableError({}, 'ControlConnection is not connected at the time'));
+    }
+
     const request = typeof cqlQuery === 'string' ? new requests.QueryRequest(cqlQuery, null, null) : cqlQuery;
     self.connection.sendStream(request, null, callback);
   }
-  if (!this.connection) {
-    if (!waitReconnect) {
-      return callback(new errors.NoHostAvailableError(null));
-    }
+
+  if (!this.connection && waitReconnect) {
     // Wait until its reconnected (or timer elapses)
     return this.waitForReconnection(function waitCallback(err) {
       if (err) {
@@ -802,6 +911,7 @@ ControlConnection.prototype.query = function (cqlQuery, waitReconnect, callback)
       queryOnConnection();
     });
   }
+
   queryOnConnection();
 };
 
@@ -859,6 +969,18 @@ ControlConnection.prototype.getLocalAddress = function () {
   }
 
   return this.connection.getLocalAddress();
+};
+
+/**
+ * Gets the address and port of host the control connection is connected to.
+ * @returns {String|undefined}
+ */
+ControlConnection.prototype.getEndpoint = function () {
+  if (!this.connection) {
+    return undefined;
+  }
+
+  return this.connection.endpoint;
 };
 
 /**

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -167,23 +167,25 @@ ControlConnection.prototype.init = function (callback) {
     return callback();
   }
 
+  const contactPointsResolutionCb = (err) => {
+    if (!err && this._contactPoints.size === 0) {
+      err = new errors.NoHostAvailableError({}, 'No host could be resolved');
+    }
+
+    if (err) {
+      return callback(err);
+    }
+
+    this.refresh(false, err => {
+      this.initialized = !err;
+      callback(err);
+    });
+  };
+
   utils.each(
     this.options.contactPoints,
     (name, eachNext) => this.parseEachContactPoint(name, eachNext),
-    (err) => {
-      if (!err && this._contactPoints.size === 0) {
-        err = new errors.NoHostAvailableError({}, 'No host could be resolved');
-      }
-
-      if (err) {
-        return callback(err);
-      }
-
-      this.refresh(false, err => {
-        this.initialized = !err;
-        callback(err);
-      });
-    });
+    contactPointsResolutionCb);
 };
 
 ControlConnection.prototype.setHealthListeners = function (host, connection) {
@@ -293,9 +295,13 @@ ControlConnection.prototype.borrowHostConnection = function (host, callback) {
   host.borrowConnection(null, null, callback);
 };
 
-/** Default implementation for creating initial connections, that can be injected at constructor level */
-ControlConnection.prototype.createConnection = function (endpoint, callback) {
-  const c = new Connection(endpoint, null, this.options);
+/**
+ * Default implementation for creating initial connections, that can be injected at constructor level
+ * @param {String} contactPoint
+ * @param {Function} callback
+ */
+ControlConnection.prototype.createConnection = function (contactPoint, callback) {
+  const c = new Connection(contactPoint, null, this.options);
   c.open(err => {
     if (err) {
       setImmediate(() => c.close());
@@ -474,7 +480,7 @@ ControlConnection.prototype.refresh = function (reuseQueryPlan, callback) {
         (initializing
           ? `ControlConnection using protocol version 0x${self.protocolVersion.toString(16)},`
           : `ControlConnection`) +
-        ` connected to ${self.connection.endpoint}`);
+        ` connected to ${self.connection.endpointFriendlyName}`);
 
       self.refreshHosts(initializing, true, next);
     },
@@ -714,11 +720,13 @@ ControlConnection.prototype.setLocalInfo = function (initializing, setCurrentHos
 
   let localHost;
 
+  const endpoint = c.endpoint;
+
   if (initializing) {
-    localHost = new Host(c.endpoint, this.protocolVersion, this.options, this.metadata);
-    this.hosts.set(c.endpoint, localHost);
+    localHost = new Host(endpoint, this.protocolVersion, this.options, this.metadata);
+    this.hosts.set(endpoint, localHost);
   } else {
-    localHost = this.hosts.get(c.endpoint);
+    localHost = this.hosts.get(endpoint);
 
     if (!localHost) {
       this.log('error', 'Localhost could not be found');

--- a/lib/host-connection-pool.js
+++ b/lib/host-connection-pool.js
@@ -227,6 +227,12 @@ class HostConnectionPool extends events.EventEmitter {
   /** @returns {Connection} */
   _createConnection() {
     const c = new Connection(this._address, this.protocolVersion, this.options);
+    this._addListeners(c);
+    return c;
+  }
+
+  /** @param {Connection} c */
+  _addListeners(c) {
     c.on('responseDequeued', () => this.responseCounter++);
 
     const self = this;
@@ -236,7 +242,13 @@ class HostConnectionPool extends events.EventEmitter {
     }
     c.on('idleRequestError', connectionErrorCallback);
     c.on('socketClose', connectionErrorCallback);
-    return c;
+  }
+
+  addExistingConnection(c) {
+    this._addListeners(c);
+    // Use a copy of the connections array
+    this.connections = this.connections.slice(0);
+    this.connections.push(c);
   }
 
   /**

--- a/lib/host.js
+++ b/lib/host.js
@@ -68,6 +68,14 @@ function Host(address, protocolVersion, options, metadata) {
    * @type {Array}
    */
   this.tokens = null;
+
+  /**
+   * Gets the id of the host.
+   * <p>This identifier is used by the server for internal communication / gossip.</p>
+   * @type {Uuid}
+   */
+  this.hostId = null;
+
   // the distance as last set using the load balancing policy
   this._distance = types.distance.ignored;
   this._healthResponseCounter = 0;

--- a/test/integration/short/metadata-tests.js
+++ b/test/integration/short/metadata-tests.js
@@ -1326,6 +1326,17 @@ describe('metadata', function () {
     });
   });
 
+  describe('Client#hosts', () => {
+    it('should contain the hosts metadata information', () => {
+      setupInfo.client.hosts.values().forEach(host => {
+        assert.strictEqual(host.datacenter, 'dc1');
+        assert.strictEqual(typeof host.rack, 'string');
+        helper.assertInstanceOf(host.hostId, types.Uuid);
+        helper.assertInstanceOf(host.tokens, Array);
+      });
+    });
+  });
+
   describe('ResultSet', function () {
     describe('#info.isSchemaInAgreement', function () {
       const client = setupInfo.client;

--- a/test/integration/short/pool-simulator-tests.js
+++ b/test/integration/short/pool-simulator-tests.js
@@ -29,7 +29,7 @@ describe('pool', function () {
       contactPoints: cluster.getContactPoints(),
       // Use a LBP with a fixed order to have predictable behaviour
       // Warning: OrderedLoadBalancingPolicy is only suitable for testing!
-      policies: { loadBalancing: new helper.OrderedLoadBalancingPolicy() },
+      policies: { loadBalancing: new helper.OrderedLoadBalancingPolicy(cluster) },
       pooling: {
         coreConnectionsPerHost: {
           [types.distance.local]: 2
@@ -40,11 +40,11 @@ describe('pool', function () {
     }));
     beforeEach(done => cluster.prime({
       when: { query: 'SELECT * FROM paused' },
-      then: { result: 'success', delay_in_ms: 1000 }
+      then: { result: 'success', delay_in_ms: 2000 }
     }, done));
     beforeEach(done => cluster.node(0).prime({
       when: { query: 'SELECT * FROM paused_on_first' },
-      then: { result: 'success', delay_in_ms: 1000 }
+      then: { result: 'success', delay_in_ms: 2000 }
     }, done));
     afterEach(() => client.shutdown());
     afterEach(done => cluster.unregister(done));
@@ -53,13 +53,13 @@ describe('pool', function () {
       return client.connect()
         .then(() => Promise.all(new Array(150).fill(null).map(() => client.execute('SELECT * FROM paused'))))
         .then(results => {
-          const hosts = client.hosts.keys();
+          const hosts = cluster.dc(0).nodes.map(n => n.address);
           // First 100 items should be the first host (50 * 2 connections)
           assertArray(results.slice(0, 100).map(rs => rs.info.queriedHost), hosts[0]);
           // The next 50 items should be the second host
           assertArray(results.slice(100).map(rs => rs.info.queriedHost), hosts[1]);
         })
-        .then(() => validateStateOfPool(client));
+        .then(() => validateStateOfPool(client, cluster));
     });
 
     it('should fail when all hosts are busy', function () {
@@ -75,7 +75,7 @@ describe('pool', function () {
             .then(() => resultTuple);
         })))
         .then(results => {
-          const hosts = client.hosts.keys();
+          const hosts = cluster.dc(0).nodes.map(x => x.address);
 
           // The first 300 requests should have succeed
           assertArray(results.slice(0, 100).map(r => r.coordinator), hosts[0]);
@@ -92,7 +92,7 @@ describe('pool', function () {
             });
           });
         })
-        .then(() => validateStateOfPool(client));
+        .then(() => validateStateOfPool(client, cluster));
     });
 
     it('should increase and decrease response dequeued counter', function() {
@@ -128,7 +128,7 @@ describe('pool', function () {
       const client = new Client({
         contactPoints: cluster.getContactPoints(),
         policies: {
-          loadBalancing: new helper.OrderedLoadBalancingPolicy(),
+          loadBalancing: new helper.OrderedLoadBalancingPolicy(cluster),
           retry: retryPolicy
         },
         pooling: {
@@ -141,7 +141,7 @@ describe('pool', function () {
       });
 
       return client.connect()
-        .then(() => firstHost = client.hosts.values()[0].address)
+        .then(() => firstHost = cluster.node(0).address)
         .then(() => client.execute('SELECT * FROM paused_on_first', null, { readTimeout: 200, isIdempotent: true }))
         .then(() => assert.strictEqual(retryCount, 2))
         .then(() => client.shutdown());
@@ -166,7 +166,7 @@ describe('pool', function () {
       const client = new Client({
         contactPoints: cluster.getContactPoints(),
         policies: {
-          loadBalancing: new helper.OrderedLoadBalancingPolicy(),
+          loadBalancing: new helper.OrderedLoadBalancingPolicy(cluster),
           retry: retryPolicy
         },
         pooling: {
@@ -182,11 +182,11 @@ describe('pool', function () {
 
       return client.connect()
         .then(() => {
-          firstHost = client.hosts.values()[0];
+          firstHost = client.hosts.get(cluster.node(0).address);
 
           // Create 99 in-flight requests
           promises.push.apply(promises, new Array(99).fill(0).map(() =>
-            client.execute('SELECT * FROM paused_on_first', null, { readTimeout: 2000 })));
+            client.execute('SELECT * FROM paused_on_first', null, { readTimeout: 10000 })));
 
           // The pool will be busy after this request, so the retry will occur on the next host
           const p2 = client.execute('SELECT * FROM paused_on_first', null, { readTimeout: 50, isIdempotent: true });
@@ -194,7 +194,7 @@ describe('pool', function () {
           return p2;
         })
         // The query will be retried on the next host
-        .then(rs => assert.strictEqual(rs.info.queriedHost, client.hosts.values()[1].address))
+        .then(rs => assert.strictEqual(rs.info.queriedHost, cluster.node(1).address))
         .then(() => {
           assert.strictEqual(firstHost.getInFlight(), 100);
           assert.strictEqual(client.getState().getInFlightQueries(firstHost), 100);
@@ -254,6 +254,107 @@ describe('pool', function () {
           client.controlConnection.host.address.split(':')[0].split('.')[3],
           secondNodeLastOctet.toString()))
         .then(() => client.shutdown());
+    });
+
+    it('should have a single connection when warmup is false', () => {
+      // Use a single contact point to make sure control connection uses the first host
+      const contactPoints = [ cluster.getContactPoints()[0] ];
+
+      const client = new Client({
+        contactPoints,
+        localDataCenter: 'dc1',
+        pooling: { warmup: false, coreConnectionsPerHost: { [types.distance.local]: 3 } }
+      });
+
+      after(() => client.shutdown());
+
+      return client.connect()
+        .then(() => {
+          assert.strictEqual(client.hosts.length, 3);
+          const state = client.getState();
+          const hosts = state.getConnectedHosts();
+          assert.deepStrictEqual(hosts.map(h => h.address), contactPoints);
+          assert.strictEqual(state.getOpenConnections(hosts[0]), 1);
+        });
+    });
+
+    it('should maintain the same ControlConnection host after nodes going UP and DOWN and back UP', () => {
+      const firstAddress = cluster.getContactPoints()[0];
+
+      const client = new Client({
+        contactPoints: [ firstAddress ],
+        localDataCenter: 'dc1',
+        policies: { reconnection: new policies.reconnection.ConstantReconnectionPolicy(100) },
+        pooling: { heartBeatInterval: 50 }
+      });
+
+      after(() => client.shutdown());
+
+      let secondAddress;
+
+      return client.connect()
+        .then(() => {
+          assert.strictEqual(client.getState().getConnectedHosts().length, 3);
+          assert.strictEqual(client.controlConnection.getEndpoint(), firstAddress);
+        })
+        .then(() => promiseFromCallback(cb => cluster.node(firstAddress).stop(cb)))
+        .then(() => helper.setIntervalUntilPromise(
+          () => (client.controlConnection.getEndpoint() || firstAddress) !== firstAddress, 20, 5000
+        ))
+        .then(() => {
+          // Validate CC is now connected to another host
+          assert.notEqual(client.controlConnection.getEndpoint(), undefined);
+          assert.notStrictEqual(client.controlConnection.getEndpoint(), firstAddress);
+          secondAddress = client.controlConnection.getEndpoint();
+        })
+        .then(() => promiseFromCallback(cb => cluster.node(firstAddress).start(cb)))
+        .then(() => helper.setIntervalUntilPromise(
+          () => client.hosts.values().find(h => !h.isUp()) === undefined, 20, 5000
+        ))
+        .then(() => {
+          assert.strictEqual(client.getState().getConnectedHosts().length, 3);
+          // Validate that events of original node going back UP don't affect the ControlConnection
+          assert.strictEqual(client.controlConnection.getEndpoint(), secondAddress);
+        });
+    });
+
+    it('should stop attempting to reconnect to down after shutdown', () => {
+      const firstAddress = cluster.getContactPoints()[0];
+      const reconnectionDelay = 20;
+
+      const client = new Client({
+        contactPoints: [ firstAddress ],
+        localDataCenter: 'dc1',
+        policies: { reconnection: new policies.reconnection.ConstantReconnectionPolicy(reconnectionDelay) },
+        pooling: { heartBeatInterval: 50 }
+      });
+
+      after(() => client.shutdown());
+
+      // Validate via log messages
+      const logMessages = [];
+
+      return client.connect()
+        .then(() => {
+          assert.strictEqual(client.getState().getConnectedHosts().length, 3);
+          assert.strictEqual(client.controlConnection.getEndpoint(), firstAddress);
+        })
+        .then(() => Promise.all(
+          client.hosts.values()
+            .map(h => h.address).slice(0, 2)
+            .map(address => promiseFromCallback(cb => cluster.node(address).stop(cb)))
+        ))
+        .then(() => helper.setIntervalUntilPromise(
+          () => (client.controlConnection.getEndpoint() || firstAddress) !== firstAddress, 20, 5000
+        ))
+        .then(() => {
+          assert.notEqual(client.controlConnection.getEndpoint(), undefined);
+          assert.notStrictEqual(client.controlConnection.getEndpoint(), firstAddress);
+        })
+        .then(() => client.shutdown())
+        .then(() => client.on('log', (level, message) => logMessages.push([ level, message ])))
+        .then(() => new Promise(r => setTimeout(r, reconnectionDelay * 2)))
+        .then(() => assert.deepStrictEqual(logMessages, []));
     });
   });
 
@@ -366,12 +467,12 @@ function assertArray(arr, value) {
 /**
  * Asserts that all nodes are UP and that the LBP is selecting the first healthy node.
  */
-function validateStateOfPool(client) {
+function validateStateOfPool(client, cluster) {
   return client.execute('SELECT * FROM system.local')
     .then(rs => {
       // Assert it didn't affect the state of the pool
       assertArray(client.hosts.values().map(h => h.isUp()), true);
-      return assert.strictEqual(rs.info.queriedHost, client.hosts.keys()[0]);
+      return assert.strictEqual(rs.info.queriedHost, cluster.node(0).address);
     });
 }
 

--- a/test/integration/short/pool-simulator-tests.js
+++ b/test/integration/short/pool-simulator-tests.js
@@ -315,7 +315,8 @@ describe('pool', function () {
           assert.strictEqual(client.getState().getConnectedHosts().length, 3);
           // Validate that events of original node going back UP don't affect the ControlConnection
           assert.strictEqual(client.controlConnection.getEndpoint(), secondAddress);
-        });
+        })
+        .then(() => client.shutdown());
     });
 
     it('should stop attempting to reconnect to down after shutdown', () => {

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -1133,15 +1133,32 @@ function executeIfVersion (testVersion, func, args) {
  * Policy only suitable for testing, it creates a fixed query plan containing the nodes in the same order, i.e. [a, b].
  * @constructor
  */
-function OrderedLoadBalancingPolicy() {
+class OrderedLoadBalancingPolicy extends policies.loadBalancing.RoundRobinPolicy {
 
+  /**
+   * Creates a new instance.
+   * @param {Array<String>|SimulacronCluster} [addresses] When specified, it uses the order from the provided host
+   * addresses.
+   */
+  constructor(addresses) {
+    super();
+
+    if (addresses && typeof addresses.dc === 'function') {
+      // With Simulacron, use the nodes from the first DC in that order
+      addresses = addresses.dc(0).nodes.map(n => n.address);
+    }
+
+    this.addresses = addresses;
+  }
+
+  newQueryPlan(keyspace, info, callback) {
+    const hosts = !this.addresses
+      ? this.hosts.values()
+      : this.addresses.map(address => this.hosts.get(address));
+
+    return callback(null, hosts[Symbol.iterator]());
+  }
 }
-
-util.inherits(OrderedLoadBalancingPolicy, policies.loadBalancing.RoundRobinPolicy);
-
-OrderedLoadBalancingPolicy.prototype.newQueryPlan = function (keyspace, info, callback) {
-  callback(null, utils.arrayIterator(this.hosts.values()));
-};
 
 module.exports = helper;
 module.exports.RetryMultipleTimes = RetryMultipleTimes;

--- a/test/unit/control-connection-tests.js
+++ b/test/unit/control-connection-tests.js
@@ -49,37 +49,31 @@ describe('ControlConnection', function () {
         expectedResolved = expectedHosts;
       }
 
-      const cc = new CcMock(clientOptions.extend({ contactPoints: ['my-host-name'] }), null, getContext({
-        queryResults: { 'system\\.peers': {
-          rows: expectedHosts
-            .filter(address => address !== '1:9042')
-            .map(address => ({'rpc_address': address.split(':')[0] }))
-        }}
-      }));
+      const state = {};
+      const cc = new CcMock(clientOptions.extend({ contactPoints: ['my-host-name'] }), null, getContext({ failBorrow: 10, state}));
 
       cc.init(function (err) {
-        const hosts = cc.hosts.values();
         cc.shutdown();
-        cc.hosts.values().forEach(h => h.shutdown());
-        assert.ifError(err);
-        assert.deepEqual(hosts.map(h => h.address), expectedHosts);
+        helper.assertInstanceOf(err, errors.NoHostAvailableError);
+        assert.deepStrictEqual(state.connectionAttempts.sort(), expectedHosts.sort());
         const resolvedContactPoints = cc.getResolvedContactPoints();
         assert.deepStrictEqual(resolvedContactPoints.get('my-host-name'), expectedResolved);
         done();
       });
     }
+
     it('should resolve IPv4 and IPv6 addresses', function (done) {
       if (!useLocalhost || !useIp6 ) {
         return done();
       }
-      const cc = newInstance({ contactPoints: [ 'localhost' ] }, getContext());
+
+      const state = {};
+      const cc = newInstance({ contactPoints: [ 'localhost' ] }, getContext({ state, failBorrow: [ 0, 1 ]}));
+
       cc.init(function (err) {
         cc.shutdown();
-        cc.hosts.values().forEach(h => h.shutdown());
-        assert.ifError(err);
-        const hosts = cc.hosts.values();
-        assert.strictEqual(hosts.length, 2);
-        assert.deepEqual(hosts.map(h => h.address).sort(), [ '127.0.0.1:9042', '::1:9042' ]);
+        helper.assertInstanceOf(err, errors.NoHostAvailableError);
+        assert.deepEqual(state.connectionAttempts.sort(), [ '127.0.0.1:9042', '::1:9042' ]);
         done();
       });
     });
@@ -93,8 +87,9 @@ describe('ControlConnection', function () {
         cc.hosts.values().forEach(h => h.shutdown());
         assert.ifError(err);
         const hosts = cc.hosts.values();
-        assert.ok(hosts.length >= 1);
-        assert.strictEqual(hosts.filter(h => h.address === '127.0.0.1:9999').length, 1);
+        assert.strictEqual(hosts.length, 1);
+        // Resolved to ::1 or 127.0.0.
+        helper.assertContains(hosts[0].address, '1:9999');
         done();
       });
     });
@@ -162,14 +157,15 @@ describe('ControlConnection', function () {
       testResolution(ControlConnectionMock, [ '123:9042' ], done);
     });
     it('should continue iterating through the hosts when borrowing a connection fails', function (done) {
-      const hosts = [];
-      const cc = newInstance({ contactPoints: [ '::1', '::2' ] }, getContext({ hosts: hosts, failBorrow: [ 0 ] }));
+      const state = {};
+      const contactPoints = [ '::1', '::2' ];
+      const cc = newInstance({ contactPoints }, getContext({ state, failBorrow: [ 0 ] }));
+
       cc.init(function (err) {
         cc.shutdown();
-        cc.hosts.values().forEach(h => h.shutdown());
         assert.ifError(err);
-        assert.strictEqual(hosts.length, 2);
         assert.ok(cc.initialized);
+        assert.deepStrictEqual(state.connectionAttempts.sort(), contactPoints.map(x => `${x}:9042`));
         helper.assertMapEqual(
           cc.getResolvedContactPoints(),
           new Map([['::1', ['[::1]:9042']], ['::2', ['[::2]:9042']]]));
@@ -180,15 +176,13 @@ describe('ControlConnection', function () {
       // collect unique permutations of borrow order.
       const borrowOrders = new Set();
       utils.times(20, (i, next) => {
-        const hosts = [];
-        const cc = newInstance({ contactPoints: [ '::1', '::2', '::3', '::4' ] }, getContext({ hosts: hosts, failBorrow: [ 0, 1, 2 ] }));
+        const state = {};
+        const cc = newInstance({ contactPoints: [ '::1', '::2', '::3', '::4' ] }, getContext({ state, failBorrow: 4 }));
         cc.init(function (err) {
           cc.shutdown();
           cc.hosts.values().forEach(h => h.shutdown());
-          assert.ifError(err);
-          assert.strictEqual(hosts.length, 4);
-          assert.ok(cc.initialized);
-          borrowOrders.add(hosts.map((h) => h.address).join());
+          helper.assertInstanceOf(err, errors.NoHostAvailableError);
+          borrowOrders.add(state.connectionAttempts.join());
           next();
         });
       }, (err) => {
@@ -199,23 +193,21 @@ describe('ControlConnection', function () {
       });
     });
     it('should callback with NoHostAvailableError when borrowing all connections fail', function (done) {
-      const hosts = [];
-      const cc = newInstance({ contactPoints: [ '::1', '::2' ] }, getContext({ hosts: hosts, failBorrow: [ 0, 1] }));
+      const cc = newInstance({ contactPoints: [ '::1', '::2' ] }, getContext({ failBorrow: 2 }));
       cc.init(function (err) {
         cc.shutdown();
         cc.hosts.values().forEach(h => h.shutdown());
         helper.assertInstanceOf(err, errors.NoHostAvailableError);
         assert.strictEqual(Object.keys(err.innerErrors).length, 2);
-        assert.strictEqual(hosts.length, 2);
         assert.ok(!cc.initialized);
         done();
       });
     });
     it('should continue iterating through the hosts when metadata retrieval fails', function (done) {
-      const hosts = [];
       const cc = newInstance({ contactPoints: [ '::1', '::2' ] }, getContext({
-        hosts: hosts, queryResults: { '::1': 'Test error, failed query' }
+        queryResults: { '::1': 'Test error, failed query' }
       }));
+
       cc.init(function (err) {
         cc.shutdown();
         cc.hosts.values().forEach(h => h.shutdown());
@@ -225,20 +217,25 @@ describe('ControlConnection', function () {
     });
     it('should listen to socketClose and reconnect', function (done) {
       const state = {};
-      const hostsTried = [];
+      const peersRows = [
+        {'rpc_address': types.InetAddress.fromString('::2') }
+      ];
+
       const lbp = new policies.loadBalancing.RoundRobinPolicy();
+
       const cc = newInstance({ contactPoints: [ '::1', '::2' ], policies: { loadBalancing: lbp } }, getContext({
-        state: state, hosts: hostsTried
+        state, queryResults: { 'peers': peersRows }
       }));
       cc.init(function (err) {
         assert.ifError(err);
         assert.ok(state.connection);
-        assert.strictEqual(hostsTried.length, 1);
+        assert.strictEqual(state.hostsTried.length, 0);
+        assert.strictEqual(state.connectionAttempts.length, 1);
         lbp.init(null, cc.hosts, utils.noop);
         state.connection.emit('socketClose');
         setImmediate(function () {
           // Attempted reconnection and succeeded
-          assert.strictEqual(hostsTried.length, 2);
+          assert.strictEqual(state.hostsTried.length, 1);
           cc.shutdown();
           cc.hosts.values().forEach(h => h.shutdown());
           done();
@@ -377,7 +374,6 @@ describe('ControlConnection', function () {
   describe('#refresh()', function () {
     it('should schedule reconnection when it cant borrow a connection', function (done) {
       const state = {};
-      const hostsTried = [];
       const lbp = new policies.loadBalancing.RoundRobinPolicy();
       lbp.queryPlanCount = 0;
       lbp.newQueryPlan = function (ks, o, cb) {
@@ -385,41 +381,42 @@ describe('ControlConnection', function () {
           // Return an empty query plan the first time
           return cb(null, utils.arrayIterator([]));
         }
-        return cb(null, utils.arrayIterator(lbp.hosts.values()));
+        return cb(null, [ lbp.hosts.values()[1], lbp.hosts.values()[0] ][Symbol.iterator]());
       };
-      const rp = new policies.reconnection.ConstantReconnectionPolicy(10);
+
+      const rp = new policies.reconnection.ConstantReconnectionPolicy(40);
       rp.nextDelayCount = 0;
-      rp.newSchedule = function () {
-        return {
-          next: function () {
-            rp.nextDelayCount++;
-            return { value: 10, done: false};
-          }
-        };
+      rp.newSchedule = function*() {
+        rp.nextDelayCount++;
+        yield this.delay;
       };
-      const cc = newInstance({ contactPoints: [ '::1', '::2' ], policies: { loadBalancing: lbp, reconnection: rp } },
-        getContext({ state: state, hosts: hostsTried }));
+
+      const cc = newInstance({ contactPoints: [ '::1' ], policies: { loadBalancing: lbp, reconnection: rp } },
+        getContext({ state: state, queryResults: { 'peers': [ {'rpc_address': types.InetAddress.fromString('::2') } ] }}));
+
       cc.init(function (err) {
         assert.ifError(err);
         assert.ok(state.connection);
-        assert.strictEqual(hostsTried.length, 1);
+        assert.strictEqual(state.hostsTried.length, 0);
+        assert.strictEqual(cc.hosts.length, 2);
+
         lbp.init(null, cc.hosts, utils.noop);
-        state.connection.emit('socketClose');
         const previousConnection = state.connection;
+        state.connection.emit('socketClose');
+
         setImmediate(function () {
-          // Attempted reconnection and there isn't a host available
-          assert.strictEqual(hostsTried.length, 1);
           // Scheduled reconnection
-          assert.strictEqual(rp.nextDelayCount, 1);
+          // nextDelayCount should be 2 as both the host and the control connection are reconnecting
+          assert.strictEqual(rp.nextDelayCount, 2);
           setTimeout(function () {
             // Reconnected
-            assert.strictEqual(hostsTried.length, 2);
+            assert.strictEqual(state.hostsTried.length, 1);
             // Changed connection
             assert.notEqual(state.connection, previousConnection);
             cc.shutdown();
             cc.hosts.values().forEach(h => h.shutdown());
             done();
-          }, 20);
+          }, 50);
         });
       });
     });
@@ -460,11 +457,18 @@ function getFakeConnection(endpoint, queryResults) {
         break;
       }
     }
-    if (typeof result === 'string') {
-      return cb(new Error(result));
+
+    if (Array.isArray(result)) {
+      result = { rows: result };
     }
-    cb(null, result || defaultResult);
+
+    if (typeof result === 'string') {
+      cb(new Error(result));
+    } else {
+      cb(null, result || defaultResult);
+    }
   };
+  c.close = cb => (cb ? cb() : null);
   return c;
 }
 
@@ -476,19 +480,37 @@ function getFakeConnection(endpoint, queryResults) {
 function getContext(options) {
   options = options || {};
   // hosts that the ControlConnection used to borrow a connection
-  const hosts = options.hosts || [];
   const state = options.state || {};
-  const failBorrow = options.failBorrow || [];
+  state.connectionAttempts = [];
+  state.hostsTried = [];
+  let failBorrow = options.failBorrow || [];
+
+  if (typeof failBorrow === 'number') {
+    failBorrow = Array.from(new Array(failBorrow).keys());
+  }
+
+  let index = 0;
+
   return {
     borrowHostConnection: function (h, callback) {
-      const i = hosts.length;
-      hosts.push(h);
+      const i = options.state.hostsTried.length;
+      options.state.hostsTried.push(h);
       state.host = h;
       if (failBorrow.indexOf(i) >= 0) {
         return callback(new Error('Test error'));
       }
+
       state.connection = getFakeConnection(h.address, options.queryResults);
-      return callback(null, state.connection);
+      callback(null, state.connection);
+    },
+    createConnection: function (endpoint, callback) {
+      state.connectionAttempts.push(endpoint);
+      if (failBorrow.indexOf(index++) >= 0) {
+        return callback(new Error('Fake connect error'));
+      }
+
+      state.connection = getFakeConnection(endpoint, options.queryResults);
+      callback(null, state.connection);
     }
   };
 }


### PR DESCRIPTION
https://datastax-oss.atlassian.net/browse/NODEJS-500
https://datastax-oss.atlassian.net/browse/NODEJS-501

Several changes to the internal behaviour of the `ControlConnection`:

- Create initial connection without the notion of `Host`
- Small refactor for resolution and minor improvements
- Include `hostId` in `Host` metadata
- Integration tests using simulacron to validate reconnection behaviour