### PR TITLE
Fix for PreparedQueries.prototype._validateOverflow

### DIFF
--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -1037,7 +1037,7 @@ PreparedQueries.prototype._validateOverflow = function () {
   this._logger('warning',
     'Prepared statements exceeded maximum. This could be caused by preparing queries that contain parameters');
   const existingKeys = Object.keys(this._mapByKey);
-  for (let i = 0; i < existingKeys.length && this.length - toRemove.length < this._maxPrepared; i++) {
+  for (let i = 0; i < existingKeys.length && this.length - toRemove.length >= this._maxPrepared; i++) {
     const info = this._mapByKey[existingKeys[i]];
     if (!info.queryId) {
       // Only remove queries that contain queryId
@@ -1046,7 +1046,7 @@ PreparedQueries.prototype._validateOverflow = function () {
     toRemove.push(info);
   }
   toRemove.forEach(function (item) {
-    delete this._mapByKey[item.query];
+    delete this._mapByKey[this._getKey(item.keyspace, item.query)];
     delete this._mapById[item.queryId];
     this.length--;
   }, this);


### PR DESCRIPTION
Hi,

The ```PreparedQueries#_validateOverflow``` function has two bugs that can lead to a memory leak:
1. The comparison operator when comparing keys to this._maxPrepared should be ```>=```, not ```<```.
2. The key used to delete the entry from ```this._mapByKey``` should be generated using ```this._getKey()``` instead of using the query directly.