### PR TITLE
Use proxyquire, sinon and chai

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+# TypeScript: js files are generated using tsc transpiler
+/test/unit/typescript/*.js
+
+# Integer is part of the Closure Library
+/lib/types/integer.js

--- a/lib/client.js
+++ b/lib/client.js
@@ -28,13 +28,9 @@ const ClientState = require('./metadata/client-state');
 const description = require('../package.json').description;
 const version = require('../package.json').version;
 const DefaultExecutionOptions = require('./execution-options').DefaultExecutionOptions;
-
-// Allow injection of the following modules
-/* eslint-disable prefer-const */
-let ControlConnection = require('./control-connection');
-let RequestHandler = require('./request-handler');
-let PrepareHandler = require('./prepare-handler');
-/* eslint-enable prefer-const */
+const ControlConnection = require('./control-connection');
+const RequestHandler = require('./request-handler');
+const PrepareHandler = require('./prepare-handler');
 
 /**
  * Max amount of pools being warmup in parallel, when warmup is enabled

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -19,6 +19,7 @@
 const events = require('events');
 const util = require('util');
 const tls = require('tls');
+const net = require('net');
 
 const Encoder = require('./encoder.js');
 const WriteQueue = require('./writers').WriteQueue;
@@ -30,10 +31,6 @@ const errors = require('./errors');
 const StreamIdStack = require('./stream-id-stack');
 const OperationState = require('./operation-state');
 const ExecutionOptions = require('./execution-options').ExecutionOptions;
-
-// Allow injection of net module
-// eslint-disable-next-line prefer-const
-let net = require('net');
 
 /**
  * Represents a connection to a Cassandra node

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -18,6 +18,7 @@
 const events = require('events');
 const util = require('util');
 const net = require('net');
+const dns = require('dns');
 
 const errors = require('./errors');
 const Host = require('./host').Host;
@@ -29,8 +30,6 @@ const requests = require('./requests');
 const utils = require('./utils');
 const types = require('./types');
 const f = util.format;
-// eslint-disable-next-line prefer-const
-let dns = require('dns');
 
 const selectPeers = "SELECT * FROM system.peers";
 const selectLocal = "SELECT * FROM system.local WHERE key='local'";

--- a/lib/metadata/schema-parser.js
+++ b/lib/metadata/schema-parser.js
@@ -1404,3 +1404,4 @@ function getByVersion(options, cc, udtResolver, version, currentInstance) {
 }
 
 exports.getByVersion = getByVersion;
+exports.isDoneForToken = isDoneForToken;

--- a/lib/stream-id-stack.js
+++ b/lib/stream-id-stack.js
@@ -51,8 +51,7 @@ const maxGroupsFor2Bytes = 256;
  * @const
  * @type {number}
  */
-// eslint-disable-next-line prefer-const
-let releaseDelay = 5000;
+const defaultReleaseDelay = 5000;
 
 /**
  * Represents a queue of ids from 0 to maximum stream id supported by the protocol version.
@@ -62,7 +61,7 @@ let releaseDelay = 5000;
 class StreamIdStack {
   /**
    * Creates a new instance of StreamIdStack.
-   * @param {Number} version Protocol version
+   * @param {number} version Protocol version
    * @constructor
    */
   constructor(version) {
@@ -78,6 +77,7 @@ class StreamIdStack {
      * @member {number}
      */
     this.inUse = 0;
+    this.releaseDelay = defaultReleaseDelay;
   }
 
   /**
@@ -166,8 +166,8 @@ class StreamIdStack {
       //Nothing to release or a release delay has been issued
       return;
     }
-    const self = this;
-    this.releaseTimeout = setTimeout(() => self._releaseGroups(), releaseDelay);
+
+    this.releaseTimeout = setTimeout(() => this._releaseGroups(), this.releaseDelay);
   }
 
   _releaseGroups() {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   },
   "devDependencies": {
     "mocha": "~5.2.0",
-    "proxyquire": "~2.1.3"
+    "proxyquire": "~2.1.3",
+    "sinon": "~7.5.0",
+    "chai": "4.2.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "mocha": "~5.2.0",
-    "rewire": "^4.0.1"
+    "proxyquire": "~2.1.3"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ci_jenkins": "./node_modules/.bin/mocha test/unit test/integration/short --recursive -R mocha-jenkins-reporter --exit",
     "ci_appveyor": "./node_modules/.bin/mocha test/unit test/integration/short --recursive -R mocha-appveyor-reporter --exit",
     "ci_unit_appveyor": "./node_modules/.bin/mocha test/unit --recursive -R mocha-appveyor-reporter --exit",
-    "eslint": "eslint lib test --ignore-pattern '/lib/types/integer.js'"
+    "eslint": "eslint lib test"
   },
   "engines": {
     "node": ">=4"

--- a/test/integration/short/connection-tests.js
+++ b/test/integration/short/connection-tests.js
@@ -15,7 +15,8 @@
  */
 
 "use strict";
-const assert = require('assert');
+const assert = require('chai').assert;
+const sinon = require('sinon');
 
 const Connection = require('../../../lib/connection.js');
 const defaultOptions = require('../../../lib/client-options.js').defaultOptions();
@@ -101,25 +102,37 @@ describe('Connection', function () {
         localCon.close(done);
       });
     });
