### PR TITLE
Fix typeName with taling whitespace

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -1330,6 +1330,7 @@ function defineInstanceMembers() {
         frozen: false
       }
     };
+    typeName = typeName.trim();
     startIndex = startIndex || 0;
     let params;
     if (!length) {


### PR DESCRIPTION
Problem:

While processing `parseFqTypeName()`, `typeName` for vector field ( `vector<float, x>` ) contains tailing whitespace like "org.apache.cassandra.db.marshal.FloatType ".

```
TypeError: Not a valid type "org.apache.cassandra.db.marshal.FloatType "
 ❯ parseFqTypeName node_modules/.pnpm/cassandra-driver@4.7.2/node_modules/cassandra-driver/lib/encoder.js:1372:13
 ❯ Encoder.parseVectorTypeArgs node_modules/.pnpm/cassandra-driver@4.7.2/node_modules/cassandra-driver/lib/encoder.js:994:24
 ❯ Encoder.encodeCustom node_modules/.pnpm/cassandra-driver@4.7.2/node_modules/cassandra-driver/lib/encoder.js:716:44
 ❯ Encoder.encode node_modules/.pnpm/cassandra-driver@4.7.2/node_modules/cassandra-driver/lib/encoder.js:1703:18
 ❯ node_modules/.pnpm/cassandra-driver@4.7.2/node_modules/cassandra-driver/lib/requests.js:458:71
 ❯ BatchRequest.eachQuery node_modules/.pnpm/cassandra-driver@4.7.2/node_modules/cassandra-driver/lib/requests.js:458:14
 ❯ BatchRequest.write node_modules/.pnpm/cassandra-driver@4.7.2/node_modules/cassandra-driver/lib/requests.js:440:18
 ❯ WriteQueue.process node_modules/.pnpm/cassandra-driver@4.7.2/node_modules/cassandra-driver/lib/writers.js:247:44
 ```

This problem is caused by Cassandra's prepared statement functionality.
While the driver tries to get columns info from Cassandra, it sends response like;

```
columns: [
  { name: 'document_id', type: { code: 13, type: null } },
  { name: 'chunk_number', type: { code: 2, type: null } },
  {
    name: 'embedding',
    type: {
      code: 0,
      type: null,
      info: 'org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.FloatType , 256)'
    }
  },
  { name: 'chunk', type: { code: 13, type: null } },
  { name: 'language', type: { code: 13, type: null } }
]
```

(Cassandra version 5.0.1)

The string literal "org.apache.cassandra.db.marshal.VectorType(org.apache.cassandra.db.marshal.FloatType , 256)" seems to be valid for `type.info`, so I believe the driver should trim tailing whitespace in `parseFqTypeName()`.