### PR TITLE
Prevent the ControlConnection to enqueue requests after shutdown

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -305,8 +305,10 @@ Connection.prototype.clearAndInvokePending = function (innerError) {
   if (innerError) {
     err.innerError = innerError;
   }
+
   //copy all handlers
   const operations = utils.objectValues(this._operations);
+
   //remove it from the map
   this._operations = {};
   if (operations.length > 0) {
@@ -668,16 +670,20 @@ Connection.prototype.handleRow = function (header, row, meta, rowLength, flags) 
  */
 Connection.prototype.close = function (callback) {
   callback = callback || utils.noop;
+
   if (!this.connected && !this.isSocketOpen) {
     return callback();
   }
+
   this.connected = false;
   // Drain is never going to be emitted, once it is set to closed
   this.removeAllListeners('drain');
   this.clearAndInvokePending();
+
   if (!this.isSocketOpen) {
     return callback();
   }
+
   // Set the socket as closed now (before socket.end() is called) to avoid being invoked more than once
   this.isSocketOpen = false;
   this.log('verbose', `Closing connection to ${this.endpointFriendlyName}`);
@@ -697,10 +703,14 @@ Connection.prototype.close = function (callback) {
     }
     setImmediate(callback);
   });
-  // Prevent 'error' listener to be executed before 'close' listener
+
+  // At this point, the error event can be triggered because:
+  // - It's connected and writes haven't completed yet
+  // - The server abruptly closed its end of the connection (ECONNRESET) as a result of protocol error / auth error
+  // We need to remove any listeners and make sure we callback are pending writes
   this.netClient.removeAllListeners('error');
-  // Add a noop handler for 'error' event to prevent Socket to throw the error
-  this.netClient.on('error', utils.noop);
+  this.netClient.on('error', err => this.clearAndInvokePending(err));
+
   // Half-close the socket, it will result in 'close' event being fired
   this.netClient.end();
 };

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -906,7 +906,7 @@ ControlConnection.prototype.query = function (cqlQuery, waitReconnect, callback)
   const self = this;
 
   function queryOnConnection() {
-    if (!self.connection) {
+    if (!self.connection || self.isShuttingDown) {
       return callback(new errors.NoHostAvailableError({}, 'ControlConnection is not connected at the time'));
     }
 

--- a/test/integration/short/client-pool-tests.js
+++ b/test/integration/short/client-pool-tests.js
@@ -75,7 +75,7 @@ describe('Client', function () {
       client.connect(function (err) {
         assert.ok(err);
         helper.assertInstanceOf(err, errors.NoHostAvailableError);
-        done();
+        client.shutdown(done);
       });
     });
     it('should select a tokenizer', function (done) {
@@ -296,18 +296,14 @@ describe('Client', function () {
       const client = newInstance(options);
       utils.times(100, function (n, next) {
         client.connect(next);
-      }, function (err) {
-        done(err);
-      });
+      }, helper.finish(client, done));
     });
     it('should connect using the plain text authenticator when calling execute', function (done) {
       const options = {authProvider: new PlainTextAuthProvider('cassandra', 'cassandra'), keyspace: 'system'};
       const client = newInstance(options);
       utils.times(100, function (n, next) {
         client.execute('SELECT * FROM local', next);
-      }, function (err) {
-        done(err);
-      });
+      }, helper.finish(client, done));
     });
     it('should return an AuthenticationError', function (done) {
       const options = {authProvider: new PlainTextAuthProvider('not___EXISTS', 'not___EXISTS'), keyspace: 'system'};
@@ -320,7 +316,7 @@ describe('Client', function () {
           helper.assertInstanceOf(helper.values(err.innerErrors)[0], errors.AuthenticationError);
           next();
         });
-      }, done);
+      }, helper.finish(client, done));
     });
     it('should return an AuthenticationError when calling execute', function (done) {
       const options = {authProvider: new PlainTextAuthProvider('not___EXISTS', 'not___EXISTS'), keyspace: 'system'};
@@ -333,7 +329,7 @@ describe('Client', function () {
           helper.assertInstanceOf(helper.values(err.innerErrors)[0], errors.AuthenticationError);
           next();
         });
-      }, done);
+      }, helper.finish(client, done));
     });
   });
   describe('#connect() with ipv6', function () {
@@ -363,7 +359,7 @@ describe('Client', function () {
           assert.strictEqual(client.hosts.values()[0].address, expected);
           utils.times(10, function (n, next) {
             client.execute(helper.queries.basic, next);
-          }, testDone);
+          }, helper.finish(client, testDone));
         });
       }
     });
