### PR TITLE
Support DSE auth transitional mode

### DIFF
--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 'use strict';
+
 /**
  * DSE Authentication module.
  * <p>
@@ -21,9 +22,18 @@
  * </p>
  * @module auth
  */
-const baseProvider = require('./provider.js');
-exports.AuthProvider = baseProvider.AuthProvider;
-exports.Authenticator = baseProvider.Authenticator;
-exports.PlainTextAuthProvider = require('./plain-text-auth-provider.js');
-exports.DseGssapiAuthProvider = require('./dse-gssapi-auth-provider');
-exports.DsePlainTextAuthProvider = require('./dse-plain-text-auth-provider');
+
+const { Authenticator, AuthProvider } = require('./provider');
+const { PlainTextAuthProvider } = require('./plain-text-auth-provider');
+const DseGssapiAuthProvider = require('./dse-gssapi-auth-provider');
+const DsePlainTextAuthProvider = require('./dse-plain-text-auth-provider');
+const NoAuthProvider = require('./no-auth-provider');
+
+module.exports = {
+  Authenticator,
+  AuthProvider,
+  DseGssapiAuthProvider,
+  DsePlainTextAuthProvider,
+  NoAuthProvider,
+  PlainTextAuthProvider
+};

--- a/lib/auth/no-auth-provider.js
+++ b/lib/auth/no-auth-provider.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const { AuthProvider, Authenticator } = require('./provider');
+const { PlainTextAuthenticator } = require('./plain-text-auth-provider');
+const errors = require('../errors');
+
+const dseAuthenticator = 'com.datastax.bdp.cassandra.auth.DseAuthenticator';
+
+/**
+ * Internal authentication provider that is used when no provider has been set by the user.
+ * @ignore
+ */
+class NoAuthProvider extends AuthProvider {
+  newAuthenticator(endpoint, name) {
+    if (name === dseAuthenticator) {
+      // Try to use transitional mode
+      return new TransitionalModePlainTextAuthenticator();
+    }
+
+    // Use an authenticator that doesn't allow auth flow
+    return new NoAuthAuthenticator(endpoint);
+  }
+}
+
+/**
+ * An authenticator throws an error when authentication flow is started.
+ * @ignore
+ */
+class NoAuthAuthenticator extends Authenticator {
+  constructor(endpoint) {
+    super();
+    this.endpoint = endpoint;
+  }
+
+  initialResponse(callback) {
+    callback(new errors.AuthenticationError(
+      `Host ${this.endpoint} requires authentication, but no authenticator found in the options`));
+  }
+}
+
+/**
+ * Authenticator that accounts for DSE authentication configured with transitional mode: normal.
+ *
+ * In this situation, the client is allowed to connect without authentication, but DSE
+ * would still send an AUTHENTICATE response. This Authenticator handles this situation
+ * by sending back a dummy credential.
+ */
+class TransitionalModePlainTextAuthenticator extends PlainTextAuthenticator {
+  constructor() {
+    super('', '');
+  }
+}
+
+module.exports = NoAuthProvider;

--- a/lib/auth/plain-text-auth-provider.js
+++ b/lib/auth/plain-text-auth-provider.js
@@ -75,4 +75,7 @@ PlainTextAuthenticator.prototype.evaluateChallenge = function (challenge, callba
   callback();
 };
 