-    it('should set the timeout for the heartbeat', function (done) {
-      const options = utils.extend({}, defaultOptions);
-      options.pooling.heartBeatInterval = 100;
-      const c = newInstance(null, undefined, options);
-      let sendCounter = 0;
-      c.open(function (err) {
-        assert.ifError(err);
-        const originalSend = c.sendStream;
-        c.sendStream = function() {
-          sendCounter++;
-          originalSend.apply(c, arguments);
-        };
-        setTimeout(function () {
-          assert.ok(sendCounter > 3, 'sendCounter ' + sendCounter);
+
+    context('using timers', () => {
+      let clock;
+
+      before(() => clock = sinon.useFakeTimers({ shouldAdvanceTime: true }));
+      after(() => clock.restore());
+
+      it('should set the timeout for the heartbeat', function (done) {
+        const c = sinon.spy(newInstance());
+
+        c.open(function (err) {
+          assert.ifError(err);
+
+          const initialSendCalls = c.sendStream.callCount;
+
+          // Default is 30s
+          clock.tick(defaultOptions.pooling.heartBeatInterval);
+
+          assert.strictEqual(c.sendStream.callCount, initialSendCalls + 1);
+
+          const request = c.sendStream.getCall(c.sendStream.callCount-1).args[0];
+
+          assert.strictEqual(request, requests.options);
+
+          c.close();
           done();
-        }, 600);
+        });
       });
     });
   });
+
   describe('#open with ssl', function () {
     before(helper.ccmHelper.start(1, {ssl: true}));
     after(helper.ccmHelper.remove);
@@ -280,7 +293,11 @@ function newInstance(address, protocolVersion, options){
   }
   //var logEmitter = function (name, type) { if (type === 'verbose') { return; } console.log.apply(console, arguments);};
   options = utils.deepExtend({logEmitter: helper.noop}, options || defaultOptions);
-  return new Connection(address + ':' + options.protocolOptions.port, protocolVersion, options);
+
+  const c = new Connection(address + ':' + options.protocolOptions.port, protocolVersion, options);
+
+  after(() => c.close());
+  return c;
 }
 
 function getRequest(query) {

--- a/test/integration/short/numeric-tests.js
+++ b/test/integration/short/numeric-tests.js
@@ -16,7 +16,7 @@
 
 'use strict';
 
-const assert = require('assert');
+const expect = require('chai').expect;
 const Client = require('../../../lib/client');
 const types = require('../../../lib/types');
 const helper = require('../../test-helper');
@@ -75,10 +75,10 @@ module.exports = function (keyspace, prepare) {
         .then(rs => {
           const row = rs.first();
           ['bigint_value', 'varint_value', 'int_value'].forEach(columnName =>
-            assert.strictEqual(row[columnName].toString(), intValue));
+            expect(row[columnName].toString()).to.be.equal(intValue));
 
           ['decimal_value', 'double_value', 'float_value'].forEach(columnName =>
-            assert.strictEqual(row[columnName].toString(), decimalValue));
+            expect(row[columnName].toString()).to.be.equal(decimalValue));
         });
     });
 
@@ -100,10 +100,10 @@ module.exports = function (keyspace, prepare) {
         .then(() => client.execute('SELECT * FROM tbl_numeric_collections WHERE id = ?', [ id ]))
         .then(rs => {
           const row = rs.first();
-          assert.strictEqual(row['list_bigint'][0].toString(), intValue);
-          assert.strictEqual(row['list_decimal'][0].toString(), decimalValue);
-          assert.strictEqual(row['set_float'][0].toString(), decimalValue);
-          assert.strictEqual(row['set_int'][0].toString(), intValue);
+          expect(row['list_bigint'][0].toString()).to.be.equal(intValue);
+          expect(row['list_decimal'][0].toString()).to.be.equal(decimalValue);
+          expect(row['set_float'][0].toString()).to.be.equal(decimalValue);
+          expect(row['set_int'][0].toString()).to.be.equal(intValue);
         });
     });
 
@@ -132,7 +132,7 @@ module.exports = function (keyspace, prepare) {
         .then(rs => {
           const row = rs.first();
           ['bigint_value', 'varint_value'].forEach(columnName =>
-            assert.strictEqual(row[columnName].toString(), intValue));
+            expect(row[columnName].toString()).to.be.equal(intValue));
         });
     });
   });
