### PR TITLE
Mapper: select table using clustering keys from "order by"

### DIFF
--- a/lib/mapping/cache.js
+++ b/lib/mapping/cache.js
@@ -65,9 +65,16 @@ class Cache {
         yield '|l|';
       }
 
-      if (docInfo.orderBy && docInfo.orderBy.length > 0) {
+      if (docInfo.orderBy) {
         yield '|o|';
-        yield* docInfo.orderBy;
+
+        // orderBy is uses property names as keys and 'asc'/'desc' as values
+        const keys = Object.keys(docInfo.orderBy);
+        for (let i = 0; i < keys.length; i++) {
+          const key = keys[i];
+          yield key;
+          yield docInfo.orderBy[key];
+        }
       }
     }
   }

--- a/lib/mapping/object-selector.js
+++ b/lib/mapping/object-selector.js
@@ -86,10 +86,14 @@ class ObjectSelector {
             continue;
           }
 
-          // ORDER BY fields must be part of the clustering keys
-          // On the mapper we only validate that are part of the table
+          // CQL:
+          // - "ORDER BY" is currently only supported on the clustered columns of the PRIMARY KEY
+          // - "ORDER BY" currently only support the ordering of columns following their declared order in
+          //   the PRIMARY KEY
+          //
+          // In the mapper, we validate that the ORDER BY columns appear in the same order as in the clustering keys
           const containsAllOrderByColumns = orderByColumns
