### PR TITLE
Fix retry on socket error

### DIFF
--- a/lib/request-execution.js
+++ b/lib/request-execution.js
@@ -126,7 +126,7 @@ class RequestExecution {
       } catch (err) {
         // When its a socket error, attempt to retry.
         // Otherwise, rethrow the error to the user.
-        return this._handleError(err, RequestExecution._getErrorCode(err));
+        return this._handleError(RequestExecution._getErrorCode(err), err);
       }
     }
 


### PR DESCRIPTION
Hello,

Please correct if I am wrong. Reading about the retry mechanisms in the `RequestExecution` class, I found something very strange and I think it is an error:

1. [This](https://github.com/datastax/nodejs-driver/blob/804e0bb7f3447c74e4b21e45c3ed50037b2768dc/lib/request-execution.js#L121-L131) portion of code, in the best case and in non-strict mode only rethrow in a non-standard way with an `err` value as a `number` instead of an error object.

2. In strict mode, as specified at the top of the file, calling this method should raise `Error: Cannot create property 'coordinator' on number 'err'` at [this](https://github.com/datastax/nodejs-driver/blob/804e0bb7f3447c74e4b21e45c3ed50037b2768dc/lib/request-execution.js#L284) line.

Potentially generating an erroneous error in business code without providing the desired logic.

Thank you very much for your response.

Have a good day,
Luc