@@ -178,12 +178,12 @@ module.exports = function (keyspace, prepare) {
           .then(() => client.execute(selectQuery, [ textValue, value ], { hints, prepare }))
           .then(rs => {
             const row = rs.first();
-            assert.strictEqual(row['id1'], value.toString());
-            assert.strictEqual(row['id2'], value);
-            assert.strictEqual(row['varint1'], value);
-            assert.deepStrictEqual(row['list1'], [value, value]);
-            assert.deepStrictEqual(row['set1'], new Set([value]));
-            assert.deepStrictEqual(row['set2'], new Set([value]));
+            expect(row['id1']).to.be.equal(value.toString());
+            expect(row['id2']).to.be.equal(value);
+            expect(row['varint1']).to.be.equal(value);
+            expect(row['list1']).to.be.an('array').to.have.all.members([value, value]);
+            expect(row['set1']).to.be.instanceOf(Set).and.to.have.all.keys(value);
+            expect(row['set2']).to.be.instanceOf(Set).and.to.have.all.keys(value);
           });
       })));
 
@@ -199,9 +199,9 @@ module.exports = function (keyspace, prepare) {
           .then(() => client.execute(selectQuery, [ textValue, BigInt(0) ], { hints, prepare }))
           .then(rs => {
             const row = rs.first();
-            assert.strictEqual(row['id1'], value.toString());
-            assert.strictEqual(row['varint1'], value);
-            assert.deepStrictEqual(row['set2'], new Set([value]));
+            expect(row['id1']).to.be.equal(value.toString());
+            expect(row['varint1']).to.be.equal(value);
+            expect(row['set2']).to.be.instanceOf(Set).and.to.have.all.keys(value);
           });
       })));
   });

--- a/test/integration/short/tracker-simulator-tests.js
+++ b/test/integration/short/tracker-simulator-tests.js
@@ -16,8 +16,9 @@
 
 'use strict';
 
-const assert = require('assert');
-const helper = require('../../test-helper');
+const assert = require('chai').assert;
+const sinon = require('sinon');
+
 const tracker = require('../../../lib/tracker');
 const errors = require('../../../lib/errors');
 const utils = require('../../../lib/utils');
