### PR TITLE
Fix eachRow types to use ValueCallback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,16 +57,16 @@ export class Client extends events.EventEmitter {
 
   execute(query: string, callback: ValueCallback<types.ResultSet>): void;
 
-  eachRow<T>(query: string,
+  eachRow(query: string,
           params: ArrayOrObject,
           options: QueryOptions,
           rowCallback: (n: number, row: types.Row) => void,
-          callback?: ValueCallback<T>): void;
+          callback?: ValueCallback<types.ResultSet>): void;
 
-  eachRow<T>(query: string,
+  eachRow(query: string,
           params: ArrayOrObject,
           rowCallback: (n: number, row: types.Row) => void,
-          callback?: ValueCallback<T>): void;
+          callback?: ValueCallback<types.ResultSet>): void;
 
   eachRow(query: string,
           rowCallback: (n: number, row: types.Row) => void): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,16 +57,16 @@ export class Client extends events.EventEmitter {
 
   execute(query: string, callback: ValueCallback<types.ResultSet>): void;
 
-  eachRow(query: string,
+  eachRow<T>(query: string,
           params: ArrayOrObject,
           options: QueryOptions,
           rowCallback: (n: number, row: types.Row) => void,
-          callback?: EmptyCallback): void;
+          callback?: ValueCallback<T>): void;
 
-  eachRow(query: string,
+  eachRow<T>(query: string,
           params: ArrayOrObject,
           rowCallback: (n: number, row: types.Row) => void,
-          callback?: EmptyCallback): void;
+          callback?: ValueCallback<T>): void;
 
   eachRow(query: string,
           rowCallback: (n: number, row: types.Row) => void): void;


### PR DESCRIPTION
Hi,
Currently EmptyCallback is used for eachRow's callback type, but it should be ValueCallback.

from [jsdoc](https://github.com/datastax/nodejs-driver/blob/master/lib/client.js#L573)
> callback Executes callback(err, result)
