### PR TITLE
Fix "for...of" loop on `Result<T>` objects

### DIFF
--- a/lib/mapping/index.d.ts
+++ b/lib/mapping/index.d.ts
@@ -51,6 +51,8 @@ export namespace mapping {
     forEach(callback: (currentValue: T, index: number) => void, thisArg?: any): void;
 
     toArray(): T[];
+
+    [Symbol.iterator](): Iterator<T>;
   }
 
   type MappingExecutionOptions = {


### PR DESCRIPTION
Trying to iterate over a `Result<T>` object (e.g. one returned by calling `find`) using a "for...of" loop results in the following TypeScript error:

> TS2488: Type Result<T> must have a \[Symbol.iterator]() method that returns an iterator.

But, `Result<T>` [explicitly](https://github.com/datastax/nodejs-driver/blob/f767bcc6dad71939a3314f71eac8d43607e9c8aa/lib/mapping/result.js#L95) implements `[Symbol.iterator]`, so ignoring this type error fixes the "for...of" iteration.

This PR adds the missing method to the type definition.