@@ -51,7 +52,7 @@ describe('tracker', function () {
         const requestType = prepare ? 'EXECUTE' : 'QUERY';
 
         it('should be called when a valid response is obtained for ' + requestType + ' request', () => {
-          const requestTracker = new TestTracker();
+          const requestTracker = sinon.createStubInstance(tracker.RequestTracker);
           const client = new Client({ contactPoints: [ simulacron.startingIp ], localDataCenter: 'dc1', requestTracker });
           const query = 'SELECT * FROM system.local';
           const parameters = [ 'local' ];
@@ -63,7 +64,7 @@ describe('tracker', function () {
       });
 
       it('should be called when a error response is obtained', () => {
-        const requestTracker = new TestTracker();
+        const requestTracker = sinon.createStubInstance(tracker.RequestTracker);
         const client = new Client({ contactPoints: [ simulacron.startingIp ], localDataCenter: 'dc1', requestTracker });
         const query = 'SELECT * FROM system.failing';
         const parameters = [ 'abc' ];
@@ -74,7 +75,7 @@ describe('tracker', function () {
             verifyError(requestTracker, query, parameters);
             err = e;
           })
-          .then(() => helper.assertInstanceOf(err, errors.ResponseError))
+          .then(() => assert.instanceOf(err, errors.ResponseError))
           .then(() => client.shutdown());
       });
     });
@@ -84,7 +85,7 @@ describe('tracker', function () {
         const requestType = prepare ? 'bound statements' : 'queries';
 
         it('should be called when a valid response is obtained for BATCH request containing ' + requestType, () => {
-          const requestTracker = new TestTracker();
+          const requestTracker = sinon.createStubInstance(tracker.RequestTracker);
           const client = new Client({ contactPoints: [ simulacron.startingIp ], localDataCenter: 'dc1', requestTracker });
           const queries = [
             { query: 'SELECT * FROM system.local WHERE key = ?', params: [] }
@@ -98,7 +99,7 @@ describe('tracker', function () {
       });
 
       it('should be called when a error response is obtained', () => {
-        const requestTracker = new TestTracker();
+        const requestTracker = sinon.createStubInstance(tracker.RequestTracker);
         const client = new Client({ contactPoints: [ simulacron.startingIp ], localDataCenter: 'dc1', requestTracker });
         const query = 'SELECT INVALID';
         const parameters = [ 'abc' ];
@@ -114,7 +115,7 @@ describe('tracker', function () {
         const requestType = prepare ? 'EXECUTE' : 'QUERY';
 
         it('should be called when a valid response is obtained for ' + requestType + ' request', () => {
-          const requestTracker = new TestTracker();
+          const requestTracker = sinon.createStubInstance(tracker.RequestTracker);
           const client = new Client({ contactPoints: [ simulacron.startingIp ], localDataCenter: 'dc1', requestTracker });
           const query = 'SELECT * FROM system.local';
           const parameters = ['local'];
@@ -129,12 +130,12 @@ describe('tracker', function () {
     });
 
     it('should be called when client is being shutdown', () => {
-      const requestTracker = new TestTracker();
+      const requestTracker = sinon.createStubInstance(tracker.RequestTracker);
       const client = new Client({ contactPoints: [ simulacron.startingIp ], localDataCenter: 'dc1', requestTracker });
       return client.connect()
-        .then(() => assert.strictEqual(requestTracker.shutdownCalled, 0))
+        .then(() => assert.strictEqual(requestTracker.shutdown.callCount, 0))
         .then(() => client.shutdown())
-        .then(() => assert.strictEqual(requestTracker.shutdownCalled, 1));
+        .then(() => assert.strictEqual(requestTracker.shutdown.callCount, 1));
     });
   });
 
@@ -164,8 +165,8 @@ describe('tracker', function () {
           .then(() => {
             assert.strictEqual(slowMessages.length, 1);
             assert.strictEqual(largeMessages.length, 0);
-            helper.assertContains(slowMessages[0], 'Slow request, took');
-            helper.assertContains(slowMessages[0], `${queryDelayed} [${id}]`);
+            assert.match(slowMessages[0], /Slow request, took/);
+            assert.include(slowMessages[0], `${queryDelayed} [${id}]`);
           });
       });
 
@@ -177,8 +178,8 @@ describe('tracker', function () {
           .then(() => {
             assert.strictEqual(slowMessages.length, 0);
             assert.strictEqual(largeMessages.length, 1);
-            helper.assertContains(largeMessages[0], 'Request exceeded length');
-            helper.assertContains(largeMessages[0], query);
+            assert.include(largeMessages[0], 'Request exceeded length');
+            assert.include(largeMessages[0], query);
           });
       });
     });
@@ -193,12 +194,12 @@ describe('tracker', function () {
             .then(() => {
               assert.strictEqual(slowMessages.length, 0);
               assert.strictEqual(largeMessages.length, 1);
-              helper.assertContains(largeMessages[0], 'Request exceeded length');
+              assert.match(largeMessages[0], /Request exceeded length/);
               if (logged) {
-                helper.assertContains(largeMessages[0], ': LOGGED BATCH w/ 1 queries (' + query);
+                assert.include(largeMessages[0], ': LOGGED BATCH w/ 1 queries (' + query);
               }
               else {
-                helper.assertContains(largeMessages[0], ': BATCH w/ 1 queries (' + query);
+                assert.include(largeMessages[0], ': BATCH w/ 1 queries (' + query);
               }
             });
         });
@@ -208,26 +209,28 @@ describe('tracker', function () {
 });
 
 function verifyResponse(tracker, query, parameters) {
-  assert.strictEqual(tracker.responses.length, 1);
-  assert.strictEqual(tracker.errors.length, 0);
-  const r = tracker.responses[0];
+  assert.isTrue(tracker.onSuccess.calledOnce);
+  assert.isTrue(tracker.onError.notCalled);
+
+  const r = tracker.onSuccess.getCall(0).args;
 
   verifyCommon(r, query, parameters);
 
   const responseLength = r[5];
-  assert.strictEqual(typeof responseLength, 'number');
-  assert.ok(responseLength > 0);
+  assert.typeOf(responseLength, 'number');
+  assert.isAbove(responseLength, 0);
 }
 
 function verifyError(tracker, query, parameters) {
-  assert.strictEqual(tracker.responses.length, 0);
-  assert.strictEqual(tracker.errors.length, 1);
-  const errorInfo = tracker.errors[0];
+  assert.isTrue(tracker.onSuccess.notCalled);
+  assert.isTrue(tracker.onError.calledOnce);
+
+  const errorInfo = tracker.onError.getCall(0).args;
   verifyCommon(errorInfo, query, parameters);
 }
 
 function verifyCommon(info, query, parameters) {
-  helper.assertInstanceOf(info[0], Host);
+  assert.instanceOf(info[0], Host);
   if (Array.isArray(query)) {
     assert.deepEqual(info[1].map(x => ({ query: x.query, params: x.params })), query);
   } else {
@@ -238,32 +241,11 @@ function verifyCommon(info, query, parameters) {
 
   const requestLength = info[4];
   const latency = info[info.length - 1];
-  assert.strictEqual(typeof requestLength, 'number');
+  assert.typeOf(requestLength, 'number');
 
   // latency is an Array with 2 integers: seconds, nanos
-  assert.ok(Array.isArray(latency));
+  assert.isArray(latency);
   assert.strictEqual(latency.length, 2);
   assert.strictEqual(latency[0], 0);
-  assert.ok(latency[1] > 0);
-}
-
-class TestTracker extends tracker.RequestTracker {
-  constructor() {
-    super();
-    this.responses = [];
-    this.errors = [];
-    this.shutdownCalled = 0;
-  }
-
-  onSuccess() {
-    this.responses.push(Array.prototype.slice.call(arguments));
-  }
-
-  onError() {
-    this.errors.push(Array.prototype.slice.call(arguments));
-  }
-
-  shutdown() {
-    this.shutdownCalled++;
-  }
+  assert.isAbove(latency[1], 0);
 }

--- a/test/unit/basic-tests.js
+++ b/test/unit/basic-tests.js
@@ -15,7 +15,7 @@
  */
 
 "use strict";
-const assert = require('assert');
+const assert = require('chai').assert;
 const util = require('util');
 
 const Client = require('../../lib/client.js');
@@ -265,7 +265,7 @@ describe('types', function () {
         ].forEach(function (value) {
           assert.throws(function () {
             LocalDate.fromString(value);
-          }, Error, 'For value: ' + value);
+          });
         });
       });
     });
@@ -366,7 +366,7 @@ describe('types', function () {
       const stream = new types.ResultStream();
       
       stream.on('end', function streamEnd() {
-        assert.equal(Buffer.concat(buf).toString(), 'Jimmy McNulty');
+        assert.strictEqual(Buffer.concat(buf).toString(), 'Jimmy McNulty');
         done();
       });
       stream.on('readable', function streamReadable() {
@@ -546,7 +546,7 @@ describe('types', function () {
     it('should generate using date and microseconds parts', function () {
       let date = new Date();
       let value = types.generateTimestamp(date, 123);
-      helper.assertInstanceOf(value, types.Long);
+      assert.instanceOf(value, types.Long);
       assert.strictEqual(value.toString(), types.Long
         .fromNumber(date.getTime())
         .multiply(types.Long.fromInt(1000))
@@ -555,7 +555,7 @@ describe('types', function () {
 
       date = new Date('2010-04-29');
       value = types.generateTimestamp(date, 898);
-      helper.assertInstanceOf(value, types.Long);
+      assert.instanceOf(value, types.Long);
       assert.strictEqual(value.toString(), types.Long
         .fromNumber(date.getTime())
         .multiply(types.Long.fromInt(1000))
@@ -885,14 +885,14 @@ describe('exports', function () {
     //policies modules
     assert.strictEqual(api.policies.loadBalancing, loadBalancing);
     assert.strictEqual(typeof api.policies.loadBalancing.LoadBalancingPolicy, 'function');
-    helper.assertInstanceOf(api.policies.defaultLoadBalancingPolicy(), api.policies.loadBalancing.LoadBalancingPolicy);
+    assert.instanceOf(api.policies.defaultLoadBalancingPolicy(), api.policies.loadBalancing.LoadBalancingPolicy);
     assert.strictEqual(api.policies.retry, retry);
     assert.strictEqual(typeof api.policies.retry.RetryPolicy, 'function');
     assert.strictEqual(typeof api.policies.retry.IdempotenceAwareRetryPolicy, 'function');
-    helper.assertInstanceOf(api.policies.defaultRetryPolicy(), api.policies.retry.RetryPolicy);
+    assert.instanceOf(api.policies.defaultRetryPolicy(), api.policies.retry.RetryPolicy);
     assert.strictEqual(api.policies.reconnection, require('../../lib/policies/reconnection'));
     assert.strictEqual(typeof api.policies.reconnection.ReconnectionPolicy, 'function');
-    helper.assertInstanceOf(api.policies.defaultReconnectionPolicy(), api.policies.reconnection.ReconnectionPolicy);
+    assert.instanceOf(api.policies.defaultReconnectionPolicy(), api.policies.reconnection.ReconnectionPolicy);
     assert.strictEqual(api.policies.speculativeExecution, speculativeExecution);
     assert.strictEqual(typeof speculativeExecution.NoSpeculativeExecutionPolicy, 'function');
     assert.strictEqual(typeof speculativeExecution.ConstantSpeculativeExecutionPolicy, 'function');
@@ -900,7 +900,7 @@ describe('exports', function () {
     assert.strictEqual(api.policies.timestampGeneration, timestampGeneration);
     assert.strictEqual(typeof timestampGeneration.TimestampGenerator, 'function');
     assert.strictEqual(typeof timestampGeneration.MonotonicTimestampGenerator, 'function');
-    helper.assertInstanceOf(api.policies.defaultTimestampGenerator(), timestampGeneration.MonotonicTimestampGenerator);
+    assert.instanceOf(api.policies.defaultTimestampGenerator(), timestampGeneration.MonotonicTimestampGenerator);
     assert.strictEqual(api.auth, require('../../lib/auth'));
 
     // mapping module

--- a/test/unit/client-tests.js
+++ b/test/unit/client-tests.js
@@ -54,7 +54,7 @@ describe('Client', function () {
 
     it('should create Metadata instance', function () {
       const client = new Client({ contactPoints: ['192.168.10.10'] });
-      helper.assertInstanceOf(client.metadata, Metadata);
+      assert.instanceOf(client.metadata, Metadata);
     });
 
     context('with useBigIntAsLong or useBigIntAsVarint set', () => {
@@ -77,10 +77,10 @@ describe('Client', function () {
       const client = new Client(options);
       client.connect(function (err) {
         assert.ok(err);
-        helper.assertInstanceOf(err, errors.NoHostAvailableError);
-        assert.ok(err.message.indexOf('resolve') > 0, 'Message was: ' + err.message);
+        assert.instanceOf(err, errors.NoHostAvailableError);
+        assert.match(err.message, /resolve/);
         assert.ok(client.hosts);
-        assert.strictEqual(client.hosts.length, 0);
+        assert.lengthOf(client.hosts, 0);
 
         const resolvedContactPoints = client.controlConnection.getResolvedContactPoints();
         contactPoints.forEach(name => assert.strictEqual(resolvedContactPoints.get(name), utils.emptyArray));
@@ -148,7 +148,7 @@ describe('Client', function () {
       ], function (err) {
         assert.ifError(err);
         client.connect(function (err) {
-          helper.assertInstanceOf(err, errors.NoHostAvailableError);
+          assert.instanceOf(err, errors.NoHostAvailableError);
           assert.ok(err.message.indexOf('after shutdown') >= 0, 'Error message does not contain occurrence: ' + err.message);
           done();
         });
@@ -158,9 +158,9 @@ describe('Client', function () {
       it('should return a promise', function (done) {
         const client = new Client(helper.baseOptions);
         const p = client.connect();
-        helper.assertInstanceOf(p, Promise);
+        assert.instanceOf(p, Promise);
         p.catch(function (err) {
-          helper.assertInstanceOf(err, errors.NoHostAvailableError);
+          assert.instanceOf(err, errors.NoHostAvailableError);
           done();
         });
       });
@@ -171,7 +171,7 @@ describe('Client', function () {
     it('should not support named parameters for simple statements', function (done) {
       const client = newConnectedInstance();
       client.execute('QUERY', {named: 'parameter'}, function (err) {
-        helper.assertInstanceOf(err, errors.ArgumentError);
+        assert.instanceOf(err, errors.ArgumentError);
         done();
       });
     });
@@ -258,7 +258,7 @@ describe('Client', function () {
         assert.strictEqual(hints[4].code, types.dataTypes.map);
         assert.ok(util.isArray(hints[4].info));
         assert.ok(hints[4].info[0]);
-        assert.strictEqual(hints[4].info[0].code, types.dataTypes.uuid);
+        assert.propertyVal(hints[4].info[0], 'code', types.dataTypes.uuid);
         assert.strictEqual(hints[4].info[1].code, types.dataTypes.set);
         assert.strictEqual(hints[4].info[1].info.code, types.dataTypes.text);
         done();
@@ -275,19 +275,19 @@ describe('Client', function () {
       utils.series([
         function (next) {
           client.execute(query, [], { hints: ['int2']}, function (err) {
-            helper.assertInstanceOf(err, TypeError);
+            assert.instanceOf(err, TypeError);
             next();
           });
         },
         function (next) {
           client.execute(query, [], { hints: ['map<zeta>']}, function (err) {
-            helper.assertInstanceOf(err, TypeError);
+            assert.instanceOf(err, TypeError);
             next();
           });
         },
         function (next) {
           client.execute(query, [], { hints: ['udt<myudt>']}, function (err) {
-            helper.assertInstanceOf(err, TypeError);
+            assert.instanceOf(err, TypeError);
             next();
           });
         }
@@ -424,18 +424,18 @@ describe('Client', function () {
       it('should return a promise', function (done) {
         const client = new Client(helper.baseOptions);
         const p = client.execute('Q', [ 1, 2 ], { prepare: true });
-        helper.assertInstanceOf(p, Promise);
+        assert.instanceOf(p, Promise);
         p.catch(function (err) {
-          helper.assertInstanceOf(err, errors.NoHostAvailableError);
+          assert.instanceOf(err, errors.NoHostAvailableError);
           done();
         });
       });
       it('should reject the promise when an ExecutionProfile is not found', function (done) {
         const client = new Client(helper.baseOptions);
         const p = client.execute('Q', [ 1, 2 ], { executionProfile: 'non_existent' });
-        helper.assertInstanceOf(p, Promise);
+        assert.instanceOf(p, Promise);
         p.catch(function (err) {
-          helper.assertInstanceOf(err, errors.ArgumentError);
+          assert.instanceOf(err, errors.ArgumentError);
           done();
         });
       });
@@ -504,9 +504,9 @@ describe('Client', function () {
       it('should reject the promise when queries is not an Array', function (done) {
         const client = new Client(helper.baseOptions);
         const p = client.batch('Q', null);
-        helper.assertInstanceOf(p, Promise);
+        assert.instanceOf(p, Promise);
         p.catch(function (err) {
-          helper.assertInstanceOf(err, errors.ArgumentError);
+          assert.instanceOf(err, errors.ArgumentError);
           done();
         });
       });
@@ -517,14 +517,14 @@ describe('Client', function () {
     it('should callback with error if the queries are not string', function (done) {
       const client = newConnectedInstance(undefined, undefined, PrepareHandler);
       client.batch([{ noQuery: true }], { prepare: true }, function (err) {
-        helper.assertInstanceOf(err, errors.ArgumentError);
+        assert.instanceOf(err, errors.ArgumentError);
         done();
       });
     });
     it('should callback with error if the queries are undefined', function (done) {
       const client = newConnectedInstance(undefined, undefined, PrepareHandler);
       client.batch([ undefined, undefined, 'q3' ], { prepare: true }, function (err) {
-        helper.assertInstanceOf(err, errors.ArgumentError);
+        assert.instanceOf(err, errors.ArgumentError);
         done();
       });
     });
@@ -608,7 +608,7 @@ describe('Client', function () {
       const logEvents = [];
       client.on('log', logEvents.push.bind(logEvents));
       client.connect(function (err) {
-        helper.assertInstanceOf(err, errors.NoHostAvailableError);
+        assert.instanceOf(err, errors.NoHostAvailableError);
         client.shutdown(function clientShutdownCallback(err) {
           assert.ifError(err);
           setTimeout(function () {
@@ -626,7 +626,7 @@ describe('Client', function () {
       it('should return a promise', function (done) {
         const client = new Client(helper.baseOptions);
         const p = client.shutdown();
-        helper.assertInstanceOf(p, Promise);
+        assert.instanceOf(p, Promise);
         p.then(done);
       });
     });

--- a/test/unit/control-connection-tests.js
+++ b/test/unit/control-connection-tests.js
@@ -17,7 +17,7 @@
 "use strict";
 const assert = require('assert');
 const events = require('events');
-const rewire = require('rewire');
+const proxyquire = require('proxyquire');
 const dns = require('dns');
 
 const helper = require('../test-helper.js');
@@ -110,8 +110,7 @@ describe('ControlConnection', function () {
       });
     });
     it('should resolve all IPv4 and IPv6 addresses provided by dns.resolve()', function (done) {
-      const ControlConnectionMock = rewire('../../lib/control-connection');
-      ControlConnectionMock.__set__('dns', {
+      const ControlConnectionMock = proxyquire('../../lib/control-connection', { dns: {
         resolve4: function (name, cb) {
           cb(null, ['1', '2']);
         },
@@ -121,15 +120,14 @@ describe('ControlConnection', function () {
         lookup: function () {
           throw new Error('dns.lookup() should not be used');
         }
-      });
+      }});
 
       testResolution(ControlConnectionMock,
         [ '1:9042', '2:9042', '10:9042', '20:9042' ],
         [ '1:9042', '2:9042', '[10]:9042', '[20]:9042' ], done);
     });
     it('should ignore IPv4 or IPv6 resolution errors', function (done) {
-      const ControlConnectionMock = rewire('../../lib/control-connection');
-      ControlConnectionMock.__set__('dns', {
+      const ControlConnectionMock = proxyquire('../../lib/control-connection', { dns: {
         resolve4: function (name, cb) {
           cb(null, ['1', '2']);
         },
@@ -139,12 +137,12 @@ describe('ControlConnection', function () {
         lookup: function () {
           throw new Error('dns.lookup() should not be used');
         }
-      });
+      }});
+
       testResolution(ControlConnectionMock, [ '1:9042', '2:9042'], done);
     });
     it('should use dns.lookup() as failover', function (done) {
-      const ControlConnectionMock = rewire('../../lib/control-connection');
-      ControlConnectionMock.__set__('dns', {
+      const ControlConnectionMock = proxyquire('../../lib/control-connection', { dns: {
         resolve4: function (name, cb) {
           cb(new Error('Test error'));
         },
@@ -154,12 +152,12 @@ describe('ControlConnection', function () {
         lookup: function (name, cb) {
           cb(null, '123');
         }
-      });
+      }});
+
       testResolution(ControlConnectionMock, [ '123:9042' ], done);
     });
     it('should use dns.lookup() when no address was resolved', function (done) {
-      const ControlConnectionMock = rewire('../../lib/control-connection');
-      ControlConnectionMock.__set__('dns', {
+      const ControlConnectionMock = proxyquire('../../lib/control-connection', { dns: {
         resolve4: function (name, cb) {
           cb(null);
         },
@@ -169,7 +167,8 @@ describe('ControlConnection', function () {
         lookup: function (name, cb) {
           cb(null, '123');
         }
-      });
+      }});
+
       testResolution(ControlConnectionMock, [ '123:9042' ], done);
     });
     it('should continue iterating through the hosts when borrowing a connection fails', function (done) {

--- a/test/unit/metadata-tests.js
+++ b/test/unit/metadata-tests.js
@@ -18,7 +18,6 @@
 const assert = require('assert');
 const util = require('util');
 const events = require('events');
-const rewire = require('rewire');
 
 const helper = require('../test-helper.js');
 const clientOptions = require('../../lib/client-options.js');
@@ -35,6 +34,7 @@ const dataTypes = types.dataTypes;
 const utils = require('../../lib/utils');
 const errors = require('../../lib/errors');
 const Encoder = require('../../lib/encoder');
+const isDoneForToken = require('../../lib/metadata/schema-parser').isDoneForToken;
 
 describe('Metadata', function () {
   describe('#refreshKeyspace()', function () {
@@ -2625,7 +2625,6 @@ describe('Metadata', function () {
   });
 });
 describe('SchemaParser', function () {
-  const isDoneForToken = rewire('../../lib/metadata/schema-parser')['__get__']('isDoneForToken');
   describe('isDoneForToken()', function () {
     it('should skip if dc not included in topology', function () {
       const replicationFactors = { 'dc1': 3, 'dc2': 1 };

--- a/test/unit/stream-id-stack-tests.js
+++ b/test/unit/stream-id-stack-tests.js
@@ -17,7 +17,7 @@
 "use strict";
 const assert = require('assert');
 const util = require('util');
-const rewire = require('rewire');
+const StreamIdStack = require('../../lib/stream-id-stack');
 
 describe('StreamIdStack', function () {
   this.timeout(2000);
@@ -155,9 +155,9 @@ describe('StreamIdStack', function () {
 
 /** @returns {StreamIdStack}  */
 function newInstance(version, releaseDelay) {
-  const StreamIdStack = rewire('../../lib/stream-id-stack');
-  StreamIdStack.__set__("releaseDelay", releaseDelay || 100);
-  return new StreamIdStack(version || 3);
+  const stack = new StreamIdStack(version || 3);
+  stack.releaseDelay = releaseDelay || 100;
+  return stack;
 }
 
 function pop(stack, n) {

--- a/test/unit/stream-id-stack-tests.js
+++ b/test/unit/stream-id-stack-tests.js
@@ -15,13 +15,18 @@
  */
 
 "use strict";
+const sinon = require('sinon');
 const assert = require('assert');
-const util = require('util');
+
 const StreamIdStack = require('../../lib/stream-id-stack');
 
 describe('StreamIdStack', function () {
+  let clock;
+
+  before(() => clock = sinon.useFakeTimers());
+  after(() => clock.restore());
+
   this.timeout(2000);
-  const osPrecision = 30;
   it('should pop and push', function () {
     const stack = newInstance();
     assert.strictEqual(stack.pop(), 0);
@@ -78,8 +83,8 @@ describe('StreamIdStack', function () {
     assert.strictEqual(stack.groups.length, 4);
     stack.clear();
   });
-  it('should release unused groups', function (done) {
-    const releaseDelay = 100;
+  it('should release unused groups', function () {
+    const releaseDelay = 5000;
     const stack = newInstance(3, releaseDelay);
     //6 groups,
     const length = 128 * 5 + 2;
@@ -98,17 +103,17 @@ describe('StreamIdStack', function () {
     push(stack, 0, 10);
 
     assert.strictEqual(stack.groups.length, 6);
-    setTimeout(function () {
-      //there should be 5 groups now
-      assert.strictEqual(stack.groups.length, 5);
 
-      assert.strictEqual(stack.inUse, length - 12);
+    clock.tick(releaseDelay);
 
-      stack.clear();
-      done();
-    }, releaseDelay + osPrecision);
+    //there should be 5 groups now
+    assert.strictEqual(stack.groups.length, 5);
+
+    assert.strictEqual(stack.inUse, length - 12);
+
+    stack.clear();
   });
-  it('should not release the current group', function (done) {
+  it('should not release the current group', function () {
     const releaseDelay = 100;
     const stack = newInstance(3, releaseDelay);
 
@@ -120,14 +125,14 @@ describe('StreamIdStack', function () {
     //the last group is completed and but can not be released as is the current one
     stack.push(128 * 5 + 1);
     assert.strictEqual(stack.groups.length, 6);
-    setTimeout(function () {
-      //there should be 5 groups now
-      assert.strictEqual(stack.groups.length, 6);
-      stack.clear();
-      done();
-    }, releaseDelay + osPrecision);
+
+    clock.tick(releaseDelay);
+
+    //there should be 5 groups now
+    assert.strictEqual(stack.groups.length, 6);
+    stack.clear();
   });
-  it('should not release more than release size per time', function (done) {
+  it('should not release more than release size per time', function () {
     const releaseDelay = 100;
     const stack = newInstance(3, releaseDelay);
     //12 groups,
@@ -140,16 +145,17 @@ describe('StreamIdStack', function () {
     assert.strictEqual(stack.inUse, 0);
     assert.strictEqual(stack.pop(), 127); //last from the first group
     assert.strictEqual(stack.inUse, 1);
-    setTimeout(function () {
-      //there should be 12 - 4 groups now
-      assert.strictEqual(stack.groups.length, 8);
-    }, releaseDelay + osPrecision);
-    setTimeout(function () {
-      //there should be 12 - 8 groups now
-      assert.strictEqual(stack.groups.length, 4);
-      stack.clear();
-      done();
-    }, releaseDelay * 2 + osPrecision);
+
+    clock.tick(releaseDelay);
+
+    //there should be 12 - 4 groups now
+    assert.strictEqual(stack.groups.length, 8);
+
+    clock.tick(releaseDelay);
+
+    //there should be 12 - 8 groups now
+    assert.strictEqual(stack.groups.length, 4);
+    stack.clear();
   });
 });
 
@@ -169,7 +175,7 @@ function pop(stack, n) {
 }
 
 function push(stack, initialValue, length) {
-  if (util.isArray(initialValue)) {
+  if (Array.isArray(initialValue)) {
     initialValue.forEach(stack.push.bind(stack));
     return;
   }


### PR DESCRIPTION
Replaced `rewire` (not maintained) with `proxyquire`.

Added `sinon` for fake timers, stubs and spies and `chai` to simplify assertions.