@@ -371,6 +367,9 @@ describe('Client', function () {
   describe('#connect() with nodes failing', function () {
     it('should connect after a failed attempt', function (done) {
       const client = newInstance();
+
+      after(() => client.shutdown());
+
       utils.series([
         helper.ccmHelper.removeIfAny,
         function (next) {
@@ -679,6 +678,9 @@ describe('Client', function () {
     it('should failover after a node goes down', function (done) {
       // treat queries as idempotent so they can be safely retried on another node
       const client = newInstance({ queryOptions: { isIdempotent: true } });
+
+      after(() => client.shutdown());
+
       const hosts = {};
       const hostsDown = [];
       utils.series([
@@ -749,9 +751,13 @@ describe('Client', function () {
           '2': 0
         }
       };
+
       const client = new Client(options);
       const hosts = {};
       const query = helper.queries.basic;
+
+      after(() => client.shutdown());
+
       utils.series([
         function (next) {
           // wait for all initial events to ensure we don't incidentally get an 'UP' event for node 2

--- a/test/integration/short/pool-simulator-tests.js
+++ b/test/integration/short/pool-simulator-tests.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const simulacron = require('../simulacron');
 const helper = require('../../test-helper');
 const errors = require('../../../lib/errors');
+const utils = require('../../../lib/utils');
 const types = require('../../../lib/types');
 const policies = require('../../../lib/policies');
 
@@ -356,6 +357,81 @@ describe('pool', function () {
         .then(() => client.on('log', (level, message) => logMessages.push([ level, message ])))
         .then(() => new Promise(r => setTimeout(r, reconnectionDelay * 2)))
         .then(() => assert.deepStrictEqual(logMessages, []));
+    });
+
+    [
+      {
+        name: 'using the control connection',
+        fn: (client, cb) => client.controlConnection.query(helper.queries.basic, false, cb)
+      }, {
+        name: 'using client execute',
+        fn: (client, cb) => client.execute(helper.queries.basic, cb)
+      }
+    ].forEach(item => {
+      it(`should reject requests immediately after shutdown ${item.name}`, () => {
+        const client = new Client({
+          contactPoints: cluster.getContactPoints(),
+          localDataCenter: 'dc1',
+          pooling: { heartBeatInterval: 10000 }
+        });
+
+        after(() => client.shutdown());
+
+        let stop = false;
+        let requestCounter = 0;
+        let responseCounter = 0;
+        const results = [];
+        const maxResults = 1000;
+
+        return client.connect()
+          .then(() => {
+            // Execute queries in the background
+            utils.whilst(
+              () => !stop,
+              next => {
+                utils.timesLimit(100, 32, (i, timesNext) => {
+
+                  const checkReject = client.isShuttingDown;
+                  let timePassed = false;
+
+                  if (checkReject) {
+                    setTimeout(() => timePassed = true, 20);
+                  }
+
+                  requestCounter++;
+
+                  item.fn(client, err => {
+                    responseCounter++;
+                    if (checkReject && results.length < maxResults) {
+                      results.push({ timePassed, err });
+                    }
+
+                    if (err && client.isShuttingDown) {
+                      err = null;
+                    }
+
+                    timesNext(err);
+                  });
+                }, err => setImmediate(next, err));
+              },
+              utils.noop
+            );
+          })
+          .then(() => new Promise(r => setTimeout(r, 20)))
+          // Shutdown while there are queries in progress
+          .then(() => client.shutdown())
+          .then(() => new Promise(r => setTimeout(r, 200)))
+          .then(() => stop = true)
+          .then(() => new Promise(r => setTimeout(r, 200)))
+          .then(() => {
+            assert.ok(results.length > 0);
+            results.forEach(r => {
+              helper.assertInstanceOf(r.err, Error);
+              assert.strictEqual(r.timePassed, false);
+            });
+            assert.strictEqual(responseCounter, requestCounter);
+          });
+      });
     });
   });
 


### PR DESCRIPTION
https://datastax-oss.atlassian.net/browse/NODEJS-506

Validates that the `ControlConnection` is not shutdown before sending a request.

Additionally, in case the write is ongoing when a `Connection` is being closed, it clears all pending operations on socket error (it's unlikely, but I was able to reproduce it locally).

It contains some small pool test improvements: making sure the client is shutdown at the end of each test.