### PR TITLE
Correct Client.stream return type: from EventEmitter to ResultStream

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -94,7 +94,7 @@ export class Client extends events.EventEmitter {
   eachRow(query: string,
           rowCallback: (n: number, row: types.Row) => void): void;
 
-  stream(query: string, params?: ArrayOrObject, options?: QueryOptions, callback?: EmptyCallback): events.EventEmitter;
+  stream(query: string, params?: ArrayOrObject, options?: QueryOptions, callback?: EmptyCallback): types.ResultStream;
 
   batch(
     queries: Array<string|{query: string, params?: ArrayOrObject}>,


### PR DESCRIPTION
The client implementation of the `stream` method returns a `ResultStream`. This commit corrects the type listed in the index.ts file to line up with the implementation