### PR TITLE
Support empty buffers as result cell values

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -78,6 +78,12 @@ const singleFqTypeNamesLength = Object.keys(singleTypeNames).reduce(function (pr
 const durationTypeName = 'org.apache.cassandra.db.marshal.DurationType';
 const nullValueBuffer = utils.allocBufferFromArray([255, 255, 255, 255]);
 const unsetValueBuffer = utils.allocBufferFromArray([255, 255, 255, 254]);
+
+/**
+ * For backwards compatibility, empty buffers as text/blob/custom values are supported.
+ * In the case of other types, they are going to be decoded as a <code>null</code> value.
+ * @type {Set}
+ */
 const zeroLengthTypesSupported = new Set([
   dataTypes.text,
   dataTypes.ascii,
@@ -263,7 +269,7 @@ function defineInstanceMembers() {
         offset += keyLength;
         const valueLength = self.decodeCollectionLength(bytes, offset);
         offset += self.collectionLengthSize;
-        if (valueLength < 0 || (valueLength === 0 && !zeroLengthTypesSupported.has(subtypes[1].code))) {
+        if (valueLength < 0) {
           callback.call(thisArg, key, null);
           continue;
         }
@@ -1392,13 +1398,16 @@ function setEncoders() {
  * @param {Object} [type.info] Additional information on the type for complex / nested types.
  */
 Encoder.prototype.decode = function (buffer, type) {
-  if (buffer === null) {
+  if (buffer === null || (buffer.length === 0 && !zeroLengthTypesSupported.has(type.code))) {
     return null;
   }
+
   const decoder = this.decoders[type.code];
+
   if (!decoder) {
     throw new Error('Unknown data type: ' + type.code);
   }
+
   return decoder.call(this, buffer, type.info);
 };
 

--- a/test/integration/short/client-execute-tests.js
+++ b/test/integration/short/client-execute-tests.js
@@ -44,6 +44,7 @@ describe('Client', function () {
         });
       });
     });
+
     context('with incorrect query parameters', () => {
       const client = setupInfo.client;
       const query = `INSERT INTO ${table} (id, bigint_sample) VALUES (?, ?)`;
@@ -93,6 +94,7 @@ describe('Client', function () {
         );
       });
     });
+
     it('should callback with an empty Array instance as rows when not found', function (done) {
       const client = setupInfo.client;
       client.execute(helper.queries.basicNoResults, function (err, result) {
@@ -104,6 +106,29 @@ describe('Client', function () {
         done();
       });
     });
+
+    it('should support retrieving empty buffers as values', () => {
+      // Include some columns to make sure the behaviour is consistent across different types.
+      // Inserting empty buffers fails server side for some types, e.g., "Not enough bytes to read a list"
+      const columnsAsNulls = ['bigint_sample', 'int_sample', 'double_sample', 'timeuuid_sample'];
+      const columns = ['text_sample', 'blob_sample'].concat(columnsAsNulls);
+      const insertQuery = `INSERT INTO ${table} (id, ${columns.join(',')})` +
+        ` VALUES (?, ${columns.map(() => '?').join(',')})`;
+      const selectQuery = `SELECT * FROM ${table} WHERE id = ?`;
+      const emptyBuffer = utils.allocBufferUnsafe(0);
+      const id = types.Uuid.random();
+      const client = setupInfo.client;
+
+      return client.execute(insertQuery, [ id ].concat(columns.map(() => emptyBuffer)))
+        .then(() => client.execute(selectQuery, [ id ]))
+        .then(rs => {
+          const row = rs.first();
+          columnsAsNulls.forEach(c => assert.strictEqual(row[c], null));
+          assert.strictEqual(row['text_sample'], '');
+          assert.deepStrictEqual(row['blob_sample'], utils.allocBufferUnsafe(0));
+        });
+    });
+
     it('should handle 250 parallel queries', function (done) {
       const client = setupInfo.client;
       utils.times(250, function (n, next) {


### PR DESCRIPTION
https://datastax-oss.atlassian.net/browse/NODEJS-475

When an empty buffer is obtained from C*, it returns `null` for most types except for ones that are supported: text types, `blob` and `custom`.

It basically generalizes the solution in #294.