### PR TITLE
Support string for numeric values

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -364,21 +364,43 @@ function defineInstanceMembers() {
 
   //Encoding methods
   this.encodeFloat = function (value) {
+    if (typeof value === 'string') {
+      // All numeric types are supported as strings for historical reasons
+      value = parseFloat(value);
+
+      if (Number.isNaN(value)) {
+        throw new TypeError(`Expected string representation of a number, obtained ${util.inspect(value)}`);
+      }
+    }
+
     if (typeof value !== 'number') {
       throw new TypeError('Expected Number, obtained ' + util.inspect(value));
     }
+
     const buf = utils.allocBufferUnsafe(4);
     buf.writeFloatBE(value, 0);
     return buf;
   };
+
   this.encodeDouble = function (value) {
+    if (typeof value === 'string') {
+      // All numeric types are supported as strings for historical reasons
+      value = parseFloat(value);
+
+      if (Number.isNaN(value)) {
+        throw new TypeError(`Expected string representation of a number, obtained ${util.inspect(value)}`);
+      }
+    }
+
     if (typeof value !== 'number') {
       throw new TypeError('Expected Number, obtained ' + util.inspect(value));
     }
+
     const buf = utils.allocBufferUnsafe(8);
     buf.writeDoubleBE(value, 0);
     return buf;
   };
+
   /**
    * @param {Date|String|Long|Number} value
    * @private
@@ -509,6 +531,11 @@ function defineInstanceMembers() {
   };
 
   this._encodeBigIntFromBigInt = function (value) {
+    if (typeof value === 'string') {
+      // All numeric types are supported as strings for historical reasons
+      value = BigInt(value);
+    }
+
     // eslint-disable-next-line valid-typeof
     if (typeof value !== 'bigint') {
       // Only BigInt values are supported
@@ -551,6 +578,11 @@ function defineInstanceMembers() {
   };
 
   this._encodeVarintFromBigInt = function (value) {
+    if (typeof value === 'string') {
+      // All numeric types are supported as strings for historical reasons
+      value = BigInt(value);
+    }
+
     // eslint-disable-next-line valid-typeof
     if (typeof value !== 'bigint') {
       throw new TypeError('Not a valid varint, expected BigInt, obtained ' + util.inspect(value));

--- a/test/integration/short/client-execute-prepared-tests.js
+++ b/test/integration/short/client-execute-prepared-tests.js
@@ -28,7 +28,7 @@ const vit = helper.vit;
 const vdescribe = helper.vdescribe;
 const Uuid = types.Uuid;
 const commonKs = helper.getRandomName('ks');
-const bigIntTests = require('./es-bigint-tests');
+const numericTests = require('./numeric-tests');
 
 describe('Client', function () {
   this.timeout(120000);
@@ -1197,7 +1197,7 @@ describe('Client', function () {
       });
     });
 
-    bigIntTests(commonKs, true);
+    numericTests(commonKs, true);
   });
 });
 

--- a/test/integration/short/client-execute-tests.js
+++ b/test/integration/short/client-execute-tests.js
@@ -26,7 +26,7 @@ const utils = require('../../../lib/utils.js');
 const errors = require('../../../lib/errors.js');
 const vit = helper.vit;
 const vdescribe = helper.vdescribe;
-const bigIntTests = require('./es-bigint-tests');
+const numericTests = require('./numeric-tests');
 
 describe('Client', function () {
   this.timeout(120000);
@@ -1155,7 +1155,7 @@ describe('Client', function () {
       });
     });
 
-    bigIntTests(keyspace, false);
+    numericTests(keyspace, false);
   });
 });
 

--- a/test/unit/encoder-tests.js
+++ b/test/unit/encoder-tests.js
@@ -114,9 +114,6 @@ describe('encoder', function () {
         typeEncoder.encode('hello', 'int');
       }, TypeError);
       assert.throws(function () {
-        typeEncoder.encode('1.1', 'float');
-      }, TypeError);
-      assert.throws(function () {
         typeEncoder.encode(100, dataTypes.uuid);
       }, TypeError);
       assert.throws(function () {
@@ -739,6 +736,30 @@ describe('encoder', function () {
         assert.strictEqual(encoder.encode(buffer, dataTypes[typeName]), buffer);
       });
     });
+
+    it('should encode string representations of numeric values', () => {
+      const encoder = newInstance();
+      assertBuffer(encoder.encode('3', getType(dataTypes.bigint)), 8);
+      assertBuffer(encoder.encode('3', getType(dataTypes.varint)), 1);
+      assertBuffer(encoder.encode('3', getType(dataTypes.int)), 4);
+      assertBuffer(encoder.encode('3.375', getType(dataTypes.float)), 4);
+      assertBuffer(encoder.encode('3.375', getType(dataTypes.double)), 8);
+      assertBuffer(encoder.encode('3.375', getType(dataTypes.decimal)), 6);
+      assertBuffer(encoder.encode(NaN, getType(dataTypes.double)), 8);
+    });
+
+    it('should encode NaN', () => {
+      const encoder = newInstance();
+      assertBuffer(encoder.encode(NaN, getType(dataTypes.double)), 8);
+      assertBuffer(encoder.encode(NaN, getType(dataTypes.float)), 4);
+    });
+
+    it('should throw an error for invalid string representations of numeric values', () => {
+      const encoder = newInstance();
+      assert.throws(() => encoder.encode('hello!', getType(dataTypes.int)), TypeError);
+      assert.throws(() => encoder.encode('hello!', getType(dataTypes.double)), TypeError);
+      assert.throws(() => encoder.encode('hello!', getType(dataTypes.float)), TypeError);
+    });
   });
 
   describe('#setRoutingKeyFromUser()', function () {
@@ -1270,4 +1291,17 @@ function getExecOptions(options) {
   result.getHints = () => options.hints;
   result.getRoutingIndexes = () => options.routingIndexes;
   return result;
+}
+
+function newInstance(protocolVersion, clientOptions) {
+  return new Encoder(protocolVersion || types.protocolVersion.maxSupported, clientOptions || {});
+}
+
+function getType(typeCode) {
+  return { code: typeCode };
+}
+
+function assertBuffer(buffer, length) {
+  helper.assertInstanceOf(buffer, Buffer);
+  assert.strictEqual(buffer.length, length);
 }


### PR DESCRIPTION
To have an uniform behaviour, this adds support for providing string values for queries expecting any numeric value (new for double/float/bigint).

https://datastax-oss.atlassian.net/browse/NODEJS-514