### PR TITLE
Remove deprecated @types/long dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "license": "Apache-2.0",
   "types": "./index.d.ts",
   "dependencies": {
-    "@types/long": "~5.0.0",
     "@types/node": ">=8",
     "adm-zip": "~0.5.10",
     "long": "~5.2.3"


### PR DESCRIPTION
This pull request addresses the issue of the deprecated `@types/long` dependency in the `cassandra-driver` package. The `long` library, which is a dependency of `cassandra-driver`, has provided its own TypeScript definitions for some time. The presence of `@types/long` can lead to conflicts and issues with TypeScript projects, especially those using newer versions of TypeScript.

### Changes:
- Removed `@types/long` from `package.json`.

### Impact:
- This change simplifies the dependency tree and reduces potential conflicts with TypeScript's type resolution system.
- It ensures better compatibility with projects using the latest TypeScript versions.

I believe this update will benefit the community by providing a cleaner and more maintainable codebase. Looking forward to feedback and suggestions.
