### PR TITLE
Minor token ring creation optimization + rebuild token rings on hosts refresh

### DIFF
--- a/lib/control-connection.js
+++ b/lib/control-connection.js
@@ -384,6 +384,9 @@ class ControlConnection extends events.EventEmitter {
     const rsPeers = await c.send(new requests.QueryRequest(selectPeers), null);
     await this.setPeersInfo(initializing, rsPeers);
 
+    this.metadata.setCassandraVersion(this.host.getCassandraVersion());
+    this.metadata.buildTokens(this.hosts);
+
     if (!this.initialized) {
       // resolve protocol version from highest common version among hosts.
       const highestCommon = types.protocolVersion.getHighestCommon(c, this.hosts);
@@ -408,10 +411,6 @@ class ControlConnection extends events.EventEmitter {
           throw err;
         }
       }
-
-      // To acquire metadata we need to specify the cassandra version
-      this.metadata.setCassandraVersion(this.host.getCassandraVersion());
-      this.metadata.buildTokens(this.hosts);
 
       if (!this.options.isMetadataSyncEnabled) {
         this.metadata.initialized = true;

--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -146,7 +146,7 @@ class Metadata {
       return this.log('error', 'Tokenizer could not be determined');
     }
     //Get a sorted array of tokens
-    const allSorted = [];
+    const tempRing = [];
     //Get a map of <token, primaryHost>
     const primaryReplicas = {};
     //Depending on the amount of tokens, this could be an expensive operation
@@ -159,7 +159,7 @@ class Metadata {
       }
       h.tokens.forEach((tokenString) => {
         const token = this.tokenizer.parse(tokenString);
-        utils.insertSorted(allSorted, token, (t1, t2) => t1.compare(t2));
+        tempRing.push(token);
         primaryReplicas[stringify(token)] = h;
       });
       let dc = datacenters[h.datacenter];
@@ -175,7 +175,7 @@ class Metadata {
     //Primary replica for given token
     this.primaryReplicas = primaryReplicas;
     //All the tokens in ring order
-    this.ring = allSorted;
+    this.ring = tempRing.sort((t1, t2) => t1.compare(t2));
     // Build TokenRanges.
     const tokenRanges = new Set();
     if (this.ring.length === 1) {
@@ -192,12 +192,15 @@ class Metadata {
     }
     this.tokenRanges = tokenRanges;
     //Compute string versions as it's potentially expensive and frequently reused later
-    this.ringTokensAsStrings = new Array(allSorted.length);
-    for (let i = 0; i < allSorted.length; i++) {
-      this.ringTokensAsStrings[i] = stringify(allSorted[i]);
+    this.ringTokensAsStrings = new Array(tempRing.length);
+    for (let i = 0; i < tempRing.length; i++) {
+      this.ringTokensAsStrings[i] = stringify(tempRing[i]);
     }
     //Datacenter metadata (host length and racks)
     this.datacenters = datacenters;
+    if (this.keyspaces) {
+      Object.values(this.keyspaces).forEach(k => k.replicas = undefined);
+    }
   }
 
   /**

--- a/test/unit/metadata-tests.js
+++ b/test/unit/metadata-tests.js
@@ -2437,6 +2437,23 @@ describe('Metadata', function () {
       assert.deepEqual(metadata.getReplicas(null, Array.from(ranges)[0]), [h2]);
       done();
     });
+
+    it('should clear cached keyspace replicas on rebuild', function () {
+      const metadata = new Metadata(clientOptions.defaultOptions(), null);
+      metadata.tokenizer = getTokenizer();
+      const hosts = new HostMap();
+      const h1 = new Host('127.0.0.1', 2, clientOptions.defaultOptions());
+      h1.tokens = ['10'];
+      hosts.set(h1.address, h1);
+
+      assert.deepEqual(metadata.keyspaces, {});
+      metadata.keyspaces = {
+        test_ks: { replicas: { '10': [h1] } }
+      };
+
+      metadata.buildTokens(hosts);
+      assert.deepEqual(metadata.keyspaces, { test_ks: { replicas: undefined } });
+    });
   });
 
   describe('#newToken()', function () {


### PR DESCRIPTION
Improves a couple aspects of token ring handling, namely:
- Brings token ring initialization from O(N^2) -> O(N log N)
- Always rebuilds token rings in `_refreshHosts`

The second is the more important change, this way token-aware routing isn't broken due to topology changes during the runtime of the session (plus, `metadata.getTokenRanges()` _is_ also a public method, so users could technically be consuming stale information)

As a precedent, I checked Go's implementation which refreshes the ring on one of three conditions (see `host_source.go`):
- Reconnection <-  ✅ `_refresh()` calls `_refreshHosts()`
- Topology events <- ✅ `_nodeTopologyChangeHandler()` puts `_refreshHosts()` in the debouncer
- On NODE UP _when the host is not recognized_ <- ❌ not sure how necessary this is; it seems on the defensive side

I believe Java is similar to Go here, though I didn't look too long/hard at it (its implementation was a little harder to follow)

This is definitely not my ideal implementation by any means, but it's the minimal fix. The topology events definitely should have their own dedicated debouncer, but that's out of scope for this PR.

Additional notes:
- I did not write any tests for `_refreshHosts()` specifically as there were no existing tests for that method.
- `buildTokens()` has to explicitly invalidates `keyspaces[*].replicas` now; this wasn't an issue before since there were never any replicas prior to the token ring being built during initialization