### PR TITLE
NODEJS-681: ControlConnection Concurrent Read and Write on .host and .connection

### DIFF
--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -454,7 +454,7 @@ class ControlConnection extends events.EventEmitter {
     this._refreshInProgress = true;
 
     try {
-      return await this._unsafeDoRefresh(hostIterator)
+      return await this._unsafeDoRefresh(hostIterator);
     } finally {
       this._refreshInProgress = false;
     }

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -87,6 +87,7 @@ class ControlConnection extends events.EventEmitter {
     this._addressTranslator = this.options.policies.addressResolution;
     this._reconnectionPolicy = this.options.policies.reconnection;
     this._reconnectionSchedule = this._reconnectionPolicy.newSchedule();
+    this._refreshInProgress = false;
     this._isShuttingDown = false;
 
     // Reference to the encoder of the last valid connection
@@ -216,7 +217,6 @@ class ControlConnection extends events.EventEmitter {
 
   _setHealthListeners(host, connection) {
     const self = this;
-    let wasRefreshCalled = 0;
 
     function removeListeners() {
       host.removeListener('down', downOrIgnoredHandler);
@@ -225,11 +225,6 @@ class ControlConnection extends events.EventEmitter {
     }
 
     function startReconnecting(hostDown) {
-      if (wasRefreshCalled++ !== 0) {
-        // Prevent multiple calls to reconnect
-        return;
-      }
-
       removeListeners();
 
       if (self._isShuttingDown) {
@@ -446,13 +441,31 @@ class ControlConnection extends events.EventEmitter {
   }
 
   /**
-   * Acquires a new connection and refreshes topology and keyspace metadata.
+   * Acquires a new connection and refreshes topology and keyspace metadata, with protection against concurrent refreshes.
    * <p>When it fails obtaining a connection and there aren't any more hosts, it schedules reconnection.</p>
    * <p>When it fails obtaining the metadata, it marks connection and/or host unusable and retries using the same
    * iterator from query plan / host list</p>
    * @param {Iterator<Host>} [hostIterator]
    */
   async _refresh(hostIterator) {
+    if (this._refreshInProgress) {
+      return;
+    }
+    this._refreshInProgress = true;
+
+    try {
+      return await this._unsafeDoRefresh(hostIterator)
+    } finally {
+      this._refreshInProgress = false;
+    }
+  }
+
+  /**
+   * The actual implementation of the refresh logic, without protection against concurrent executions.
+   * <p>Should only be used via _refresh.</p>
+   * @param {Iterator<Host>} [hostIterator]
+   */
+  async _unsafeDoRefresh(hostIterator) {
     if (this._isShuttingDown) {
       this.log('info', 'The ControlConnection will not be refreshed as the Client is being shutdown');
       return;
@@ -499,7 +512,7 @@ class ControlConnection extends events.EventEmitter {
       }
 
       // Retry the whole thing with the same query plan
-      return await this._refresh(hostIterator);
+      return await this._unsafeDoRefresh(hostIterator);
     }
 
     this._reconnectionSchedule = this._reconnectionPolicy.newSchedule();

--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -87,7 +87,7 @@ class ControlConnection extends events.EventEmitter {
     this._addressTranslator = this.options.policies.addressResolution;
     this._reconnectionPolicy = this.options.policies.reconnection;
     this._reconnectionSchedule = this._reconnectionPolicy.newSchedule();
-    this._refreshInProgress = false;
+    this._refreshPromise = null;
     this._isShuttingDown = false;
 
     // Reference to the encoder of the last valid connection
@@ -227,8 +227,9 @@ class ControlConnection extends events.EventEmitter {
     function startReconnecting(hostDown) {
       removeListeners();
 
+      // Don't attempt to reconnect when the ControlConnection is being shutdown
       if (self._isShuttingDown) {
-        // Don't attempt to reconnect when the ControlConnection is being shutdown
+        this.log('info', 'The ControlConnection will not be refreshed as the Client is being shutdown');
         return;
       }
 
@@ -407,15 +408,13 @@ class ControlConnection extends events.EventEmitter {
       // To acquire metadata we need to specify the cassandra version
       this.metadata.setCassandraVersion(this.host.getCassandraVersion());
       this.metadata.buildTokens(this.hosts);
-
-      if (!this.options.isMetadataSyncEnabled) {
-        this.metadata.initialized = true;
-        return;
-      }
-
-      await this.metadata.refreshKeyspacesInternal(false);
-      this.metadata.initialized = true;
     }
+
+    if (isReconnecting && this.options.isMetadataSyncEnabled) {
+      await this.metadata.refreshKeyspacesInternal(false);
+    }
+
+    this.metadata.initialized = true;
   }
 
   async _refreshControlConnection(hostIterator) {
@@ -448,15 +447,16 @@ class ControlConnection extends events.EventEmitter {
    * @param {Iterator<Host>} [hostIterator]
    */
   async _refresh(hostIterator) {
-    if (this._refreshInProgress) {
-      return;
+    if (this._refreshPromise) {
+      return await this._refreshPromise;
     }
-    this._refreshInProgress = true;
+
+    this._refreshPromise = this._unsafeDoRefresh(hostIterator);
 
     try {
-      return await this._unsafeDoRefresh(hostIterator);
+      return await this._refreshPromise;
     } finally {
-      this._refreshInProgress = false;
+      this._refreshPromise = null;
     }
   }
 

--- a/lib/promise-utils.js
+++ b/lib/promise-utils.js
@@ -149,7 +149,7 @@ function times(count, limit, fn) {
  * @returns {undefined}
  */
 function toBackground(promise) {
-  promise.catch(() => {});
+  promise?.catch(() => {});
 }
 
 /**

--- a/lib/promise-utils.js
+++ b/lib/promise-utils.js
@@ -145,13 +145,11 @@ function times(count, limit, fn) {
 
 /**
  * Deals with unexpected rejections in order to avoid the unhandled promise rejection warning or failure.
- * @param {Promise | undefined} promise
+ * @param {Promise} promise
  * @returns {undefined}
  */
 function toBackground(promise) {
-  if (promise) {
-    promise.catch(() => {});
-  }
+  void promise.catch(() => {});
 }
 
 /**

--- a/lib/promise-utils.js
+++ b/lib/promise-utils.js
@@ -145,11 +145,13 @@ function times(count, limit, fn) {
 
 /**
  * Deals with unexpected rejections in order to avoid the unhandled promise rejection warning or failure.
- * @param {Promise} promise
+ * @param {Promise | undefined} promise
  * @returns {undefined}
  */
 function toBackground(promise) {
-  promise?.catch(() => {});
+  if (promise) {
+    promise.catch(() => {});
+  }
 }
 
 /**

--- a/lib/promise-utils.js
+++ b/lib/promise-utils.js
@@ -149,7 +149,7 @@ function times(count, limit, fn) {
  * @returns {undefined}
  */
 function toBackground(promise) {
-  void promise.catch(() => {});
+  promise.catch(() => {});
 }
 
 /**

--- a/test/integration/short/control-connection-tests.js
+++ b/test/integration/short/control-connection-tests.js
@@ -153,6 +153,25 @@ describe('ControlConnection', function () {
       assert.strictEqual(cc.hosts.length, 1);
     });
 
+    it('should not break when refreshing concurrently', async () => {
+      const cc = newInstance();
+      cc.options.policies.loadBalancing = new policies.loadBalancing.RoundRobinPolicy();
+      disposeAfter(cc);
+
+      await cc.init();
+      await new Promise(r => cc.options.policies.loadBalancing.init(null, cc.hosts, r));
+
+      const refreshPromises = [];
+      // randomly emit cc._refresh 100 times
+      for (let i = 0; i < 100; i++) {
+        refreshPromises.push(cc._refresh());
+        await helper.delayAsync(~~(Math.random() * 100));
+      }
+      await Promise.all(refreshPromises);
+      assert.ok(cc.host);
+      assert.ok(cc.connection);
+    });
+
     it('should reconnect when host used goes down', async () => {
       const options = clientOptions.extend(
         utils.extend({ pooling: helper.getPoolingOptions(1, 1, 500) }, helper.baseOptions));


### PR DESCRIPTION
This PR superceeds Jane He's #430 with her blessing

After some investigation, we were unable to figure out the root cause behind the NPEs, with there being multiple potential avenues where the issue may have originated from, and so we decided to fix the issue at the lowest and simplest level we could–simply adding a stronger concurrency control to `_refresh` directly via a `_refreshInProgress` flag

I personally believe the issue stemmed from `_setHealthListeners` being called multiple times on the same host/connection, causing the listeners to trigger refreshes multiple times for the same event, leading to the NPEs mentioned in the ticket. 

However the issue is quite hard to organically reproduce so the theory remains a theory.

<details>
<summary>Potential trace</summary>
<ol>
<li> _refresh() is called
<li>  _refresh() calls _refreshControlConnection()
<li> _refreshControlConnection() fails to borrow a connection so it calls _initializeConnection()
<li> _initializeConnection() calls _setHealthListeners() 
<li> _refresh() gets back in control and then also calls _setHealthListeners()
</ol>

which means that there's the potential of, sequentially:

<ol>
<li> A new host and connection being set (call them H1 and C1)
<li> Listeners being attached to the H1 and C1
<li> A newer host being set (call it H2)
<li> Listeners being attached to the H2 and C1 without the previous listeners being removed
</ol>
</details>