### PR TITLE
TypeScript: ResultSet extends AsyncIterable<Row>

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -319,7 +319,7 @@ export namespace types {
     toString(): string;
   }
 
-  interface ResultSet extends Iterator<Row> {
+  interface ResultSet extends Iterable<Row>, AsyncIterable<Row> {
     info: {
       queriedHost: string,
       triedHosts: { [key: string]: any; },

--- a/test/unit/typescript/tsconfig.json
+++ b/test/unit/typescript/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "lib": ["es2015"],
-    "target": "es5",
+    "target": "es2015",
     "sourceMap": false,
     "strict": true
   },

--- a/test/unit/typescript/types-test.ts
+++ b/test/unit/typescript/types-test.ts
@@ -14,24 +14,27 @@
  * limitations under the License.
  */
 
-import { types } from "../../../index";
+import { types, Client } from "../../../index";
 import Uuid = types.Uuid;
 import TimeUuid = types.TimeUuid;
 import Long = types.Long;
 import BigDecimal = types.BigDecimal;
 import InetAddress = types.InetAddress;
 import Tuple = types.Tuple;
+import ResultSet = types.ResultSet;
+import Row = types.Row;
 
 /*
  * TypeScript definitions compilation tests for types module.
  */
 
-function myTest(): void {
+async function myTest(): Promise<void> {
   let id:Uuid;
   let tid:TimeUuid;
   let b: boolean;
   let s: string;
   let buffer: Buffer;
+  let rs: ResultSet;
 
   types.protocolVersion.isSupported(types.protocolVersion.v4);
 
@@ -61,4 +64,23 @@ function myTest(): void {
   long.div(long);
   // Use constructor
   long = new Long(1, 2);
+
+  const client = new Client({
+    contactPoints: ['host1'],
+    localDataCenter: 'dc1'
+  });
+
+  rs = await client.execute('SELECT * FROM ks1.table1');
+  // Test iteration
+  for (const row of rs) {
+    // Check is of type Row
+    const r: Row = row;
+  }
+
+  rs = await client.execute('SELECT * FROM ks1.table1');
+  // Test async iteration
+  for await (const row of rs) {
+    // Check is of type Row
+    const r: Row = row;
+  }
 }


### PR DESCRIPTION
Include `extends Iterable<Row>, AsyncIterable<Row>` in the TypeScript
definition that is matched by the exiting JavaScript functionality.

https://datastax-oss.atlassian.net/browse/NODEJS-610