### PR TITLE
Error when using batching with custom mapping

### DIFF
--- a/lib/mapping/model-batch-item.js
+++ b/lib/mapping/model-batch-item.js
@@ -90,7 +90,7 @@ class ModelBatchItem {
         // Either all queries are counter mutation or we let it fail at server level
         isCounter = q.isCounter;
 
-        arr.push({ query: q.query, params: q.paramsGetter(this.doc, this.docInfo) });
+        arr.push({ query: q.query, params: q.paramsGetter(this.doc, this.docInfo, this.getMappingInfo()) });
       });
 
       return { isIdempotent, isCounter };


### PR DESCRIPTION
When using batching with custom mappings the driver returns an error because mapping information is not passed to parameter getter in ModelBatchItem