### PR TITLE
[Performance] Increase unsafe buffer pool size

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,7 @@ const util = require('util');
 const net = require('net');
 const EventEmitter = require('events');
 const errors = require('./errors');
+const Pool = require('nbufpool');
 
 /**
  * Max int that can be accurately represented with 64-bit Number (2^53)
@@ -30,6 +31,10 @@ const maxInt = 9007199254740992;
 const maxInt32 = 0x7fffffff;
 
 const emptyObject = Object.freeze({});
+
+const unsafePoolSize = 2097152; // 2MB
+
+const unsafePool = new Pool(unsafePoolSize);
 
 function noop() {}
 
@@ -43,7 +48,7 @@ const allocBuffer = Buffer.alloc || allocBufferFillDeprecated;
  * Forward-compatible unsafe allocation of buffer.
  * @type {Function}
  */
-const allocBufferUnsafe = Buffer.allocUnsafe || allocBufferDeprecated;
+const allocBufferUnsafe = Buffer.allocUnsafe ? unsafePool.allocUnsafe.bind(unsafePool) : allocBufferDeprecated;
 
 /**
  * Forward-compatible allocation of buffer to contain a string.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "long": "^2.2.0",
     "adm-zip": "^0.4.13",
     "@types/node": ">=4",
-    "@types/long": "^4.0.0"
+    "@types/long": "^4.0.0",
+    "nbufpool": "^0.1.0"
   },
   "devDependencies": {
     "mocha": "~5.2.0",


### PR DESCRIPTION
Writer objects in `nodejs-driver` seem to do quite a lot of `Buffer.allocUnsafe` calls. As you may know, `Buffer.allocUnsafe` uses a global pool (strictly speaking, it's not a "classical" object pool, but let's use this terminology), i.e. pre-allocated internal `Buffer` which is then sliced for newly allocated buffers, when possible. The size of the pool may be configured by setting `Buffer.poolSize` property (8KB by default). Once the current internal buffer fills up, a new one is allocated by the pool.

The problem with this approach is that this pool is global, so its size can't be configured by a Node.js library. Of course, a library can change `Buffer.poolSize`, but that may clash with another library or the final application which may also change it.

This PR migrates `Buffer.allocUnsafe` calls to [`nbufpool`](https://github.com/puzpuzpuz/nbufpool) library, which is just a port of the built-in pool to user-land. The pool has the same performance as the built-in pool when used with the default 8KB size. And when it's used with a more sane size (2MB) it's [significantly faster](https://github.com/puzpuzpuz/nbufpool#benchmark-results).

I'm not able to proof performance improvements in the library as I failed to find public available benchmarks. If you point me at them, I can include benchmark results.

P.S. If you don't like the idea of adding another 3-rd party library into dependencies, I have nothing against embedding it as a part of `nodejs-driver`'s code base.

P.P.S. Off-topic (as there are no GH issue in this repo, I'm writing them here):
It's better to do the following enhancements in the library:
* Add `package-lock.json` to `.gitignore`
* Freeze dependency versions in `package.json` (avoid using wildcards for minor versions - `^`)