### PR TITLE
Remove `@types/long` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "4.7.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/long": "~5.0.0",
         "@types/node": "^18.11.18",
         "adm-zip": "~0.5.10",
         "long": "~5.2.3"
@@ -70,15 +69,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
-    },
-    "node_modules/@types/long": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-5.0.0.tgz",
-      "integrity": "sha512-eQs9RsucA/LNjnMoJvWG/nXa7Pot/RbBzilF/QRIU/xRl+0ApxrSUFsV5lmf01SvSlqMzJ7Zwxe440wmz2SJGA==",
-      "deprecated": "This is a stub types definition. long provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "long": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "18.19.53",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "license": "Apache-2.0",
   "types": "./index.d.ts",
   "dependencies": {
-    "@types/long": "~5.0.0",
     "@types/node": "^18.11.18",
     "adm-zip": "~0.5.10",
     "long": "~5.2.3"


### PR DESCRIPTION
I've removed the `@types/long` dependency, in order to avoid the following deprecation warning:
```
This is a stub types definition. long provides its own type definitions, so you do not need this installed.
```