-module.exports = PlainTextAuthProvider;
+module.exports = {
+  PlainTextAuthenticator,
+  PlainTextAuthProvider,
+};

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -257,17 +257,18 @@ function validateSocketOptions(socketOptions) {
  * @private
  */
 function validateAuthenticationOptions(options) {
-  const credentials = options.credentials;
+  if (!options.authProvider) {
+    const credentials = options.credentials;
+    if (credentials) {
+      if (typeof credentials.username !== 'string' || typeof credentials.password !== 'string') {
+        throw new TypeError('credentials username and password must be a string');
+      }
 
-  if (credentials && !options.authProvider) {
-    if (typeof credentials.username !== 'string' || typeof credentials.password !== 'string') {
-      throw new TypeError('credentials username and password must be a string');
+      options.authProvider = new auth.PlainTextAuthProvider(credentials.username, credentials.password);
+    } else {
+      options.authProvider = new auth.NoAuthProvider();
     }
-
-    options.authProvider = new auth.PlainTextAuthProvider(credentials.username, credentials.password);
-  }
-
-  if (options.authProvider && !(options.authProvider instanceof auth.AuthProvider)) {
+  } else if (!(options.authProvider instanceof auth.AuthProvider)) {
     throw new TypeError('options.authProvider must be an instance of AuthProvider');
   }
 }

--- a/lib/datastax/cloud/index.js
+++ b/lib/datastax/cloud/index.js
@@ -24,7 +24,7 @@ const { URL } = require('url');
 
 const errors = require('../../errors');
 const utils = require('../../utils');
-const { DsePlainTextAuthProvider } = require('../../auth');
+const { DsePlainTextAuthProvider, NoAuthProvider } = require('../../auth');
 
 // Use the callback-based method fs.readFile() instead of fs.promises as we have to support Node.js 8+
 const readFile = util.promisify(fs.readFile);
@@ -91,7 +91,7 @@ class CloudOptions {
       return;
     }
 
-    if (this.clientOptions.authProvider) {
+    if (this.clientOptions.authProvider && !(this.clientOptions.authProvider instanceof NoAuthProvider)) {
       // There is an auth provider set by the user
       return;
     }

--- a/lib/insights-client.js
+++ b/lib/insights-client.js
@@ -26,6 +26,7 @@ const requests = require('./requests');
 const { ExecutionOptions } = require('./execution-options');
 const packageInfo = require('../package.json');
 const VersionNumber = require('./types/version-number');
+const { NoAuthProvider } = require('./auth');
 
 let kerberosModule;
 
@@ -223,7 +224,7 @@ class InsightsClient {
           certValidation: options.sslOptions ? !!options.sslOptions.rejectUnauthorized : undefined
         },
         authProvider: {
-          type: getConstructor(options.authProvider),
+          type: !(options.authProvider instanceof NoAuthProvider) ? getConstructor(options.authProvider) : undefined,
         },
         otherOptions: {
           coalescingThreshold: options.socketOptions.coalescingThreshold,

--- a/test/integration/short/auth/dse-plain-text-auth-provider-tests.js
+++ b/test/integration/short/auth/dse-plain-text-auth-provider-tests.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 'use strict';
-const assert = require('assert');
+const { assert } = require('chai');
 const helper = require('../../../test-helper');
 const DsePlainTextAuthProvider = require('../../../../lib/auth/dse-plain-text-auth-provider');
 const Client = require('../../../../lib/client');
@@ -22,16 +22,17 @@ const vdescribe = helper.vdescribe;
 
 vdescribe('dse-5.0', 'DsePlainTextAuthProvider @SERVER_API', function () {
   this.timeout(180000);
-  it('should authenticate against DSE daemon instance', function (done) {
-    const testClusterOptions = {
+
+  context('with Cassandra PasswordAuthenticator', () => {
+    helper.setup(1, { initClient: false, ccmOptions: {
       yaml: ['authenticator:PasswordAuthenticator'],
       jvmArgs: ['-Dcassandra.superuser_setup_delay_ms=0']
-    };
-    helper.ccm.startAll(1, testClusterOptions, function (err) {
-      assert.ifError(err);
+    }});
+
+    it('should authenticate against DSE daemon instance', function (done) {
       const authProvider = new DsePlainTextAuthProvider('cassandra', 'cassandra');
       const clientOptions = helper.getOptions({ authProvider: authProvider });
-      const client = new Client(clientOptions);
+      const client = helper.shutdownAfterThisTest(new Client(clientOptions));
       client.connect(function (err) {
         assert.ifError(err);
         assert.notEqual(client.hosts.length, 0);
@@ -40,22 +41,38 @@ vdescribe('dse-5.0', 'DsePlainTextAuthProvider @SERVER_API', function () {
     });
   });
 
-  it('should authenticate against DSE 5+ DseAuthenticator', function (done) {
-    const testClusterOptions = {
+  context('with DSE 5+ DseAuthenticator', () => {
+    helper.setup(1, { initClient: false, ccmOptions: {
       yaml: ['authenticator:com.datastax.bdp.cassandra.auth.DseAuthenticator'],
       jvmArgs: ['-Dcassandra.superuser_setup_delay_ms=0'],
       dseYaml: ['authentication_options.enabled:true', 'authentication_options.default_scheme:internal']
-    };
-    helper.ccm.startAll(1, testClusterOptions, function (err) {
-      assert.ifError(err);
+    }});
+
+    it('should authenticate against DSE 5+ DseAuthenticator', async () => {
       const authProvider = new DsePlainTextAuthProvider('cassandra', 'cassandra');
-      const clientOptions = helper.getOptions({ authProvider: authProvider });
-      const client = new Client(clientOptions);
-      client.connect(function (err) {
-        assert.ifError(err);
-        assert.notEqual(client.hosts.length, 0);
-        client.shutdown(done);
-      });
+      const clientOptions = helper.getOptions({ authProvider });
+      const client = helper.shutdownAfterThisTest(new Client(clientOptions));
+      await client.connect();
+      // There is an open connection
+      assert.strictEqual(client.getState().getOpenConnections(client.hosts.values()[0]), 1);
+      await client.shutdown();
+    });
+  });
+
+  context('with transitional mode normal', () => {
+    helper.setup(1, { initClient: false, ccmOptions: {
+      yaml: ['authenticator:com.datastax.bdp.cassandra.auth.DseAuthenticator'],
+      jvmArgs: ['-Dcassandra.superuser_setup_delay_ms=0'],
+      dseYaml: ['authentication_options.enabled:true', 'authentication_options.default_scheme:internal', 'authentication_options.transitional_mode:normal']
+    }});
+
+    it('should support transitional mode', async () => {
+      // Without setting an authenticator
+      const clientOptions = helper.getOptions({});
+      const client = helper.shutdownAfterThisTest(new Client(clientOptions));
+      await client.connect();
+      await client.execute('SELECT * FROM system.local');
+      await client.shutdown();
     });
   });
 });

--- a/test/integration/short/cloud/cloud-tests.js
+++ b/test/integration/short/cloud/cloud-tests.js
@@ -152,7 +152,7 @@ vdescribe('dse-6.7', 'Cloud support', function () {
         // Ignore auth error
       }
 
-      assert.strictEqual(client.options.authProvider, null);
+      assert.instanceOf(client.options.authProvider, auth.NoAuthProvider);
     });
 
     it('should support overriding the auth provider', async () => {

--- a/test/unit/typescript/api-generation-test.ts
+++ b/test/unit/typescript/api-generation-test.ts
@@ -64,7 +64,7 @@ export async function generatedFn() {
   printClasses(root, 'root', new Set([ 'Encoder' ]));
   printObjects(root, 'root', new Set([ 'token' ]));
 
-  printClasses(auth, 'auth');
+  printClasses(auth, 'auth', new Set(['NoAuthProvider']));
   printClasses(errors, 'errors');
   printFunctions(concurrent, 'concurrent');
   printClasses(concurrent, 'concurrent');


### PR DESCRIPTION
Introduce an internal auth provider, `NoAuthProvider` that supports transitional mode and handles auth flow when no credentials/provider where provided by the user.

https://datastax-oss.atlassian.net/browse/NODEJS-609