### PR TITLE
Mapper: clarify error message when mapping info not found

### DIFF
--- a/lib/mapping/mapper.js
+++ b/lib/mapping/mapper.js
@@ -92,11 +92,17 @@ class Mapper {
 
       if (mappingInfo === undefined) {
         if (!this.client.keyspace) {
-          throw new Error(
-            'You must set the Client keyspace or specify the keyspace of the model in the MappingOptions');
+          throw new Error(`No mapping information found for model '${name}'. ` +
+            `Mapper is unable to create default mappings without setting the keyspace`);
         }
 
         mappingInfo = ModelMappingInfo.createDefault(name, this.client.keyspace);
+        this.client.log('info', `Mapping information for model '${name}' not found, creating default mapping. ` +
+          `Keyspace: ${mappingInfo.keyspace}; Table: ${mappingInfo.tables[0].name}.`);
+      } else {
+        this.client.log('info', `Creating model mapper for '${name}' using mapping information. Keyspace: ${
+          mappingInfo.keyspace}; Table${mappingInfo.tables.length > 1? 's' : ''}: ${
+          mappingInfo.tables.map(t => t.name)}.`);
       }
 
       modelMapper = new ModelMapper(name, new MappingHandler(this.client, mappingInfo));

--- a/test/unit/mapping/model-mapper-mutation-tests.js
+++ b/test/unit/mapping/model-mapper-mutation-tests.js
@@ -66,6 +66,7 @@ describe('ModelMapper', () => {
       const client = {
         connect: () => Promise.resolve(),
         keyspace: 'ks1',
+        log: () => {},
         metadata: {
           getTable: () => Promise.reject(error)
         }
@@ -99,7 +100,7 @@ describe('ModelMapper', () => {
       }
     ]));
 
-    it('should warn when cache reaches 100 different queries', () => {
+    it('should warn when cache reaches 100 different queries', async () => {
       const clientInfo = mapperTestHelper.getClient(['id1'], [ 1 ], 'ks1');
       const modelMapper = mapperTestHelper.getModelMapper(clientInfo);
 
@@ -110,16 +111,17 @@ describe('ModelMapper', () => {
         promises.push(modelMapper.insert({ id1: 1, [`col${i % (cacheHighWaterMark-1)}`]: 1}));
       }
 
-      return Promise.all(promises)
-        // No warnings logged when there are 99 different queries
-        .then(() => assert.strictEqual(clientInfo.logMessages.length, 0))
-        // One more query
-        .then(() => modelMapper.insert({ id1: 1, anotherColumn: 1 }))
-        .then(() => {
-          assert.strictEqual(clientInfo.logMessages.length, 1);
-          assert.strictEqual(clientInfo.logMessages[0].level, 'warning');
-          helper.assertContains(clientInfo.logMessages[0].message, `ModelMapper cache reached ${cacheHighWaterMark}`);
-        });
+      await Promise.all(promises);
+
+      // No warnings logged when there are 99 different queries
+      assert.strictEqual(clientInfo.logMessages.filter(l => l.level === 'warning').length, 0);
+
+      // One more query
+      await modelMapper.insert({ id1: 1, anotherColumn: 1 });
+
+      const warnings = clientInfo.logMessages.filter(l => l.level === 'warning');
+      assert.strictEqual(warnings.length, 1);
+      helper.assertContains(warnings[0].message, `ModelMapper cache reached ${cacheHighWaterMark}`);
     });
   });
 

--- a/test/unit/mapping/model-mapper-select-tests.js
+++ b/test/unit/mapping/model-mapper-select-tests.js
@@ -227,7 +227,7 @@ describe('ModelMapper', () => {
   });
 
   describe('#mapWithQuery', () => {
-    it('should warn when cache reaches 100 different queries', () => {
+    it('should warn when cache reaches 100 different queries', async () => {
       const clientInfo = mapperTestHelper.getClient(['id1'], [ 1 ], 'ks1', emptyResponse);
       const modelMapper = mapperTestHelper.getModelMapper(clientInfo);
 
@@ -239,18 +239,19 @@ describe('ModelMapper', () => {
         promises.push(executor());
       }
 
-      return Promise.all(promises)
-        // No warnings logged when there are 99 different queries
-        .then(() => assert.strictEqual(clientInfo.logMessages.length, 0))
-        // One more query
-        .then(() => modelMapper.mapWithQuery(`query-limit`, () => [])())
-        .then(() => {
-          assert.strictEqual(clientInfo.logMessages.length, 1);
-          assert.strictEqual(clientInfo.logMessages[0].level, 'warning');
-          assert.strictEqual(clientInfo.logMessages[0].message,
-            `Custom queries cache reached ${cacheHighWaterMark} items, this could be caused by ` +
-            `hard-coding parameter values inside the query, which should be avoided`);
-        });
+      await Promise.all(promises);
+
+      // No warnings logged when there are 99 different queries
+      assert.strictEqual(clientInfo.logMessages.filter(l => l.level === 'warning').length, 0);
+
+      // One more query
+      await modelMapper.mapWithQuery(`query-limit`, () => [])();
+
+      const warnings = clientInfo.logMessages.filter(l => l.level === 'warning');
+      assert.strictEqual(warnings.length, 1);
+      assert.strictEqual(warnings[0].message,
+        `Custom queries cache reached ${cacheHighWaterMark} items, this could be caused by ` +
+        `hard-coding parameter values inside the query, which should be avoided`);
     });
   });
 });


### PR DESCRIPTION
Use a more clear error message when the model can not be found and log when creating the `ModelMapper` instance the first time.