### PR TITLE
WebSockets support

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,32 @@ client.on('log', (level, loggerName, message, furtherInfo) => {
 The `level` being passed to the listener can be `verbose`, `info`, `warning` or `error`. Visit the [logging
 documentation][doc-logging] for more information. 
 
+## WebSockets
+
+You can use websocket as transport. But Cassandra doesn't support this protocol 
+so some proxy should be deployed in front of Cassandra, which can handle this transport protocol.
+
+```javascript
+ const client = new cassandra.Client({
+ transport: 'WebSocket',
+ contactPoints: [
+  // some proxies that support websocket transport
+  '127.0.0.1:9043',
+  'localhost:9044'
+ ],
+ webSocketOptions: {
+  // some client websocket options
+  protocolVersion: 13,
+  ...
+ }
+});
+```
+
+You can configure your websocket client with `webSocketOptions`.
+To properly configure it follow [websocket/ws doc][ws-doc].
+
+You also can use websockets over SSL by passing `transport: 'SecureWebSocket'`.
+
 ## Compatibility
 
 - Apache Cassandra versions 2.1 and above.
@@ -292,3 +318,4 @@ Unless required by applicable law or agreed to in writing, software distributed 
 [cql-udt]: https://cassandra.apache.org/doc/latest/cql/types.html#udts
 [dse]: https://www.datastax.com/products/datastax-enterprise
 [astra]: https://www.datastax.com/products/datastax-astra
+[ws-doc]: https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketaddress-protocols-options

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,7 @@ import { metrics } from './lib/metrics';
 import { tracker } from './lib/tracker';
 import { metadata } from './lib/metadata';
 import { datastax } from './lib/datastax/';
+import { ClientRequestArgs } from 'http';
 import Long = types.Long;
 import Uuid = types.Uuid;
 import graph = datastax.graph;
@@ -191,7 +192,11 @@ export interface ExecutionOptions {
   setHints(hints: string[]): void;
 }
 
+export type WebSocketClientOptions = (ClientOptions | ClientRequestArgs) 
+    & {protocols?: string | string[] | undefined};
+
 export interface ClientOptions {
+  transport?: 'SecureWebSocket' | 'WebSocket' | undefined
   contactPoints?: string[];
   localDataCenter?: string;
   keyspace?: string;
@@ -253,6 +258,7 @@ export interface ClientOptions {
     tcpNoDelay?: boolean;
   };
   sslOptions?: tls.ConnectionOptions;
+  webSocketOptions?: WebSocketClientOptions;
 }
 
 export interface QueryOptions {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -32,6 +32,7 @@ const StreamIdStack = require('./stream-id-stack');
 const OperationState = require('./operation-state');
 const promiseUtils = require('./promise-utils');
 const { ExecutionOptions } = require('./execution-options');
+const { WebSocketWrapper } = require('./websocket');
 
 /**
  * Represents a connection to a Cassandra node
@@ -171,30 +172,68 @@ class Connection extends events.EventEmitter {
     const self = this;
     this.log('info', `Connecting to ${this.endpointFriendlyName}`);
 
-    if (!this.options.sslOptions) {
-      this.netClient = new net.Socket({ highWaterMark: this.options.socketOptions.coalescingThreshold });
-      this.netClient.connect(this.port, this.address, function connectCallback() {
-        self.log('verbose', `Socket connected to ${self.endpointFriendlyName}`);
-        self.bindSocketListeners();
-        self.startup(callback);
-      });
-    }
-    else {
-      // Use TLS
-      const sslOptions = utils.extend({ rejectUnauthorized: false }, this.options.sslOptions);
+    if (this.options.transport) {
+      if (this.options.transport.toLowerCase() === 'securewebsocket') {
+        // Use secure WebSocket
+        const options = utils.extend({ rejectUnauthorized: false, transport: this.options.transport },
+          this.options.webSocketOptions);
 
-      if (this.options.sni) {
-        sslOptions.servername = this._serverName;
+        if (!options.protocols)
+          options.protocols = ['cql']
+
+        this.netClient = new WebSocketWrapper(options);
+
+        this.netClient.connect(this.port, this.address, function connectCallback() {
+          self.log('verbose', `Secure WebSocket to ${self.endpointFriendlyName}`);
+          self.bindSocketListeners();
+          self.startup(callback);
+        });
+      } else {
+        // Use WebSocket
+        const options = utils.extend({
+          transport: this.options.transport,
+          highWaterMark: this.options.socketOptions.coalescingThreshold,
+          handshakeTimeout: this.options.socketOptions.connectTimeout,
+        }, this.options.webSocketOptions);
+
+        if (!options.protocols)
+          options.protocols = ['cql']
+
+        this.netClient = new WebSocketWrapper(options);
+
+        this.netClient.connect(this.port, this.address, function connectCallback() {
+          self.log('verbose', `WebSocket connected to ${self.endpointFriendlyName}`);
+          self.bindSocketListeners();
+          self.startup(callback);
+        });
       }
+    } else {
+      // Use Socket
+      if (!this.options.sslOptions) {
+        this.netClient = new net.Socket({ highWaterMark: this.options.socketOptions.coalescingThreshold });
 
-      this.netClient = tls.connect(this.port, this.address, sslOptions, function tlsConnectCallback() {
-        self.log('verbose', `Secure socket connected to ${self.endpointFriendlyName} with protocol ${self.netClient.getProtocol()}`);
-        self.bindSocketListeners();
-        self.startup(callback);
-      });
+        this.netClient.connect(this.port, this.address, function connectCallback() {
+          self.log('verbose', `Socket connected to ${self.endpointFriendlyName}`);
+          self.bindSocketListeners();
+          self.startup(callback);
+        });
+      } else {
+        // Use Socket with TLS
+        const sslOptions = utils.extend({ rejectUnauthorized: false }, this.options.sslOptions);
 
-      // TLSSocket will validate for values from 512 to 16K (depending on the SSL protocol version)
-      this.netClient.setMaxSendFragment(this.options.socketOptions.coalescingThreshold);
+        if (this.options.sni) {
+          sslOptions.servername = this._serverName;
+        }
+
+        this.netClient = tls.connect(this.port, this.address, sslOptions, function tlsConnectCallback() {
+          self.log('verbose', `Secure socket connected to ${self.endpointFriendlyName} with protocol ${self.netClient.getProtocol()}`);
+          self.bindSocketListeners();
+          self.startup(callback);
+        });
+
+        // TLSSocket will validate for values from 512 to 16K (depending on the SSL protocol version)
+        this.netClient.setMaxSendFragment(this.options.socketOptions.coalescingThreshold);
+      }
     }
 
     this.netClient.once('error', function socketError(err) {

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -1,0 +1,73 @@
+const { EventEmitter } = require('events')
+const { WebSocket } = require('ws')
+
+/**
+ * WebSocketWrapper is a wrapper on the `ws.Websocket` which implements
+ * `net.Socket` interface to be used by the `cassandra.Connection`
+ */
+class WebSocketWrapper extends EventEmitter {
+  /**
+   * Creates a websocket wrapper instance. To connect use `connect` method
+   * @param {object} options client options for a websocket
+   */
+  constructor(options) {
+    super();
+    this.options = options;
+  }
+
+  /**
+   * Creates an instance of a websocket and connects
+   * @param {String} port
+   * @param {String} address
+   * @param {() => void} connectionCallback is called when connection is successfully established
+   * @returns {WebSocketWrapper} wrapper itself
+   */
+  connect(port, address, connectionCallback) {
+    const schema = this.options.transport.toLowerCase() === 'securewebsocket' ? 'wss' : 'ws'
+
+    this.ws = new WebSocket(schema+'://'+address+':'+port, this.options.protocols, this.options)
+    
+    if (connectionCallback) {
+      this.ws.on('open', connectionCallback);
+    }
+
+    const stream = WebSocket.createWebSocketStream(this.ws, this.options);
+
+    stream.on('error', err => {
+      this.emit('error', err);
+    });
+    stream.on('drain', () => {
+      this.emit('drain');
+    });
+    stream.on('close', () => {
+      this.emit('close');
+    });
+    stream.on('end', () => {
+      this.emit('end');
+    });
+
+    this.write = stream.write.bind(stream);
+    this.pipe = stream.pipe.bind(stream);
+    this.end = stream.end.bind(stream);
+    this.destroy = stream.destroy.bind(stream);
+
+    return this;
+  }
+
+  /**
+   * It is not implemented because `ws` lib doesn't provide API to work with
+   */
+  setTimeout() {}
+
+  /**
+   * It is not implemented because `ws` lib doesn't provide API to work with
+   */
+  setKeepAlive() {}
+
+  /**
+   * It is not implemented because `ws` lib doesn't provide API to work with
+   */
+  setNoDelay() {}
+}
+
+module.exports.WebSocketWrapper = WebSocketWrapper


### PR DESCRIPTION
## Introduction
Hello team,
I've been working on behalf of [shotover-proxy](https://github.com/shotover/shotover-proxy) project so we want to enable this Cassandra driver to work with Cassandra via other transports. For instance, apps can connect to Cassandra via WebSockets using [shotover-proxy](https://github.com/shotover/shotover-proxy). For more information follow its [repo](https://github.com/shotover/shotover-proxy).

Some environments support only HTTP transport like browsers, some lambda executors, etc. So, we want to make Cassandra to be reachable via WebSockets.

##  WebSocket support
Added WebSocket support to the driver by creating a wrapper on `ws.WebSocket` that satisfies `net.Socket` methods used by the driver.

## Usage
To use WebSocket user should define `options.transport` with one of the following values:
- `WebSocket` - for no secure connection
- `SecureWebScoket` - for secure connection over TLS/SSL

## Configuration
To configure WebSocket client use `options.webSocketOptions` property of the Cassandra client constructor. It accepts the same options as a default WebSocket client (follow [doc](https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketaddress-protocols-options)).

Also, a user should provide subprotocols by setting them to `options.webSocketOptions.protocols` if using such proxy as shotover.