### PR TITLE
Mapper: Defer the creation of promises in batches

### DIFF
--- a/lib/mapping/index.js
+++ b/lib/mapping/index.js
@@ -24,7 +24,7 @@
 exports.Mapper = require('./mapper');
 exports.ModelMapper = require('./model-mapper');
 exports.ModelBatchMapper = require('./model-batch-mapper');
-exports.ModelBatchItem = require('./model-batch-item');
+exports.ModelBatchItem = require('./model-batch-item').ModelBatchItem;
 exports.Result = require('./result');
 const tableMappingsModule = require('./table-mappings');
 exports.TableMappings = tableMappingsModule.TableMappings;

--- a/lib/mapping/mapper.js
+++ b/lib/mapping/mapper.js
@@ -23,7 +23,7 @@ const errors = require('../errors');
 const Result = require('./result');
 const ResultMapper = require('./result-mapper');
 const ModelMappingInfo = require('./model-mapping-info');
-const ModelBatchItem = require('./model-batch-item');
+const ModelBatchItem = require('./model-batch-item').ModelBatchItem;
 
 /**
  * Represents an object mapper for Apache Cassandra and DataStax Enterprise.

--- a/lib/mapping/model-batch-item.js
+++ b/lib/mapping/model-batch-item.js
@@ -16,22 +16,58 @@
 
 'use strict';
 
+const Cache = require('./cache');
+
 /**
  * Represents a query or a set of queries used to perform a mutation in a batch.
  * @alias module:mapping~ModelBatchItem
  */
 class ModelBatchItem {
   /**
-   * @param {Promise<Array>} queries
    * @param {Object} doc
    * @param {Object} docInfo
-   * @param {ModelMappingInfo} mappingInfo
+   * @param {MappingHandler} handler
+   * @param {Tree} cache
    */
-  constructor(queries, doc, docInfo, mappingInfo) {
-    this._queries = queries;
-    this._doc = doc;
-    this._docInfo = docInfo;
-    this._mappingInfo = mappingInfo;
+  constructor(doc, docInfo, handler, cache) {
+    this.doc = doc;
+    this.docInfo = docInfo;
+    this.handler = handler;
+    this.cache = cache;
+  }
+
+  /**
+   * @ignore
+   * @returns <Promise<Array>>
+   */
+  getQueries() {
+    const docKeys = Object.keys(this.doc);
+    const cacheItem = this.cache.getOrCreate(this.getCacheKey(docKeys), () => ({ queries: null }));
+
+    if (cacheItem.queries === null) {
+      cacheItem.queries = this.createQueries(docKeys);
+    }
+
+    return cacheItem.queries;
+  }
+
+  /**
+   * Gets the cache key for this item.
+   * @abstract
+   * @param {Array} docKeys
+   */
+  getCacheKey(docKeys) {
+    throw new Error('getCacheKey must be implemented');
+  }
+
+  /**
+   * Gets the Promise to create the queries.
+   * @abstract
+   * @param {Array} docKeys
+   * @returns {Promise<Array>}
+   */
+  createQueries(docKeys) {
+    throw new Error('getCacheKey must be implemented');
   }
 
   /**
@@ -44,7 +80,8 @@ class ModelBatchItem {
   pushQueries(arr) {
     let isIdempotent = true;
     let isCounter;
-    return this._queries.then(queries => {
+
+    return this.getQueries().then(queries => {
       queries.forEach(q => {
         // It's idempotent if all the queries contained are idempotent
         isIdempotent = isIdempotent && q.isIdempotent;
@@ -52,7 +89,7 @@ class ModelBatchItem {
         // Either all queries are counter mutation or we let it fail at server level
         isCounter = q.isCounter;
 
-        arr.push({ query: q.query, params: q.paramsGetter(this._doc, this._docInfo) });
+        arr.push({ query: q.query, params: q.paramsGetter(this.doc, this.docInfo) });
       });
 
       return { isIdempotent, isCounter };
@@ -65,8 +102,89 @@ class ModelBatchItem {
    * @ignore
    */
   getMappingInfo() {
-    return this._mappingInfo;
+    return this.handler.info;
   }
 }
 
-module.exports = ModelBatchItem;
+/**
+ * Represents a single or a set of INSERT queries in a batch.
+ * @ignore
+ * @internal
+ */
+class InsertModelBatchItem extends ModelBatchItem {
+  /**
+   * @param {Object} doc
+   * @param {Object} docInfo
+   * @param {MappingHandler} handler
+   * @param {Tree} cache
+   */
+  constructor(doc, docInfo, handler, cache) {
+    super(doc, docInfo, handler, cache);
+  }
+
+  /** @override */
+  getCacheKey(docKeys) {
+    return Cache.getInsertKey(docKeys, this.docInfo);
+  }
+
+  /** @override */
+  createQueries(docKeys) {
+    return this.handler.createInsertQueries(docKeys, this.doc, this.docInfo);
+  }
+}
+
+/**
+ * Represents a single or a set of UPDATE queries in a batch.
+ * @ignore
+ * @internal
+ */
+class UpdateModelBatchItem extends ModelBatchItem {
+  /**
+   * @param {Object} doc
+   * @param {Object} docInfo
+   * @param {MappingHandler} handler
+   * @param {Tree} cache
+   */
+  constructor(doc, docInfo, handler, cache) {
+    super(doc, docInfo, handler, cache);
+  }
+
+  /** @override */
+  getCacheKey(docKeys) {
+    return Cache.getUpdateKey(docKeys, this.doc, this.docInfo);
+  }
+
+  /** @override */
+  createQueries(docKeys) {
+    return this.handler.createUpdateQueries(docKeys, this.doc, this.docInfo);
+  }
+}
+
+/**
+ * Represents a single or a set of DELETE queries in a batch.
+ * @ignore
+ * @internal
+ */
+class RemoveModelBatchItem extends ModelBatchItem {
+  /**
+   * @param {Object} doc
+   * @param {Object} docInfo
+   * @param {MappingHandler} handler
+   * @param {Tree} cache
+   */
+  constructor(doc, docInfo, handler, cache) {
+    super(doc, docInfo, handler, cache);
+  }
+
+  /** @override */
+  getCacheKey(docKeys) {
+    return Cache.getRemoveKey(docKeys, this.doc, this.docInfo);
+  }
+
+  /** @override */
+  createQueries(docKeys) {
+    return this.handler.createDeleteQueries(docKeys, this.doc, this.docInfo);
+  }
+}
+
+module.exports = { ModelBatchItem, InsertModelBatchItem, UpdateModelBatchItem, RemoveModelBatchItem };

--- a/lib/mapping/model-batch-mapper.js
+++ b/lib/mapping/model-batch-mapper.js
@@ -16,9 +16,11 @@
 
 'use strict';
 
-const Cache = require('./cache');
 const Tree = require('./tree');
-const ModelBatchItem = require('./model-batch-item');
+const moduleBatchItemModule = require('./model-batch-item');
+const InsertModelBatchItem = moduleBatchItemModule.InsertModelBatchItem;
+const UpdateModelBatchItem = moduleBatchItemModule.UpdateModelBatchItem;
+const RemoveModelBatchItem = moduleBatchItemModule.RemoveModelBatchItem;
 
 /**
  * Provides utility methods to group multiple mutations on a single batch.
@@ -59,15 +61,7 @@ class ModelBatchMapper {
    * or a set of queries to be included in a batch.
    */
   insert(doc, docInfo) {
-    const docKeys = Object.keys(doc);
-    const cacheKey = Cache.getInsertKey(docKeys, docInfo);
-    const cacheItem = this._cache.insert.getOrCreate(cacheKey, () => ({ queries: null }));
-
-    if (cacheItem.queries === null) {
-      cacheItem.queries = this._handler.createInsertQueries(docKeys, doc, docInfo);
-    }
-
-    return new ModelBatchItem(cacheItem.queries, doc, docInfo, this._handler.info);
+    return new InsertModelBatchItem(doc, docInfo, this._handler, this._cache.insert);
   }
 
   /**
@@ -93,15 +87,7 @@ class ModelBatchMapper {
    * or a set of queries to be included in a batch.
    */
   update(doc, docInfo) {
-    const docKeys = Object.keys(doc);
-    const cacheKey = Cache.getUpdateKey(docKeys, doc, docInfo);
-    const cacheItem = this._cache.update.getOrCreate(cacheKey, () => ({ queries: null }));
-
-    if (cacheItem.queries === null) {
-      cacheItem.queries = this._handler.createUpdateQueries(docKeys, doc, docInfo);
-    }
-
-    return new ModelBatchItem(cacheItem.queries, doc, docInfo, this._handler.info);
+    return new UpdateModelBatchItem(doc, docInfo, this._handler, this._cache.update);
   }
 
   /**
@@ -132,15 +118,7 @@ class ModelBatchMapper {
    * or a set of queries to be included in a batch.
    */
   remove(doc, docInfo) {
-    const docKeys = Object.keys(doc);
-    const cacheKey = Cache.getRemoveKey(docKeys, doc, docInfo);
-    const cacheItem = this._cache.remove.getOrCreate(cacheKey, () => ({ queries: null }));
-
-    if (cacheItem.queries === null) {
-      cacheItem.queries = this._handler.createDeleteQueries(docKeys, doc, docInfo);
-    }
-
-    return new ModelBatchItem(cacheItem.queries, doc, docInfo, this._handler.info);
+    return new RemoveModelBatchItem(doc, docInfo, this._handler, this._cache.update);
   }
 }
 

