### PR TITLE
Add 5.0-beta1 to matrix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -245,8 +245,9 @@ pipeline {
     choice(
       name: 'ADHOC_BUILD_AND_EXECUTE_TESTS_SERVER_VERSION',
       choices: [
-                '3.11',    // Current Apache Cassandra
-                '4.0',     // Development Apache Cassandra
+                '3.11',    // Legacy Apache Cassandra
+                '4.0',     // Current Apache Cassandra
+                '5.0-beta1', // Development Apache Cassandra
                 'dse-5.1.35', // Legacy DataStax Enterprise
                 'dse-6.8.30', // Development DataStax Enterprise
                 'ALL'],
@@ -263,8 +264,12 @@ pipeline {
                           <td>Apache Cassandra v3.11.x</td>
                         </tr>
                         <tr>
+                          <td><strong>5.0-beta1</strong></td>
+                          <td>Apache Cassandra v5.0-beta1 (<b>CURRENTLY UNDER DEVELOPMENT</b>)</td>
+                        </tr>
+                        <tr>
                           <td><strong>4.0</strong></td>
-                          <td>Apache Cassandra v4.x (<b>CURRENTLY UNDER DEVELOPMENT</b>)</td>
+                          <td>Apache Cassandra v4.x</td>
                         </tr>
                         <tr>
                           <td><strong>dse-5.1</strong></td>
@@ -272,7 +277,7 @@ pipeline {
                         </tr>
                         <tr>
                           <td><strong>dse-6.8</strong></td>
-                          <td>DataStax Enterprise v6.8.x (<b>CURRENTLY UNDER DEVELOPMENT</b>)</td>
+                          <td>DataStax Enterprise v6.8.x</td>
                         </tr>
                       </table>''')
     booleanParam(
@@ -327,9 +332,10 @@ pipeline {
           axis {
             name 'CASSANDRA_VERSION'
             values '3.11',    // Current Apache Cassandra
-                   '4.0',     // Development Apache Cassandra
+                   '4.0',     // Current Apache Cassandra
+                   '5.0-beta1',     // Development Apache Cassandra
                    'dse-5.1.35', // Legacy DataStax Enterprise
-                   'dse-6.8.30' // Development DataStax Enterprise
+                   'dse-6.8.30' // Current DataStax Enterprise
           }
           axis {
             name 'NODEJS_VERSION'
@@ -420,7 +426,8 @@ pipeline {
           axis {
             name 'CASSANDRA_VERSION'
             values '3.11',    // Current Apache Cassandra
-                   '4.0',     // Development Apache Cassandra
+                   '4.0',     // Current Apache Cassandra
+                   '5.0-beta1',     // Development Apache Cassandra
                    'dse-5.1.35', // Legacy DataStax Enterprise
                    'dse-6.8.30' // Development DataStax Enterprise
           }
@@ -511,7 +518,8 @@ pipeline {
           axis {
             name 'CASSANDRA_VERSION'
             values '3.11',     // Current Apache Cassandra
-                   '4.0',      // Development Apache Cassandra
+                   '4.0',      // Current Apache Cassandra
+                   '5.0-beta1',      // Development Apache Cassandra
                    'dse-5.1.35', // Legacy DataStax Enterprise
                    'dse-6.8.30' // Development DataStax Enterprise
           }


### PR DESCRIPTION
Currently tests are failing and I think most (if not all) are related to cassandra.yml setting renaming that happened in C* 4.1. This is happening with other drivers as well. The Java driver already handled this in https://github.com/apache/cassandra-java-driver/pull/1924

C* 4.1 renamed some config settings but C* is still looking at the old names because of backwards compability reasons. However, C* fails to launch if it finds both the NEW name and the OLD name for a specific setting. The driver tests call ccm to add the OLD config setting but because the name is different from the one in cassadra.yml, the setting is added to cassandra.yml instead of replacing it.

I've already updated the AMI so it's already running the updated ccm that supports 5.0.