-            .reduce((acc, order) => acc && table.columnsByName[order[0]] !== undefined, true);
+            .reduce((acc, order, index) => acc && table.clusteringKeys[index].name === order[0], true);
 
           if (!containsAllOrderByColumns) {
             continue;

--- a/test/integration/short/mapping/mapper-test-helper.js
+++ b/test/integration/short/mapping/mapper-test-helper.js
@@ -56,6 +56,8 @@ const mapperHelper = module.exports = {
       `CREATE TABLE users (userid uuid, firstname varchar, lastname varchar, email text, created_date timestamp,
       PRIMARY KEY (userid))`,
       `CREATE TABLE video_rating (videoid uuid, rating_counter counter, rating_total counter, PRIMARY KEY (videoid))`,
+      `CREATE TABLE table_clustering1 (id1 text, id2 text, id3 text, value text, PRIMARY KEY (id1, id2, id3))`,
+      `CREATE TABLE table_clustering2 (id1 text, id3 text, id2 text, value text, PRIMARY KEY (id1, id3, id2))`,
 
       // Insert test data
       `INSERT INTO videos (videoid, name, userid, description, location, location_type, preview_thumbnails, tags,
@@ -68,7 +70,11 @@ const mapperHelper = module.exports = {
      '/us/vid/b3/b3a76c6b-7c7f-4af6-964f-803a9283c401')`,
       `INSERT INTO latest_videos (yyyymmdd, videoid, added_date, name, preview_image_location) VALUES ('2012-06-01',
      99051fe9-6a9c-46c2-b949-38ef78858dd0,'2012-06-01 06:00:00Z','My funny cat',
-     '/us/vid/b3/b3a76c6b-7c7f-4af6-964f-803a9283c401');`
+     '/us/vid/b3/b3a76c6b-7c7f-4af6-964f-803a9283c401');`,
+      `INSERT INTO table_clustering1 (id1, id2, id3, value) VALUES ('a', 'b', 'c', 'value_abc_table1')`,
+      `INSERT INTO table_clustering1 (id1, id2, id3, value) VALUES ('a', 'z', 'z', 'value_azz_table1')`,
+      `INSERT INTO table_clustering2 (id1, id2, id3, value) VALUES ('a', 'b', 'c', 'value_abc_table2')`,
+      `INSERT INTO table_clustering2 (id1, id2, id3, value) VALUES ('a', 'z', 'z', 'value_azz_table2')`
     ];
 
     helper.setup(1, { queries, keyspace: mapperHelper.keyspace, removeClusterAfter: false });
@@ -163,7 +169,8 @@ const mapperHelper = module.exports = {
             'videoid': 'id'
           },
           mappings: new UnderscoreCqlToCamelCaseMappings()
-        }
+        },
+        'Clustering': { tables: ['table_clustering1', 'table_clustering2'] }
       }
     });
   },

--- a/test/unit/mapping/cache-tests.js
+++ b/test/unit/mapping/cache-tests.js
@@ -58,10 +58,10 @@ describe('Cache', function() {
       assert.notDeepEqual(key1WithLimitA, key2WithLimit);
 
       // orderBy
-      const key1WithOrderByA = getKey(docKeys1, {}, { orderBy: ['abc'] });
-      const key1WithOrderByB = getKey(docKeys1, {}, { orderBy: ['def'] });
-      const key1WithOrderByC = getKey(docKeys1, {}, { orderBy: ['abc'] });
-      const key1WithOrderByD = getKey(docKeys1, {}, { orderBy: ['abc', 'def'] });
+      const key1WithOrderByA = getKey(docKeys1, {}, { orderBy: {'abc': 'asc'} });
+      const key1WithOrderByB = getKey(docKeys1, {}, { orderBy: {'def': 'desc'} });
+      const key1WithOrderByC = getKey(docKeys1, {}, { orderBy: {'abc': 'asc'} });
+      const key1WithOrderByD = getKey(docKeys1, {}, { orderBy: {'abc': 'asc', 'def': 'desc'} });
 
       assert.notDeepEqual(key1WithOrderByA, key1WithOrderByB);
       assert.notDeepEqual(key1WithOrderByA, key1WithOrderByD);

--- a/test/unit/mapping/mapper-unit-test-helper.js
+++ b/test/unit/mapping/mapper-unit-test-helper.js
@@ -26,18 +26,28 @@ const Mapper = require('../../../lib/mapping/mapper');
 const mapperHelper = module.exports = {
   /**
    * Gets a fake client instance that returns metadata for a single table
-   * @param {Array} columns
+   * @param {Array|Function} columns
    * @param {Array} primaryKeys
    * @param {String} [keyspace]
    * @param {Object} [response]
    * @return {{executions: Array, batchExecutions: Array, client: Client}}
    */
   getClient: function (columns, primaryKeys, keyspace, response) {
-    columns = columns.map(c => (typeof c === 'string' ? { name: c, type: { code: dataTypes.text }} : c));
-    const partitionKeys = columns.slice(0, primaryKeys[0]);
-    const clusteringKeys = primaryKeys[1] !== undefined
-      ? columns.slice(primaryKeys[0], primaryKeys[1] + primaryKeys[0])
-      : [];
+
+    const getTableMetadata = typeof columns === 'function'
+      ? columns
+      : (ks, name) => {
+        // Build a fake table metadata
+        columns = columns.map(c => (typeof c === 'string' ? {name: c, type: {code: dataTypes.text}} : c));
+        const partitionKeys = columns.slice(0, primaryKeys[0]);
+        const clusteringKeys = primaryKeys[1] !== undefined
+          ? columns.slice(primaryKeys[0], primaryKeys[1] + primaryKeys[0])
+          : [];
+
+        const table = {name, partitionKeys, clusteringKeys, columnsByName: {}, columns};
+        table.columns.forEach(c => table.columnsByName[c.name] = c);
+        return Promise.resolve(table);
+      };
 
     const result = {
       executions: [],
@@ -47,11 +57,7 @@ const mapperHelper = module.exports = {
         connect: () => Promise.resolve(),
         keyspace: keyspace === undefined ? 'ks1' : keyspace,
         metadata: {
-          getTable: (ks, name) => {
-            const table = { name, partitionKeys, clusteringKeys, columnsByName: {}, columns };
-            table.columns.forEach(c => table.columnsByName[c.name] = c);
-            return Promise.resolve(table);
-          },
+          getTable: getTableMetadata,
         },
         execute: function (query, params, options) {
           result.executions.push({ query, params, options });
@@ -70,14 +76,14 @@ const mapperHelper = module.exports = {
     return result;
   },
 
-  getModelMapper: function (clientInfo) {
-    const mapper = mapperHelper.getMapper(clientInfo);
+  getModelMapper: function (clientInfo, models) {
+    const mapper = mapperHelper.getMapper(clientInfo, models);
     return mapper.forModel('Sample');
   },
 
-  getMapper: function (clientInfo) {
+  getMapper: function (clientInfo, models) {
     return new Mapper(clientInfo.client, {
-      models: {
+      models: models || {
         'Sample': {
           tables: [ 'table1' ],
           columns: {

--- a/test/unit/mapping/model-mapper-select-tests.js
+++ b/test/unit/mapping/model-mapper-select-tests.js
@@ -18,6 +18,7 @@
 
 const assert = require('assert');
 const q = require('../../../lib/mapping/q').q;
+const dataTypes = require('../../../lib/types').dataTypes;
 const helper = require('../../test-helper');
 const mapperTestHelper = require('./mapper-unit-test-helper');
 
@@ -61,16 +62,31 @@ describe('ModelMapper', () => {
     it('should support orderBy in correct order', () => testQueries('find', [
       {
         doc: { id1: 'value2' },
-        docInfo: { orderBy: {'locationType': 'desc' }},
+        docInfo: { orderBy: {'id2': 'desc' }},
         query:
-          'SELECT * FROM ks1.table1 WHERE id1 = ? ORDER BY location_type DESC',
+          'SELECT * FROM ks1.table1 WHERE id1 = ? ORDER BY id2 DESC',
         params: [ 'value2' ]
       }, {
-        doc: { id1: 'value1', id2: q.gte('e') },
-        docInfo: { fields: ['name'], limit: 20, orderBy: {'description': 'asc', 'locationType': 'desc' }},
+        doc: { id1: 'value3' },
+        docInfo: { orderBy: {'id2': 'asc' }},
         query:
-          'SELECT name FROM ks1.table1 WHERE id1 = ? AND id2 >= ? ORDER BY description ASC, location_type DESC LIMIT ?',
+          'SELECT * FROM ks1.table1 WHERE id1 = ? ORDER BY id2 ASC',
+        params: [ 'value3' ]
+      }, {
+        doc: { id1: 'value1', id2: q.gte('e') },
+        docInfo: { fields: ['name'], limit: 20, orderBy: {'id2': 'asc' }},
+        query:
+          'SELECT name FROM ks1.table1 WHERE id1 = ? AND id2 >= ? ORDER BY id2 ASC LIMIT ?',
         params: [ 'value1', 'e', 20 ]
+      }]));
+
+    it('should support ordering by clustering key only providing a partition key', () => testQueries('find', [
+      {
+        doc: { id1: 'value2' },
+        docInfo: { orderBy: {'id2': 'asc' }},
+        query:
+          'SELECT * FROM ks1.table1 WHERE id1 = ? ORDER BY id2 ASC',
+        params: [ 'value2' ]
       }]));
 
     it('should throw an error when filter, fields or orderBy are not valid', () =>
@@ -132,6 +148,45 @@ describe('ModelMapper', () => {
         assert.strictEqual(execution.query, 'SELECT * FROM ks1.NoTableSpecified WHERE id1 = ? AND id2 = ?');
       });
     });
+
+    it('should use the correct table when order by a clustering key', () => {
+      // Mock table metadata
+      function getTableMetadata(ks, name) {
+        // Equivalent of
+        // CREATE TABLE table1 (id1 text, id2 text, id3 text, PRIMARY KEY (id1, id2, id3))
+        // CREATE TABLE table2 (id1 text, id2 text, id3 text, PRIMARY KEY (id1, id3, id2))
+        const columns = [ 'id1', 'id2', 'id3', 'value' ].map(c => ({ name: c, type: { code: dataTypes.text }}));
+        const partitionKeys = [ columns[0] ];
+        const clusteringKeys = name === 'table1' ? [ columns[1], columns[2] ] : [ columns[2], columns[1] ];
+
+        const table = { name, partitionKeys, clusteringKeys, columnsByName: {}, columns };
+        table.columns.forEach(c => table.columnsByName[c.name] = c);
+        return Promise.resolve(table);
+      }
+
+      const models = { 'Sample': { tables: [ 'table1', 'table2' ] } };
+
+      const clientInfo = mapperTestHelper.getClient(getTableMetadata, null, 'ks1', emptyResponse);
+      const modelMapper = mapperTestHelper.getModelMapper(clientInfo, models);
+
+      return modelMapper
+        .find({ id1: 'a' }, { orderBy: { 'id3': 'asc' }})
+        .then(() => modelMapper.find({ id1: 'a' }, { orderBy: { 'id2': 'desc', 'id3': 'desc' }}))
+        .then(() => modelMapper.find({ id1: 'a' }, { orderBy: { 'id2': 'asc' }}))
+        .then(() => {
+          [
+            // Selected "table2" for the first query
+            'SELECT * FROM ks1.table2 WHERE id1 = ? ORDER BY id3 ASC',
+            // Selected "table1" for the second query
+            'SELECT * FROM ks1.table1 WHERE id1 = ? ORDER BY id2 DESC, id3 DESC',
+            // Selected "table1" for the third query
+            'SELECT * FROM ks1.table1 WHERE id1 = ? ORDER BY id2 ASC'
+          ].forEach((query, index) => {
+            assert.strictEqual(clientInfo.executions[index].query, query);
+            assert.deepStrictEqual(clientInfo.executions[index].params, [ 'a' ]);
+          });
+        });
+    });
   });
 
   describe('#get()', () => {
@@ -168,20 +223,6 @@ describe('ModelMapper', () => {
         docInfo: { fields: ['name', 'description', 'locationType'] },
         query: 'SELECT name, description, location_type FROM ks1.table1',
         params: []
-      }]));
-
-    it('should support orderBy in correct order', () => testQueries('findAll', [
-      {
-        docInfo: { orderBy: {'locationType': 'desc' }},
-        query:
-          'SELECT * FROM ks1.table1 ORDER BY location_type DESC',
-        params: []
-      }, {
-        doc: { id1: 'value1', id2: q.gte('e') },
-        docInfo: { fields: ['name'], limit: 20, orderBy: {'description': 'asc', 'locationType': 'desc' }},
-        query:
-          'SELECT name FROM ks1.table1 ORDER BY description ASC, location_type DESC LIMIT ?',
-        params: [ 20 ]
       }]));
   });
 


### PR DESCRIPTION
The table or view selection now expects the clustering keys to
appear in the same order as the ORDER BY clause.

Also, it fixes a bug where the select cache key used orderBy as an
Array when an Object is expected.

https://datastax-oss.atlassian.net/browse/NODEJS-512
https://datastax-oss.atlassian.net/browse/NODEJS-527
