### PR TITLE
Fix deprecated IdempotencyAwareRetryPolicy

### DIFF
--- a/lib/policies/retry.js
+++ b/lib/policies/retry.js
@@ -183,7 +183,7 @@ IdempotenceAwareRetryPolicy.prototype.onReadTimeout = function (info, consistenc
  * If the query is not idempotent, it returns a rethrow decision. Otherwise, it relies on the child policy to decide.
  */
 IdempotenceAwareRetryPolicy.prototype.onRequestError = function (info, consistency, err) {
-  if (info.options.isIdempotent) {
+  if (info.executionOptions.isIdempotent()) {
     return this._childPolicy.onRequestError(info, consistency, err);
   }
   return this.rethrowResult();
@@ -197,7 +197,7 @@ IdempotenceAwareRetryPolicy.prototype.onUnavailable = function (info, consistenc
  * If the query is not idempotent, it return a rethrow decision. Otherwise, it relies on the child policy to decide.
  */
 IdempotenceAwareRetryPolicy.prototype.onWriteTimeout = function (info, consistency, received, blockFor, writeType) {
-  if (info.options.isIdempotent) {
+  if (info.executionOptions.isIdempotent()) {
     return this._childPolicy.onWriteTimeout(info, consistency, received, blockFor, writeType);
   }
   return this.rethrowResult();

--- a/test/unit/retry-policy-tests.js
+++ b/test/unit/retry-policy-tests.js
@@ -19,6 +19,7 @@ const assert = require('assert');
 
 const types = require('../../lib/types');
 const policies = require('../../lib/policies');
+const ExecutionOptions = require('../../lib/execution-options').ExecutionOptions;
 const RetryPolicy = policies.retry.RetryPolicy;
 const IdempotenceAwareRetryPolicy = policies.retry.IdempotenceAwareRetryPolicy;
 
@@ -94,10 +95,12 @@ describe('IdempotenceAwareRetryPolicy', function () {
           return { decision: RetryPolicy.retryDecision.retry };
         }
       };
+
       const policy = new IdempotenceAwareRetryPolicy(childPolicy);
-      const result = policy.onReadTimeout(1, 2, 3, 4, 5);
+      const info = getRequestInfo(1);
+      const result = policy.onReadTimeout(info, 2, 3, 4, 5);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
-      assert.deepEqual(actual, { info: 1, consistency: 2, received: 3, blockFor: 4, isDataPresent: 5 });
+      assert.deepStrictEqual(actual, { info, consistency: 2, received: 3, blockFor: 4, isDataPresent: 5 });
     });
   });
   describe('#onRequestError()', function () {
@@ -111,16 +114,18 @@ describe('IdempotenceAwareRetryPolicy', function () {
     it('should rethrow for non-idempotent queries', function () {
       actual = null;
       const policy = new IdempotenceAwareRetryPolicy(childPolicy);
-      const result = policy.onRequestError({ options: { isIdempotent: false } }, 2, 3);
+      const result = policy.onRequestError(getRequestInfo(0), 2, 3);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
       assert.strictEqual(actual, null);
     });
     it('should rely on the child policy when query is idempotent', function () {
       actual = null;
       const policy = new IdempotenceAwareRetryPolicy(childPolicy);
-      const result = policy.onRequestError({ options: { isIdempotent: true } }, 2, 3);
+      const info = getRequestInfo(0);
+      info.executionOptions.isIdempotent = () => true;
+      const result = policy.onRequestError(info, 2, 3);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
-      assert.deepEqual(actual, { info: { options: { isIdempotent: true } }, consistency: 2, err: 3 });
+      assert.deepEqual(actual, { info, consistency: 2, err: 3 });
     });
   });
   describe('#onWriteTimeout()', function () {
@@ -134,18 +139,18 @@ describe('IdempotenceAwareRetryPolicy', function () {
     it('should rethrow for non-idempotent queries', function () {
       actual = null;
       const policy = new IdempotenceAwareRetryPolicy(childPolicy);
-      const result = policy.onWriteTimeout({ options: { isIdempotent: false } }, 2, 3, 4, 5);
+      const result = policy.onWriteTimeout(getRequestInfo(0), 2, 3, 4, 5);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.rethrow);
       assert.strictEqual(actual, null);
     });
     it('should rely on the child policy when query is idempotent', function () {
       actual = null;
       const policy = new IdempotenceAwareRetryPolicy(childPolicy);
-      const result = policy.onWriteTimeout({ options: { isIdempotent: true } }, 2, 3, 4, 5);
+      const info = getRequestInfo(0);
+      info.executionOptions.isIdempotent = () => true;
+      const result = policy.onWriteTimeout(info, 2, 3, 4, 5);
       assert.strictEqual(result.decision, RetryPolicy.retryDecision.retry);
-      assert.deepEqual(actual, {
-        info: { options: { isIdempotent: true } }, consistency: 2, received: 3, blockFor: 4, writeType: 5
-      });
+      assert.deepStrictEqual(actual, { info, consistency: 2, received: 3, blockFor: 4, writeType: 5 });
     });
   });
   describe('#onUnavailable()', function () {
@@ -167,8 +172,8 @@ describe('IdempotenceAwareRetryPolicy', function () {
 
 function getRequestInfo(nbRetry) {
   return {
-    handler: {},
     nbRetry: nbRetry || 0,
-    request: {}
+    query: 'SAMPLE',
+    executionOptions: new ExecutionOptions()
   };
 }


### PR DESCRIPTION
The policy, which is deprecated since 4.0, had a bug where it checked
the `options` instead `executionOptions` (introduced in 4.0).