### PR TITLE
NODEJS-668: Handle empty pages in async pagination

### DIFF
--- a/lib/types/result-set.js
+++ b/lib/types/result-set.js
@@ -233,7 +233,7 @@ ResultSet.prototype[asyncIteratorSymbol] = function getAsyncGenerator() {
   let pageState = this.rawPageState;
   let rows = this.rows;
 
-  if (!rows || rows.length === 0) {
+  if (!pageState && (!rows || rows.length === 0)) {
     return { next: () => Promise.resolve({ done: true }) };
   }
 
@@ -257,7 +257,13 @@ ResultSet.prototype[asyncIteratorSymbol] = function getAsyncGenerator() {
         return { done: false, value: rows[index++] };
       }
 
-      return { done: true };
+      if (!pageState) {
+        return { done: true };
+      }
+      
+      // We could reach this point if an empty page is returned.
+      // An empty page doesn't necessarily mean the end of the results.
+      return this.next();
     }
   };
 };


### PR DESCRIPTION
This fixes an issue where an empty page in the results would cause pagination to end, even if there were more results to be returned.

In practice this has happened when using `allow filtering` or when encountering deleted rows in Scylla materialised views.