### PR TITLE
Replace deprecated usages of `util.isDate` & `util.isString`

### DIFF
--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -391,7 +391,7 @@ class Metadata {
     if (Array.isArray(components)) {
       return this.tokenizer.hash(Buffer.concat(components));
     }
-    else if (util.isString(components)) {
+    else if (typeof components === "string") {
       return this.tokenizer.parse(components);
     }
     return this.tokenizer.hash(components);

--- a/lib/types/local-time.js
+++ b/lib/types/local-time.js
@@ -124,7 +124,7 @@ LocalTime.now = function (nanoseconds) {
  * @returns {LocalTime}
  */
 LocalTime.fromDate = function (date, nanoseconds) {
-  if (!util.isDate(date)) {
+  if (!(date instanceof Date)) {
     throw new Error('Not a valid date');
   }
   //Use the local representation, only the milliseconds portion

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -213,7 +213,7 @@ function deepExtend(target) {
         targetType === 'number' ||
         targetType === 'string' ||
         Array.isArray(targetProp) ||
-        util.isDate(targetProp) ||
+        targetProp instanceof Date ||
         targetProp.constructor.name !== 'Object') {
         target[prop] = source[prop];
       }


### PR DESCRIPTION
The functions `util.isDate` & `util.isString` have been deprecated for a few years, and have been removed in Node.js 23.  

In order for _nodejs-driver_ to be supported on recent Node.js versions, I've replaced their usages with the ones recommended in the [docs](https://nodejs.org/docs/latest/api/deprecations.html).