### PR TITLE
Re-resolve contact points after total disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ChangeLog - DataStax Node.js Driver
 
+## 4.6.3
+
+2021-05-??
+
+### Bug fixes
+
+- [NODEJS-632] - Re-resolve contact points on reconnect when all nodes are unavailable
+
 ## 4.6.2
 
 2021-03-30

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -130,18 +130,13 @@ class ControlConnection extends events.EventEmitter {
     // Use RFC 3986 for IPv4 and IPv6
     const standardEndpoint = !isIPv6 ? endpoint : `[${address}]:${portNumber}`;
 
-    const resolvedAddressedByName = this._getResolvedContactPoints(name);
-    resolvedAddressedByName.push(standardEndpoint);
-  }
-
-  _getResolvedContactPoints(name) {
-
-    let rv = this._resolvedContactPoints.get(name);
-    if (rv === undefined) {
-      rv = [];
-      this._resolvedContactPoints.set(name, rv);
+    let resolvedAddressedByName = this._resolvedContactPoints.get(name);
+    if (resolvedAddressedByName === undefined) {
+      resolvedAddressedByName = [];
+      this._resolvedContactPoints.set(name, resolvedAddressedByName);
     }
-    return rv;
+
+    resolvedAddressedByName.push(standardEndpoint);
   }
 
   async _parseContactPoint(name) {

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -130,7 +130,7 @@ class ControlConnection extends events.EventEmitter {
     // Use RFC 3986 for IPv4 and IPv6
     const standardEndpoint = !isIPv6 ? endpoint : `[${address}]:${portNumber}`;
 
-    let resolvedAddressedByName = this._getResolvedContactPoints(name);
+    const resolvedAddressedByName = this._getResolvedContactPoints(name);
     resolvedAddressedByName.push(standardEndpoint);
   }
 
@@ -142,11 +142,6 @@ class ControlConnection extends events.EventEmitter {
       this._resolvedContactPoints.set(name, rv);
     }
     return rv;
-  }
-
-  async _clearResolvedContactPoints(name) {
-
-    this._getResolvedContactPoints(name).clear();
   }
 
   async _parseContactPoint(name) {
@@ -425,6 +420,26 @@ class ControlConnection extends events.EventEmitter {
     }
   }
 
+  async _refreshControlConnection(hostIterator) {
+
+    try {
+
+      this.connection = this._borrowAConnection(hostIterator);
+    }
+    catch(err) {
+
+      /* NODEJS-632: refresh nodes before getting hosts for reconnect since some hostnames may have
+       * shifted during the flight. */
+      this.log("info", "ControlConnection could not reconnect using existing connections.  Refreshing contact points and retrying");
+      this._contactPoints.clear();
+      this._resolvedContactPoints.clear();
+      await Promise.all(this.options.contactPoints.map(name => this._parseContactPoint(name)));
+      const refreshedContactPoints = Array.from(this._contactPoints).join(',');
+      this.log('info', `Refreshed contact points: ${refreshedContactPoints}`);
+      await this._initializeConnection();
+    }
+  }
+
   /**
    * Acquires a new connection and refreshes topology and keyspace metadata.
    * <p>When it fails obtaining a connection and there aren't any more hosts, it schedules reconnection.</p>
@@ -449,21 +464,7 @@ class ControlConnection extends events.EventEmitter {
         hostIterator = await promiseUtils.newQueryPlan(this._profileManager.getDefaultLoadBalancing(), null, null);
       }
 
-      try {
-
-        this.connection = this._borrowAConnection(hostIterator);
-      }
-      catch(err) {
-
-        /* NODEJS-632: refresh nodes before getting hosts for reconnect since some hostnames may have
-         * shifted during the flight. */
-        this.log("info", "ControlConnection could not reconnect using existing connections.  Refreshing contact points and retrying");
-        await Promise.all(
-          this.options.contactPoints.map(name =>
-            this._clearResolvedContactPoints(name)
-            .then(this._parseContactPoint(name)))
-        ).then(this._initializeConnection());
-      }
+      await this._refreshControlConnection(hostIterator);
     } catch (err) {
       // There was a failure obtaining a connection or during metadata retrieval
       this.log('error', 'ControlConnection failed to acquire a connection', err);

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -130,13 +130,23 @@ class ControlConnection extends events.EventEmitter {
     // Use RFC 3986 for IPv4 and IPv6
     const standardEndpoint = !isIPv6 ? endpoint : `[${address}]:${portNumber}`;
 
-    let resolvedAddressedByName = this._resolvedContactPoints.get(name);
-    if (resolvedAddressedByName === undefined) {
-      resolvedAddressedByName = [];
-      this._resolvedContactPoints.set(name, resolvedAddressedByName);
-    }
-
+    let resolvedAddressedByName = this._getResolvedContactPoints(name);
     resolvedAddressedByName.push(standardEndpoint);
+  }
+
+  _getResolvedContactPoints(name) {
+
+    let rv = this._resolvedContactPoints.get(name);
+    if (rv === undefined) {
+      rv = [];
+      this._resolvedContactPoints.set(name, rv);
+    }
+    return rv;
+  }
+
+  async _clearResolvedContactPoints(name) {
+
+    this._getResolvedContactPoints(name).clear();
   }
 
   async _parseContactPoint(name) {
@@ -436,17 +446,24 @@ class ControlConnection extends events.EventEmitter {
       if (!hostIterator) {
         this.log('info', 'Trying to acquire a connection to a new host');
         this._triedHosts = {};
-
-        /* NODEJS-632: refresh nodes before getting hosts for reconnect since some hostnames may have
-         * shifted during the flight. */
-        this.log("info", "Refreshing contact points");
-        await Promise.all(this.options.contactPoints.map(name => this._parseContactPoint(name)));
-
         hostIterator = await promiseUtils.newQueryPlan(this._profileManager.getDefaultLoadBalancing(), null, null);
       }
 
-      this.connection = this._borrowAConnection(hostIterator);
+      try {
 
+        this.connection = this._borrowAConnection(hostIterator);
+      }
+      catch(err) {
+
+        /* NODEJS-632: refresh nodes before getting hosts for reconnect since some hostnames may have
+         * shifted during the flight. */
+        this.log("info", "ControlConnection could not reconnect using existing connections.  Refreshing contact points and retrying");
+        await Promise.all(
+          this.options.contactPoints.map(name =>
+            this._clearResolvedContactPoints(name)
+            .then(this._parseContactPoint(name)))
+        ).then(this._initializeConnection());
+      }
     } catch (err) {
       // There was a failure obtaining a connection or during metadata retrieval
       this.log('error', 'ControlConnection failed to acquire a connection', err);

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -436,6 +436,12 @@ class ControlConnection extends events.EventEmitter {
       if (!hostIterator) {
         this.log('info', 'Trying to acquire a connection to a new host');
         this._triedHosts = {};
+
+        /* NODEJS-632: refresh nodes before getting hosts for reconnect since some hostnames may have
+         * shifted during the flight. */
+        this.log("info", "Refreshing contact points");
+        await Promise.all(this.options.contactPoints.map(name => this._parseContactPoint(name)));
+
         hostIterator = await promiseUtils.newQueryPlan(this._profileManager.getDefaultLoadBalancing(), null, null);
       }
 

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -417,21 +417,23 @@ class ControlConnection extends events.EventEmitter {
 
   async _refreshControlConnection(hostIterator) {
 
-    try {
-
+    if (this.options.sni) {
       this.connection = this._borrowAConnection(hostIterator);
     }
-    catch(err) {
+    else {
+      try { this.connection = this._borrowAConnection(hostIterator); }
+      catch(err) {
 
-      /* NODEJS-632: refresh nodes before getting hosts for reconnect since some hostnames may have
-       * shifted during the flight. */
-      this.log("info", "ControlConnection could not reconnect using existing connections.  Refreshing contact points and retrying");
-      this._contactPoints.clear();
-      this._resolvedContactPoints.clear();
-      await Promise.all(this.options.contactPoints.map(name => this._parseContactPoint(name)));
-      const refreshedContactPoints = Array.from(this._contactPoints).join(',');
-      this.log('info', `Refreshed contact points: ${refreshedContactPoints}`);
-      await this._initializeConnection();
+        /* NODEJS-632: refresh nodes before getting hosts for reconnect since some hostnames may have
+         * shifted during the flight. */
+        this.log("info", "ControlConnection could not reconnect using existing connections.  Refreshing contact points and retrying");
+        this._contactPoints.clear();
+        this._resolvedContactPoints.clear();
+        await Promise.all(this.options.contactPoints.map(name => this._parseContactPoint(name)));
+        const refreshedContactPoints = Array.from(this._contactPoints).join(',');
+        this.log('info', `Refreshed contact points: ${refreshedContactPoints}`);
+        await this._initializeConnection();
+      }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cassandra-driver",
-  "version": "4.6.3",
+  "version": "4.6.2",
   "description": "DataStax Node.js Driver for Apache Cassandra",
   "author": "DataStax",
   "keywords": [
@@ -43,6 +43,7 @@
     "test": "./node_modules/.bin/mocha test/unit -R spec -t 5000 --recursive",
     "ci_jenkins": "./node_modules/.bin/mocha test/unit test/integration/short --recursive -R mocha-jenkins-reporter --exit",
     "ci_appveyor": "./node_modules/.bin/mocha test/unit test/integration/short --recursive -R mocha-appveyor-reporter --exit",
+    "foo": "./node_modules/.bin/mocha test/integration/short --recursive -R spec --exit -g 'should subscribe to TOPOLOGY_CHANGE'",
     "ci_unit_appveyor": "./node_modules/.bin/mocha test/unit --recursive -R mocha-appveyor-reporter --exit",
     "server_api": "./node_modules/.bin/mocha test/integration/short -g '@SERVER_API' --recursive --exit",
     "eslint": "eslint lib test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cassandra-driver",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "description": "DataStax Node.js Driver for Apache Cassandra",
   "author": "DataStax",
   "keywords": [

--- a/test/integration/short/control-connection-tests.js
+++ b/test/integration/short/control-connection-tests.js
@@ -116,7 +116,7 @@ describe('ControlConnection', function () {
       await cc.init();
       await new Promise(r => options.policies.loadBalancing.init(null, cc.hosts, r));
 
-      await util.promisify(helper.ccmHelper.bootstrapNode)(3);
+      await util.promisify(helper.ccmHelper.bootstrapNode)({nodeIndex: 3, dc: 'dc1'});
       await util.promisify(helper.ccmHelper.startNode)(3);
 
       // While the host is started, it's not a given that it will have been connected and marked up,

--- a/test/unit/control-connection-tests.js
+++ b/test/unit/control-connection-tests.js
@@ -422,8 +422,9 @@ describe('ControlConnection', function () {
         yield this.delay;
       };
 
-      const cc = newInstance({ contactPoints: [ '::1' ], policies: { loadBalancing: lbp, reconnection: rp } },
-        getContext({ state: state, queryResults: { 'peers': [ {'rpc_address': types.InetAddress.fromString('::2') } ] }}));
+      const cc = newInstance(
+        { contactPoints: [ '::1' ], policies: { loadBalancing: lbp, reconnection: rp } },
+        getContext({ state: state, queryResults: { 'peers': [ {'rpc_address': types.InetAddress.fromString('::2') } ] }, failBorrow: [-1,1]}));
 
       await cc.init();
 


### PR DESCRIPTION
When we have to do a complete refresh of the control connection make sure to re-resolve contact points.  This looks to be the underlying issue for https://datastax-oss.atlassian.net/browse/NODEJS-632... it was also the subject of https://datastax-oss.atlassian.net/browse/NODEJS-577.