--- a/test/integration/short/mapping/mapper-tests.js
+++ b/test/integration/short/mapping/mapper-tests.js
@@ -126,7 +126,8 @@ describe('Mapper', function () {
 
       return mapper
         .batch([
-          userMapper.batching.update(userDoc, { ifExists: true })
+          userMapper.batching.update(userDoc, { ifExists: true }),
+          userMapper.batching.update(userDoc)
         ])
         .then(result => {
           helper.assertInstanceOf(result, Result);

--- a/test/unit/mapping/mapper-tests.js
+++ b/test/unit/mapping/mapper-tests.js
@@ -20,8 +20,6 @@ const assert = require('assert');
 const Mapper = require('../../../lib/mapping/mapper');
 const helper = require('../../test-helper');
 const mapperTestHelper = require('./mapper-unit-test-helper');
-const ModelBatchItem = require('../../../lib/mapping/model-batch-item');
-const utils = require('../../../lib/utils');
 
 describe('Mapper', () => {
   describe('constructor', () => {
@@ -113,15 +111,66 @@ describe('Mapper', () => {
       }));
     });
 
+    it('should not create unhandled promises', () => {
+      const clientInfo = mapperTestHelper.getClient([ 'id1', 'id2', 'name'], [ 1, 1 ]);
+      const mapper = mapperTestHelper.getMapper(clientInfo);
+      const modelMapper = mapper.forModel('Sample');
+      const unhandled = [];
+
+      function unhandledRejectionFn(reason, promise) {
+        unhandled.push({ reason, promise });
+      }
+
+      process.on('unhandledRejection', unhandledRejectionFn);
+
+      modelMapper.batching.insert({ z: 'this column does not exist' });
+      modelMapper.batching.update({ z: 'this column does not exist' });
+      modelMapper.batching.remove({ z: 'this column does not exist' });
+
+      return new Promise(r => setImmediate(r))
+        .then(() => process.removeListener('unhandledRejection', unhandledRejectionFn))
+        .then(() => assert.strictEqual(unhandled.length, 0));
+    });
+
+    it('should throw error when one of the ModelBatchItem is invalid', () => {
+      const clientInfo = mapperTestHelper.getClient([ 'id1', 'id2', 'name'], [ 1, 1 ]);
+      const mapper = mapperTestHelper.getMapper(clientInfo);
+      const modelMapper = mapper.forModel('Sample');
+      const unhandled = [];
+
+      function unhandledRejectionFn(reason, promise) {
+        unhandled.push({ reason, promise });
+      }
+
+      process.on('unhandledRejection', unhandledRejectionFn);
+      let error;
+
+      return mapper
+        .batch([
+          modelMapper.batching.insert({ z: 'this column does not exist' }),
+          modelMapper.batching.update({ z: 'this column does not exist' }),
+          modelMapper.batching.remove({ z: 'this column does not exist' })
+        ])
+        .catch(err => error = err)
+        .then(() => new Promise(r => setImmediate(r)))
+        .then(() => {
+          process.removeListener('unhandledRejection', unhandledRejectionFn);
+          helper.assertInstanceOf(error, Error);
+          helper.assertContains(error.message, 'No table matches');
+          assert.strictEqual(unhandled.length, 0);
+        });
+    });
+
     it('should set idempotency based on the items idempotency', () =>
       Promise.all([ true, false ].map((isIdempotent) => {
         const clientInfo = mapperTestHelper.getClient([ 'id1'], [ 1 ]);
         const mapper = mapperTestHelper.getMapper(clientInfo);
+        const modelMapper = mapper.forModel('Sample');
 
         // 2 queries, one using the provided idempotency to test
         const items = [
-          new ModelBatchItem(Promise.resolve([ { isIdempotent, paramsGetter: utils.noop }])),
-          new ModelBatchItem(Promise.resolve([ { isIdempotent: true, paramsGetter: utils.noop }])),
+          modelMapper.batching.insert({ id1: 'value1' }, { ifNotExists: !isIdempotent }),
+          modelMapper.batching.insert({ id1: 'value2' }),
         ];
 
         return mapper.batch(items)
@@ -129,27 +178,5 @@ describe('Mapper', () => {
             assert.strictEqual(clientInfo.batchExecutions[0].options.isIdempotent, isIdempotent);
           });
       })));
-
-    it('should allow multiple calls using the same ModelBatchItem', () => {
-      const clientInfo = mapperTestHelper.getClient([ 'id1'], [ 1 ]);
-      const mapper = mapperTestHelper.getMapper(clientInfo);
-
-      let resolve = null;
-
-      // 2 queries, one using the provided idempotency to test
-      const items = [
-        new ModelBatchItem(new Promise(r => resolve = r)),
-        new ModelBatchItem(Promise.resolve([ { isIdempotent: true, paramsGetter: utils.noop }])),
-      ];
-
-      // call it multiple times with the same queries
-      const promises = [ mapper.batch(items), mapper.batch(items) ];
-
-      resolve([ { isIdempotent: false, paramsGetter: utils.noop }]);
-
-      return Promise.all(promises.map((p, index) => p.then(() => {
-        assert.strictEqual(clientInfo.batchExecutions[index].options.isIdempotent, false);
-      })));
-    });
   });
 });


### PR DESCRIPTION
https://datastax-oss.atlassian.net/browse/NODEJS-509

The creation of `Promise` instances ahead of the execution could cause unhandled promise rejections. For that reason, I've changed how `ModelBatchItem` works internally in order to create the queries when the batch is executed.