### PR TITLE
Fix graph Direction serialization

### DIFF
--- a/lib/datastax/graph/index.d.ts
+++ b/lib/datastax/graph/index.d.ts
@@ -82,4 +82,11 @@ export namespace graph {
     const label: EnumValue;
     const value: EnumValue;
   }
+
+  namespace direction {
+    // `in` is a reserved word
+    const in_: EnumValue;
+    const out: EnumValue;
+    const both: EnumValue;
+  }
 }

--- a/lib/datastax/graph/index.js
+++ b/lib/datastax/graph/index.js
@@ -46,12 +46,18 @@ const t = {
   value: new EnumValue('T', 'value'),
 };
 
+/**
+ * Represents the edge direction.
+ */
 const direction = {
   'both': new EnumValue('Direction', 'BOTH'),
   'in': new EnumValue('Direction', 'IN'),
   'out': new EnumValue('Direction', 'OUT')
 };
 
+// `in` is a reserved keyword depending on the context
+// TinkerPop JavaScript GLV only exposes `in` but it can lead to issues for TypeScript users and others.
+// Expose an extra property to represent `Direction.IN`.
 direction.in_ = direction.in;
 
 module.exports = {

--- a/lib/datastax/graph/index.js
+++ b/lib/datastax/graph/index.js
@@ -46,6 +46,14 @@ const t = {
   value: new EnumValue('T', 'value'),
 };
 
+const direction = {
+  'both': new EnumValue('Direction', 'BOTH'),
+  'in': new EnumValue('Direction', 'IN'),
+  'out': new EnumValue('Direction', 'OUT')
+};
+
+direction.in_ = direction.in;
+
 module.exports = {
   Edge,
   Element,
@@ -59,6 +67,7 @@ module.exports = {
   asFloat,
   asTimestamp,
   asUdt,
+  direction,
   getCustomTypeSerializers,
   GraphResultSet,
   GraphTypeWrapper,

--- a/lib/datastax/graph/type-serializers.js
+++ b/lib/datastax/graph/type-serializers.js
@@ -30,13 +30,14 @@
 // Replace dependencies to minimize code changes from Apache TinkerPop
 const t = {
   P: UnsupportedType, TextP: UnsupportedType, Traversal: UnsupportedType, Traverser: UnsupportedType,
-  EnumValue: UnsupportedType, direction: {}
+  EnumValue: UnsupportedType
 };
 const ts = { TraversalStrategy: UnsupportedType };
 const Bytecode = UnsupportedType;
 const g = require('./index');
 const utils = { Long: UnsupportedType };
 t.t = g.t;
+t.direction = g.direction;
 
 function UnsupportedType() { }
 

--- a/test/unit/api-tests.js
+++ b/test/unit/api-tests.js
@@ -85,6 +85,15 @@ describe('API', function () {
       assert.equal(api.datastax.graph.t[name].toString(), name);
     });
 
+    [
+      'in',
+      'out',
+      'both'
+    ].forEach(name => {
+      assert.isObject(api.datastax.graph.direction[name]);
+      assert.equal(api.datastax.graph.direction[name].toString().toLowerCase(), name);
+    });
+
     checkConstructor(api.datastax.graph, 'UdtGraphWrapper');
     checkConstructor(api.datastax.graph, 'GraphTypeWrapper');
   });

--- a/test/unit/api-tests.js
+++ b/test/unit/api-tests.js
@@ -94,6 +94,8 @@ describe('API', function () {
       assert.equal(api.datastax.graph.direction[name].toString().toLowerCase(), name);
     });
 
+    assert.equal(api.datastax.graph.direction['in_'].toString(), 'IN');
+
     checkConstructor(api.datastax.graph, 'UdtGraphWrapper');
     checkConstructor(api.datastax.graph, 'GraphTypeWrapper');
   });

--- a/test/unit/typescript/graph-tests.ts
+++ b/test/unit/typescript/graph-tests.ts
@@ -39,4 +39,7 @@ async function myTest(client: Client): Promise<any> {
   let tokenString: string;
   tokenString = datastax.graph.t.id.toString();
   tokenString = datastax.graph.t.label.toString();
+  tokenString = datastax.graph.direction.in_.toString();
+  tokenString = datastax.graph.direction.out.toString();
+  tokenString = datastax.graph.direction.both.toString();
 }


### PR DESCRIPTION
Expose `direction` object and fix Direction serialization. Similar to #359 .

https://datastax-oss.atlassian.net/browse/NODEJS-606

I went over all deserializers in TinkerPop JavaScript GLV just to make sure we're not missing anything and this kind of issue never occurs again. There are TinkerPop serializers for the following js types: `Number`, `Date`, `Traverser`, `Vertex`, `VertexProperty`, `Property`, `Edge`, `Path`, `T`, `Direction`, `Array`, `BulkSet` and `Map` which, with this patch, are all now covered in the driver. 