### PR TITLE
Cancel scheduled ControlConnection refresh if shutdown was called

### DIFF
--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -99,6 +99,8 @@ class ControlConnection extends events.EventEmitter {
     this._topologyChangeTimeout = null;
     // Timeout used for delayed handling of node status changes
     this._nodeStatusChangeTimeout = null;
+    // Timeout used for scheduling reconnect
+    this._reconnectTimeout = null;
 
     if (context && context.borrowHostConnection) {
       this._borrowHostConnection = context.borrowHostConnection;
@@ -475,7 +477,8 @@ class ControlConnection extends events.EventEmitter {
       if (!this._isShuttingDown) {
         const delay = this._reconnectionSchedule.next().value;
         this.log('warning', `ControlConnection could not reconnect, scheduling reconnection in ${delay}ms`);
-        setTimeout(() => this._refresh(), delay);
+        clearTimeout(this._reconnectTimeout);
+        this._reconnectTimeout = setTimeout(() => this._refresh(), delay);
         this.emit('newConnection', err);
       }
 
@@ -997,6 +1000,7 @@ class ControlConnection extends events.EventEmitter {
     // Cancel timers
     clearTimeout(this._topologyChangeTimeout);
     clearTimeout(this._nodeStatusChangeTimeout);
+    clearTimeout(this._reconnectTimeout);
   }
 
   /**

--- a/test/integration/short/control-connection-tests.js
+++ b/test/integration/short/control-connection-tests.js
@@ -196,7 +196,7 @@ describe('ControlConnection', function () {
       const options = clientOptions.extend(utils.extend({ pooling: { coreConnectionsPerHost: {}}}, helper.baseOptions));
       const reconnectionDelay = 200;
       options.policies.reconnection = new policies.reconnection.ConstantReconnectionPolicy(reconnectionDelay);
-      const cc = newInstance(options, 1, 1);
+      const cc = newInstance(options, 1);
       disposeAfter(cc);
 
       await cc.init();
@@ -242,38 +242,14 @@ describe('ControlConnection', function () {
       const options = clientOptions.extend(utils.extend({ pooling: { coreConnectionsPerHost: {}}}, helper.baseOptions));
       const reconnectionDelay = 200;
       options.policies.reconnection = new policies.reconnection.ConstantReconnectionPolicy(reconnectionDelay);
-      const cc = newInstance(options, 1, 1);
+      const cc = newInstance(options);
       disposeAfter(cc);
 
       await cc.init();
 
-      assert.ok(cc.host);
-      assert.strictEqual(helper.lastOctetOf(cc.host), '1');
-      const lbp = cc.options.policies.loadBalancing;
-
-      await new Promise(r => lbp.init({ log: utils.noop, options: { localDataCenter: 'dc1' }}, cc.hosts, r));
-
-      // the control connection host should be local or remote to trigger DOWN events
-      for (const h of cc.hosts.values()) {
-        h.setDistance(lbp.getDistance(h));
-        await h.warmupPool();
-      }
-
       // stop nodes 1 and 2 and make sure they both go down.
       await util.promisify(helper.ccmHelper.stopNode)(1);
       await helper.wait.forNodeDown(cc.hosts, 1);
-      await util.promisify(helper.ccmHelper.stopNode)(2);
-      await helper.wait.forNodeDown(cc.hosts, 2);
-
-      // check that both hosts are down.
-      cc.hosts.forEach(h => {
-        if (helper.lastOctetOf(h) === '1') {
-          assert.strictEqual(h.isUp(), false);
-        }
-        else {
-          assert.strictEqual(h.isUp(), false);
-        }
-      });
 
       // start spying on _refresh calls
       cc._refresh = sinon.spy(cc._refresh);


### PR DESCRIPTION
Store timeout, used to schedule refresh call, and clear it on shutdown.

Even though refresh call has check if shutdown was called, timeout itself may prevent nodejs process from shutting down until timeout is reached.

I have some concerns about test itself. Not sure that all the setup steps are required. But I've copied it mostly from previous test "should reconnect when all hosts go down and back up". What I wanted from the test:
 * spin up cluster
 * open control connection and ensure that it is live
 * stop cluster
 * call control connection shutdown
 * verify that refresh was not called

So the main test is pasted below, the rest is a boilerplate copied from other test.

```javascript
// start spying on _refresh calls
cc._refresh = sinon.spy(cc._refresh);

cc.shutdown();

// wait for reconnectionDelay with 10% lag
await helper.delayAsync(parseInt(reconnectionDelay * 1.1, 10));

assert.ok(cc._refresh.notCalled);
```